### PR TITLE
[Feature][Zeta] Add dirty job tracking for member-loss recovery attempts

### DIFF
--- a/config/seatunnel.yaml
+++ b/config/seatunnel.yaml
@@ -20,6 +20,9 @@ seatunnel:
     classloader-cache-mode: true
     history-job-expire-minutes: 1440
     backup-count: 1
+    dirty-task:
+      event-history-size: 10
+      pending-incident-ttl: 10m
     queue-type: blockingqueue
     print-execution-info-interval: 60
     print-job-metrics-info-interval: 60

--- a/docs/en/introduction/configuration/JobEnvConfig.md
+++ b/docs/en/introduction/configuration/JobEnvConfig.md
@@ -51,6 +51,14 @@ This counter accumulates for the life of the pipeline; an intermediate successfu
 
 Used to control the default retry interval when a job fails. The default value is 3 seconds, and it only works in the Zeta engine.
 
+### job.dirty-task.threshold
+
+Controls the optional Zeta dirty-job label. The default value is `-1`; values less than or equal to zero disable tracking. A positive value marks the job `DIRTY` after that many job-level deployment generations associated with Hazelcast member loss. This option does not change `job.retry.times`, stop the job, or replace the primary job status.
+
+One member-loss recovery that redeploys multiple pipelines counts as one first-generation attempt. A later redeployment advances the generation once. Ordinary connector, data, or user-code failures without an active member-loss recovery episode are not counted. Kubernetes Pod restart, manual deletion, and rolling replacement are observed as unclassified member loss unless a future trusted planned-leave protocol proves otherwise, so their redeployment attempts are counted.
+
+Running and finished job APIs expose an optional `dirtyTask` object when tracking is enabled. Its `evaluationStatus` is `CLEAN`, `DIRTY`, or `UNKNOWN`. `UNKNOWN` means the engine cannot prove tracking completeness after a state-store or failover problem and must not be interpreted as clean.
+
 ### savemode.execute.location
 
 This parameter is used to specify the location of the savemode when the job is executed in the Zeta engine.

--- a/docs/zh/introduction/configuration/JobEnvConfig.md
+++ b/docs/zh/introduction/configuration/JobEnvConfig.md
@@ -51,6 +51,14 @@
 
 用于控制作业失败时的默认重试间隔。默认值为3秒，并且仅适用于Zeta引擎。
 
+### job.dirty-task.threshold
+
+用于启用 Zeta 脏任务标记。默认值为 `-1`，小于等于 0 时关闭。配置为正数后，由 Hazelcast 成员离线引起的作业级部署代数达到该阈值时，作业会被标记为 `DIRTY`。该选项不会修改 `job.retry.times`、停止作业或替代原有作业状态。
+
+一次成员离线恢复即使重新部署多个 Pipeline，首次部署也只计为一个作业级尝试；后续再次部署时，代数只增加一次。没有处于成员离线恢复上下文中的 Connector、数据或用户代码异常不会计入。Kubernetes Pod 重启、手动删除和滚动替换在缺少可信计划下线协议时只能识别为未分类成员离线，因此对应的重新部署尝试会被计入。
+
+启用后，运行中和已完成作业接口会返回可选的 `dirtyTask` 对象，其中 `evaluationStatus` 为 `CLEAN`、`DIRTY` 或 `UNKNOWN`。`UNKNOWN` 表示状态存储或故障转移期间无法证明观测完整，不能把该作业判断为干净任务。
+
 ### savemode.execute.location
 
 此参数用于指定在Zeta引擎中执行作业时SaveMode执行的时机。

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
@@ -58,6 +58,14 @@ public class EnvCommonOptions {
                     .defaultValue(3)
                     .withDescription("The retry interval seconds of this job");
 
+    public static Option<Integer> DIRTY_JOB_RESTORE_THRESHOLD =
+            Options.key("job.dirty-task.threshold")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "The member-loss recovery deployment threshold used to mark a job as dirty. "
+                                    + "A value less than or equal to zero disables dirty-job tracking.");
+
     public static Option<Long> CHECKPOINT_INTERVAL =
             Options.key("checkpoint.interval")
                     .longType()

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
@@ -59,6 +59,17 @@ public class Constant {
 
     public static final String IMAP_PENDING_JOB_CLEANUP = "engine_pendingJobCleanup";
 
+    public static final String IMAP_DIRTY_JOB_STATE = "engine_jobDirtyState";
+
+    public static final String IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE =
+            "engine_jobDirtyMemberEventSequence";
+
+    public static final String IMAP_DIRTY_JOB_PENDING_MEMBER_EVENTS =
+            "engine_jobDirtyPendingMemberEvents";
+
+    public static final String IMAP_DIRTY_JOB_ENABLED_THRESHOLDS =
+            "engine_jobDirtyEnabledThresholds";
+
     public static final String IMAP_CONNECTOR_JAR_REF_COUNTERS = "engine_connectorJarRefCounters";
 
     /**

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
@@ -32,6 +32,7 @@ import org.apache.seatunnel.engine.common.runtime.ExecutionMode;
 
 import lombok.Data;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -90,6 +91,16 @@ public class EngineConfig {
 
     private long stateCleanupDelayMillis =
             ServerConfigOptions.MasterServerConfigOptions.STATE_CLEANUP_DELAY_MILLIS.defaultValue();
+
+    // Maximum closed recovery episodes retained in each dirty-job state.
+    private int dirtyJobEventHistorySize =
+            ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_EVENT_HISTORY_SIZE
+                    .defaultValue();
+
+    // Lifetime shared by incomplete episodes and acknowledged journal tombstones.
+    private Duration dirtyJobPendingIncidentTtl =
+            ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_PENDING_INCIDENT_TTL
+                    .defaultValue();
 
     private ClusterRole clusterRole = ClusterRole.MASTER_AND_WORKER;
 
@@ -198,6 +209,24 @@ public class EngineConfig {
                             + " must be >= 0");
         }
         this.stateCleanupDelayMillis = stateCleanupDelayMillis;
+    }
+
+    public void setDirtyJobEventHistorySize(int dirtyJobEventHistorySize) {
+        checkPositive(
+                dirtyJobEventHistorySize,
+                ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_EVENT_HISTORY_SIZE
+                        + " must be > 0");
+        this.dirtyJobEventHistorySize = dirtyJobEventHistorySize;
+    }
+
+    public void setDirtyJobPendingIncidentTtl(Duration dirtyJobPendingIncidentTtl) {
+        checkNotNull(dirtyJobPendingIncidentTtl);
+        if (dirtyJobPendingIncidentTtl.isZero() || dirtyJobPendingIncidentTtl.isNegative()) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_PENDING_INCIDENT_TTL
+                            + " must be > 0");
+        }
+        this.dirtyJobPendingIncidentTtl = dirtyJobPendingIncidentTtl;
     }
 
     public EngineConfig setQueueType(QueueType queueType) {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -48,6 +48,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -235,6 +236,9 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                     .key()
                     .equals(name)) {
                 engineConfig.setStateCleanupDelayMillis(Long.parseLong(getTextContent(node)));
+            } else if (ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_CONFIG.equals(
+                    name)) {
+                parseDirtyJobConfig(node, engineConfig);
             } else if (ServerConfigOptions.MasterServerConfigOptions.CONNECTOR_JAR_STORAGE_CONFIG
                     .key()
                     .equals(name)) {
@@ -343,6 +347,29 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
             // If dynamic slot is enabled, the schedule strategy must be REJECT
             LOGGER.info("Dynamic slot is enabled, the schedule strategy is set to REJECT");
             engineConfig.setScheduleStrategy(ScheduleStrategy.REJECT);
+        }
+    }
+
+    private void parseDirtyJobConfig(Node dirtyJobNode, EngineConfig engineConfig) {
+        for (Node node : childElements(dirtyJobNode)) {
+            String name = cleanNodeName(node);
+            if (ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_EVENT_HISTORY_SIZE
+                    .key()
+                    .equals(name)) {
+                engineConfig.setDirtyJobEventHistorySize(
+                        getIntegerValue(name, getTextContent(node)));
+            } else if (ServerConfigOptions.MasterServerConfigOptions.DIRTY_JOB_PENDING_INCIDENT_TTL
+                    .key()
+                    .equals(name)) {
+                engineConfig.setDirtyJobPendingIncidentTtl(
+                        org.apache.seatunnel.api.configuration.ReadonlyConfig.fromMap(
+                                        Collections.singletonMap(name, getTextContent(node)))
+                                .get(
+                                        ServerConfigOptions.MasterServerConfigOptions
+                                                .DIRTY_JOB_PENDING_INCIDENT_TTL));
+            } else {
+                LOGGER.warning("Unrecognized element: " + name);
+            }
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.api.configuration.Option;
 import org.apache.seatunnel.api.configuration.Options;
 import org.apache.seatunnel.api.metadata.MetadataConfig;
 
+import java.time.Duration;
 import java.util.Map;
 
 /** Declares the server-side configuration keys that are exposed through `seatunnel.yaml`. */
@@ -143,6 +144,8 @@ public class ServerConfigOptions {
     /** The options for master. */
     public static class MasterServerConfigOptions {
 
+        public static final String DIRTY_JOB_CONFIG = "dirty-task";
+
         public static final Option<Integer> PRINT_EXECUTION_INFO_INTERVAL =
                 Options.key("print-execution-info-interval")
                         .intType()
@@ -188,6 +191,20 @@ public class ServerConfigOptions {
                         .withDescription(
                                 "How long to retain terminal job/pipeline/task state in distributed maps before removing it. "
                                         + "This delay allows late asynchronous callbacks to observe a terminal tombstone instead of a missing state entry.");
+
+        public static final Option<Integer> DIRTY_JOB_EVENT_HISTORY_SIZE =
+                Options.key("event-history-size")
+                        .intType()
+                        .defaultValue(10)
+                        .withDescription(
+                                "The maximum number of completed member-loss recovery episodes retained per job.");
+
+        public static final Option<Duration> DIRTY_JOB_PENDING_INCIDENT_TTL =
+                Options.key("pending-incident-ttl")
+                        .durationType()
+                        .defaultValue(Duration.ofMinutes(10))
+                        .withDescription(
+                                "The maximum lifetime of an incomplete member-loss recovery episode.");
         // The options about Hazelcast IMAP store end
         /////////////////////////////////////////////////
 

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobEvaluationStatus.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobEvaluationStatus.java
@@ -17,34 +17,13 @@
 
 package org.apache.seatunnel.engine.common.job;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
-
-@AllArgsConstructor
-@Data
-@NoArgsConstructor
-public final class JobStatusData implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    private Long jobId;
-    private String jobName;
-    private JobStatus jobStatus;
-    private long submitTime;
-    private Long startTime;
-    private Long finishTime;
-    // Optional additive projection; null preserves disabled-job semantics.
-    private DirtyJobSummary dirtyTask;
-
-    public JobStatusData(
-            Long jobId,
-            String jobName,
-            JobStatus jobStatus,
-            long submitTime,
-            Long startTime,
-            Long finishTime) {
-        this(jobId, jobName, jobStatus, submitTime, startTime, finishTime, null);
-    }
+/**
+ * Evaluation result for member-loss recovery tracking.
+ *
+ * <p>UNKNOWN is intentionally distinct from CLEAN when tracking evidence is incomplete.
+ */
+public enum DirtyJobEvaluationStatus {
+    CLEAN,
+    DIRTY,
+    UNKNOWN
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobMemberEvent.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobMemberEvent.java
@@ -23,28 +23,32 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
+/**
+ * HA journal entry for a member removal that may outlive the active coordinator which observed it.
+ */
 @AllArgsConstructor
 @Data
 @NoArgsConstructor
-public final class JobStatusData implements Serializable {
+public class DirtyJobMemberEvent implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private Long jobId;
-    private String jobName;
-    private JobStatus jobStatus;
-    private long submitTime;
-    private Long startTime;
-    private Long finishTime;
-    // Optional additive projection; null preserves disabled-job semantics.
-    private DirtyJobSummary dirtyTask;
+    // Global cluster watermark, or -1 when only local fallback evidence exists.
+    private long sequence;
+    // Stable Hazelcast identity used for idempotent journal updates.
+    private String memberUuid;
+    // Diagnostic host used to match persisted task assignments.
+    private String memberHost;
+    // Diagnostic port used with the host for exact assignment matching.
+    private int memberPort;
+    // Original observation time retained across active-master replay.
+    private long eventTime;
 
-    public JobStatusData(
-            Long jobId,
-            String jobName,
-            JobStatus jobStatus,
-            long submitTime,
-            Long startTime,
-            Long finishTime) {
-        this(jobId, jobName, jobStatus, submitTime, startTime, finishTime, null);
+    /**
+     * Returns the diagnostic address without using it as the member identity.
+     *
+     * @return host and port used only for affected-task matching and diagnostics
+     */
+    public String getAddressText() {
+        return memberHost + ":" + memberPort;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobState.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobState.java
@@ -1,0 +1,610 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.common.job;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * HA state used to evaluate member-loss recovery degradation for one job.
+ *
+ * <p>The state separates member incidents, job recovery episodes, and per-pipeline deployment
+ * attempts. Only confirmed deployment generations advance the job counter. Incident UUIDs, attempt
+ * IDs, and the cluster member-event watermark make replay idempotent and prevent incomplete
+ * tracking from being reported as clean.
+ */
+@Data
+@NoArgsConstructor
+public class DirtyJobState implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    // Stable engine job identity and distributed-map key.
+    private long jobId;
+    // Submission creation time preventing delayed updates from crossing job-ID reuse boundaries.
+    private long jobCreateTime;
+    // Positive job-scoped attempt threshold captured at submission.
+    private int threshold;
+    // Irreversible flag once the cumulative attempt threshold is reached.
+    private boolean dirty;
+    // Query result which is independent from the primary JobStatus.
+    private DirtyJobEvaluationStatus evaluationStatus;
+    // False whenever the engine can no longer prove the observation is complete.
+    private boolean trackingComplete;
+    // Cumulative job-level attempt generations across all episodes.
+    private int recoveryAttemptCount;
+    // Number of member-loss recovery episodes created for this job.
+    private int recoveryEpisodeCount;
+    // Number of distinct member UUID incidents accepted for this job.
+    private int memberLossIncidentCount;
+    // Mutable context for the member-loss recovery currently in progress.
+    private ActiveRecoveryEpisode activeEpisode;
+    // Bounded diagnostic summaries for completed, aborted, or expired episodes.
+    private List<RecoveryEpisodeSummary> recentEpisodes;
+    // Bounded member UUID identities used for idempotent replay.
+    private Set<String> recentIncidentIds;
+    // First time the cumulative threshold was reached.
+    private Long firstDirtyTime;
+    // Most recent time a job-level generation advanced.
+    private Long lastCountedTime;
+    // Highest cluster member-event sequence processed by this job.
+    private long lastProcessedMemberEventSequence;
+    // Most recent trusted or unclassified departure classification.
+    private MemberLeaveClassification lastLeaveClassification;
+    // Diagnostic UUID of the most recently accepted member incident.
+    private String lastLostMemberUuid;
+    // Diagnostic host and port of the most recently accepted incident.
+    private String lastLostAddress;
+    // Operator-facing evidence explaining an UNKNOWN result.
+    private String incompleteReason;
+    // Maximum retained episode summaries used by this serialized state.
+    private int eventHistorySize;
+    // Maximum lifetime of an episode which never completes deployment.
+    private long pendingIncidentTtlMillis;
+
+    public static DirtyJobState create(
+            long jobId,
+            int threshold,
+            int eventHistorySize,
+            long pendingIncidentTtlMillis,
+            long memberEventSequence) {
+        return create(
+                jobId,
+                0L,
+                threshold,
+                eventHistorySize,
+                pendingIncidentTtlMillis,
+                memberEventSequence);
+    }
+
+    public static DirtyJobState create(
+            long jobId,
+            long jobCreateTime,
+            int threshold,
+            int eventHistorySize,
+            long pendingIncidentTtlMillis,
+            long memberEventSequence) {
+        DirtyJobState state = new DirtyJobState();
+        state.jobId = jobId;
+        state.jobCreateTime = jobCreateTime;
+        state.threshold = threshold;
+        state.evaluationStatus = DirtyJobEvaluationStatus.CLEAN;
+        state.trackingComplete = true;
+        state.recentEpisodes = new ArrayList<>();
+        state.recentIncidentIds = new LinkedHashSet<>();
+        state.eventHistorySize = eventHistorySize;
+        state.pendingIncidentTtlMillis = pendingIncidentTtlMillis;
+        state.lastProcessedMemberEventSequence = memberEventSequence;
+        return state;
+    }
+
+    public void validateConfiguration(
+            int configuredThreshold,
+            int configuredEventHistorySize,
+            long configuredPendingIncidentTtlMillis) {
+        ensureCollections();
+        if (threshold != configuredThreshold
+                || eventHistorySize != configuredEventHistorySize
+                || pendingIncidentTtlMillis != configuredPendingIncidentTtlMillis) {
+            markTrackingIncomplete("Dirty-job configuration changed for an existing job");
+        }
+    }
+
+    public void processMemberEvent(
+            long memberEventSequence,
+            String lostMemberUuid,
+            String lostAddress,
+            MemberLeaveClassification classification,
+            Collection<Integer> affectedPipelineIds,
+            long now) {
+        ensureCollections();
+        lastProcessedMemberEventSequence =
+                Math.max(lastProcessedMemberEventSequence, memberEventSequence);
+        if (affectedPipelineIds == null || affectedPipelineIds.isEmpty()) {
+            refreshEvaluation();
+            return;
+        }
+
+        String incidentId = jobId + ":" + lostMemberUuid;
+        lastLeaveClassification = classification;
+        lastLostMemberUuid = lostMemberUuid;
+        lastLostAddress = lostAddress;
+        if (recentIncidentIds.contains(incidentId)) {
+            refreshEvaluation();
+            return;
+        }
+
+        rememberIncident(incidentId);
+        expireStaleEpisode(now);
+        if (activeEpisode == null) {
+            activeEpisode =
+                    ActiveRecoveryEpisode.create(
+                            jobId + "-" + memberEventSequence,
+                            affectedPipelineIds,
+                            classification,
+                            now);
+            recoveryEpisodeCount++;
+        } else {
+            activeEpisode.addIncident(affectedPipelineIds, classification);
+        }
+        memberLossIncidentCount++;
+        refreshEvaluation();
+    }
+
+    public void advanceMemberEventSequence(long memberEventSequence) {
+        lastProcessedMemberEventSequence =
+                Math.max(lastProcessedMemberEventSequence, memberEventSequence);
+        refreshEvaluation();
+    }
+
+    /**
+     * Creates or reuses the stable PREPARED attempt for an affected, not-yet-recovered pipeline.
+     */
+    public String prepareRecoveryAttempt(int pipelineId, long now) {
+        ensureCollections();
+        expireStaleEpisode(now);
+        if (activeEpisode == null
+                || !activeEpisode.affectedPipelineIds.contains(pipelineId)
+                || activeEpisode.recoveredPipelineIds.contains(pipelineId)) {
+            return null;
+        }
+        RecoveryDeploymentAttempt currentAttempt = activeEpisode.currentAttempts.get(pipelineId);
+        if (currentAttempt != null && currentAttempt.status == RecoveryAttemptStatus.PREPARED) {
+            return currentAttempt.attemptId;
+        }
+        int prepareSequence = activeEpisode.nextPrepareSequence(pipelineId);
+        String attemptId = activeEpisode.episodeId + ":" + pipelineId + ":" + prepareSequence;
+        activeEpisode.currentAttempts.put(
+                pipelineId,
+                new RecoveryDeploymentAttempt(
+                        attemptId,
+                        pipelineId,
+                        prepareSequence,
+                        RecoveryAttemptStatus.PREPARED,
+                        now,
+                        null));
+        return attemptId;
+    }
+
+    /**
+     * Confirms a stable attempt after the recovery pipeline state is durably set to DEPLOYING.
+     *
+     * @param attemptId stable identity allocated during restore preparation
+     */
+    public void confirmRecoveryAttempt(int pipelineId, String attemptId, long now) {
+        ensureCollections();
+        if (activeEpisode == null) {
+            return;
+        }
+        RecoveryDeploymentAttempt attempt = activeEpisode.currentAttempts.get(pipelineId);
+        if (attempt == null || !attempt.attemptId.equals(attemptId)) {
+            return;
+        }
+        confirmAttempt(attempt, now);
+    }
+
+    /**
+     * Reconciles the current attempt after an active-master switch without allocating a new ID.
+     *
+     * @param pipelineId restored pipeline whose persisted state proves deployment started
+     */
+    public String confirmCurrentRecoveryAttempt(int pipelineId, long now) {
+        ensureCollections();
+        if (activeEpisode == null) {
+            return null;
+        }
+        RecoveryDeploymentAttempt attempt = activeEpisode.currentAttempts.get(pipelineId);
+        if (attempt != null) {
+            confirmAttempt(attempt, now);
+            return attempt.attemptId;
+        }
+        return null;
+    }
+
+    /**
+     * Marks one affected pipeline recovered only when the confirmed attempt reached RUNNING.
+     *
+     * @param attemptId stable confirmed attempt which completed deployment
+     */
+    public void completeRecoveryPipeline(int pipelineId, String attemptId, long now) {
+        ensureCollections();
+        if (activeEpisode == null) {
+            return;
+        }
+        RecoveryDeploymentAttempt attempt = activeEpisode.currentAttempts.get(pipelineId);
+        if (attempt == null
+                || !attempt.attemptId.equals(attemptId)
+                || attempt.status != RecoveryAttemptStatus.CONFIRMED) {
+            return;
+        }
+        completePipeline(pipelineId, now);
+    }
+
+    /**
+     * Completes the current confirmed attempt during active-master reconciliation.
+     *
+     * @param pipelineId restored pipeline whose task groups are all RUNNING
+     */
+    public void completeCurrentRecoveryPipeline(int pipelineId, long now) {
+        ensureCollections();
+        if (activeEpisode == null) {
+            return;
+        }
+        RecoveryDeploymentAttempt attempt = activeEpisode.currentAttempts.get(pipelineId);
+        if (attempt != null && attempt.status == RecoveryAttemptStatus.CONFIRMED) {
+            completePipeline(pipelineId, now);
+        }
+    }
+
+    /**
+     * Snapshots an unfinished episode as aborted before terminal job history is written.
+     *
+     * @param now terminal snapshot time
+     */
+    public void finishActiveEpisode(long now) {
+        ensureCollections();
+        if (activeEpisode != null) {
+            addRecentEpisode(activeEpisode.toSummary(RecoveryEpisodeStatus.ABORTED, now));
+            activeEpisode = null;
+        }
+        refreshEvaluation();
+    }
+
+    /**
+     * Permanently prevents this running state from being evaluated as CLEAN.
+     *
+     * @param reason missing or inconsistent evidence exposed to operators
+     */
+    public void markTrackingIncomplete(String reason) {
+        trackingComplete = false;
+        incompleteReason = reason;
+        evaluationStatus = DirtyJobEvaluationStatus.UNKNOWN;
+    }
+
+    /**
+     * Returns a query-safe copy evaluated against the current cluster member-event watermark.
+     *
+     * @return evaluated copy which does not mutate HA state
+     */
+    public DirtyJobState evaluatedCopy(long currentMemberEventSequence) {
+        return evaluatedCopy(currentMemberEventSequence, System.currentTimeMillis());
+    }
+
+    /**
+     * Evaluates watermark and episode TTL completeness without mutating the HA state.
+     *
+     * @param now query time used for deterministic TTL evaluation
+     * @return evaluated copy
+     */
+    public DirtyJobState evaluatedCopy(long currentMemberEventSequence, long now) {
+        ensureCollections();
+        DirtyJobState copy = copy();
+        if (copy.lastProcessedMemberEventSequence < currentMemberEventSequence) {
+            copy.markTrackingIncomplete("Member-event watermark is behind the cluster sequence");
+        } else if (copy.activeEpisode != null
+                && copy.pendingIncidentTtlMillis > 0
+                && now - copy.activeEpisode.startedTime > copy.pendingIncidentTtlMillis) {
+            copy.markTrackingIncomplete(
+                    "A member-loss recovery episode exceeded its configured lifetime");
+        } else {
+            copy.refreshEvaluation();
+        }
+        return copy;
+    }
+
+    /**
+     * Builds the bounded list-response projection.
+     *
+     * @return dirty flag, evaluation status, and cumulative attempt count
+     */
+    public DirtyJobSummary toSummary() {
+        return new DirtyJobSummary(dirty, evaluationStatus, recoveryAttemptCount);
+    }
+
+    private void confirmAttempt(RecoveryDeploymentAttempt attempt, long now) {
+        if (attempt.status == RecoveryAttemptStatus.CONFIRMED) {
+            return;
+        }
+        attempt.status = RecoveryAttemptStatus.CONFIRMED;
+        attempt.confirmedTime = now;
+        int generation = attempt.prepareSequence;
+        if (generation > activeEpisode.confirmedGeneration) {
+            recoveryAttemptCount += generation - activeEpisode.confirmedGeneration;
+            activeEpisode.confirmedGeneration = generation;
+            lastCountedTime = now;
+        }
+        if (!dirty && recoveryAttemptCount >= threshold) {
+            dirty = true;
+            firstDirtyTime = now;
+        }
+        refreshEvaluation();
+    }
+
+    private void completePipeline(int pipelineId, long now) {
+        activeEpisode.recoveredPipelineIds.add(pipelineId);
+        if (activeEpisode.recoveredPipelineIds.containsAll(activeEpisode.affectedPipelineIds)) {
+            addRecentEpisode(activeEpisode.toSummary(RecoveryEpisodeStatus.COMPLETED, now));
+            activeEpisode = null;
+        }
+        refreshEvaluation();
+    }
+
+    private void expireStaleEpisode(long now) {
+        if (activeEpisode == null
+                || pendingIncidentTtlMillis <= 0
+                || now - activeEpisode.startedTime <= pendingIncidentTtlMillis) {
+            return;
+        }
+        addRecentEpisode(activeEpisode.toSummary(RecoveryEpisodeStatus.EXPIRED, now));
+        activeEpisode = null;
+        markTrackingIncomplete("A member-loss recovery episode expired before recovery completed");
+    }
+
+    private void rememberIncident(String incidentId) {
+        recentIncidentIds.add(incidentId);
+        int incidentLimit = Math.max(1, eventHistorySize * 4);
+        while (recentIncidentIds.size() > incidentLimit) {
+            String oldest = recentIncidentIds.iterator().next();
+            recentIncidentIds.remove(oldest);
+            markTrackingIncomplete(
+                    "Member-loss incident deduplication history exceeded its configured bound");
+        }
+    }
+
+    private void addRecentEpisode(RecoveryEpisodeSummary summary) {
+        recentEpisodes.add(summary);
+        while (recentEpisodes.size() > eventHistorySize) {
+            recentEpisodes.remove(0);
+        }
+    }
+
+    private void refreshEvaluation() {
+        if (!trackingComplete) {
+            evaluationStatus = DirtyJobEvaluationStatus.UNKNOWN;
+        } else if (dirty) {
+            evaluationStatus = DirtyJobEvaluationStatus.DIRTY;
+        } else {
+            evaluationStatus = DirtyJobEvaluationStatus.CLEAN;
+        }
+    }
+
+    private void ensureCollections() {
+        if (recentEpisodes == null) {
+            recentEpisodes = new ArrayList<>();
+        }
+        if (recentIncidentIds == null) {
+            recentIncidentIds = new LinkedHashSet<>();
+        }
+        if (activeEpisode != null) {
+            activeEpisode.ensureCollections();
+        }
+    }
+
+    private DirtyJobState copy() {
+        DirtyJobState copy = new DirtyJobState();
+        copy.jobId = jobId;
+        copy.jobCreateTime = jobCreateTime;
+        copy.threshold = threshold;
+        copy.dirty = dirty;
+        copy.evaluationStatus = evaluationStatus;
+        copy.trackingComplete = trackingComplete;
+        copy.recoveryAttemptCount = recoveryAttemptCount;
+        copy.recoveryEpisodeCount = recoveryEpisodeCount;
+        copy.memberLossIncidentCount = memberLossIncidentCount;
+        copy.activeEpisode = activeEpisode;
+        copy.recentEpisodes = new ArrayList<>(recentEpisodes);
+        copy.recentIncidentIds = new LinkedHashSet<>(recentIncidentIds);
+        copy.firstDirtyTime = firstDirtyTime;
+        copy.lastCountedTime = lastCountedTime;
+        copy.lastProcessedMemberEventSequence = lastProcessedMemberEventSequence;
+        copy.lastLeaveClassification = lastLeaveClassification;
+        copy.lastLostMemberUuid = lastLostMemberUuid;
+        copy.lastLostAddress = lastLostAddress;
+        copy.incompleteReason = incompleteReason;
+        copy.eventHistorySize = eventHistorySize;
+        copy.pendingIncidentTtlMillis = pendingIncidentTtlMillis;
+        return copy;
+    }
+
+    /**
+     * Active, bounded recovery context for pipelines affected by member loss.
+     *
+     * <p>Recovered pipelines cannot consume ordinary failures until a new incident affects them.
+     */
+    @Data
+    @NoArgsConstructor
+    public static class ActiveRecoveryEpisode implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        // Stable episode identity derived from job and first event sequence.
+        private String episodeId;
+        // Original member-event observation time.
+        private long startedTime;
+        // Pipelines which must recover before this episode can close.
+        private Set<Integer> affectedPipelineIds;
+        // Affected pipelines already recovered by a confirmed attempt.
+        private Set<Integer> recoveredPipelineIds;
+        // Monotonic per-pipeline preparation sequence used in stable attempt IDs.
+        private Map<Integer, Integer> prepareSequences;
+        // Current prepared or confirmed attempt for each affected pipeline.
+        private Map<Integer, RecoveryDeploymentAttempt> currentAttempts;
+        // Highest confirmed per-pipeline generation already counted at job level.
+        private int confirmedGeneration;
+        // Distinct member incidents merged into this continuous episode.
+        private int incidentCount;
+        // Most conservative classification among merged incidents.
+        private MemberLeaveClassification classification;
+
+        private static ActiveRecoveryEpisode create(
+                String episodeId,
+                Collection<Integer> affectedPipelineIds,
+                MemberLeaveClassification classification,
+                long now) {
+            ActiveRecoveryEpisode episode = new ActiveRecoveryEpisode();
+            episode.episodeId = episodeId;
+            episode.startedTime = now;
+            episode.affectedPipelineIds = new LinkedHashSet<>(affectedPipelineIds);
+            episode.recoveredPipelineIds = new LinkedHashSet<>();
+            episode.prepareSequences = new LinkedHashMap<>();
+            episode.currentAttempts = new LinkedHashMap<>();
+            episode.incidentCount = 1;
+            episode.classification = classification;
+            return episode;
+        }
+
+        private void addIncident(
+                Collection<Integer> pipelineIds, MemberLeaveClassification newClassification) {
+            ensureCollections();
+            affectedPipelineIds.addAll(pipelineIds);
+            recoveredPipelineIds.removeAll(pipelineIds);
+            incidentCount++;
+            if (newClassification == MemberLeaveClassification.UNCLASSIFIED) {
+                classification = MemberLeaveClassification.UNCLASSIFIED;
+            }
+        }
+
+        private int nextPrepareSequence(int pipelineId) {
+            int sequence = prepareSequences.getOrDefault(pipelineId, 0) + 1;
+            prepareSequences.put(pipelineId, sequence);
+            return sequence;
+        }
+
+        private RecoveryEpisodeSummary toSummary(RecoveryEpisodeStatus status, long now) {
+            return new RecoveryEpisodeSummary(
+                    episodeId,
+                    status,
+                    startedTime,
+                    now,
+                    affectedPipelineIds.size(),
+                    incidentCount,
+                    confirmedGeneration,
+                    classification);
+        }
+
+        private void ensureCollections() {
+            if (affectedPipelineIds == null) {
+                affectedPipelineIds = new LinkedHashSet<>();
+            }
+            if (recoveredPipelineIds == null) {
+                recoveredPipelineIds = new LinkedHashSet<>();
+            }
+            if (prepareSequences == null) {
+                prepareSequences = new LinkedHashMap<>();
+            }
+            if (currentAttempts == null) {
+                currentAttempts = new LinkedHashMap<>();
+            }
+        }
+    }
+
+    /**
+     * Stable identity and lifecycle for one recovery deployment attempt.
+     *
+     * <p>PREPARED is reused across a master switch and counted only after confirmation.
+     */
+    @AllArgsConstructor
+    @Data
+    @NoArgsConstructor
+    public static class RecoveryDeploymentAttempt implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        // Stable identity reused by active-master reconciliation.
+        private String attemptId;
+        // Pipeline owning this deployment attempt.
+        private int pipelineId;
+        // Per-pipeline generation embedded in the stable identity.
+        private int prepareSequence;
+        // PREPARED attempts are not counted until they become CONFIRMED.
+        private RecoveryAttemptStatus status;
+        // Time restore preparation allocated this identity.
+        private long preparedTime;
+        // Time persisted pipeline state proved deployment had started.
+        private Long confirmedTime;
+    }
+
+    /**
+     * Bounded episode record retained after the active context closes.
+     *
+     * <p>The record intentionally stores counts rather than unbounded task-group detail.
+     */
+    @AllArgsConstructor
+    @Data
+    @NoArgsConstructor
+    public static class RecoveryEpisodeSummary implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        // Stable identity of the closed episode.
+        private String episodeId;
+        // Terminal outcome of the bounded episode summary.
+        private RecoveryEpisodeStatus status;
+        // Original event time retained for diagnostics.
+        private long startedTime;
+        // Completion, abort, or expiry time.
+        private long finishedTime;
+        // Number of distinct pipelines involved in the episode.
+        private int affectedPipelineCount;
+        // Number of member incidents merged into the episode.
+        private int incidentCount;
+        // Highest deployment generation counted for the episode.
+        private int confirmedGeneration;
+        // Conservative departure classification for the episode.
+        private MemberLeaveClassification classification;
+    }
+
+    /** Distinguishes allocated attempts from attempts proven to have started deployment. */
+    public enum RecoveryAttemptStatus {
+        PREPARED,
+        CONFIRMED
+    }
+
+    /** Terminal outcome retained for a bounded recovery episode summary. */
+    public enum RecoveryEpisodeStatus {
+        COMPLETED,
+        ABORTED,
+        EXPIRED
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobSummary.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/DirtyJobSummary.java
@@ -23,28 +23,21 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
+/**
+ * Bounded dirty-job fields suitable for job list responses.
+ *
+ * <p>Episode and incident detail remains in the job-detail response to keep list payloads small.
+ */
 @AllArgsConstructor
 @Data
 @NoArgsConstructor
-public final class JobStatusData implements Serializable {
+public class DirtyJobSummary implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private Long jobId;
-    private String jobName;
-    private JobStatus jobStatus;
-    private long submitTime;
-    private Long startTime;
-    private Long finishTime;
-    // Optional additive projection; null preserves disabled-job semantics.
-    private DirtyJobSummary dirtyTask;
-
-    public JobStatusData(
-            Long jobId,
-            String jobName,
-            JobStatus jobStatus,
-            long submitTime,
-            Long startTime,
-            Long finishTime) {
-        this(jobId, jobName, jobStatus, submitTime, startTime, finishTime, null);
-    }
+    // Irreversible threshold result for the current job ID.
+    private boolean dirty;
+    // CLEAN, DIRTY, or UNKNOWN completeness-aware projection.
+    private DirtyJobEvaluationStatus evaluationStatus;
+    // Cumulative job-level deployment generations caused by member loss.
+    private int recoveryAttemptCount;
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/MemberLeaveClassification.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/MemberLeaveClassification.java
@@ -17,34 +17,12 @@
 
 package org.apache.seatunnel.engine.common.job;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.io.Serializable;
-
-@AllArgsConstructor
-@Data
-@NoArgsConstructor
-public final class JobStatusData implements Serializable {
-    private static final long serialVersionUID = 1L;
-
-    private Long jobId;
-    private String jobName;
-    private JobStatus jobStatus;
-    private long submitTime;
-    private Long startTime;
-    private Long finishTime;
-    // Optional additive projection; null preserves disabled-job semantics.
-    private DirtyJobSummary dirtyTask;
-
-    public JobStatusData(
-            Long jobId,
-            String jobName,
-            JobStatus jobStatus,
-            long submitTime,
-            Long startTime,
-            Long finishTime) {
-        this(jobId, jobName, jobStatus, submitTime, startTime, finishTime, null);
-    }
+/**
+ * Classification supplied by the control plane for a member departure.
+ *
+ * <p>Phase one emits UNCLASSIFIED because no trusted planned-leave protocol exists yet.
+ */
+public enum MemberLeaveClassification {
+    UNCLASSIFIED,
+    PLANNED_VERIFIED
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/resources/seatunnel.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/resources/seatunnel.yaml
@@ -18,6 +18,9 @@
 seatunnel:
     engine:
         backup-count: 1
+        dirty-task:
+            event-history-size: 10
+            pending-incident-ttl: 10m
         queue-type: blockingqueue
         print-execution-info-interval: 60
         print-job-metrics-info-interval: 60

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelConfigParserTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.YamlClientConfigBuilder;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import static com.hazelcast.internal.config.DeclarativeConfigUtil.YAML_ACCEPTED_SUFFIXES;
 
@@ -44,6 +45,10 @@ public class YamlSeaTunnelConfigParserTest {
         Assertions.assertNotNull(config);
 
         Assertions.assertEquals(1, config.getEngineConfig().getBackupCount());
+
+        Assertions.assertEquals(12, config.getEngineConfig().getDirtyJobEventHistorySize());
+        Assertions.assertEquals(
+                Duration.ofMinutes(5), config.getEngineConfig().getDirtyJobPendingIncidentTtl());
 
         Assertions.assertEquals(2, config.getEngineConfig().getPrintExecutionInfoInterval());
 

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/DirtyJobStateTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/DirtyJobStateTest.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.common.job;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Covers dirty-job generation counting, replay idempotency, and incomplete tracking semantics.
+ *
+ * <p>The cases protect the boundary that ordinary business restore must not consume member-loss
+ * context.
+ */
+class DirtyJobStateTest {
+
+    @Test
+    void shouldCountJobLevelRecoveryGenerationsAcrossPipelines() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Arrays.asList(1, 2),
+                100L);
+
+        String pipelineOneAttempt = state.prepareRecoveryAttempt(1, 110L);
+        state.confirmRecoveryAttempt(1, pipelineOneAttempt, 120L);
+        String pipelineTwoAttempt = state.prepareRecoveryAttempt(2, 130L);
+        state.confirmRecoveryAttempt(2, pipelineTwoAttempt, 140L);
+
+        Assertions.assertEquals(1, state.getRecoveryAttemptCount());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.CLEAN, state.getEvaluationStatus());
+
+        String secondGeneration = state.prepareRecoveryAttempt(1, 150L);
+        state.confirmRecoveryAttempt(1, secondGeneration, 160L);
+        state.confirmRecoveryAttempt(1, secondGeneration, 170L);
+
+        Assertions.assertEquals(2, state.getRecoveryAttemptCount());
+        Assertions.assertTrue(state.isDirty());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.DIRTY, state.getEvaluationStatus());
+    }
+
+    @Test
+    void shouldIgnoreOrdinaryRestoreWithoutMemberLossEpisode() {
+        DirtyJobState state = DirtyJobState.create(1L, 1, 10, 600_000L, 0L);
+
+        String attemptId = state.prepareRecoveryAttempt(1, 100L);
+
+        Assertions.assertNull(attemptId);
+        Assertions.assertEquals(0, state.getRecoveryAttemptCount());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.CLEAN, state.getEvaluationStatus());
+    }
+
+    @Test
+    void shouldReusePreparedAttemptUntilDeploymentIsConfirmed() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                100L);
+
+        String firstPreparation = state.prepareRecoveryAttempt(1, 110L);
+        String preparationAfterMasterSwitch = state.prepareRecoveryAttempt(1, 120L);
+        state.confirmRecoveryAttempt(1, preparationAfterMasterSwitch, 130L);
+
+        Assertions.assertEquals(firstPreparation, preparationAfterMasterSwitch);
+        Assertions.assertEquals(1, state.getRecoveryAttemptCount());
+    }
+
+    @Test
+    void shouldReturnStableAttemptDuringMasterSwitchReconciliation() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                100L);
+        String preparedAttempt = state.prepareRecoveryAttempt(1, 110L);
+
+        String reconciledAttempt = state.confirmCurrentRecoveryAttempt(1, 120L);
+        state.completeRecoveryPipeline(1, reconciledAttempt, 130L);
+
+        Assertions.assertEquals(preparedAttempt, reconciledAttempt);
+        Assertions.assertEquals(1, state.getRecoveryAttemptCount());
+        Assertions.assertNull(state.getActiveEpisode());
+    }
+
+    @Test
+    void shouldDeduplicateMemberEventAndAttemptConfirmation() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                100L);
+        state.processMemberEvent(
+                2L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                110L);
+        String attemptId = state.prepareRecoveryAttempt(1, 120L);
+
+        state.confirmRecoveryAttempt(1, attemptId, 130L);
+        state.confirmRecoveryAttempt(1, attemptId, 140L);
+
+        Assertions.assertEquals(1, state.getRecoveryEpisodeCount());
+        Assertions.assertEquals(1, state.getMemberLossIncidentCount());
+        Assertions.assertEquals(1, state.getRecoveryAttemptCount());
+        Assertions.assertEquals(2L, state.getLastProcessedMemberEventSequence());
+    }
+
+    @Test
+    void shouldReportUnknownWhenMemberEventWatermarkLags() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 10, 600_000L, 3L);
+
+        DirtyJobState evaluated = state.evaluatedCopy(4L);
+
+        Assertions.assertFalse(evaluated.isTrackingComplete());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.UNKNOWN, evaluated.getEvaluationStatus());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.CLEAN, state.getEvaluationStatus());
+    }
+
+    @Test
+    void shouldReportUnknownWhenActiveEpisodeExpires() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 10, 100L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                100L);
+
+        DirtyJobState evaluated = state.evaluatedCopy(1L, 201L);
+
+        Assertions.assertEquals(DirtyJobEvaluationStatus.UNKNOWN, evaluated.getEvaluationStatus());
+        Assertions.assertTrue(state.isTrackingComplete());
+    }
+
+    @Test
+    void shouldRequireReaffectedPipelineToRecoverAgain() {
+        DirtyJobState state = DirtyJobState.create(1L, 3, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Arrays.asList(1, 2),
+                100L);
+        String firstAttempt = state.prepareRecoveryAttempt(1, 110L);
+        state.confirmRecoveryAttempt(1, firstAttempt, 120L);
+        state.completeRecoveryPipeline(1, firstAttempt, 130L);
+
+        state.processMemberEvent(
+                2L,
+                "member-2",
+                "10.0.0.2:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                140L);
+
+        Assertions.assertFalse(state.getActiveEpisode().getRecoveredPipelineIds().contains(1));
+    }
+
+    @Test
+    void shouldIgnoreBusinessFailureAfterPipelineRecoveredWithinActiveEpisode() {
+        DirtyJobState state = DirtyJobState.create(1L, 3, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Arrays.asList(1, 2),
+                100L);
+        String memberLossAttempt = state.prepareRecoveryAttempt(1, 110L);
+        state.confirmRecoveryAttempt(1, memberLossAttempt, 120L);
+        state.completeRecoveryPipeline(1, memberLossAttempt, 130L);
+
+        String businessFailureAttempt = state.prepareRecoveryAttempt(1, 140L);
+
+        Assertions.assertNull(businessFailureAttempt);
+        Assertions.assertEquals(1, state.getRecoveryAttemptCount());
+    }
+
+    @Test
+    void shouldCloseEpisodeOnlyAfterEveryAffectedPipelineRecovers() {
+        DirtyJobState state = DirtyJobState.create(1L, 3, 10, 600_000L, 0L);
+        state.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Arrays.asList(1, 2),
+                100L);
+        String firstAttempt = state.prepareRecoveryAttempt(1, 110L);
+        String secondAttempt = state.prepareRecoveryAttempt(2, 120L);
+        state.confirmRecoveryAttempt(1, firstAttempt, 130L);
+        state.confirmRecoveryAttempt(2, secondAttempt, 140L);
+
+        state.completeRecoveryPipeline(1, firstAttempt, 150L);
+        Assertions.assertNotNull(state.getActiveEpisode());
+
+        state.completeRecoveryPipeline(2, secondAttempt, 160L);
+        Assertions.assertNull(state.getActiveEpisode());
+        Assertions.assertEquals(1, state.getRecentEpisodes().size());
+        Assertions.assertEquals(
+                DirtyJobState.RecoveryEpisodeStatus.COMPLETED,
+                state.getRecentEpisodes().get(0).getStatus());
+    }
+
+    @Test
+    void shouldBecomeUnknownWhenIncidentDeduplicationHistoryOverflows() {
+        DirtyJobState state = DirtyJobState.create(1L, 2, 1, 60_000L, 0L);
+
+        for (int sequence = 1; sequence <= 5; sequence++) {
+            state.processMemberEvent(
+                    sequence,
+                    "member-" + sequence,
+                    "127.0.0.1:" + sequence,
+                    MemberLeaveClassification.UNCLASSIFIED,
+                    Collections.singletonList(1),
+                    sequence);
+        }
+        String attemptId = state.prepareRecoveryAttempt(1, 10L);
+        state.confirmRecoveryAttempt(1, attemptId, 11L);
+        state.completeRecoveryPipeline(1, attemptId, 12L);
+        state.advanceMemberEventSequence(6L);
+        DirtyJobState evaluated = state.evaluatedCopy(6L, 13L);
+
+        Assertions.assertFalse(state.isTrackingComplete());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.UNKNOWN, state.getEvaluationStatus());
+        Assertions.assertNull(state.getActiveEpisode());
+        Assertions.assertEquals(DirtyJobEvaluationStatus.UNKNOWN, evaluated.getEvaluationStatus());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-common/src/test/resources/seatunnel.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/resources/seatunnel.yaml
@@ -18,6 +18,9 @@
 seatunnel:
     engine:
         backup-count: 1
+        dirty-task:
+            event-history-size: 12
+            pending-incident-ttl: 5m
         print-execution-info-interval: 2
         slot-service:
             dynamic-slot: false

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -41,6 +41,7 @@ import org.apache.seatunnel.engine.common.exception.JobNotFoundException;
 import org.apache.seatunnel.engine.common.exception.JobRestoreInProgressException;
 import org.apache.seatunnel.engine.common.exception.SavePointFailedException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
+import org.apache.seatunnel.engine.common.job.DirtyJobMemberEvent;
 import org.apache.seatunnel.engine.common.job.JobResult;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
@@ -75,6 +76,7 @@ import org.apache.seatunnel.engine.server.master.JobHistoryService;
 import org.apache.seatunnel.engine.server.master.JobMaster;
 import org.apache.seatunnel.engine.server.master.cleanup.JobCleanupRecord;
 import org.apache.seatunnel.engine.server.master.cleanup.PipelineCleanupRecord;
+import org.apache.seatunnel.engine.server.master.dirty.DirtyJobService;
 import org.apache.seatunnel.engine.server.metrics.JobMetricsUtil;
 import org.apache.seatunnel.engine.server.resourcemanager.NoEnoughResourceException;
 import org.apache.seatunnel.engine.server.resourcemanager.ResourceManager;
@@ -138,6 +140,12 @@ public class CoordinatorService {
     private volatile ResourceManager resourceManager;
 
     private JobHistoryService jobHistoryService;
+
+    // Owns bounded HA updates for the optional dirty-job observation path.
+    private DirtyJobService dirtyJobService;
+
+    // Prevents event acknowledgement and restored-job scheduling before final replay completes.
+    private volatile boolean restoringJobsAfterMasterSwitch;
 
     /**
      * IMap key is jobId and value is {@link JobInfo}. Tuple2 key is JobMaster init timestamp and
@@ -217,7 +225,7 @@ public class CoordinatorService {
 
     private EventProcessor eventProcessor;
 
-    private PassiveCompletableFuture restoreAllJobFromMasterNodeSwitchFuture;
+    private volatile PassiveCompletableFuture<Void> restoreAllJobFromMasterNodeSwitchFuture;
 
     private final boolean isWaitStrategy;
 
@@ -234,6 +242,12 @@ public class CoordinatorService {
         this.engineContext = engineContext;
         this.engineConfig = engineConfig;
         this.logger = nodeEngine.getLogger(getClass());
+        this.dirtyJobService =
+                new DirtyJobService(
+                        nodeEngine,
+                        logger,
+                        engineConfig.getDirtyJobEventHistorySize(),
+                        engineConfig.getDirtyJobPendingIncidentTtl().toMillis());
         this.executorService = createCoordinatorExecutor();
 
         int metricsFetchThreads =
@@ -320,12 +334,19 @@ public class CoordinatorService {
      * @throws InterruptedException if queue waiting or retry sleep is interrupted
      */
     private void pendingJobSchedule() throws InterruptedException {
+        if (restoreAllJobFromMasterNodeSwitchFuture != null) {
+            restoreAllJobFromMasterNodeSwitchFuture.join();
+        }
         PendingJobInfo pendingJobInfo = pendingJobQueue.peekBlocking();
         if (Objects.isNull(pendingJobInfo)) {
             // This situation almost never happens because pendingJobSchedule is single-threaded
             logger.warning("The peek job info is null");
             Thread.sleep(3000);
             return;
+        }
+        PassiveCompletableFuture<Void> restoreFuture = restoreAllJobFromMasterNodeSwitchFuture;
+        if (restoreFuture != null) {
+            restoreFuture.join();
         }
         Long jobId = pendingJobInfo.getJobId();
         final JobMaster jobMaster = pendingJobInfo.getJobMaster();
@@ -371,6 +392,15 @@ public class CoordinatorService {
         // When deleting jobmaster from pendingJobQueue, make sure that there is a corresponding
         // jobMaster in the runningJobMasterMap
         runningJobMasterMap.put(jobId, jobMaster);
+        if (pendingJobInfo.getPendingSourceState() == PendingSourceState.SUBMIT
+                && dirtyJobService != null) {
+            try {
+                dirtyJobService.synchronizeMemberEventSequence(jobMaster);
+            } catch (Throwable trackingError) {
+                reportDirtyJobTrackingFailure(
+                        jobId, "synchronize member-event sequence", trackingError);
+            }
+        }
         final PendingJobInfo finalPendingJobInfo = pendingJobQueue.take();
         final JobMaster finalJobMaster = finalPendingJobInfo.getJobMaster();
         PendingSourceState pendingSourceState = finalPendingJobInfo.getPendingSourceState();
@@ -540,7 +570,8 @@ public class CoordinatorService {
                         nodeEngine
                                 .getHazelcastInstance()
                                 .getMap(Constant.IMAP_FINISHED_JOB_VERTEX_INFO),
-                        engineConfig.getHistoryJobExpireMinutes());
+                        engineConfig.getHistoryJobExpireMinutes(),
+                        dirtyJobService);
         eventProcessor =
                 createJobEventProcessor(
                         engineConfig.getEventReportHttpApi(),
@@ -559,10 +590,43 @@ public class CoordinatorService {
         }
 
         reschedulePendingJobCleanup();
-        restoreAllJobFromMasterNodeSwitchFuture =
-                new PassiveCompletableFuture(
-                        CompletableFuture.runAsync(
-                                this::restoreAllRunningJobFromMasterNodeSwitch, executorService));
+        restoringJobsAfterMasterSwitch = true;
+        CompletableFuture<Void> restoreFuture = new CompletableFuture<>();
+        restoreAllJobFromMasterNodeSwitchFuture = new PassiveCompletableFuture(restoreFuture);
+        try {
+            executorService.submit(
+                    () -> {
+                        boolean restored = false;
+                        Throwable restoreError = null;
+                        List<DirtyJobMemberEvent> replayedEvents = Collections.emptyList();
+                        try {
+                            replayedEvents = restoreAllRunningJobFromMasterNodeSwitch();
+                            restored = true;
+                        } catch (Throwable error) {
+                            restoreError = error;
+                        } finally {
+                            restoringJobsAfterMasterSwitch = false;
+                            if (restored) {
+                                try {
+                                    dirtyJobService.removePendingMemberEvents(replayedEvents);
+                                    dirtyJobService.removePendingMemberEvents(
+                                            dirtyJobService.getPendingMemberEvents());
+                                } catch (Throwable acknowledgeError) {
+                                    logger.warning(
+                                            "Failed to acknowledge replayed dirty-job member events",
+                                            acknowledgeError);
+                                } finally {
+                                    restoreFuture.complete(null);
+                                }
+                            } else {
+                                restoreFuture.completeExceptionally(restoreError);
+                            }
+                        }
+                    });
+        } catch (Throwable submitError) {
+            restoringJobsAfterMasterSwitch = false;
+            restoreFuture.completeExceptionally(submitError);
+        }
     }
 
     private void reschedulePendingJobCleanup() {
@@ -790,8 +854,11 @@ public class CoordinatorService {
 
         JobInfo currentJobInfo = runningJobInfoIMap.get(jobId);
         if (currentJobInfo == null) {
-            cleanupPendingJobStateMaps(record);
-            removePendingJobCleanupRecord(jobId, record);
+            if (cleanupPendingJobStateMaps(jobId, record)) {
+                removePendingJobCleanupRecord(jobId, record);
+            } else {
+                schedulePendingJobCleanupRetry(jobId, record);
+            }
             return;
         }
         if (!isCleanupOwnedByCurrentJob(currentJobInfo, jobId, record)) {
@@ -802,8 +869,11 @@ public class CoordinatorService {
         if (!runningJobInfoIMap.remove(jobId, currentJobInfo)) {
             JobInfo latestJobInfo = runningJobInfoIMap.get(jobId);
             if (latestJobInfo == null) {
-                cleanupPendingJobStateMaps(record);
-                removePendingJobCleanupRecord(jobId, record);
+                if (cleanupPendingJobStateMaps(jobId, record)) {
+                    removePendingJobCleanupRecord(jobId, record);
+                } else {
+                    schedulePendingJobCleanupRetry(jobId, record);
+                }
             } else if (!Objects.equals(
                     latestJobInfo.getInitializationTimestamp(),
                     record.getOwnerInitializationTimestamp())) {
@@ -812,8 +882,22 @@ public class CoordinatorService {
             return;
         }
 
-        cleanupPendingJobStateMaps(record);
-        removePendingJobCleanupRecord(jobId, record);
+        if (cleanupPendingJobStateMaps(jobId, record)) {
+            removePendingJobCleanupRecord(jobId, record);
+        } else {
+            schedulePendingJobCleanupRetry(jobId, record);
+        }
+    }
+
+    private void schedulePendingJobCleanupRetry(long jobId, JobCleanupRecord record) {
+        ScheduledExecutorService cleanupScheduler = seaTunnelServer.getMonitorService();
+        if (cleanupScheduler == null || cleanupScheduler.isShutdown()) {
+            return;
+        }
+        cleanupScheduler.schedule(
+                () -> processPendingJobCleanup(jobId, record),
+                PIPELINE_CLEANUP_INTERVAL_SECONDS,
+                TimeUnit.SECONDS);
     }
 
     private void removePendingJobCleanupRecord(long jobId, JobCleanupRecord record) {
@@ -856,9 +940,10 @@ public class CoordinatorService {
         return jobState instanceof JobStatus && ((JobStatus) jobState).isEndState();
     }
 
-    private void cleanupPendingJobStateMaps(JobCleanupRecord record) {
+    private boolean cleanupPendingJobStateMaps(long jobId, JobCleanupRecord record) {
         removeKeys(runningJobStateIMap, record.getStateKeys());
         removeKeys(runningJobStateTimestampsIMap, record.getTimestampKeys());
+        return dirtyJobService == null || dirtyJobService.removeRunningState(jobId);
     }
 
     private void removeKeys(IMap<Object, ?> map, Set<Object> keys) {
@@ -890,7 +975,7 @@ public class CoordinatorService {
      * JobMaster}. Each restored job is re-enqueued as a pending job so it can re-enter the normal
      * scheduling path on the new master.
      */
-    private void restoreAllRunningJobFromMasterNodeSwitch() {
+    private List<DirtyJobMemberEvent> restoreAllRunningJobFromMasterNodeSwitch() {
         List<Map.Entry<Long, JobInfo>> needRestoreFromMasterNodeSwitchJobs;
         try {
             needRestoreFromMasterNodeSwitchJobs =
@@ -912,7 +997,7 @@ public class CoordinatorService {
                     "Failed to fetch running jobs from IMap during master switch restore", e);
         }
         if (needRestoreFromMasterNodeSwitchJobs.isEmpty()) {
-            return;
+            return dirtyJobService.getPendingMemberEvents();
         }
         // Pre-filter: clean up terminal-state zombie jobs immediately before waiting for workers.
         // Zombies do not need a worker — they only need IMap cleanup. Processing them here avoids
@@ -940,12 +1025,13 @@ public class CoordinatorService {
                 continue;
             }
             if (jobState instanceof JobStatus && ((JobStatus) jobState).isEndState()) {
-                restoreJobFromMasterActiveSwitch(entry.getKey(), entry.getValue());
+                restoreJobFromMasterActiveSwitch(
+                        entry.getKey(), entry.getValue(), Collections.emptyMap());
                 zombieIterator.remove();
             }
         }
         if (needRestoreFromMasterNodeSwitchJobs.isEmpty()) {
-            return;
+            return dirtyJobService.getPendingMemberEvents();
         }
         // waiting have worker registered
         while (getResourceManager().workerCount(Collections.emptyMap()) == 0) {
@@ -957,6 +1043,26 @@ public class CoordinatorService {
                 throw new SeaTunnelEngineException("wait worker register error", e);
             }
         }
+        Map<Long, Map<String, Set<Integer>>> memberEventAssignmentSnapshots = new HashMap<>();
+        needRestoreFromMasterNodeSwitchJobs.forEach(
+                entry -> {
+                    Map<String, Set<Integer>> assignmentSnapshot = Collections.emptyMap();
+                    try {
+                        assignmentSnapshot =
+                                dirtyJobService.runBoundedObservation(
+                                        () ->
+                                                snapshotRecoverablePipelineAssignments(
+                                                        entry.getKey()));
+                    } catch (Throwable trackingError) {
+                        reportDirtyJobTrackingFailure(
+                                entry.getKey(),
+                                entry.getValue(),
+                                "snapshot member-event pipeline assignments",
+                                trackingError);
+                    }
+                    memberEventAssignmentSnapshots.put(entry.getKey(), assignmentSnapshot);
+                });
+        AtomicBoolean restoreFailed = new AtomicBoolean(false);
         List<CompletableFuture<Void>> collect =
                 needRestoreFromMasterNodeSwitchJobs.stream()
                         .map(
@@ -973,9 +1079,12 @@ public class CoordinatorService {
                                                                 entry.getKey())) {
                                                             restoreJobFromMasterActiveSwitch(
                                                                     entry.getKey(),
-                                                                    entry.getValue());
+                                                                    entry.getValue(),
+                                                                    memberEventAssignmentSnapshots
+                                                                            .get(entry.getKey()));
                                                         }
                                                     } catch (Exception e) {
+                                                        restoreFailed.set(true);
                                                         logger.severe(e);
                                                     }
                                                     logger.info(
@@ -990,10 +1099,26 @@ public class CoordinatorService {
             CompletableFuture<Void> voidCompletableFuture =
                     CompletableFuture.allOf(collect.toArray(new CompletableFuture[0]));
             voidCompletableFuture.get();
+            if (restoreFailed.get()) {
+                throw new SeaTunnelEngineException(
+                        "At least one job failed to restore after the master switch");
+            }
         } catch (Exception e) {
             logger.severe(ExceptionUtils.getMessage(e));
             throw new SeaTunnelEngineException(e);
         }
+        List<DirtyJobMemberEvent> replayedEvents = dirtyJobService.getPendingMemberEvents();
+        needRestoreFromMasterNodeSwitchJobs.forEach(
+                entry -> {
+                    JobMaster jobMaster = getJobMaster(entry.getKey());
+                    if (jobMaster != null) {
+                        replayPendingMemberEvents(
+                                jobMaster,
+                                memberEventAssignmentSnapshots.get(entry.getKey()),
+                                replayedEvents);
+                    }
+                });
+        return replayedEvents;
     }
 
     /**
@@ -1006,8 +1131,13 @@ public class CoordinatorService {
      *
      * @param jobId restored job identifier
      * @param jobInfo distributed immutable job metadata captured before the master switch
+     * @param memberEventAssignmentSnapshot persisted worker assignments captured before any job is
+     *     initialized
      */
-    private void restoreJobFromMasterActiveSwitch(@NonNull Long jobId, @NonNull JobInfo jobInfo) {
+    private void restoreJobFromMasterActiveSwitch(
+            @NonNull Long jobId,
+            @NonNull JobInfo jobInfo,
+            @NonNull Map<String, Set<Integer>> memberEventAssignmentSnapshot) {
         Object jobState;
         try {
             jobState =
@@ -1051,12 +1181,19 @@ public class CoordinatorService {
                         runningJobInfoIMap,
                         engineConfig,
                         seaTunnelServer);
-
         try {
             jobMaster.init(jobInfo.getInitializationTimestamp(), true);
         } catch (Exception e) {
             throw new SeaTunnelEngineException(String.format("Job id %s init failed", jobId), e);
         }
+        try {
+            dirtyJobService.initialize(jobMaster.getJobImmutableInformation(), true);
+        } catch (Throwable trackingError) {
+            reportDirtyJobTrackingFailure(
+                    jobId, "initialize dirty-job state after master switch", trackingError);
+        }
+        replayPendingMemberEvents(
+                jobMaster, memberEventAssignmentSnapshot, dirtyJobService.getPendingMemberEvents());
 
         PendingJobInfo pendingJobInfo = new PendingJobInfo(PendingSourceState.RESTORE, jobMaster);
         pendingJobQueue.put(pendingJobInfo);
@@ -1068,13 +1205,23 @@ public class CoordinatorService {
         JobImmutableInformation jobImmutableInformation = restoreJobImmutableInformation(jobInfo);
         cleanupTerminalZombieCheckpointIfNecessary(jobId, jobImmutableInformation, finalStatus);
         persistTerminalZombieHistoryIfNecessary(jobId, jobImmutableInformation, finalStatus);
-        cleanupPendingJobStateMaps(createTerminalZombieCleanupRecord(jobId, jobInfo, finalStatus));
+        JobCleanupRecord cleanupRecord =
+                createTerminalZombieCleanupRecord(jobId, jobInfo, finalStatus);
+        if (!cleanupPendingJobStateMaps(jobId, cleanupRecord)) {
+            rememberPendingTerminalZombieCleanup(jobId, cleanupRecord);
+        }
         runningJobInfoIMap.remove(jobId);
     }
 
     private void cleanupPendingJobStateForRestore(long jobId, JobCleanupRecord record) {
         removeKeys(runningJobStateIMap, record.getStateKeys());
         removeKeys(runningJobStateTimestampsIMap, record.getTimestampKeys());
+        if (dirtyJobService != null && !dirtyJobService.removeRunningState(jobId)) {
+            logger.warning(
+                    String.format(
+                            "Failed to remove stale dirty-job state for job %s; the new submission will overwrite it",
+                            jobId));
+        }
         removePendingJobCleanupRecord(jobId, record);
         runningJobInfoIMap.remove(jobId);
     }
@@ -1174,6 +1321,7 @@ public class CoordinatorService {
         if (!coordinatorServiceCleared.compareAndSet(false, true)) {
             return;
         }
+        dirtyJobService.clearLocalCoordinatorState();
         // interrupt all JobMaster
         runningJobMasterMap.values().forEach(JobMaster::interrupt);
         if (isWaitStrategy) {
@@ -1269,6 +1417,7 @@ public class CoordinatorService {
                 () -> {
                     JobMaster jobMaster = null;
                     JobInfo submittedJobInfo = null;
+                    boolean dirtyJobInitialized = false;
                     try {
                         JobImmutableInformation submittedJobImmutableInformation =
                                 deserializeJobImmutableInformation(jobImmutableInformation);
@@ -1320,6 +1469,14 @@ public class CoordinatorService {
                                 new JobInfo(initializationTimestamp, jobImmutableInformation);
                         runningJobInfoIMap.put(jobId, submittedJobInfo);
                         jobMaster.init(initializationTimestamp, false);
+                        dirtyJobInitialized = true;
+                        try {
+                            dirtyJobService.initialize(
+                                    jobMaster.getJobImmutableInformation(), false);
+                        } catch (Throwable trackingError) {
+                            reportDirtyJobTrackingFailure(
+                                    jobId, "initialize dirty-job state", trackingError);
+                        }
                         // Initialize the JobMaster and add it to the pendingJobQueue, ensuring that
                         // calling the getJobMaster method does not return NULL when the
                         // jobSubmitFuture is still running.
@@ -1346,6 +1503,9 @@ public class CoordinatorService {
                         }
                         runningJobMasterMap.remove(jobId);
                         pendingJobQueue.removeById(jobId);
+                        if (dirtyJobInitialized) {
+                            dirtyJobService.removeRunningState(jobId);
+                        }
                     }
                 });
         return new PassiveCompletableFuture<>(jobSubmitFuture);
@@ -1872,7 +2032,10 @@ public class CoordinatorService {
                         getJobStateTimestamp(jobId, JobStatus.SCHEDULED),
                         getJobStateTimestamp(jobId, finalStatus),
                         Collections.emptyMap(),
-                        null));
+                        null,
+                        dirtyJobService.createUnknownState(
+                                jobImmutableInformation,
+                                "Dirty-job state was unavailable during terminal-job recovery")));
     }
 
     private Long getJobStateTimestamp(long jobId, JobStatus status) {
@@ -1888,12 +2051,39 @@ public class CoordinatorService {
 
     private JobCleanupRecord createTerminalZombieCleanupRecord(
             long jobId, JobInfo jobInfo, JobStatus finalStatus) {
+        long createTimeMillis =
+                Math.max(
+                        0L, System.currentTimeMillis() - engineConfig.getStateCleanupDelayMillis());
         return new JobCleanupRecord(
                 jobInfo.getInitializationTimestamp(),
                 finalStatus,
                 collectTerminalZombieKeys(runningJobStateIMap, jobId),
                 collectTerminalZombieKeys(runningJobStateTimestampsIMap, jobId),
-                System.currentTimeMillis());
+                createTimeMillis);
+    }
+
+    /**
+     * Persists terminal zombie cleanup work so dirty-job state removal can retry after transient
+     * IMap failures without recreating the old running-job metadata.
+     */
+    private void rememberPendingTerminalZombieCleanup(long jobId, JobCleanupRecord cleanupRecord) {
+        if (pendingJobCleanupIMap == null) {
+            logger.warning(
+                    String.format(
+                            "Failed to retain pending terminal zombie cleanup for job %s because the cleanup map is unavailable",
+                            jobId));
+            return;
+        }
+        try {
+            pendingJobCleanupIMap.put(jobId, cleanupRecord);
+            schedulePendingJobCleanup(jobId, cleanupRecord);
+        } catch (Exception e) {
+            logger.warning(
+                    String.format(
+                            "Failed to retain pending terminal zombie cleanup for job %s: %s",
+                            jobId, ExceptionUtils.getMessage(e)),
+                    e);
+        }
     }
 
     private Set<Object> collectTerminalZombieKeys(IMap<Object, ?> sourceMap, long jobId) {
@@ -1955,6 +2145,7 @@ public class CoordinatorService {
 
     public void shutdown() {
         isActive = false;
+        dirtyJobService.shutdown();
         if (masterActiveListener != null) {
             masterActiveListener.shutdown();
         }
@@ -1974,10 +2165,104 @@ public class CoordinatorService {
         return isActive;
     }
 
-    public void failedTaskOnMemberRemoved(MembershipServiceEvent event) {
+    public synchronized void failedTaskOnMemberRemoved(MembershipServiceEvent event) {
+        DirtyJobMemberEvent dirtyJobMemberEvent = createMemberEventForTracking(event);
+        java.util.concurrent.CompletableFuture<Void> tracking =
+                failTasksOnMemberRemoved(event, dirtyJobMemberEvent);
+        removeMemberEventWhenProcessed(dirtyJobMemberEvent, tracking);
+    }
+
+    private java.util.concurrent.CompletableFuture<Void> failTasksOnMemberRemoved(
+            MembershipServiceEvent event, DirtyJobMemberEvent dirtyJobMemberEvent) {
         Address lostAddress = event.getMember().getAddress();
-        runningJobMasterMap.forEach(
+        long memberEventSequence =
+                dirtyJobMemberEvent == null ? -1L : dirtyJobMemberEvent.getSequence();
+        String lostMemberUuid =
+                dirtyJobMemberEvent == null
+                        ? event.getMember().getUuid().toString()
+                        : dirtyJobMemberEvent.getMemberUuid();
+        String lostAddressText =
+                dirtyJobMemberEvent == null
+                        ? lostAddress.toString()
+                        : dirtyJobMemberEvent.getAddressText();
+        Map<Long, JobMaster> trackedJobMasters = new HashMap<>(runningJobMasterMap);
+        Set<Long> runningJobIds = new HashSet<>(runningJobMasterMap.keySet());
+        List<java.util.concurrent.CompletableFuture<Void>> trackingUpdates = new ArrayList<>();
+        pendingJobQueue
+                .getJobIdMap()
+                .values()
+                .forEach(
+                        pendingJobInfo ->
+                                trackedJobMasters.putIfAbsent(
+                                        pendingJobInfo.getJobId(), pendingJobInfo.getJobMaster()));
+        trackedJobMasters.forEach(
                 (aLong, jobMaster) -> {
+                    boolean trackingEnabled = false;
+                    try {
+                        trackingEnabled =
+                                dirtyJobMemberEvent != null && dirtyJobService.isEnabled(jobMaster);
+                    } catch (Throwable trackingError) {
+                        logger.warning(
+                                String.format(
+                                        "Failed to inspect dirty-job tracking for job %s; continuing member recovery",
+                                        aLong),
+                                trackingError);
+                    }
+                    boolean terminalJob = false;
+                    try {
+                        terminalJob = jobMaster.getJobStatus().isEndState();
+                    } catch (Throwable statusError) {
+                        logger.warning(
+                                String.format(
+                                        "Failed to read job %s status during member recovery; continuing failover",
+                                        aLong),
+                                statusError);
+                    }
+                    if (terminalJob) {
+                        if (trackingEnabled) {
+                            try {
+                                trackingUpdates.add(
+                                        dirtyJobService.processMemberEvent(
+                                                jobMaster,
+                                                memberEventSequence,
+                                                lostMemberUuid,
+                                                lostAddressText,
+                                                Collections.emptySet(),
+                                                dirtyJobMemberEvent.getEventTime()));
+                            } catch (Throwable trackingError) {
+                                logger.warning(
+                                        String.format(
+                                                "Failed to update dirty-job tracking for terminal job %s",
+                                                aLong),
+                                        trackingError);
+                            }
+                        }
+                        return;
+                    }
+                    Set<Integer> affectedPipelineIds = Collections.emptySet();
+                    if (trackingEnabled) {
+                        try {
+                            affectedPipelineIds =
+                                    collectAffectedPipelineIds(jobMaster, lostAddress);
+                            trackingUpdates.add(
+                                    dirtyJobService.processMemberEvent(
+                                            jobMaster,
+                                            memberEventSequence,
+                                            lostMemberUuid,
+                                            lostAddressText,
+                                            affectedPipelineIds,
+                                            dirtyJobMemberEvent.getEventTime()));
+                        } catch (Throwable trackingError) {
+                            logger.warning(
+                                    String.format(
+                                            "Failed to update dirty-job tracking for job %s; continuing member recovery",
+                                            aLong),
+                                    trackingError);
+                        }
+                    }
+                    if (!runningJobIds.contains(aLong)) {
+                        return;
+                    }
                     jobMaster
                             .getPhysicalPlan()
                             .getPipelineList()
@@ -1989,19 +2274,48 @@ public class CoordinatorService {
                                                 subPlan.getPhysicalVertexList(), lostAddress);
                                     });
                 });
+        return java.util.concurrent.CompletableFuture.allOf(
+                trackingUpdates.toArray(new java.util.concurrent.CompletableFuture[0]));
+    }
+
+    private Set<Integer> collectAffectedPipelineIds(JobMaster jobMaster, Address lostAddress) {
+        return jobMaster.getPhysicalPlan().getPipelineList().stream()
+                .filter(
+                        subPlan ->
+                                hasAffectedTask(subPlan.getCoordinatorVertexList(), lostAddress)
+                                        || hasAffectedTask(
+                                                subPlan.getPhysicalVertexList(), lostAddress))
+                .map(SubPlan::getPipelineId)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean hasAffectedTask(List<PhysicalVertex> physicalVertexList, Address lostAddress) {
+        return physicalVertexList.stream()
+                .anyMatch(physicalVertex -> isTaskAffected(physicalVertex, lostAddress));
+    }
+
+    private boolean isTaskAffected(PhysicalVertex physicalVertex, Address lostAddress) {
+        Address deployAddress = physicalVertex.getCurrentExecutionAddress();
+        return deployAddress != null
+                && deployAddress.equals(lostAddress)
+                && isRecoverableMemberLossState(physicalVertex);
+    }
+
+    private boolean isRecoverableMemberLossState(PhysicalVertex physicalVertex) {
+        return isRecoverableMemberLossState(physicalVertex.getExecutionState());
+    }
+
+    private boolean isRecoverableMemberLossState(ExecutionState executionState) {
+        return executionState == ExecutionState.DEPLOYING
+                || executionState == ExecutionState.RUNNING
+                || executionState == ExecutionState.CANCELING;
     }
 
     private void makeTasksFailed(
             @NonNull List<PhysicalVertex> physicalVertexList, @NonNull Address lostAddress) {
         physicalVertexList.forEach(
                 physicalVertex -> {
-                    Address deployAddress = physicalVertex.getCurrentExecutionAddress();
-                    ExecutionState executionState = physicalVertex.getExecutionState();
-                    if (null != deployAddress
-                            && deployAddress.equals(lostAddress)
-                            && (executionState.equals(ExecutionState.DEPLOYING)
-                                    || executionState.equals(ExecutionState.RUNNING)
-                                    || executionState.equals(ExecutionState.CANCELING))) {
+                    if (isTaskAffected(physicalVertex, lostAddress)) {
                         TaskGroupLocation taskGroupLocation = physicalVertex.getTaskGroupLocation();
                         physicalVertex.updateStateByExecutionService(
                                 new TaskExecutionState(
@@ -2016,10 +2330,162 @@ public class CoordinatorService {
     }
 
     public void memberRemoved(MembershipServiceEvent event) {
+        memberRemoved(event, createMemberEventForTracking(event));
+    }
+
+    void memberRemoved(MembershipServiceEvent event, DirtyJobMemberEvent dirtyJobMemberEvent) {
         if (isCoordinatorActive()) {
             this.getResourceManager().memberRemoved(event);
         }
-        this.failedTaskOnMemberRemoved(event);
+        java.util.concurrent.CompletableFuture<Void> tracking =
+                failTasksOnMemberRemoved(event, dirtyJobMemberEvent);
+        removeMemberEventWhenProcessed(dirtyJobMemberEvent, tracking);
+    }
+
+    private void removeMemberEventWhenProcessed(
+            DirtyJobMemberEvent event,
+            java.util.concurrent.CompletableFuture<Void> trackingUpdate) {
+        trackingUpdate.whenComplete(
+                (ignored, error) -> {
+                    if (!restoringJobsAfterMasterSwitch) {
+                        dirtyJobService.removePendingMemberEvent(event);
+                    }
+                });
+    }
+
+    DirtyJobMemberEvent recordMemberEvent(MembershipServiceEvent event) {
+        Address address = event.getMember().getAddress();
+        return dirtyJobService.recordMemberEvent(
+                event.getMember().getUuid().toString(), address.getHost(), address.getPort());
+    }
+
+    private DirtyJobMemberEvent createMemberEventForTracking(MembershipServiceEvent event) {
+        try {
+            return dirtyJobService.shouldTrackMemberEvents() ? recordMemberEvent(event) : null;
+        } catch (Throwable trackingError) {
+            logger.warning(
+                    "Failed to prepare dirty-job member event; continuing member recovery",
+                    trackingError);
+            Address address = event.getMember().getAddress();
+            return new DirtyJobMemberEvent(
+                    -1L,
+                    event.getMember().getUuid().toString(),
+                    address.getHost(),
+                    address.getPort(),
+                    System.currentTimeMillis());
+        }
+    }
+
+    void rememberMemberEventLocally(MembershipServiceEvent event) {
+        Address address = event.getMember().getAddress();
+        dirtyJobService.rememberMemberEventLocally(
+                event.getMember().getUuid().toString(), address.getHost(), address.getPort());
+    }
+
+    private Map<String, Set<Integer>> snapshotRecoverablePipelineAssignments(long jobId) {
+        Map<String, Set<Integer>> assignments = new HashMap<>();
+        ownedSlotProfilesIMap.keySet().stream()
+                .filter(pipelineLocation -> pipelineLocation.getJobId() == jobId)
+                .forEach(
+                        pipelineLocation -> {
+                            Map<TaskGroupLocation, SlotProfile> slotProfiles =
+                                    ownedSlotProfilesIMap.get(pipelineLocation);
+                            if (slotProfiles == null) {
+                                return;
+                            }
+                            slotProfiles.forEach(
+                                    (taskGroupLocation, slotProfile) -> {
+                                        Object state = runningJobStateIMap.get(taskGroupLocation);
+                                        if (slotProfile == null
+                                                || !(state instanceof ExecutionState)
+                                                || !isRecoverableMemberLossState(
+                                                        (ExecutionState) state)) {
+                                            return;
+                                        }
+                                        Address worker = slotProfile.getWorker();
+                                        assignments
+                                                .computeIfAbsent(
+                                                        memberAddressKey(
+                                                                worker.getHost(), worker.getPort()),
+                                                        ignored -> new HashSet<>())
+                                                .add(pipelineLocation.getPipelineId());
+                                    });
+                        });
+        return assignments;
+    }
+
+    private void replayPendingMemberEvents(
+            JobMaster jobMaster,
+            Map<String, Set<Integer>> assignmentSnapshot,
+            Collection<DirtyJobMemberEvent> pendingMemberEvents) {
+        try {
+            if (!dirtyJobService.isEnabled(jobMaster)) {
+                return;
+            }
+        } catch (Throwable trackingError) {
+            reportDirtyJobTrackingFailure(
+                    jobMaster.getJobId(),
+                    "inspect dirty-job tracking configuration",
+                    trackingError);
+            return;
+        }
+        for (DirtyJobMemberEvent event : pendingMemberEvents) {
+            try {
+                Set<Integer> affectedPipelineIds =
+                        assignmentSnapshot.getOrDefault(
+                                memberAddressKey(event.getMemberHost(), event.getMemberPort()),
+                                Collections.emptySet());
+                java.util.concurrent.CompletableFuture<Void> update =
+                        dirtyJobService.processMemberEvent(
+                                jobMaster,
+                                event.getSequence(),
+                                event.getMemberUuid(),
+                                event.getAddressText(),
+                                affectedPipelineIds,
+                                event.getEventTime());
+                dirtyJobService.awaitMemberEventReplay(jobMaster.getJobId(), update);
+            } catch (Throwable trackingError) {
+                reportDirtyJobTrackingFailure(
+                        jobMaster.getJobId(), "replay dirty-job member event", trackingError);
+            }
+        }
+    }
+
+    private void reportDirtyJobTrackingFailure(
+            long jobId, String operation, Throwable trackingError) {
+        logger.warning(
+                String.format(
+                        "Failed to %s for job %s; continuing the original recovery path",
+                        operation, jobId),
+                trackingError);
+        try {
+            dirtyJobService.reportTrackingFailure(jobId, operation, trackingError);
+        } catch (Throwable reportError) {
+            logger.warning(
+                    String.format("Failed to persist dirty-job tracking failure for job %s", jobId),
+                    reportError);
+        }
+    }
+
+    private void reportDirtyJobTrackingFailure(
+            long jobId, JobInfo jobInfo, String operation, Throwable trackingError) {
+        logger.warning(
+                String.format(
+                        "Failed to %s for job %s; continuing the original recovery path",
+                        operation, jobId),
+                trackingError);
+        try {
+            long jobCreateTime = restoreJobImmutableInformation(jobInfo).getCreateTime();
+            dirtyJobService.reportTrackingFailure(jobId, jobCreateTime, operation, trackingError);
+        } catch (Throwable reportError) {
+            logger.warning(
+                    String.format("Failed to persist dirty-job tracking failure for job %s", jobId),
+                    reportError);
+        }
+    }
+
+    private String memberAddressKey(String host, int port) {
+        return host + '\u0000' + port;
     }
 
     public void printExecutionInfo() {
@@ -2235,6 +2701,10 @@ public class CoordinatorService {
 
     public EngineConfig getEngineConfig() {
         return engineConfig;
+    }
+
+    public DirtyJobService getDirtyJobService() {
+        return dirtyJobService;
     }
 
     @VisibleForTesting

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineRetryableException;
+import org.apache.seatunnel.engine.common.job.DirtyJobMemberEvent;
 import org.apache.seatunnel.engine.core.classloader.ClassLoaderService;
 import org.apache.seatunnel.engine.core.classloader.DefaultClassLoaderService;
 import org.apache.seatunnel.engine.server.checkpoint.monitor.CheckpointMonitorService;
@@ -262,8 +263,46 @@ public class SeaTunnelServer
     @Override
     public void memberRemoved(MembershipServiceEvent event) {
         try {
+            boolean trackDirtyJobMemberEvent = false;
+            if (coordinatorService != null) {
+                try {
+                    trackDirtyJobMemberEvent =
+                            coordinatorService.getDirtyJobService().shouldTrackMemberEvents();
+                } catch (Throwable trackingError) {
+                    LOGGER.warning(
+                            "Failed to inspect dirty-job member tracking; tracking conservatively",
+                            trackingError);
+                    trackDirtyJobMemberEvent = true;
+                }
+                if (trackDirtyJobMemberEvent) {
+                    try {
+                        coordinatorService.rememberMemberEventLocally(event);
+                    } catch (Throwable trackingError) {
+                        LOGGER.warning(
+                                "Failed to retain local dirty-job member event; continuing member recovery",
+                                trackingError);
+                    }
+                }
+            }
             if (isMasterNode()) {
-                this.getCoordinatorService().memberRemoved(event);
+                DirtyJobMemberEvent dirtyJobMemberEvent = null;
+                if (trackDirtyJobMemberEvent) {
+                    try {
+                        dirtyJobMemberEvent = coordinatorService.recordMemberEvent(event);
+                    } catch (Throwable trackingError) {
+                        LOGGER.warning(
+                                "Failed to journal dirty-job member event; continuing member recovery",
+                                trackingError);
+                        dirtyJobMemberEvent =
+                                new DirtyJobMemberEvent(
+                                        -1L,
+                                        event.getMember().getUuid().toString(),
+                                        event.getMember().getAddress().getHost(),
+                                        event.getMember().getAddress().getPort(),
+                                        System.currentTimeMillis());
+                    }
+                }
+                this.getCoordinatorService().memberRemoved(event, dirtyJobMemberEvent);
             }
         } catch (SeaTunnelEngineException e) {
             LOGGER.severe("Error when handle member removed event", e);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServerStarter.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServerStarter.java
@@ -17,12 +17,14 @@
 
 package org.apache.seatunnel.engine.server;
 
+import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.EngineConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.server.telemetry.metrics.ExportsInstanceInitializer;
 
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
@@ -55,6 +57,8 @@ public class SeaTunnelServerStarter {
     private static HazelcastInstanceImpl initializeHazelcastInstance(
             @NonNull SeaTunnelConfig seaTunnelConfig, String customInstanceName) {
 
+        configureDirtyJobMaps(seaTunnelConfig);
+
         // set the default async executor for Hazelcast InvocationFuture
         ConcurrencyUtil.setDefaultAsyncExecutor(CompletableFuture.EXECUTOR);
 
@@ -78,6 +82,30 @@ public class SeaTunnelServerStarter {
         }
 
         return original;
+    }
+
+    static void configureDirtyJobMaps(SeaTunnelConfig seaTunnelConfig) {
+        int backupCount = Math.max(1, seaTunnelConfig.getEngineConfig().getBackupCount());
+        configureDirtyJobMap(seaTunnelConfig, Constant.IMAP_DIRTY_JOB_STATE, backupCount);
+        configureDirtyJobMap(
+                seaTunnelConfig, Constant.IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE, backupCount);
+        configureDirtyJobMap(
+                seaTunnelConfig, Constant.IMAP_DIRTY_JOB_PENDING_MEMBER_EVENTS, backupCount);
+        configureDirtyJobMap(
+                seaTunnelConfig, Constant.IMAP_DIRTY_JOB_ENABLED_THRESHOLDS, backupCount);
+    }
+
+    private static void configureDirtyJobMap(
+            SeaTunnelConfig seaTunnelConfig, String mapName, int backupCount) {
+        MapConfig mapConfig = seaTunnelConfig.getHazelcastConfig().getMapConfigs().get(mapName);
+        if (mapConfig == null) {
+            mapConfig = new MapConfig(mapName).setBackupCount(backupCount).setAsyncBackupCount(0);
+            seaTunnelConfig.getHazelcastConfig().addMapConfig(mapConfig);
+            return;
+        }
+        if (mapConfig.getBackupCount() != backupCount || mapConfig.getAsyncBackupCount() != 0) {
+            mapConfig.setBackupCount(backupCount).setAsyncBackupCount(0);
+        }
     }
 
     public static HazelcastInstanceImpl createMasterAndWorkerHazelcastInstance(

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/SubPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/SubPlan.java
@@ -44,7 +44,6 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -100,6 +99,9 @@ public class SubPlan {
     private PassiveCompletableFuture<Void> reSchedulerPipelineFuture;
 
     private AtomicInteger pipelineRestoreNum;
+
+    // Stable attempt identity retained across PREPARED and DEPLOYING transitions.
+    private String dirtyJobRecoveryAttemptId;
 
     private final Object restoreLock = new Object();
 
@@ -390,6 +392,9 @@ public class SubPlan {
                             exception -> ExceptionUtil.isOperationNeedRetryException(exception),
                             Constant.OPERATION_RETRY_SLEEP));
             this.currPipelineStatus = targetState;
+            if (targetState == PipelineStatus.DEPLOYING) {
+                jobMaster.confirmDirtyJobRecoveryAttempt(pipelineId, dirtyJobRecoveryAttemptId);
+            }
             log.info(
                     String.format(
                             "%s turned from state %s to %s.",
@@ -490,6 +495,7 @@ public class SubPlan {
         synchronized (restoreLock) {
             try {
                 pipelineRestoreNum.getAndIncrement();
+                dirtyJobRecoveryAttemptId = jobMaster.prepareDirtyJobRecoveryAttempt(pipelineId);
                 log.info(
                         String.format(
                                 "Restore time %s, pipeline %s",
@@ -576,32 +582,26 @@ public class SubPlan {
                             task.restoreExecutionState();
                         });
 
+        PipelineStatus restoredPipelineState = getPipelineState();
+        boolean allTasksRunning = areAllTasksRunning();
+        boolean recovered = restoredPipelineState == PipelineStatus.RUNNING && allTasksRunning;
+        dirtyJobRecoveryAttemptId =
+                jobMaster.reconcileDirtyJobRecoveryPipeline(
+                        pipelineId,
+                        restoredPipelineState == PipelineStatus.DEPLOYING
+                                || restoredPipelineState == PipelineStatus.RUNNING,
+                        recovered);
+        if (recovered) {
+            dirtyJobRecoveryAttemptId = null;
+        }
+
         if (getPipelineState().ordinal() < PipelineStatus.RUNNING.ordinal()) {
             updatePipelineState(PipelineStatus.CANCELING);
         } else if (PipelineStatus.RUNNING.equals(getPipelineState())) {
-            AtomicBoolean allTaskRunning = new AtomicBoolean(true);
-            getCoordinatorVertexList()
-                    .forEach(
-                            task -> {
-                                if (!task.getExecutionState().equals(ExecutionState.RUNNING)) {
-                                    allTaskRunning.set(false);
-                                    return;
-                                }
-                            });
-
-            getPhysicalVertexList()
-                    .forEach(
-                            task -> {
-                                if (!task.getExecutionState().equals(ExecutionState.RUNNING)) {
-                                    allTaskRunning.set(false);
-                                    return;
-                                }
-                            });
-
             jobMaster
                     .getCheckpointManager()
                     .reportedPipelineRunning(
-                            this.getPipelineLocation().getPipelineId(), allTaskRunning.get());
+                            this.getPipelineLocation().getPipelineId(), allTasksRunning);
         }
         startSubPlanStateProcess();
     }
@@ -716,7 +716,13 @@ public class SubPlan {
                                 task.makeTaskGroupDeploy();
                             }
                         });
+                boolean recovered = areAllTasksRunning();
                 updatePipelineState(PipelineStatus.RUNNING);
+                if (recovered) {
+                    jobMaster.completeDirtyJobRecoveryPipeline(
+                            pipelineId, dirtyJobRecoveryAttemptId);
+                    dirtyJobRecoveryAttemptId = null;
+                }
                 break;
             case RUNNING:
                 break;
@@ -762,5 +768,12 @@ public class SubPlan {
     public void makePipelineFailing(Throwable e) {
         errorByPhysicalVertex.compareAndSet(null, ExceptionUtils.getMessage(e));
         updatePipelineState(PipelineStatus.FAILING);
+    }
+
+    private boolean areAllTasksRunning() {
+        return coordinatorVertexList.stream()
+                        .allMatch(task -> task.getExecutionState() == ExecutionState.RUNNING)
+                && physicalVertexList.stream()
+                        .allMatch(task -> task.getExecutionState() == ExecutionState.RUNNING);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobHistoryService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobHistoryService.java
@@ -25,6 +25,8 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.seatunnel.api.common.metrics.JobMetrics;
 import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
+import org.apache.seatunnel.engine.common.job.DirtyJobState;
+import org.apache.seatunnel.engine.common.job.DirtyJobSummary;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.job.JobStatusData;
 import org.apache.seatunnel.engine.core.job.ExecutionAddress;
@@ -35,6 +37,7 @@ import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.execution.ExecutionState;
 import org.apache.seatunnel.engine.server.execution.PendingJobInfo;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
+import org.apache.seatunnel.engine.server.master.dirty.DirtyJobService;
 import org.apache.seatunnel.engine.server.telemetry.log.operation.CleanLogOperation;
 import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
 
@@ -53,6 +56,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -110,6 +114,8 @@ public class JobHistoryService {
 
     private final int finishedJobExpireTime;
 
+    private final DirtyJobService dirtyJobService;
+
     private final Map<String, AtomicLong> finishedJobCleanupTotals = new ConcurrentHashMap<>();
 
     public JobHistoryService(
@@ -121,7 +127,8 @@ public class JobHistoryService {
             IMap<Long, JobState> finishedJobStateImap,
             IMap<Long, JobMetrics> finishedJobMetricsImap,
             IMap<Long, JobDAGInfo> finishedJobVertexInfoImap,
-            int finishedJobExpireTime) {
+            int finishedJobExpireTime,
+            DirtyJobService dirtyJobService) {
         this.nodeEngine = nodeEngine;
         this.runningJobStateIMap = runningJobStateIMap;
         this.logger = logger;
@@ -139,6 +146,7 @@ public class JobHistoryService {
         this.objectMapper = new ObjectMapper();
         this.objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         this.finishedJobExpireTime = finishedJobExpireTime;
+        this.dirtyJobService = dirtyJobService;
     }
 
     // Gets the status of a running and completed job.
@@ -154,9 +162,26 @@ public class JobHistoryService {
 
     public List<JobStatusData> getJobStatusData() {
         List<JobStatusData> status = new ArrayList<>();
+        Set<Long> dirtyEnabledActiveJobIds = new HashSet<>();
+        runningJobMasterMap.values().stream()
+                .filter(dirtyJobService::isEnabled)
+                .map(JobMaster::getJobId)
+                .forEach(dirtyEnabledActiveJobIds::add);
+        pendingJobInfoMap.values().stream()
+                .map(PendingJobInfo::getJobMaster)
+                .filter(dirtyJobService::isEnabled)
+                .map(JobMaster::getJobId)
+                .forEach(dirtyEnabledActiveJobIds::add);
+        Map<Long, DirtyJobState> dirtyJobStates =
+                dirtyJobService.getEvaluatedStates(dirtyEnabledActiveJobIds);
         final List<JobState> runningJobStateList =
                 runningJobMasterMap.values().stream()
-                        .map(master -> toJobStateMapper(master, true))
+                        .map(
+                                master ->
+                                        toJobStateMapper(
+                                                master,
+                                                true,
+                                                dirtyJobStates.get(master.getJobId())))
                         .collect(Collectors.toList());
         Set<Long> runningJonIds =
                 runningJobStateList.stream().map(JobState::getJobId).collect(Collectors.toSet());
@@ -170,6 +195,10 @@ public class JobHistoryService {
                                             entry.getValue()
                                                     .getJobMaster()
                                                     .getJobImmutableInformation();
+                                    DirtyJobState dirtyJobState =
+                                            resolveDirtyJobState(
+                                                    entry.getValue().getJobMaster(),
+                                                    dirtyJobStates.get(jobId));
                                     return new JobState(
                                             jobId,
                                             jobImmutableInformation.getJobName(),
@@ -178,7 +207,8 @@ public class JobHistoryService {
                                             null,
                                             null,
                                             null,
-                                            null);
+                                            null,
+                                            dirtyJobState);
                                 })
                         .collect(Collectors.toList());
         Set<Long> pendingJobIds =
@@ -201,7 +231,8 @@ public class JobHistoryService {
                                             jobState.getJobStatus(),
                                             jobState.getSubmitTime(),
                                             jobState.getStartTime(),
-                                            jobState.getFinishTime());
+                                            jobState.getFinishTime(),
+                                            toDirtyJobSummary(jobState.getDirtyTask()));
                             status.add(jobStatusData);
                         });
         return status;
@@ -211,8 +242,9 @@ public class JobHistoryService {
     public JobState getJobDetailState(Long jobId) {
         if (pendingJobInfoMap.containsKey(jobId)) {
             // return pending job state
+            JobMaster pendingJobMaster = pendingJobInfoMap.get(jobId).getJobMaster();
             JobImmutableInformation jobImmutableInformation =
-                    pendingJobInfoMap.get(jobId).getJobMaster().getJobImmutableInformation();
+                    pendingJobMaster.getJobImmutableInformation();
             return new JobState(
                     jobId,
                     jobImmutableInformation.getJobName(),
@@ -221,7 +253,8 @@ public class JobHistoryService {
                     null,
                     null,
                     null,
-                    null);
+                    null,
+                    resolveDirtyJobState(pendingJobMaster, getDirtyJobState(pendingJobMaster)));
         }
         return runningJobMasterMap.containsKey(jobId)
                 ? toJobStateMapper(runningJobMasterMap.get(jobId), false)
@@ -255,12 +288,55 @@ public class JobHistoryService {
     }
 
     public void storeFinishedJobState(JobMaster jobMaster) {
-        JobState jobState = toJobStateMapper(jobMaster, false);
+        DirtyJobState dirtyJobState = null;
+        try {
+            boolean dirtyTrackingEnabled = dirtyJobService.isEnabled(jobMaster);
+            dirtyJobState =
+                    dirtyTrackingEnabled
+                            ? dirtyJobService.finishAndGetState(jobMaster.getJobId())
+                            : null;
+            if (dirtyJobState == null && dirtyTrackingEnabled) {
+                dirtyJobState =
+                        dirtyJobService.createUnknownState(
+                                jobMaster.getJobImmutableInformation(),
+                                "Dirty-job state was unavailable while writing finished history");
+            }
+        } catch (Throwable trackingError) {
+            logger.warning(
+                    String.format(
+                            "Failed to snapshot dirty-job state for finished job %s; continuing history persistence",
+                            jobMaster.getJobId()),
+                    trackingError);
+            try {
+                dirtyJobState =
+                        dirtyJobService.createUnknownState(
+                                jobMaster.getJobImmutableInformation(),
+                                "Dirty-job snapshot failed while writing finished history");
+            } catch (Throwable ignored) {
+                // The primary job history must still be persisted.
+            }
+        }
+        JobState jobState = toJobStateMapper(jobMaster, false, dirtyJobState);
         jobState.setErrorMessage(jobMaster.getErrorMessage());
         finishedJobStateImap.put(jobState.jobId, jobState, finishedJobExpireTime, TimeUnit.MINUTES);
     }
 
     public void storeFinishedJobState(JobState jobState) {
+        if (jobState.getDirtyTask() != null) {
+            try {
+                DirtyJobState dirtyJobState =
+                        dirtyJobService.finishAndGetState(jobState.getJobId());
+                if (dirtyJobState != null) {
+                    jobState.setDirtyTask(dirtyJobState);
+                }
+            } catch (Throwable trackingError) {
+                logger.warning(
+                        String.format(
+                                "Failed to finalize dirty-job state for finished job %s; continuing history persistence",
+                                jobState.getJobId()),
+                        trackingError);
+            }
+        }
         finishedJobStateImap.put(jobState.jobId, jobState, finishedJobExpireTime, TimeUnit.MINUTES);
     }
 
@@ -271,6 +347,11 @@ public class JobHistoryService {
     }
 
     private JobState toJobStateMapper(JobMaster jobMaster, boolean simple) {
+        return toJobStateMapper(jobMaster, simple, getDirtyJobState(jobMaster));
+    }
+
+    private JobState toJobStateMapper(
+            JobMaster jobMaster, boolean simple, DirtyJobState dirtyJobState) {
         Long jobId = jobMaster.getJobImmutableInformation().getJobId();
         Map<PipelineLocation, PipelineStateData> pipelineStateMapperMap = new HashMap<>();
         if (!simple) {
@@ -337,7 +418,38 @@ public class JobHistoryService {
                 startTime,
                 finishTime,
                 pipelineStateMapperMap,
-                null);
+                null,
+                resolveDirtyJobState(jobMaster, dirtyJobState));
+    }
+
+    private DirtyJobState getDirtyJobState(JobMaster jobMaster) {
+        return dirtyJobService.isEnabled(jobMaster)
+                ? dirtyJobService.getEvaluatedState(jobMaster.getJobId())
+                : null;
+    }
+
+    private DirtyJobSummary toDirtyJobSummary(DirtyJobState dirtyJobState) {
+        return dirtyJobState == null ? null : dirtyJobState.toSummary();
+    }
+
+    private DirtyJobState resolveDirtyJobState(JobMaster jobMaster, DirtyJobState dirtyJobState) {
+        if (dirtyJobState != null) {
+            return dirtyJobState;
+        }
+        try {
+            if (!dirtyJobService.isEnabled(jobMaster)) {
+                return null;
+            }
+            return dirtyJobService.createUnknownState(
+                    jobMaster.getJobImmutableInformation(),
+                    "Dirty-job state was unavailable while building job status");
+        } catch (Throwable trackingError) {
+            logger.warning(
+                    String.format(
+                            "Failed to resolve dirty-job state for job %s", jobMaster.getJobId()),
+                    trackingError);
+            return null;
+        }
     }
 
     public void storeJobInfo(long jobId, JobDAGInfo jobInfo) {
@@ -389,6 +501,28 @@ public class JobHistoryService {
         private Long finishTime;
         private Map<PipelineLocation, PipelineStateData> pipelineStateMapperMap;
         private String errorMessage;
+        private DirtyJobState dirtyTask;
+
+        public JobState(
+                Long jobId,
+                String jobName,
+                JobStatus jobStatus,
+                long submitTime,
+                Long startTime,
+                Long finishTime,
+                Map<PipelineLocation, PipelineStateData> pipelineStateMapperMap,
+                String errorMessage) {
+            this(
+                    jobId,
+                    jobName,
+                    jobStatus,
+                    submitTime,
+                    startTime,
+                    finishTime,
+                    pipelineStateMapperMap,
+                    errorMessage,
+                    null);
+        }
     }
 
     @AllArgsConstructor

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -1353,6 +1353,104 @@ public class JobMaster {
         return this.seaTunnelServer.getCoordinatorService();
     }
 
+    /**
+     * Delegates stable dirty-attempt preparation without coupling SubPlan to the HA store.
+     *
+     * @param pipelineId pipeline entering restore preparation
+     * @return stable attempt ID, or null when no member-loss episode owns the pipeline
+     */
+    public String prepareDirtyJobRecoveryAttempt(int pipelineId) {
+        try {
+            CoordinatorService coordinatorService = getCoordinatorService();
+            if (coordinatorService == null || coordinatorService.getDirtyJobService() == null) {
+                return null;
+            }
+            return coordinatorService
+                    .getDirtyJobService()
+                    .prepareRecoveryAttempt(jobId, pipelineId);
+        } catch (Throwable trackingError) {
+            LOGGER.warning(
+                    String.format(
+                            "Failed to prepare dirty-job recovery attempt for job %s pipeline %s; continuing recovery",
+                            jobId, pipelineId),
+                    trackingError);
+            return null;
+        }
+    }
+
+    /**
+     * Confirms a dirty attempt after SubPlan persisted DEPLOYING.
+     *
+     * @param pipelineId pipeline whose deployment started
+     * @param attemptId stable attempt ID allocated during preparation
+     */
+    public void confirmDirtyJobRecoveryAttempt(int pipelineId, String attemptId) {
+        try {
+            CoordinatorService coordinatorService = getCoordinatorService();
+            if (coordinatorService != null && coordinatorService.getDirtyJobService() != null) {
+                coordinatorService
+                        .getDirtyJobService()
+                        .confirmRecoveryAttempt(jobId, pipelineId, attemptId);
+            }
+        } catch (Throwable trackingError) {
+            LOGGER.warning(
+                    String.format(
+                            "Failed to confirm dirty-job recovery attempt for job %s pipeline %s; continuing recovery",
+                            jobId, pipelineId),
+                    trackingError);
+        }
+    }
+
+    /**
+     * Marks the affected pipeline recovered after all task groups reached RUNNING.
+     *
+     * @param pipelineId recovered pipeline
+     * @param attemptId stable confirmed attempt ID
+     */
+    public void completeDirtyJobRecoveryPipeline(int pipelineId, String attemptId) {
+        try {
+            CoordinatorService coordinatorService = getCoordinatorService();
+            if (coordinatorService != null && coordinatorService.getDirtyJobService() != null) {
+                coordinatorService
+                        .getDirtyJobService()
+                        .completeRecoveryPipeline(jobId, pipelineId, attemptId);
+            }
+        } catch (Throwable trackingError) {
+            LOGGER.warning(
+                    String.format(
+                            "Failed to complete dirty-job recovery pipeline for job %s pipeline %s; continuing recovery",
+                            jobId, pipelineId),
+                    trackingError);
+        }
+    }
+
+    /**
+     * Reconciles a retained attempt from persisted pipeline and task-group state.
+     *
+     * @param pipelineId restored pipeline
+     * @param deployed whether persisted state proves deployment started
+     * @param recovered whether every persisted task group is running
+     * @return retained stable attempt ID, or null when no attempt is active
+     */
+    public String reconcileDirtyJobRecoveryPipeline(
+            int pipelineId, boolean deployed, boolean recovered) {
+        try {
+            CoordinatorService coordinatorService = getCoordinatorService();
+            if (coordinatorService != null && coordinatorService.getDirtyJobService() != null) {
+                return coordinatorService
+                        .getDirtyJobService()
+                        .reconcileRecoveryPipeline(jobId, pipelineId, deployed, recovered);
+            }
+        } catch (Throwable trackingError) {
+            LOGGER.warning(
+                    String.format(
+                            "Failed to reconcile dirty-job recovery for job %s pipeline %s; continuing recovery",
+                            jobId, pipelineId),
+                    trackingError);
+        }
+        return null;
+    }
+
     @VisibleForTesting
     public IMap<Object, Object> getRunningJobStateIMap() {
         return runningJobStateIMap;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobService.java
@@ -334,12 +334,7 @@ public class DirtyJobService {
             return events;
         } catch (Throwable error) {
             logger.warning("Failed to load pending dirty-job member events", error);
-            List<DirtyJobMemberEvent> events = new ArrayList<>(localPendingMemberEvents.values());
-            if (localTrackingGap) {
-                events.add(createLocalTrackingGapEvent());
-            }
-            events.sort((left, right) -> Long.compare(left.getSequence(), right.getSequence()));
-            return events;
+            return buildFailClosedPendingMemberEvents(localPendingMemberEvents.values());
         }
     }
 
@@ -892,7 +887,20 @@ public class DirtyJobService {
         }
     }
 
-    private DirtyJobMemberEvent createLocalTrackingGapEvent() {
+    /** Forces the current replay round to fail closed when the shared journal cannot be read. */
+    static List<DirtyJobMemberEvent> buildFailClosedPendingMemberEvents(
+            Collection<DirtyJobMemberEvent> localEvents) {
+        Map<String, DirtyJobMemberEvent> eventsByMember = new HashMap<>();
+        if (localEvents != null) {
+            localEvents.forEach(event -> eventsByMember.put(event.getMemberUuid(), event));
+        }
+        eventsByMember.put(LOCAL_TRACKING_GAP_MEMBER_UUID, createLocalTrackingGapEvent());
+        List<DirtyJobMemberEvent> events = new ArrayList<>(eventsByMember.values());
+        events.sort((left, right) -> Long.compare(left.getSequence(), right.getSequence()));
+        return events;
+    }
+
+    private static DirtyJobMemberEvent createLocalTrackingGapEvent() {
         return new DirtyJobMemberEvent(
                 -1L, LOCAL_TRACKING_GAP_MEMBER_UUID, "", 0, System.currentTimeMillis());
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobService.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.job.DirtyJobMemberEvent;
 import org.apache.seatunnel.engine.common.job.DirtyJobState;
 import org.apache.seatunnel.engine.common.job.MemberLeaveClassification;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
 
@@ -40,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -731,7 +731,7 @@ public class DirtyJobService {
 
     private long nextMemberEventSequence() {
         try {
-            CompletableFuture<Long> update =
+            java.util.concurrent.CompletableFuture<Long> update =
                     memberEventSequenceMap
                             .submitToKey(
                                     MEMBER_EVENT_SEQUENCE_KEY, new IncrementSequenceProcessor())
@@ -959,11 +959,11 @@ public class DirtyJobService {
             return CompletableFuture.completedFuture(null);
         }
         try {
-            CompletableFuture<Void> update =
+            java.util.concurrent.CompletableFuture<Void> rawUpdate =
                     dirtyJobStateMap
                             .submitToKey(jobId, new MarkIncompleteProcessor(jobCreateTime, reason))
                             .toCompletableFuture();
-            update.whenComplete(
+            rawUpdate.whenComplete(
                     (ignored, markError) -> {
                         if (markError != null) {
                             logger.warning(
@@ -974,6 +974,7 @@ public class DirtyJobService {
                             scheduleIncompleteMarkerRetry(jobId, jobCreateTime, reason);
                         }
                     });
+            CompletableFuture<Void> update = new CompletableFuture<>(rawUpdate);
             scheduleIncompleteMarkerWatchdog(jobId, jobCreateTime, reason, update);
             return update;
         } catch (Throwable markError) {
@@ -1070,6 +1071,7 @@ public class DirtyJobService {
 
     private <R> CompletableFuture<R> submitStateUpdate(
             long jobId, DirtyJobProcessor<R> processor, String operation) {
+        java.util.concurrent.CompletableFuture<R> rawUpdate;
         CompletableFuture<R> update;
         long epoch = coordinatorEpoch.get();
         try {
@@ -1083,8 +1085,9 @@ public class DirtyJobService {
                                                 ignored ->
                                                         dirtyJobStateMap.submitToKey(
                                                                 jobId, processor));
-                update = submitted.toCompletableFuture();
-                pendingStateUpdates.put(jobId, update);
+                rawUpdate = submitted.toCompletableFuture();
+                update = new CompletableFuture<>(rawUpdate);
+                pendingStateUpdates.put(jobId, rawUpdate);
             }
         } catch (Throwable error) {
             if (coordinatorEpoch.get() == epoch) {
@@ -1092,10 +1095,10 @@ public class DirtyJobService {
             }
             return CompletableFuture.completedFuture(null);
         }
-        update.whenComplete(
+        rawUpdate.whenComplete(
                 (ignored, error) -> {
                     synchronized (pendingStateUpdates) {
-                        pendingStateUpdates.remove(jobId, update);
+                        pendingStateUpdates.remove(jobId, rawUpdate);
                     }
                     if (error != null && coordinatorEpoch.get() == epoch) {
                         handleTrackingFailure(jobId, operation, error);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobService.java
@@ -1,0 +1,1597 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master.dirty;
+
+import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.job.DirtyJobMemberEvent;
+import org.apache.seatunnel.engine.common.job.DirtyJobState;
+import org.apache.seatunnel.engine.common.job.MemberLeaveClassification;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.server.master.JobMaster;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.ExtendedMapEntry;
+import com.hazelcast.map.IMap;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Coordinates backup-aware atomic dirty-job updates without changing the existing recovery result.
+ *
+ * <p>Tracking failures are converted to UNKNOWN whenever state is still reachable. Member events
+ * are journaled before coordinator readiness checks so a new master can replay the event before a
+ * restored job becomes schedulable.
+ */
+public class DirtyJobService {
+    private static final long MEMBER_EVENT_SEQUENCE_KEY = 0L;
+    private static final long TRACKING_OPERATION_TIMEOUT_MILLIS = 100L;
+    private static final long TRACKING_RETRY_DELAY_MILLIS = 1000L;
+    private static final String LOCAL_TRACKING_GAP_MEMBER_UUID = "local-tracking-gap";
+
+    // Job-scoped source of truth updated atomically with synchronous backups.
+    private final IMap<Long, DirtyJobState> dirtyJobStateMap;
+    // Cluster watermark used to detect member events missed by one job state.
+    private final IMap<Long, Long> memberEventSequenceMap;
+    // Durable event journal and short-lived acknowledgement tombstones.
+    private final IMap<String, DirtyJobMemberEvent> pendingMemberEventMap;
+    // Compact marker distinguishing disabled jobs from missing enabled state.
+    private final IMap<Long, Integer> enabledThresholdMap;
+    // Hazelcast logger keeps tracking diagnostics in the engine log path.
+    private final ILogger logger;
+    // Bound applied independently to episode and incident history.
+    private final int eventHistorySize;
+    // Shared TTL for incomplete episodes and acknowledgement tombstones.
+    private final long pendingIncidentTtlMillis;
+    // Serializes asynchronous state updates by job without blocking member removal.
+    private final Map<Long, CompletionStage<?>> pendingStateUpdates = new HashMap<>();
+    // Local fail-closed guard scoped to one submission owner.
+    private final Map<Long, Long> locallyIncompleteJobOwners = new ConcurrentHashMap<>();
+    // Covers the active master's marker-write window without a distributed custom type.
+    private final Set<Long> locallyEnabledJobIds = ConcurrentHashMap.newKeySet();
+    // Captures the submission owner used by delayed fail-closed marker processors.
+    private final Map<Long, Long> locallyOwnedJobCreateTimes = new ConcurrentHashMap<>();
+    // Survives sequence or journal outages on each master-capable member.
+    private final Map<String, DirtyJobMemberEvent> localPendingMemberEvents =
+            new ConcurrentHashMap<>();
+    // Prevents duplicate reconciliation loops for the same fallback event.
+    private final Set<String> localMemberEventReconciliations = ConcurrentHashMap.newKeySet();
+    // Retains the highest event requested for acknowledgement per member UUID.
+    private final Map<String, DirtyJobMemberEvent> pendingMemberEventAcknowledgements =
+            new ConcurrentHashMap<>();
+    // Limits acknowledgement execution to one loop per member UUID.
+    private final Set<String> runningMemberEventAcknowledgements = ConcurrentHashMap.newKeySet();
+    // Limits HA incomplete-marker retry scheduling to one loop per job execution owner.
+    private final Set<String> incompleteMarkerRetries = ConcurrentHashMap.newKeySet();
+    // Invalidates role-local tracking work after this node loses active-master ownership.
+    private final AtomicLong coordinatorEpoch = new AtomicLong();
+    // Collapses overflow into one permanent fail-closed signal instead of dropping evidence.
+    private volatile boolean localTrackingGap;
+    // Isolates journal reads, acknowledgement, and fallback reconciliation from recovery threads.
+    private final ScheduledExecutorService journalExecutor =
+            Executors.newScheduledThreadPool(
+                    2,
+                    runnable -> {
+                        Thread thread = new Thread(runnable, "dirty-job-journal");
+                        thread.setDaemon(true);
+                        return thread;
+                    });
+    // Keeps UNKNOWN watchdogs independent from potentially stalled journal operations.
+    private final ScheduledExecutorService trackingRetryExecutor =
+            Executors.newSingleThreadScheduledExecutor(
+                    runnable -> {
+                        Thread thread = new Thread(runnable, "dirty-job-tracking-retry");
+                        thread.setDaemon(true);
+                        return thread;
+                    });
+
+    public DirtyJobService(
+            NodeEngineImpl nodeEngine,
+            ILogger logger,
+            int eventHistorySize,
+            long pendingIncidentTtlMillis) {
+        this.dirtyJobStateMap =
+                nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_DIRTY_JOB_STATE);
+        this.memberEventSequenceMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE);
+        this.pendingMemberEventMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_DIRTY_JOB_PENDING_MEMBER_EVENTS);
+        this.enabledThresholdMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap(Constant.IMAP_DIRTY_JOB_ENABLED_THRESHOLDS);
+        this.logger = logger;
+        this.eventHistorySize = eventHistorySize;
+        this.pendingIncidentTtlMillis = pendingIncidentTtlMillis;
+    }
+
+    /**
+     * Creates the job state before scheduling, or validates retained state during master recovery.
+     */
+    public void initialize(JobImmutableInformation jobInformation, boolean restart) {
+        int threshold = getThreshold(jobInformation);
+        if (threshold <= 0) {
+            return;
+        }
+        long jobId = jobInformation.getJobId();
+        locallyEnabledJobIds.add(jobId);
+        registerLocalOwner(
+                locallyOwnedJobCreateTimes,
+                locallyIncompleteJobOwners,
+                jobId,
+                jobInformation.getCreateTime(),
+                restart);
+        boolean enabledMarkerIncomplete = false;
+        try {
+            enabledThresholdMap
+                    .putAsync(jobId, threshold)
+                    .toCompletableFuture()
+                    .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            locallyIncompleteJobOwners.put(jobId, jobInformation.getCreateTime());
+            enabledMarkerIncomplete = true;
+            logger.warning(
+                    String.format("Failed to persist dirty-job enabled marker for job %s", jobId),
+                    error);
+        }
+        try {
+            long sequence = getCurrentMemberEventSequence();
+            CompletableFuture<DirtyJobState> update =
+                    submitStateUpdate(
+                            jobId,
+                            new InitializeProcessor(
+                                    jobId,
+                                    jobInformation.getCreateTime(),
+                                    threshold,
+                                    eventHistorySize,
+                                    pendingIncidentTtlMillis,
+                                    sequence,
+                                    restart,
+                                    !restart,
+                                    enabledMarkerIncomplete),
+                            "initialize dirty-job state");
+            awaitStateUpdate(jobId, update, "initialize dirty-job state");
+        } catch (Throwable error) {
+            handleTrackingFailure(jobId, "initialize dirty-job state", error);
+        }
+    }
+
+    /**
+     * Returns whether the job explicitly enabled member-loss dirty tracking.
+     *
+     * @param jobMaster active or pending job master
+     * @return true only for a positive job-scoped threshold
+     */
+    public boolean isEnabled(JobMaster jobMaster) {
+        return jobMaster != null && getThreshold(jobMaster.getJobImmutableInformation()) > 0;
+    }
+
+    /**
+     * Avoids sending new tracking types during a disabled rolling upgrade.
+     *
+     * @return true when tracking is enabled locally or in HA, or when the HA check is uncertain
+     */
+    public boolean shouldTrackMemberEvents() {
+        if (!locallyEnabledJobIds.isEmpty()) {
+            return true;
+        }
+        try {
+            return CompletableFuture.supplyAsync(
+                            () -> !enabledThresholdMap.isEmpty() || !dirtyJobStateMap.isEmpty(),
+                            journalExecutor)
+                    .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            logger.warning(
+                    "Failed to determine whether dirty-job member tracking is enabled; tracking conservatively",
+                    error);
+            return true;
+        }
+    }
+
+    /**
+     * Runs an observation-only tracking read without allowing it to stall active-master recovery.
+     *
+     * @param <T> observation result type
+     * @param observation tracking read which must not mutate the original recovery state
+     * @return observation result within the shared tracking budget
+     */
+    public <T> T runBoundedObservation(Supplier<T> observation) {
+        try {
+            return CompletableFuture.supplyAsync(observation, journalExecutor)
+                    .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalStateException(
+                    "Dirty-job tracking observation failed or timed out", error);
+        }
+    }
+
+    /**
+     * Retains fallback evidence on every master-capable member before active-master selection.
+     *
+     * @param memberUuid removed Hazelcast member identity
+     * @param memberHost removed member host
+     * @param memberPort removed member port
+     */
+    public void rememberMemberEventLocally(String memberUuid, String memberHost, int memberPort) {
+        DirtyJobMemberEvent previous =
+                localPendingMemberEvents.putIfAbsent(
+                        memberUuid,
+                        new DirtyJobMemberEvent(
+                                -1L,
+                                memberUuid,
+                                memberHost,
+                                memberPort,
+                                System.currentTimeMillis()));
+        if (previous == null) {
+            boundLocalMemberEvents();
+            scheduleLocalMemberEventReconciliation(memberUuid);
+        }
+    }
+
+    /**
+     * Journals a member removal before coordinator readiness is checked. The entry remains until an
+     * active coordinator has applied it to every restored job.
+     */
+    public DirtyJobMemberEvent recordMemberEvent(
+            String memberUuid, String memberHost, int memberPort) {
+        long eventTime = System.currentTimeMillis();
+        long sequence = nextMemberEventSequence();
+        DirtyJobMemberEvent event =
+                new DirtyJobMemberEvent(sequence, memberUuid, memberHost, memberPort, eventTime);
+        if (sequence < 0) {
+            localPendingMemberEvents.put(memberUuid, event);
+            boundLocalMemberEvents();
+            return event;
+        }
+        try {
+            pendingMemberEventMap
+                    .submitToKey(memberUuid, new JournalMemberEventProcessor(event))
+                    .toCompletableFuture()
+                    .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            localPendingMemberEvents.remove(memberUuid);
+            return event;
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            logger.warning(String.format("Failed to journal removed member %s", memberUuid), error);
+            localPendingMemberEvents.put(memberUuid, event);
+            boundLocalMemberEvents();
+            return event;
+        }
+    }
+
+    /**
+     * Returns pending events in cluster sequence order so active-master recovery is deterministic.
+     */
+    public List<DirtyJobMemberEvent> getPendingMemberEvents() {
+        try {
+            Map<String, DirtyJobMemberEvent> eventsByMember = new HashMap<>();
+            Collection<DirtyJobMemberEvent> persistedEvents =
+                    CompletableFuture.supplyAsync(
+                                    () -> new ArrayList<>(pendingMemberEventMap.values()),
+                                    journalExecutor)
+                            .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            persistedEvents.forEach(event -> eventsByMember.put(event.getMemberUuid(), event));
+            localPendingMemberEvents.forEach(
+                    (memberUuid, event) ->
+                            eventsByMember.merge(
+                                    memberUuid,
+                                    event,
+                                    (left, right) ->
+                                            left.getSequence() >= right.getSequence()
+                                                    ? left
+                                                    : right));
+            addLocalTrackingGap(eventsByMember);
+            List<DirtyJobMemberEvent> events = new ArrayList<>(eventsByMember.values());
+            events.sort((left, right) -> Long.compare(left.getSequence(), right.getSequence()));
+            return events;
+        } catch (Throwable error) {
+            logger.warning("Failed to load pending dirty-job member events", error);
+            List<DirtyJobMemberEvent> events = new ArrayList<>(localPendingMemberEvents.values());
+            if (localTrackingGap) {
+                events.add(createLocalTrackingGapEvent());
+            }
+            events.sort((left, right) -> Long.compare(left.getSequence(), right.getSequence()));
+            return events;
+        }
+    }
+
+    /**
+     * Removes one journal entry only after the active coordinator has processed all current jobs.
+     */
+    public void removePendingMemberEvent(DirtyJobMemberEvent event) {
+        if (event == null) {
+            return;
+        }
+        scheduleMemberEventAcknowledgement(event, 0L);
+    }
+
+    /**
+     * Removes journal entries replayed while all running jobs were reconstructed on a new master.
+     */
+    public void removePendingMemberEvents(Collection<DirtyJobMemberEvent> events) {
+        if (events == null) {
+            return;
+        }
+        events.forEach(this::removePendingMemberEvent);
+    }
+
+    /**
+     * Creates a non-persisted UNKNOWN snapshot when enabled state cannot be read.
+     *
+     * @param jobInformation immutable job configuration
+     * @param reason evidence explaining why CLEAN cannot be asserted
+     * @return UNKNOWN state, or null when tracking is disabled
+     */
+    public DirtyJobState createUnknownState(JobImmutableInformation jobInformation, String reason) {
+        int threshold = getThreshold(jobInformation);
+        if (threshold <= 0) {
+            return null;
+        }
+        long sequence;
+        try {
+            sequence = getCurrentMemberEventSequence();
+        } catch (Throwable ignored) {
+            sequence = 0L;
+        }
+        DirtyJobState state =
+                DirtyJobState.create(
+                        jobInformation.getJobId(),
+                        jobInformation.getCreateTime(),
+                        threshold,
+                        eventHistorySize,
+                        pendingIncidentTtlMillis,
+                        sequence);
+        state.markTrackingIncomplete(reason);
+        return state;
+    }
+
+    /**
+     * Advances a newly submitted job to the current watermark immediately before scheduling.
+     *
+     * @param jobMaster job which is about to become schedulable
+     */
+    public void synchronizeMemberEventSequence(JobMaster jobMaster) {
+        if (!isEnabled(jobMaster)) {
+            return;
+        }
+        long jobId = jobMaster.getJobId();
+        try {
+            long sequence = getCurrentMemberEventSequence();
+            CompletableFuture<Void> update =
+                    submitStateUpdate(
+                            jobId,
+                            new AdvanceSequenceProcessor(
+                                    jobId,
+                                    jobMaster.getJobImmutableInformation().getCreateTime(),
+                                    getThreshold(jobMaster.getJobImmutableInformation()),
+                                    eventHistorySize,
+                                    pendingIncidentTtlMillis,
+                                    sequence),
+                            "synchronize member-event sequence");
+            awaitStateUpdate(jobId, update, "synchronize member-event sequence");
+        } catch (Throwable error) {
+            handleTrackingFailure(jobId, "synchronize member-event sequence", error);
+        }
+    }
+
+    /**
+     * Atomically advances the watermark and records an incident when this job has affected
+     * pipelines.
+     */
+    public CompletableFuture<Void> processMemberEvent(
+            JobMaster jobMaster,
+            long memberEventSequence,
+            String lostMemberUuid,
+            String lostAddress,
+            Collection<Integer> affectedPipelineIds) {
+        return processMemberEvent(
+                jobMaster,
+                memberEventSequence,
+                lostMemberUuid,
+                lostAddress,
+                affectedPipelineIds,
+                System.currentTimeMillis());
+    }
+
+    /**
+     * Replays a journaled member event with its original timestamp so stale episodes stay stale.
+     *
+     * @param eventTime original Hazelcast member-removal observation time
+     */
+    public CompletableFuture<Void> processMemberEvent(
+            JobMaster jobMaster,
+            long memberEventSequence,
+            String lostMemberUuid,
+            String lostAddress,
+            Collection<Integer> affectedPipelineIds,
+            long eventTime) {
+        if (!isEnabled(jobMaster)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        long jobId = jobMaster.getJobId();
+        if (memberEventSequence < 0) {
+            return markTrackingIncomplete(jobId, "Member-event sequence allocation failed");
+        }
+        return submitStateUpdate(
+                jobId,
+                new MemberEventProcessor(
+                        jobId,
+                        jobMaster.getJobImmutableInformation().getCreateTime(),
+                        getThreshold(jobMaster.getJobImmutableInformation()),
+                        eventHistorySize,
+                        pendingIncidentTtlMillis,
+                        memberEventSequence,
+                        lostMemberUuid,
+                        lostAddress,
+                        affectedPipelineIds,
+                        eventTime),
+                "record member-loss event");
+    }
+
+    /**
+     * Waits only for the bounded tracking budget used before a restored job becomes schedulable.
+     *
+     * @param jobId job whose replay update was submitted
+     * @param update asynchronous member-event update
+     */
+    public void awaitMemberEventReplay(long jobId, CompletableFuture<Void> update) {
+        awaitStateUpdate(jobId, update, "replay member-loss event");
+    }
+
+    /**
+     * Allocates the stable PREPARED attempt consumed by the pipeline state transition.
+     *
+     * @return stable attempt ID, or null when no member-loss episode owns the pipeline
+     */
+    public String prepareRecoveryAttempt(long jobId, int pipelineId) {
+        CompletableFuture<String> update =
+                submitStateUpdate(
+                        jobId,
+                        new PrepareAttemptProcessor(
+                                getLocallyOwnedJobCreateTime(jobId),
+                                pipelineId,
+                                System.currentTimeMillis()),
+                        "prepare recovery attempt");
+        return awaitStateUpdate(jobId, update, "prepare recovery attempt");
+    }
+
+    /**
+     * Confirms one attempt after the pipeline state is persisted as DEPLOYING.
+     *
+     * @param attemptId stable ID returned during restore preparation
+     */
+    public void confirmRecoveryAttempt(long jobId, int pipelineId, String attemptId) {
+        if (attemptId == null) {
+            return;
+        }
+        submitStateUpdate(
+                jobId,
+                new ConfirmAttemptProcessor(
+                        getLocallyOwnedJobCreateTime(jobId),
+                        pipelineId,
+                        attemptId,
+                        System.currentTimeMillis()),
+                "confirm recovery attempt");
+    }
+
+    /**
+     * Completes one pipeline only after all of its task groups report RUNNING.
+     *
+     * @param attemptId stable confirmed attempt which reached RUNNING
+     */
+    public void completeRecoveryPipeline(long jobId, int pipelineId, String attemptId) {
+        if (attemptId == null) {
+            return;
+        }
+        submitStateUpdate(
+                jobId,
+                new CompletePipelineProcessor(
+                        getLocallyOwnedJobCreateTime(jobId),
+                        pipelineId,
+                        attemptId,
+                        System.currentTimeMillis()),
+                "complete recovery pipeline");
+    }
+
+    /**
+     * Replays persisted DEPLOYING or RUNNING state idempotently after an active-master switch.
+     *
+     * @param deployed whether persisted pipeline state proves deployment started
+     * @param recovered whether persisted task state proves deployment completed
+     */
+    public String reconcileRecoveryPipeline(
+            long jobId, int pipelineId, boolean deployed, boolean recovered) {
+        if (!deployed) {
+            return null;
+        }
+        CompletableFuture<String> update =
+                submitStateUpdate(
+                        jobId,
+                        new ReconcilePipelineProcessor(
+                                getLocallyOwnedJobCreateTime(jobId),
+                                pipelineId,
+                                recovered,
+                                System.currentTimeMillis()),
+                        "reconcile recovery pipeline");
+        return awaitStateUpdate(jobId, update, "reconcile recovery pipeline");
+    }
+
+    /**
+     * Reads one state and applies current watermark and TTL completeness checks.
+     *
+     * @return evaluated copy, or null when no enabled state exists
+     */
+    public DirtyJobState getEvaluatedState(long jobId) {
+        DirtyJobState state;
+        try {
+            state = dirtyJobStateMap.get(jobId);
+            if (state == null) {
+                return null;
+            }
+            state = state.evaluatedCopy(getCurrentMemberEventSequence());
+            markLocallyIncomplete(jobId, state);
+            return state;
+        } catch (Throwable error) {
+            logger.warning(
+                    String.format("Failed to evaluate dirty-job state for job %s", jobId), error);
+            try {
+                state = dirtyJobStateMap.get(jobId);
+                if (state != null) {
+                    state = state.evaluatedCopy(state.getLastProcessedMemberEventSequence());
+                    state.markTrackingIncomplete("Failed to evaluate dirty-job state");
+                }
+                return state;
+            } catch (Throwable ignored) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Bulk-reads list-page state to avoid one distributed lookup per active job.
+     *
+     * @return evaluated states keyed by enabled job ID
+     */
+    public Map<Long, DirtyJobState> getEvaluatedStates(Collection<Long> jobIds) {
+        if (jobIds == null || jobIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<Long, DirtyJobState> states = new HashMap<>();
+        try {
+            states.putAll(dirtyJobStateMap.getAll(new HashSet<>(jobIds)));
+            long sequence = getCurrentMemberEventSequence();
+            states.replaceAll(
+                    (jobId, state) -> {
+                        DirtyJobState evaluated = state.evaluatedCopy(sequence);
+                        markLocallyIncomplete(jobId, evaluated);
+                        return evaluated;
+                    });
+        } catch (Throwable error) {
+            logger.warning("Failed to evaluate dirty-job states", error);
+            states.replaceAll(
+                    (jobId, state) -> {
+                        DirtyJobState evaluated =
+                                state.evaluatedCopy(state.getLastProcessedMemberEventSequence());
+                        evaluated.markTrackingIncomplete("Failed to evaluate dirty-job state list");
+                        return evaluated;
+                    });
+        }
+        return states;
+    }
+
+    /**
+     * Aborts any incomplete episode and returns the final history snapshot.
+     *
+     * @return evaluated terminal snapshot, or null when tracking was disabled
+     */
+    public DirtyJobState finishAndGetState(long jobId) {
+        try {
+            CompletableFuture<DirtyJobState> update =
+                    submitStateUpdate(
+                            jobId,
+                            new FinishEpisodeProcessor(
+                                    getLocallyOwnedJobCreateTime(jobId),
+                                    System.currentTimeMillis()),
+                            "finalize dirty-job state");
+            DirtyJobState state = awaitStateUpdate(jobId, update, "finalize dirty-job state");
+            if (state == null) {
+                return null;
+            }
+            state = state.evaluatedCopy(getCurrentMemberEventSequence());
+            markLocallyIncomplete(jobId, state);
+            return state;
+        } catch (Throwable error) {
+            handleTrackingFailure(jobId, "finalize dirty-job state", error);
+            return getEvaluatedState(jobId);
+        }
+    }
+
+    /**
+     * Removes running tracking state only after the delayed terminal-history cleanup boundary.
+     *
+     * @param jobId terminal job whose history snapshot has already been stored
+     * @return true when both state and enabled marker were removed or already absent
+     */
+    public boolean removeRunningState(long jobId) {
+        boolean stateRemoved = removeWithBudget(dirtyJobStateMap, jobId, "state");
+        boolean markerRemoved = removeWithBudget(enabledThresholdMap, jobId, "enabled marker");
+        boolean removed = stateRemoved && markerRemoved;
+        if (removed) {
+            locallyEnabledJobIds.remove(jobId);
+            synchronized (locallyOwnedJobCreateTimes) {
+                locallyIncompleteJobOwners.remove(jobId);
+                locallyOwnedJobCreateTimes.remove(jobId);
+            }
+        }
+        return removed;
+    }
+
+    /**
+     * Applies the local fail-closed guard to a query copy built outside this service.
+     *
+     * @param jobId queried job
+     * @param state query copy loaded by REST
+     * @return the same state, marked UNKNOWN when a bounded local update timed out
+     */
+    public DirtyJobState markUnknownIfLocallyIncomplete(long jobId, DirtyJobState state) {
+        markLocallyIncomplete(jobId, state);
+        return state;
+    }
+
+    /**
+     * Converts an exception caught by a recovery caller into local and HA UNKNOWN evidence.
+     *
+     * @param jobId affected job
+     * @param operation tracking operation which failed
+     * @param error failure isolated from the original recovery path
+     */
+    public void reportTrackingFailure(long jobId, String operation, Throwable error) {
+        handleTrackingFailure(jobId, operation, error);
+    }
+
+    /**
+     * Converts an early recovery exception using the owner read from persisted job metadata.
+     *
+     * @param jobId affected job
+     * @param jobCreateTime immutable execution owner
+     * @param operation tracking operation which failed
+     * @param error failure isolated from the original recovery path
+     */
+    public void reportTrackingFailure(
+            long jobId, long jobCreateTime, String operation, Throwable error) {
+        logger.warning(String.format("Failed to %s for job %s", operation, jobId), error);
+        markTrackingIncomplete(
+                jobId, jobCreateTime, operation + " failed: " + error.getClass().getSimpleName());
+    }
+
+    // Clears active-coordinator state while retaining member-event fallback evidence.
+    public void clearLocalCoordinatorState() {
+        coordinatorEpoch.incrementAndGet();
+        locallyEnabledJobIds.clear();
+        synchronized (locallyOwnedJobCreateTimes) {
+            locallyIncompleteJobOwners.clear();
+            locallyOwnedJobCreateTimes.clear();
+        }
+        synchronized (pendingStateUpdates) {
+            pendingStateUpdates.values().stream()
+                    .map(CompletionStage::toCompletableFuture)
+                    .forEach(future -> future.cancel(false));
+            pendingStateUpdates.clear();
+        }
+    }
+
+    // Stops bounded journal and incomplete-marker retries during server shutdown.
+    public void shutdown() {
+        journalExecutor.shutdownNow();
+        trackingRetryExecutor.shutdownNow();
+    }
+
+    private long nextMemberEventSequence() {
+        try {
+            CompletableFuture<Long> update =
+                    memberEventSequenceMap
+                            .submitToKey(
+                                    MEMBER_EVENT_SEQUENCE_KEY, new IncrementSequenceProcessor())
+                            .toCompletableFuture();
+            return update.get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            logger.warning("Failed to allocate dirty-job member-event sequence", error);
+            return -1L;
+        }
+    }
+
+    private int getThreshold(JobImmutableInformation jobInformation) {
+        if (jobInformation == null || jobInformation.getJobConfig() == null) {
+            return EnvCommonOptions.DIRTY_JOB_RESTORE_THRESHOLD.defaultValue();
+        }
+        Map<String, Object> envOptions = jobInformation.getJobConfig().getEnvOptions();
+        Object value = envOptions.get(EnvCommonOptions.DIRTY_JOB_RESTORE_THRESHOLD.key());
+        return value == null
+                ? EnvCommonOptions.DIRTY_JOB_RESTORE_THRESHOLD.defaultValue()
+                : Integer.parseInt(value.toString());
+    }
+
+    private long getLocallyOwnedJobCreateTime(long jobId) {
+        return locallyOwnedJobCreateTimes.getOrDefault(jobId, 0L);
+    }
+
+    private boolean acknowledgeMemberEvent(DirtyJobMemberEvent event) {
+        try {
+            DirtyJobMemberEvent acknowledgementCandidate = event;
+            if (event.getSequence() >= 0) {
+                acknowledgementCandidate =
+                        pendingMemberEventMap
+                                .submitToKey(
+                                        event.getMemberUuid(),
+                                        new JournalMemberEventProcessor(event))
+                                .toCompletableFuture()
+                                .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            }
+            final DirtyJobMemberEvent eventToAcknowledge = acknowledgementCandidate;
+            Set<Long> enabledJobIds = new HashSet<>(enabledThresholdMap.keySet());
+            if (!enabledJobIds.isEmpty()) {
+                Map<Long, DirtyJobState> states = dirtyJobStateMap.getAll(enabledJobIds);
+                boolean processedByEveryEnabledJob =
+                        enabledJobIds.stream()
+                                .allMatch(
+                                        jobId -> {
+                                            DirtyJobState state = states.get(jobId);
+                                            if (state == null) {
+                                                return false;
+                                            }
+                                            return eventToAcknowledge.getSequence() < 0
+                                                    ? !state.isTrackingComplete()
+                                                    : state.getLastProcessedMemberEventSequence()
+                                                            >= eventToAcknowledge.getSequence();
+                                        });
+                if (!processedByEveryEnabledJob) {
+                    return false;
+                }
+            }
+            if (eventToAcknowledge.getSequence() >= 0) {
+                boolean acknowledged =
+                        pendingMemberEventMap
+                                .submitToKey(
+                                        eventToAcknowledge.getMemberUuid(),
+                                        new AcknowledgeJournalEventProcessor(
+                                                eventToAcknowledge.getSequence(),
+                                                pendingIncidentTtlMillis))
+                                .toCompletableFuture()
+                                .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                if (!acknowledged) {
+                    return false;
+                }
+            }
+            localPendingMemberEvents.remove(eventToAcknowledge.getMemberUuid());
+            return true;
+        } catch (Throwable error) {
+            logger.warning(
+                    String.format(
+                            "Failed to acknowledge dirty-job member event %s",
+                            event.getMemberUuid()),
+                    error);
+            return false;
+        }
+    }
+
+    private void scheduleMemberEventAcknowledgement(DirtyJobMemberEvent event, long delayMillis) {
+        pendingMemberEventAcknowledgements.merge(
+                event.getMemberUuid(),
+                event,
+                (current, requested) ->
+                        current.getSequence() >= requested.getSequence() ? current : requested);
+        if (journalExecutor.isShutdown()
+                || !runningMemberEventAcknowledgements.add(event.getMemberUuid())) {
+            return;
+        }
+        try {
+            journalExecutor.schedule(
+                    () -> {
+                        DirtyJobMemberEvent requested =
+                                pendingMemberEventAcknowledgements.get(event.getMemberUuid());
+                        boolean acknowledged = acknowledgeMemberEvent(requested);
+                        if (acknowledged) {
+                            pendingMemberEventAcknowledgements.remove(
+                                    event.getMemberUuid(), requested);
+                        }
+                        runningMemberEventAcknowledgements.remove(event.getMemberUuid());
+                        DirtyJobMemberEvent remaining =
+                                pendingMemberEventAcknowledgements.get(event.getMemberUuid());
+                        if (remaining != null) {
+                            scheduleMemberEventAcknowledgement(
+                                    remaining, acknowledged ? 0L : TRACKING_RETRY_DELAY_MILLIS);
+                        }
+                    },
+                    delayMillis,
+                    TimeUnit.MILLISECONDS);
+        } catch (Throwable scheduleError) {
+            runningMemberEventAcknowledgements.remove(event.getMemberUuid());
+            logger.warning(
+                    String.format(
+                            "Failed to schedule acknowledgement for dirty-job member event %s",
+                            event.getMemberUuid()),
+                    scheduleError);
+        }
+    }
+
+    private void boundLocalMemberEvents() {
+        int limit = Math.max(1, eventHistorySize * 4);
+        while (localPendingMemberEvents.size() > limit) {
+            String oldestMemberUuid =
+                    localPendingMemberEvents.entrySet().stream()
+                            .min(
+                                    (left, right) ->
+                                            Long.compare(
+                                                    left.getValue().getEventTime(),
+                                                    right.getValue().getEventTime()))
+                            .map(Map.Entry::getKey)
+                            .orElse(null);
+            if (oldestMemberUuid == null) {
+                return;
+            }
+            localPendingMemberEvents.remove(oldestMemberUuid);
+            localMemberEventReconciliations.remove(oldestMemberUuid);
+            localTrackingGap = true;
+        }
+    }
+
+    private void addLocalTrackingGap(Map<String, DirtyJobMemberEvent> eventsByMember) {
+        if (localTrackingGap) {
+            eventsByMember.put(LOCAL_TRACKING_GAP_MEMBER_UUID, createLocalTrackingGapEvent());
+        }
+    }
+
+    private DirtyJobMemberEvent createLocalTrackingGapEvent() {
+        return new DirtyJobMemberEvent(
+                -1L, LOCAL_TRACKING_GAP_MEMBER_UUID, "", 0, System.currentTimeMillis());
+    }
+
+    private <V> boolean removeWithBudget(IMap<Long, V> map, long jobId, String stateName) {
+        try {
+            V current =
+                    map.getAsync(jobId)
+                            .toCompletableFuture()
+                            .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            return current == null
+                    || map.tryRemove(
+                            jobId, TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            logger.warning(
+                    String.format("Failed to remove dirty-job %s for job %s", stateName, jobId),
+                    error);
+            return false;
+        }
+    }
+
+    private long getCurrentMemberEventSequence() {
+        try {
+            Long sequence =
+                    memberEventSequenceMap
+                            .getAsync(MEMBER_EVENT_SEQUENCE_KEY)
+                            .toCompletableFuture()
+                            .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            return sequence == null ? 0L : sequence;
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalStateException(
+                    "Failed to read dirty-job member-event sequence", error);
+        }
+    }
+
+    private void handleTrackingFailure(long jobId, String operation, Throwable error) {
+        logger.warning(String.format("Failed to %s for job %s", operation, jobId), error);
+        markTrackingIncomplete(jobId, operation + " failed: " + error.getClass().getSimpleName());
+    }
+
+    private CompletableFuture<Void> markTrackingIncomplete(long jobId, String reason) {
+        long jobCreateTime = locallyOwnedJobCreateTimes.getOrDefault(jobId, 0L);
+        return markTrackingIncomplete(jobId, jobCreateTime, reason);
+    }
+
+    private CompletableFuture<Void> markTrackingIncomplete(
+            long jobId, long jobCreateTime, String reason) {
+        if (!registerLocalIncompleteOwner(
+                locallyOwnedJobCreateTimes, locallyIncompleteJobOwners, jobId, jobCreateTime)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        try {
+            CompletableFuture<Void> update =
+                    dirtyJobStateMap
+                            .submitToKey(jobId, new MarkIncompleteProcessor(jobCreateTime, reason))
+                            .toCompletableFuture();
+            update.whenComplete(
+                    (ignored, markError) -> {
+                        if (markError != null) {
+                            logger.warning(
+                                    String.format(
+                                            "Failed to mark dirty-job tracking incomplete for job %s",
+                                            jobId),
+                                    markError);
+                            scheduleIncompleteMarkerRetry(jobId, jobCreateTime, reason);
+                        }
+                    });
+            scheduleIncompleteMarkerWatchdog(jobId, jobCreateTime, reason, update);
+            return update;
+        } catch (Throwable markError) {
+            logger.warning(
+                    String.format("Failed to submit dirty-job incomplete marker for job %s", jobId),
+                    markError);
+            scheduleIncompleteMarkerRetry(jobId, jobCreateTime, reason);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private void scheduleIncompleteMarkerWatchdog(
+            long jobId, long jobCreateTime, String reason, CompletableFuture<Void> update) {
+        if (trackingRetryExecutor.isShutdown()) {
+            return;
+        }
+        try {
+            trackingRetryExecutor.schedule(
+                    () -> {
+                        if (!update.isDone()) {
+                            scheduleIncompleteMarkerRetry(jobId, jobCreateTime, reason);
+                        }
+                    },
+                    TRACKING_OPERATION_TIMEOUT_MILLIS,
+                    TimeUnit.MILLISECONDS);
+        } catch (Throwable scheduleError) {
+            logger.warning(
+                    String.format(
+                            "Failed to schedule dirty-job incomplete marker watchdog for job %s",
+                            jobId),
+                    scheduleError);
+        }
+    }
+
+    private void scheduleIncompleteMarkerRetry(long jobId, long jobCreateTime, String reason) {
+        String retryKey = jobId + ":" + jobCreateTime;
+        if (trackingRetryExecutor.isShutdown() || !incompleteMarkerRetries.add(retryKey)) {
+            return;
+        }
+        try {
+            trackingRetryExecutor.schedule(
+                    () -> {
+                        incompleteMarkerRetries.remove(retryKey);
+                        markTrackingIncomplete(jobId, jobCreateTime, reason);
+                    },
+                    TRACKING_RETRY_DELAY_MILLIS,
+                    TimeUnit.MILLISECONDS);
+        } catch (Throwable scheduleError) {
+            incompleteMarkerRetries.remove(retryKey);
+            logger.warning(
+                    String.format(
+                            "Failed to schedule dirty-job incomplete marker for job %s", jobId),
+                    scheduleError);
+        }
+    }
+
+    private void scheduleLocalMemberEventReconciliation(String memberUuid) {
+        if (journalExecutor.isShutdown() || !localMemberEventReconciliations.add(memberUuid)) {
+            return;
+        }
+        journalExecutor.schedule(
+                () -> reconcileLocalMemberEvent(memberUuid),
+                TRACKING_RETRY_DELAY_MILLIS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private void reconcileLocalMemberEvent(String memberUuid) {
+        if (!localPendingMemberEvents.containsKey(memberUuid)) {
+            localMemberEventReconciliations.remove(memberUuid);
+            return;
+        }
+        try {
+            DirtyJobMemberEvent persisted =
+                    pendingMemberEventMap
+                            .getAsync(memberUuid)
+                            .toCompletableFuture()
+                            .get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            if (persisted != null && persisted.getSequence() >= 0) {
+                localPendingMemberEvents.remove(memberUuid);
+                localMemberEventReconciliations.remove(memberUuid);
+                return;
+            }
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            logger.warning(
+                    String.format("Failed to reconcile local dirty-job event %s", memberUuid),
+                    error);
+        }
+        localMemberEventReconciliations.remove(memberUuid);
+        scheduleLocalMemberEventReconciliation(memberUuid);
+    }
+
+    private <R> CompletableFuture<R> submitStateUpdate(
+            long jobId, DirtyJobProcessor<R> processor, String operation) {
+        CompletableFuture<R> update;
+        long epoch = coordinatorEpoch.get();
+        try {
+            synchronized (pendingStateUpdates) {
+                CompletionStage<?> previous = pendingStateUpdates.get(jobId);
+                CompletionStage<R> submitted =
+                        previous == null
+                                ? dirtyJobStateMap.submitToKey(jobId, processor)
+                                : previous.handle((ignored, error) -> null)
+                                        .thenCompose(
+                                                ignored ->
+                                                        dirtyJobStateMap.submitToKey(
+                                                                jobId, processor));
+                update = submitted.toCompletableFuture();
+                pendingStateUpdates.put(jobId, update);
+            }
+        } catch (Throwable error) {
+            if (coordinatorEpoch.get() == epoch) {
+                handleTrackingFailure(jobId, operation, error);
+            }
+            return CompletableFuture.completedFuture(null);
+        }
+        update.whenComplete(
+                (ignored, error) -> {
+                    synchronized (pendingStateUpdates) {
+                        pendingStateUpdates.remove(jobId, update);
+                    }
+                    if (error != null && coordinatorEpoch.get() == epoch) {
+                        handleTrackingFailure(jobId, operation, error);
+                    }
+                });
+        return update;
+    }
+
+    private <R> R awaitStateUpdate(long jobId, CompletableFuture<R> update, String operation) {
+        long epoch = coordinatorEpoch.get();
+        try {
+            return update.get(TRACKING_OPERATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            if (error instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            if (coordinatorEpoch.get() == epoch) {
+                handleTrackingFailure(jobId, operation, error);
+            }
+            return null;
+        }
+    }
+
+    private void markLocallyIncomplete(long jobId, DirtyJobState state) {
+        Long expectedJobCreateTime = locallyIncompleteJobOwners.get(jobId);
+        if (state != null
+                && expectedJobCreateTime != null
+                && expectedJobCreateTime == state.getJobCreateTime()) {
+            state.markTrackingIncomplete("A local dirty-job tracking operation did not complete");
+        }
+    }
+
+    /**
+     * Registers the current execution and removes local UNKNOWN evidence from another execution.
+     */
+    static void registerLocalOwner(
+            Map<Long, Long> owners,
+            Map<Long, Long> incompleteOwners,
+            long jobId,
+            long jobCreateTime,
+            boolean restart) {
+        synchronized (owners) {
+            owners.put(jobId, jobCreateTime);
+            Long incompleteOwner = incompleteOwners.get(jobId);
+            if (!restart || (incompleteOwner != null && incompleteOwner != jobCreateTime)) {
+                incompleteOwners.remove(jobId);
+            }
+        }
+    }
+
+    /** Retains local UNKNOWN evidence only while no different execution owns the same job ID. */
+    static boolean registerLocalIncompleteOwner(
+            Map<Long, Long> owners,
+            Map<Long, Long> incompleteOwners,
+            long jobId,
+            long jobCreateTime) {
+        synchronized (owners) {
+            Long currentOwner = owners.get(jobId);
+            if (currentOwner != null && currentOwner != jobCreateTime) {
+                return false;
+            }
+            incompleteOwners.put(jobId, jobCreateTime);
+            return true;
+        }
+    }
+
+    static boolean isOwnedBy(DirtyJobState state, long expectedJobCreateTime) {
+        return state != null && state.getJobCreateTime() == expectedJobCreateTime;
+    }
+
+    /**
+     * Base processor applying the same deterministic mutation to primary and synchronous backups.
+     */
+    private abstract static class DirtyJobProcessor<R>
+            implements EntryProcessor<Long, DirtyJobState, R>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public EntryProcessor<Long, DirtyJobState, R> getBackupProcessor() {
+            return this;
+        }
+    }
+
+    /** Initializes or validates state for one immutable job execution. */
+    private static class InitializeProcessor extends DirtyJobProcessor<DirtyJobState> {
+        private static final long serialVersionUID = 1L;
+
+        private final long jobId;
+        private final long jobCreateTime;
+        private final int threshold;
+        private final int eventHistorySize;
+        private final long pendingIncidentTtlMillis;
+        private final long memberEventSequence;
+        private final boolean missingIsIncomplete;
+        private final boolean resetExisting;
+        private final boolean enabledMarkerIncomplete;
+
+        private InitializeProcessor(
+                long jobId,
+                long jobCreateTime,
+                int threshold,
+                int eventHistorySize,
+                long pendingIncidentTtlMillis,
+                long memberEventSequence,
+                boolean missingIsIncomplete,
+                boolean resetExisting,
+                boolean enabledMarkerIncomplete) {
+            this.jobId = jobId;
+            this.jobCreateTime = jobCreateTime;
+            this.threshold = threshold;
+            this.eventHistorySize = eventHistorySize;
+            this.pendingIncidentTtlMillis = pendingIncidentTtlMillis;
+            this.memberEventSequence = memberEventSequence;
+            this.missingIsIncomplete = missingIsIncomplete;
+            this.resetExisting = resetExisting;
+            this.enabledMarkerIncomplete = enabledMarkerIncomplete;
+        }
+
+        @Override
+        public DirtyJobState process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            boolean ownerMismatch = state != null && state.getJobCreateTime() != jobCreateTime;
+            if (state == null || resetExisting || ownerMismatch) {
+                state =
+                        DirtyJobState.create(
+                                jobId,
+                                jobCreateTime,
+                                threshold,
+                                eventHistorySize,
+                                pendingIncidentTtlMillis,
+                                memberEventSequence);
+                if (missingIsIncomplete) {
+                    state.markTrackingIncomplete(
+                            "Dirty-job state was missing during active-master recovery");
+                }
+                if (ownerMismatch) {
+                    state.markTrackingIncomplete(
+                            "Dirty-job state belonged to a different job execution");
+                }
+            } else {
+                state.validateConfiguration(threshold, eventHistorySize, pendingIncidentTtlMillis);
+            }
+            if (enabledMarkerIncomplete) {
+                state.markTrackingIncomplete(
+                        "Dirty-job enabled marker was not persisted within the tracking budget");
+            }
+            entry.setValue(state);
+            return state;
+        }
+    }
+
+    /** Allocates the next cluster-wide member-event sequence. */
+    private static class IncrementSequenceProcessor extends SequenceProcessor<Long> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Long process(Map.Entry<Long, Long> entry) {
+            long next = entry.getValue() == null ? 1L : entry.getValue() + 1L;
+            entry.setValue(next);
+            return next;
+        }
+    }
+
+    /** Base processor for the synchronously backed member-event sequence map. */
+    private abstract static class SequenceProcessor<R>
+            implements EntryProcessor<Long, Long, R>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public EntryProcessor<Long, Long, R> getBackupProcessor() {
+            return this;
+        }
+    }
+
+    /** Retains only the highest observed event sequence for one member UUID. */
+    private static class JournalMemberEventProcessor
+            implements EntryProcessor<String, DirtyJobMemberEvent, DirtyJobMemberEvent>,
+                    Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final DirtyJobMemberEvent event;
+
+        private JournalMemberEventProcessor(DirtyJobMemberEvent event) {
+            this.event = event;
+        }
+
+        @Override
+        public DirtyJobMemberEvent process(Map.Entry<String, DirtyJobMemberEvent> entry) {
+            DirtyJobMemberEvent current = entry.getValue();
+            if (current == null || current.getSequence() < event.getSequence()) {
+                entry.setValue(event);
+                return event;
+            }
+            return current;
+        }
+
+        @Override
+        public EntryProcessor<String, DirtyJobMemberEvent, DirtyJobMemberEvent>
+                getBackupProcessor() {
+            return this;
+        }
+    }
+
+    /** Atomically converts one exact journal event into a short-lived acknowledgement tombstone. */
+    private static class AcknowledgeJournalEventProcessor
+            implements EntryProcessor<String, DirtyJobMemberEvent, Boolean>, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final long expectedSequence;
+        private final long tombstoneTtlMillis;
+
+        private AcknowledgeJournalEventProcessor(long expectedSequence, long tombstoneTtlMillis) {
+            this.expectedSequence = expectedSequence;
+            this.tombstoneTtlMillis = tombstoneTtlMillis;
+        }
+
+        @Override
+        public Boolean process(Map.Entry<String, DirtyJobMemberEvent> entry) {
+            DirtyJobMemberEvent current = entry.getValue();
+            if (current == null || current.getSequence() != expectedSequence) {
+                return false;
+            }
+            ((ExtendedMapEntry<String, DirtyJobMemberEvent>) entry)
+                    .setValue(current, tombstoneTtlMillis, TimeUnit.MILLISECONDS);
+            return true;
+        }
+
+        @Override
+        public EntryProcessor<String, DirtyJobMemberEvent, Boolean> getBackupProcessor() {
+            return this;
+        }
+    }
+
+    /** Advances a new job to the current watermark before scheduling can begin. */
+    private static class AdvanceSequenceProcessor extends DirtyJobProcessor<Void> {
+        private static final long serialVersionUID = 1L;
+        private final long jobId;
+        private final long jobCreateTime;
+        private final int threshold;
+        private final int eventHistorySize;
+        private final long pendingIncidentTtlMillis;
+        private final long memberEventSequence;
+
+        private AdvanceSequenceProcessor(
+                long jobId,
+                long jobCreateTime,
+                int threshold,
+                int eventHistorySize,
+                long pendingIncidentTtlMillis,
+                long memberEventSequence) {
+            this.jobId = jobId;
+            this.jobCreateTime = jobCreateTime;
+            this.threshold = threshold;
+            this.eventHistorySize = eventHistorySize;
+            this.pendingIncidentTtlMillis = pendingIncidentTtlMillis;
+            this.memberEventSequence = memberEventSequence;
+        }
+
+        @Override
+        public Void process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (state != null && !isOwnedBy(state, jobCreateTime)) {
+                return null;
+            }
+            if (state == null) {
+                state =
+                        DirtyJobState.create(
+                                jobId,
+                                jobCreateTime,
+                                threshold,
+                                eventHistorySize,
+                                pendingIncidentTtlMillis,
+                                memberEventSequence);
+                state.markTrackingIncomplete(
+                        "Dirty-job state was missing before the job became schedulable");
+            }
+            state.advanceMemberEventSequence(memberEventSequence);
+            entry.setValue(state);
+            return null;
+        }
+    }
+
+    /** Records one member-loss incident and the pipelines assigned to that member. */
+    private static class MemberEventProcessor extends DirtyJobProcessor<Void> {
+        private static final long serialVersionUID = 1L;
+
+        private final long jobId;
+        private final long jobCreateTime;
+        private final int threshold;
+        private final int eventHistorySize;
+        private final long pendingIncidentTtlMillis;
+        private final long memberEventSequence;
+        private final String lostMemberUuid;
+        private final String lostAddress;
+        private final Collection<Integer> affectedPipelineIds;
+        private final long timestamp;
+
+        private MemberEventProcessor(
+                long jobId,
+                long jobCreateTime,
+                int threshold,
+                int eventHistorySize,
+                long pendingIncidentTtlMillis,
+                long memberEventSequence,
+                String lostMemberUuid,
+                String lostAddress,
+                Collection<Integer> affectedPipelineIds,
+                long timestamp) {
+            this.jobId = jobId;
+            this.jobCreateTime = jobCreateTime;
+            this.threshold = threshold;
+            this.eventHistorySize = eventHistorySize;
+            this.pendingIncidentTtlMillis = pendingIncidentTtlMillis;
+            this.memberEventSequence = memberEventSequence;
+            this.lostMemberUuid = lostMemberUuid;
+            this.lostAddress = lostAddress;
+            this.affectedPipelineIds =
+                    affectedPipelineIds == null ? Collections.emptyList() : affectedPipelineIds;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Void process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (state != null && !isOwnedBy(state, jobCreateTime)) {
+                return null;
+            }
+            if (state == null) {
+                state =
+                        DirtyJobState.create(
+                                jobId,
+                                jobCreateTime,
+                                threshold,
+                                eventHistorySize,
+                                pendingIncidentTtlMillis,
+                                Math.max(0L, memberEventSequence - 1L));
+                state.markTrackingIncomplete(
+                        "Dirty-job state was missing while processing member loss");
+            }
+            state.processMemberEvent(
+                    memberEventSequence,
+                    lostMemberUuid,
+                    lostAddress,
+                    MemberLeaveClassification.UNCLASSIFIED,
+                    affectedPipelineIds,
+                    timestamp);
+            entry.setValue(state);
+            return null;
+        }
+    }
+
+    /** Allocates or reuses a stable attempt identity before deployment starts. */
+    private static class PrepareAttemptProcessor extends DirtyJobProcessor<String> {
+        private static final long serialVersionUID = 1L;
+        private final long expectedJobCreateTime;
+        private final int pipelineId;
+        private final long timestamp;
+
+        private PrepareAttemptProcessor(
+                long expectedJobCreateTime, int pipelineId, long timestamp) {
+            this.expectedJobCreateTime = expectedJobCreateTime;
+            this.pipelineId = pipelineId;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public String process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (!isOwnedBy(state, expectedJobCreateTime)) {
+                return null;
+            }
+            String attemptId = state.prepareRecoveryAttempt(pipelineId, timestamp);
+            entry.setValue(state);
+            return attemptId;
+        }
+    }
+
+    /** Counts an attempt only after persisted pipeline state proves deployment started. */
+    private static class ConfirmAttemptProcessor extends DirtyJobProcessor<Void> {
+        private static final long serialVersionUID = 1L;
+        private final long expectedJobCreateTime;
+        private final int pipelineId;
+        private final String attemptId;
+        private final long timestamp;
+
+        private ConfirmAttemptProcessor(
+                long expectedJobCreateTime, int pipelineId, String attemptId, long timestamp) {
+            this.expectedJobCreateTime = expectedJobCreateTime;
+            this.pipelineId = pipelineId;
+            this.attemptId = attemptId;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Void process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (isOwnedBy(state, expectedJobCreateTime)) {
+                state.confirmRecoveryAttempt(pipelineId, attemptId, timestamp);
+                entry.setValue(state);
+            }
+            return null;
+        }
+    }
+
+    /** Completes one affected pipeline after all task groups report RUNNING. */
+    private static class CompletePipelineProcessor extends DirtyJobProcessor<Void> {
+        private static final long serialVersionUID = 1L;
+        private final long expectedJobCreateTime;
+        private final int pipelineId;
+        private final String attemptId;
+        private final long timestamp;
+
+        private CompletePipelineProcessor(
+                long expectedJobCreateTime, int pipelineId, String attemptId, long timestamp) {
+            this.expectedJobCreateTime = expectedJobCreateTime;
+            this.pipelineId = pipelineId;
+            this.attemptId = attemptId;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Void process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (isOwnedBy(state, expectedJobCreateTime)) {
+                state.completeRecoveryPipeline(pipelineId, attemptId, timestamp);
+                entry.setValue(state);
+            }
+            return null;
+        }
+    }
+
+    /** Rebinds persisted deployment state to its stable attempt after an active-master switch. */
+    private static class ReconcilePipelineProcessor extends DirtyJobProcessor<String> {
+        private static final long serialVersionUID = 1L;
+        private final long expectedJobCreateTime;
+        private final int pipelineId;
+        private final boolean recovered;
+        private final long timestamp;
+
+        private ReconcilePipelineProcessor(
+                long expectedJobCreateTime, int pipelineId, boolean recovered, long timestamp) {
+            this.expectedJobCreateTime = expectedJobCreateTime;
+            this.pipelineId = pipelineId;
+            this.recovered = recovered;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public String process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (isOwnedBy(state, expectedJobCreateTime)) {
+                String attemptId = state.confirmCurrentRecoveryAttempt(pipelineId, timestamp);
+                if (recovered) {
+                    state.completeCurrentRecoveryPipeline(pipelineId, timestamp);
+                }
+                entry.setValue(state);
+                return attemptId;
+            }
+            return null;
+        }
+    }
+
+    /** Closes any unfinished episode before terminal history is persisted. */
+    private static class FinishEpisodeProcessor extends DirtyJobProcessor<DirtyJobState> {
+        private static final long serialVersionUID = 1L;
+        private final long expectedJobCreateTime;
+        private final long timestamp;
+
+        private FinishEpisodeProcessor(long expectedJobCreateTime, long timestamp) {
+            this.expectedJobCreateTime = expectedJobCreateTime;
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public DirtyJobState process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (isOwnedBy(state, expectedJobCreateTime)) {
+                state.finishActiveEpisode(timestamp);
+                entry.setValue(state);
+                return state;
+            }
+            return null;
+        }
+    }
+
+    /** Permanently changes the matching execution to UNKNOWN after tracking evidence is lost. */
+    private static class MarkIncompleteProcessor extends DirtyJobProcessor<Void> {
+        private static final long serialVersionUID = 1L;
+        private final long expectedJobCreateTime;
+        private final String reason;
+
+        private MarkIncompleteProcessor(long expectedJobCreateTime, String reason) {
+            this.expectedJobCreateTime = expectedJobCreateTime;
+            this.reason = reason;
+        }
+
+        @Override
+        public Void process(Map.Entry<Long, DirtyJobState> entry) {
+            DirtyJobState state = entry.getValue();
+            if (isOwnedBy(state, expectedJobCreateTime)) {
+                state.markTrackingIncomplete(reason);
+                entry.setValue(state);
+            }
+            return null;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
@@ -57,6 +57,8 @@ public class RestConstant {
     public static final String ERROR_MSG = "errorMsg";
 
     public static final String METRICS = "metrics";
+
+    public static final String DIRTY_TASK = "dirtyTask";
     public static final String LIMIT = "limit";
 
     public static final String TABLE_SOURCE_RECEIVED_COUNT = "TableSourceReceivedCount";

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseService.java
@@ -33,6 +33,7 @@ import org.apache.seatunnel.common.constants.PluginType;
 import org.apache.seatunnel.common.utils.DateTimeUtils;
 import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.common.job.DirtyJobState;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.core.classloader.ClassLoaderService;
@@ -450,6 +451,13 @@ public abstract class BaseService {
                 .add(
                         RestConstant.METRICS,
                         metricsToJsonObject(getJobMetrics(jobMetrics, jobDAGInfo)));
+        DirtyJobState dirtyJobState = createUnknownDirtyJobState(jobImmutableInformation);
+        if (dirtyJobState != null) {
+            dirtyJobState =
+                    resolveConfiguredDirtyJobState(
+                            jobImmutableInformation, loadDirtyJobState(jobId));
+        }
+        addDirtyJobState(jobInfoJson, dirtyJobState);
 
         if (jobStatus != null && jobStatus.isEndState()) {
             RUNNING_JOB_DAG_JSON_CACHE.remove(jobId);
@@ -508,37 +516,238 @@ public abstract class BaseService {
 
     protected JsonObject getJobInfoJson(
             JobHistoryService.JobState jobState, String jobMetrics, JobDAGInfo jobDAGInfo) {
-        return new JsonObject()
-                .add(RestConstant.JOB_ID, String.valueOf(jobState.getJobId()))
-                .add(RestConstant.JOB_NAME, jobState.getJobName())
-                .add(RestConstant.JOB_STATUS, jobState.getJobStatus().toString())
-                .add(RestConstant.ERROR_MSG, jobState.getErrorMessage())
-                .add(
-                        RestConstant.CREATE_TIME,
-                        DateTimeUtils.toString(
-                                jobState.getSubmitTime(),
-                                DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
-                .add(
-                        RestConstant.START_TIME,
-                        jobState.getStartTime() == null
-                                ? ""
-                                : DateTimeUtils.toString(
-                                        jobState.getStartTime(),
+        JsonObject jobInfoJson =
+                new JsonObject()
+                        .add(RestConstant.JOB_ID, String.valueOf(jobState.getJobId()))
+                        .add(RestConstant.JOB_NAME, jobState.getJobName())
+                        .add(RestConstant.JOB_STATUS, jobState.getJobStatus().toString())
+                        .add(RestConstant.ERROR_MSG, jobState.getErrorMessage())
+                        .add(
+                                RestConstant.CREATE_TIME,
+                                DateTimeUtils.toString(
+                                        jobState.getSubmitTime(),
                                         DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
-                .add(
-                        RestConstant.FINISH_TIME,
-                        jobState.getFinishTime() == null
-                                ? ""
-                                : DateTimeUtils.toString(
-                                        jobState.getFinishTime(),
-                                        DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
-                .add(
-                        RestConstant.JOB_DAG,
-                        jobDAGInfo != null ? jobDAGInfo.toJsonObject() : new JsonObject())
-                .add(RestConstant.PLUGIN_JARS_URLS, new JsonArray())
-                .add(
-                        RestConstant.METRICS,
-                        metricsToJsonObject(getJobMetrics(jobMetrics, jobDAGInfo)));
+                        .add(
+                                RestConstant.START_TIME,
+                                jobState.getStartTime() == null
+                                        ? ""
+                                        : DateTimeUtils.toString(
+                                                jobState.getStartTime(),
+                                                DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
+                        .add(
+                                RestConstant.FINISH_TIME,
+                                jobState.getFinishTime() == null
+                                        ? ""
+                                        : DateTimeUtils.toString(
+                                                jobState.getFinishTime(),
+                                                DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS))
+                        .add(
+                                RestConstant.JOB_DAG,
+                                jobDAGInfo != null ? jobDAGInfo.toJsonObject() : new JsonObject())
+                        .add(RestConstant.PLUGIN_JARS_URLS, new JsonArray())
+                        .add(
+                                RestConstant.METRICS,
+                                metricsToJsonObject(getJobMetrics(jobMetrics, jobDAGInfo)));
+        addDirtyJobState(jobInfoJson, jobState.getDirtyTask());
+        return jobInfoJson;
+    }
+
+    protected DirtyJobState loadDirtyJobState(long jobId) {
+        DirtyJobState state = null;
+        try {
+            IMap<Long, DirtyJobState> dirtyJobStateMap =
+                    nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_DIRTY_JOB_STATE);
+            state = dirtyJobStateMap.get(jobId);
+            if (state == null) {
+                return null;
+            }
+            IMap<Long, Long> memberEventSequenceMap =
+                    nodeEngine
+                            .getHazelcastInstance()
+                            .getMap(Constant.IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE);
+            long sequence = memberEventSequenceMap.getOrDefault(0L, 0L);
+            return applyLocalDirtyJobGuard(jobId, state.evaluatedCopy(sequence));
+        } catch (Throwable error) {
+            log.warn("Failed to load dirty-job state for job {}", jobId, error);
+            if (state != null) {
+                state = state.evaluatedCopy(state.getLastProcessedMemberEventSequence());
+                state.markTrackingIncomplete("Failed to read dirty-job tracking state");
+            }
+            return applyLocalDirtyJobGuard(jobId, state);
+        }
+    }
+
+    protected DirtyJobState createUnknownDirtyJobState(
+            JobImmutableInformation jobImmutableInformation) {
+        if (jobImmutableInformation == null || jobImmutableInformation.getJobConfig() == null) {
+            return null;
+        }
+        int threshold =
+                ReadonlyConfig.fromMap(jobImmutableInformation.getJobConfig().getEnvOptions())
+                        .get(EnvCommonOptions.DIRTY_JOB_RESTORE_THRESHOLD);
+        if (threshold <= 0) {
+            return null;
+        }
+        DirtyJobState state =
+                DirtyJobState.create(
+                        jobImmutableInformation.getJobId(),
+                        jobImmutableInformation.getCreateTime(),
+                        threshold,
+                        1,
+                        1L,
+                        0L);
+        state.markTrackingIncomplete("Dirty-job state is unavailable");
+        return state;
+    }
+
+    /**
+     * Rejects state retained for a previous execution of the same job ID.
+     *
+     * @return current evaluated state, query-only UNKNOWN state, or null when tracking is disabled
+     */
+    protected DirtyJobState resolveConfiguredDirtyJobState(
+            JobImmutableInformation jobImmutableInformation, DirtyJobState persistedState) {
+        DirtyJobState configuredState = createUnknownDirtyJobState(jobImmutableInformation);
+        if (configuredState == null) {
+            return null;
+        }
+        if (persistedState == null) {
+            return configuredState;
+        }
+        if (persistedState.getJobCreateTime() != configuredState.getJobCreateTime()
+                || persistedState.getThreshold() != configuredState.getThreshold()) {
+            configuredState.markTrackingIncomplete(
+                    "Dirty-job state belongs to a different job execution or configuration");
+            return configuredState;
+        }
+        return persistedState;
+    }
+
+    protected Map<Long, DirtyJobState> loadAllDirtyJobStates() {
+        Map<Long, DirtyJobState> states = new HashMap<>();
+        try {
+            IMap<Long, DirtyJobState> dirtyJobStateMap =
+                    nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_DIRTY_JOB_STATE);
+            dirtyJobStateMap.forEach(states::put);
+        } catch (Throwable error) {
+            log.warn("Failed to load dirty-job states", error);
+            states.values()
+                    .forEach(
+                            state ->
+                                    state.markTrackingIncomplete(
+                                            "Failed to read dirty-job tracking state"));
+            return states;
+        }
+        try {
+            IMap<Long, Long> memberEventSequenceMap =
+                    nodeEngine
+                            .getHazelcastInstance()
+                            .getMap(Constant.IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE);
+            long sequence = memberEventSequenceMap.getOrDefault(0L, 0L);
+            states.replaceAll(
+                    (jobId, state) ->
+                            applyLocalDirtyJobGuard(jobId, state.evaluatedCopy(sequence)));
+        } catch (Throwable error) {
+            log.warn("Failed to load dirty-job member-event sequence", error);
+            states.replaceAll(
+                    (jobId, state) -> {
+                        DirtyJobState evaluated =
+                                state.evaluatedCopy(state.getLastProcessedMemberEventSequence());
+                        evaluated.markTrackingIncomplete(
+                                "Failed to read dirty-job member-event sequence");
+                        return evaluated;
+                    });
+        }
+        return states;
+    }
+
+    private DirtyJobState applyLocalDirtyJobGuard(long jobId, DirtyJobState state) {
+        if (state == null) {
+            return null;
+        }
+        try {
+            SeaTunnelServer seaTunnelServer = getSeaTunnelServer(true);
+            if (seaTunnelServer != null
+                    && seaTunnelServer.getCoordinatorService().getDirtyJobService() != null) {
+                return seaTunnelServer
+                        .getCoordinatorService()
+                        .getDirtyJobService()
+                        .markUnknownIfLocallyIncomplete(jobId, state);
+            }
+        } catch (Throwable error) {
+            state.markTrackingIncomplete("Failed to read local dirty-job tracking health");
+        }
+        return state;
+    }
+
+    /**
+     * Loads the compact enabled-job markers used to distinguish disabled jobs from missing state.
+     */
+    protected Map<Long, Integer> loadDirtyJobThresholds() {
+        Map<Long, Integer> thresholds = new HashMap<>();
+        try {
+            IMap<Long, Integer> thresholdMap =
+                    nodeEngine
+                            .getHazelcastInstance()
+                            .getMap(Constant.IMAP_DIRTY_JOB_ENABLED_THRESHOLDS);
+            thresholdMap.forEach(thresholds::put);
+        } catch (Throwable error) {
+            log.warn("Failed to load dirty-job enabled thresholds", error);
+            return null;
+        }
+        return thresholds;
+    }
+
+    /**
+     * Creates a query-only UNKNOWN state when the enabled marker exists but runtime state does not.
+     */
+    protected DirtyJobState createUnknownDirtyJobState(long jobId, int threshold) {
+        DirtyJobState state = DirtyJobState.create(jobId, threshold, 1, 1L, 0L);
+        state.markTrackingIncomplete("Dirty-job state is unavailable");
+        return state;
+    }
+
+    protected void addDirtyJobSummary(JsonObject target, DirtyJobState state) {
+        if (state == null) {
+            return;
+        }
+        target.add(
+                RestConstant.DIRTY_TASK,
+                new JsonObject()
+                        .add("dirty", state.isDirty())
+                        .add("evaluationStatus", state.getEvaluationStatus().name())
+                        .add("recoveryAttemptCount", state.getRecoveryAttemptCount()));
+    }
+
+    protected void addDirtyJobState(JsonObject target, DirtyJobState state) {
+        if (state == null) {
+            return;
+        }
+        String activeEpisodeId =
+                state.getActiveEpisode() == null ? null : state.getActiveEpisode().getEpisodeId();
+        JsonObject dirtyTask =
+                new JsonObject()
+                        .add("dirty", state.isDirty())
+                        .add("evaluationStatus", state.getEvaluationStatus().name())
+                        .add("trackingComplete", state.isTrackingComplete())
+                        .add("threshold", state.getThreshold())
+                        .add("recoveryAttemptCount", state.getRecoveryAttemptCount())
+                        .add("recoveryEpisodeCount", state.getRecoveryEpisodeCount())
+                        .add("memberLossIncidentCount", state.getMemberLossIncidentCount())
+                        .add("activeEpisodeId", activeEpisodeId)
+                        .add(
+                                "lastLeaveClassification",
+                                state.getLastLeaveClassification() == null
+                                        ? null
+                                        : state.getLastLeaveClassification().name())
+                        .add("lastLostMemberUuid", state.getLastLostMemberUuid())
+                        .add("lastLostAddress", state.getLastLostAddress())
+                        .add(
+                                "lastCountedTime",
+                                state.getLastCountedTime() == null
+                                        ? JsonValue.NULL
+                                        : JsonValue.valueOf(state.getLastCountedTime()));
+        target.add(RestConstant.DIRTY_TASK, dirtyTask);
     }
 
     private Map<String, Object> getJobMetrics(String jobMetrics, JobDAGInfo jobDAGInfo) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/JobInfoService.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.config.sql.SqlConfigBuilder;
 import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
 import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.job.DirtyJobState;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.core.job.JobDAGInfo;
 import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
@@ -190,6 +191,8 @@ public class JobInfoService extends BaseService {
         IMap<Long, JobInfo> values = getRunningJobInfoMap();
         IMap<Object, Object> jobStateMap = getRunningJobStateMap();
         SeaTunnelServer seaTunnelServer = getSeaTunnelServer(true);
+        Map<Long, Integer> dirtyJobThresholds = loadDirtyJobThresholds();
+        Map<Long, DirtyJobState> dirtyJobStates = loadAllDirtyJobStates();
 
         long decodeTotalNs = 0L;
         JsonArray out = new JsonArray();
@@ -229,12 +232,24 @@ public class JobInfoService extends BaseService {
                 // ignore
             }
 
-            out.add(
+            JsonObject jobSummary =
                     new JsonObject()
                             .add(RestConstant.JOB_ID, String.valueOf(jobId))
                             .add(RestConstant.JOB_NAME, jobName)
                             .add(RestConstant.JOB_STATUS, jobStatus)
-                            .add(RestConstant.CREATE_TIME, createTime));
+                            .add(RestConstant.CREATE_TIME, createTime);
+            DirtyJobState dirtyJobState = dirtyJobStates.get(jobId);
+            Integer dirtyJobThreshold =
+                    dirtyJobThresholds == null ? null : dirtyJobThresholds.get(jobId);
+            if (dirtyJobState != null || dirtyJobThreshold != null) {
+                dirtyJobState =
+                        resolveConfiguredDirtyJobState(
+                                decodeJobImmutableInformation(jobInfo), dirtyJobState);
+            } else if (dirtyJobThresholds == null) {
+                dirtyJobState = createUnknownDirtyJobState(decodeJobImmutableInformation(jobInfo));
+            }
+            addDirtyJobSummary(jobSummary, dirtyJobState);
+            out.add(jobSummary);
         }
 
         if (!runningJobBasicInfoCache.isEmpty() && !jobIds.isEmpty()) {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.config.server.ScheduleStrategy;
 import org.apache.seatunnel.engine.common.exception.JobNotFoundException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
+import org.apache.seatunnel.engine.common.job.DirtyJobMemberEvent;
 import org.apache.seatunnel.engine.common.job.JobResult;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
@@ -50,6 +51,8 @@ import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
 import org.apache.seatunnel.engine.server.master.JobHistoryService;
 import org.apache.seatunnel.engine.server.master.JobMaster;
+import org.apache.seatunnel.engine.server.master.cleanup.JobCleanupRecord;
+import org.apache.seatunnel.engine.server.master.dirty.DirtyJobService;
 import org.apache.seatunnel.engine.server.metrics.SeaTunnelMetricsContext;
 import org.apache.seatunnel.engine.server.operation.PrintMessageOperation;
 import org.apache.seatunnel.engine.server.operation.ReturnRetryTimesOperation;
@@ -275,6 +278,94 @@ public class CoordinatorServiceTest {
         instance2.shutdown();
     }
 
+    @Test
+    void testTerminalZombieCleanupShouldRetainPendingRetryWhenDirtyStateRemovalFails()
+            throws Exception {
+        String clusterName =
+                TestUtils.getClusterName(
+                        "CoordinatorServiceTest_testTerminalZombieCleanupShouldRetainPendingRetryWhenDirtyStateRemovalFails");
+        HazelcastInstanceImpl instance =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        try {
+            SeaTunnelServer server =
+                    instance.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+            await().atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertTrue(server.isMasterNode());
+                                Assertions.assertTrue(
+                                        server.getCoordinatorService().isCoordinatorActive());
+                            });
+
+            CoordinatorService coordinatorService = server.getCoordinatorService();
+            long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+            LogicalDag logicalDag =
+                    TestUtils.createTestLogicalPlan(
+                            "stream_fake_to_console.conf",
+                            "terminal-zombie-cleanup-retry-test",
+                            jobId);
+            JobImmutableInformation jobImmutableInformation =
+                    new JobImmutableInformation(
+                            jobId,
+                            "Test",
+                            instance.getSerializationService(),
+                            logicalDag,
+                            Collections.emptyList(),
+                            Collections.emptyList());
+            long initializationTimestamp = System.currentTimeMillis();
+            JobInfo jobInfo =
+                    new JobInfo(
+                            initializationTimestamp,
+                            instance.getSerializationService().toData(jobImmutableInformation));
+
+            IMap<Long, JobInfo> runningJobInfoIMap =
+                    instance.getMap(Constant.IMAP_RUNNING_JOB_INFO);
+            IMap<Object, Object> runningJobStateIMap =
+                    instance.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+            @SuppressWarnings("unchecked")
+            IMap<Long, JobCleanupRecord> pendingJobCleanupIMap =
+                    (IMap<Long, JobCleanupRecord>)
+                            ReflectionUtils.getField(coordinatorService, "pendingJobCleanupIMap")
+                                    .orElseThrow(
+                                            () ->
+                                                    new AssertionError(
+                                                            "pendingJobCleanupIMap not found"));
+
+            runningJobInfoIMap.put(jobId, jobInfo);
+            runningJobStateIMap.put(jobId, JobStatus.CANCELED);
+
+            DirtyJobService dirtyJobService = Mockito.mock(DirtyJobService.class);
+            Mockito.when(dirtyJobService.removeRunningState(jobId)).thenReturn(false);
+            Mockito.when(
+                            dirtyJobService.createUnknownState(
+                                    Mockito.any(JobImmutableInformation.class),
+                                    Mockito.anyString()))
+                    .thenReturn(null);
+            ReflectionUtils.setField(coordinatorService, "dirtyJobService", dirtyJobService);
+
+            invokeCleanupTerminalZombieJob(coordinatorService, jobId, jobInfo, JobStatus.CANCELED);
+
+            await().atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertFalse(
+                                        runningJobInfoIMap.containsKey(jobId),
+                                        "runningJobInfoIMap should be removed after zombie cleanup");
+                                Assertions.assertTrue(
+                                        pendingJobCleanupIMap.containsKey(jobId),
+                                        "pending job cleanup record should be retained for retry");
+                            });
+
+            JobCleanupRecord cleanupRecord = pendingJobCleanupIMap.get(jobId);
+            Assertions.assertNotNull(cleanupRecord);
+            Assertions.assertEquals(
+                    initializationTimestamp, cleanupRecord.getOwnerInitializationTimestamp());
+            Mockito.verify(dirtyJobService, Mockito.atLeastOnce()).removeRunningState(jobId);
+        } finally {
+            instance.shutdown();
+        }
+    }
+
     private boolean allTaskGroupsInactive(
             SeaTunnelServer server, List<TaskGroupLocation> taskGroupLocations) {
         for (TaskGroupLocation location : taskGroupLocations) {
@@ -334,6 +425,51 @@ public class CoordinatorServiceTest {
                                 Assertions.fail("Should not throw SeaTunnelEngineException here.");
                             }
                         });
+        instance2.shutdown();
+    }
+
+    @Test
+    void testMemberEventJournalSurvivesMasterSwitch() {
+        String clusterName =
+                TestUtils.getClusterName(
+                        "CoordinatorServiceTest_testMemberEventJournalSurvivesMasterSwitch");
+        HazelcastInstanceImpl instance1 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        HazelcastInstanceImpl instance2 =
+                createHazelcastInstanceWithJoinPortTryCount(clusterName, 100);
+        SeaTunnelServer server1 =
+                instance1.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+        SeaTunnelServer server2 =
+                instance2.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+
+        await().atMost(20, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server1.isMasterNode());
+                            Assertions.assertTrue(
+                                    server1.getCoordinatorService().isCoordinatorActive());
+                            Assertions.assertEquals(2, instance1.getCluster().getMembers().size());
+                        });
+
+        instance1.shutdown();
+
+        IMap<Long, Long> memberEventSequenceMap =
+                instance2.getMap(Constant.IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE);
+        IMap<String, DirtyJobMemberEvent> pendingMemberEventMap =
+                instance2.getMap(Constant.IMAP_DIRTY_JOB_PENDING_MEMBER_EVENTS);
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(server2.isMasterNode());
+                            Assertions.assertTrue(
+                                    server2.getCoordinatorService().isCoordinatorActive());
+                            Assertions.assertTrue(
+                                    memberEventSequenceMap.getOrDefault(0L, 0L) >= 1L);
+                            Assertions.assertTrue(
+                                    pendingMemberEventMap.values().stream()
+                                            .anyMatch(event -> event.getSequence() >= 1L));
+                        });
+
         instance2.shutdown();
     }
 
@@ -1215,9 +1351,19 @@ public class CoordinatorServiceTest {
             CoordinatorService coordinatorService, long jobId, JobInfo jobInfo) throws Exception {
         Method method =
                 CoordinatorService.class.getDeclaredMethod(
-                        "restoreJobFromMasterActiveSwitch", Long.class, JobInfo.class);
+                        "restoreJobFromMasterActiveSwitch", Long.class, JobInfo.class, Map.class);
         method.setAccessible(true);
-        method.invoke(coordinatorService, jobId, jobInfo);
+        method.invoke(coordinatorService, jobId, jobInfo, Collections.emptyMap());
+    }
+
+    private void invokeCleanupTerminalZombieJob(
+            CoordinatorService coordinatorService, long jobId, JobInfo jobInfo, JobStatus status)
+            throws Exception {
+        Method method =
+                CoordinatorService.class.getDeclaredMethod(
+                        "cleanupTerminalZombieJob", long.class, JobInfo.class, JobStatus.class);
+        method.setAccessible(true);
+        method.invoke(coordinatorService, jobId, jobInfo, status);
     }
 
     private void invokeCheckNewActiveMaster(CoordinatorService coordinatorService)

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/DirtyJobMapConfigTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/DirtyJobMapConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server;
+
+import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.config.MapConfig;
+
+/**
+ * Verifies every dirty-job map is configured with synchronous backups before cluster startup.
+ *
+ * <p>This prevents a partition-owner change from silently discarding tracking evidence.
+ */
+class DirtyJobMapConfigTest {
+
+    @Test
+    void shouldConfigureSynchronousBackupsBeforeMapCreation() {
+        SeaTunnelConfig seaTunnelConfig = new SeaTunnelConfig();
+        seaTunnelConfig.getEngineConfig().setBackupCount(2);
+
+        SeaTunnelServerStarter.configureDirtyJobMaps(seaTunnelConfig);
+
+        assertMapConfig(seaTunnelConfig, Constant.IMAP_DIRTY_JOB_STATE);
+        assertMapConfig(seaTunnelConfig, Constant.IMAP_DIRTY_JOB_MEMBER_EVENT_SEQUENCE);
+        assertMapConfig(seaTunnelConfig, Constant.IMAP_DIRTY_JOB_PENDING_MEMBER_EVENTS);
+        assertMapConfig(seaTunnelConfig, Constant.IMAP_DIRTY_JOB_ENABLED_THRESHOLDS);
+    }
+
+    private void assertMapConfig(SeaTunnelConfig seaTunnelConfig, String mapName) {
+        MapConfig mapConfig = seaTunnelConfig.getHazelcastConfig().getMapConfigs().get(mapName);
+        Assertions.assertNotNull(mapConfig);
+        Assertions.assertEquals(2, mapConfig.getBackupCount());
+        Assertions.assertEquals(0, mapConfig.getAsyncBackupCount());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobServiceTest.java
@@ -17,11 +17,14 @@
 
 package org.apache.seatunnel.engine.server.master.dirty;
 
+import org.apache.seatunnel.engine.common.job.DirtyJobMemberEvent;
 import org.apache.seatunnel.engine.common.job.DirtyJobState;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -71,5 +74,29 @@ class DirtyJobServiceTest {
         DirtyJobService.registerLocalOwner(owners, incompleteOwners, 1L, 200L, true);
 
         Assertions.assertFalse(incompleteOwners.containsKey(1L));
+    }
+
+    @Test
+    void shouldInjectGapEventWhenPendingJournalReadFailsWithoutLocalFallback() {
+        List<DirtyJobMemberEvent> events =
+                DirtyJobService.buildFailClosedPendingMemberEvents(Collections.emptyList());
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals(-1L, events.get(0).getSequence());
+        Assertions.assertEquals("local-tracking-gap", events.get(0).getMemberUuid());
+    }
+
+    @Test
+    void shouldPreserveLocalFallbackWhileFailingClosedAfterJournalReadFailure() {
+        DirtyJobMemberEvent localEvent =
+                new DirtyJobMemberEvent(7L, "member-1", "127.0.0.1", 5801, 1_000L);
+
+        List<DirtyJobMemberEvent> events =
+                DirtyJobService.buildFailClosedPendingMemberEvents(
+                        Collections.singletonList(localEvent));
+
+        Assertions.assertEquals(2, events.size());
+        Assertions.assertEquals("local-tracking-gap", events.get(0).getMemberUuid());
+        Assertions.assertEquals(localEvent, events.get(1));
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/dirty/DirtyJobServiceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master.dirty;
+
+import org.apache.seatunnel.engine.common.job.DirtyJobState;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Protects execution-owner isolation for delayed dirty-job state processors. */
+class DirtyJobServiceTest {
+
+    @Test
+    void shouldRejectUnknownOrPreviousExecutionOwner() {
+        DirtyJobState state = DirtyJobState.create(1L, 200L, 2, 10, 600_000L, 0L);
+
+        Assertions.assertTrue(DirtyJobService.isOwnedBy(state, 200L));
+        Assertions.assertFalse(DirtyJobService.isOwnedBy(state, 100L));
+        Assertions.assertFalse(DirtyJobService.isOwnedBy(state, 0L));
+    }
+
+    @Test
+    void shouldNotReplaceCurrentIncompleteOwnerWithStaleRetry() {
+        Map<Long, Long> owners = new ConcurrentHashMap<>();
+        Map<Long, Long> incompleteOwners = new ConcurrentHashMap<>();
+        DirtyJobService.registerLocalOwner(owners, incompleteOwners, 1L, 200L, false);
+        Assertions.assertTrue(
+                DirtyJobService.registerLocalIncompleteOwner(owners, incompleteOwners, 1L, 200L));
+
+        Assertions.assertFalse(
+                DirtyJobService.registerLocalIncompleteOwner(owners, incompleteOwners, 1L, 100L));
+        Assertions.assertEquals(200L, incompleteOwners.get(1L));
+    }
+
+    @Test
+    void shouldRetainEarlyIncompleteEvidenceForSameRestoredExecution() {
+        Map<Long, Long> owners = new ConcurrentHashMap<>();
+        Map<Long, Long> incompleteOwners = new ConcurrentHashMap<>();
+        Assertions.assertTrue(
+                DirtyJobService.registerLocalIncompleteOwner(owners, incompleteOwners, 1L, 200L));
+
+        DirtyJobService.registerLocalOwner(owners, incompleteOwners, 1L, 200L, true);
+
+        Assertions.assertEquals(200L, incompleteOwners.get(1L));
+    }
+
+    @Test
+    void shouldRemoveIncompleteEvidenceFromPreviousExecution() {
+        Map<Long, Long> owners = new ConcurrentHashMap<>();
+        Map<Long, Long> incompleteOwners = new ConcurrentHashMap<>();
+        incompleteOwners.put(1L, 100L);
+
+        DirtyJobService.registerLocalOwner(owners, incompleteOwners, 1L, 200L, true);
+
+        Assertions.assertFalse(incompleteOwners.containsKey(1L));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceNullSafetyTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/service/BaseServiceNullSafetyTest.java
@@ -17,8 +17,14 @@
 
 package org.apache.seatunnel.engine.server.rest.service;
 
+import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.common.job.DirtyJobEvaluationStatus;
+import org.apache.seatunnel.engine.common.job.DirtyJobState;
 import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.common.job.MemberLeaveClassification;
 import org.apache.seatunnel.engine.core.job.JobDAGInfo;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
 import org.apache.seatunnel.engine.server.master.JobHistoryService;
 import org.apache.seatunnel.engine.server.rest.RestConstant;
 
@@ -34,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BaseServiceNullSafetyTest {
 
@@ -112,6 +119,81 @@ public class BaseServiceNullSafetyTest {
     }
 
     @Test
+    public void testGetJobInfoJsonWithDirtyJobState() {
+        JobHistoryService.JobState jobState = buildJobState(1000L, 2000L);
+        DirtyJobState dirtyJobState = DirtyJobState.create(12345L, 1, 10, 600_000L, 0L);
+        dirtyJobState.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                100L);
+        String attemptId = dirtyJobState.prepareRecoveryAttempt(1, 110L);
+        dirtyJobState.confirmRecoveryAttempt(1, attemptId, 120L);
+        jobState.setDirtyTask(dirtyJobState);
+
+        JsonObject result = jobInfoService.getJobInfoJson(jobState, "{}", null);
+        JsonObject dirtyTask = result.get(RestConstant.DIRTY_TASK).asObject();
+
+        Assertions.assertTrue(dirtyTask.getBoolean("dirty", false));
+        Assertions.assertEquals("DIRTY", dirtyTask.getString("evaluationStatus", null));
+        Assertions.assertEquals(1, dirtyTask.getInt("recoveryAttemptCount", 0));
+        Assertions.assertEquals(
+                "UNCLASSIFIED", dirtyTask.getString("lastLeaveClassification", null));
+    }
+
+    @Test
+    public void testMissingEnabledDirtyJobStateIsUnknown() {
+        DirtyJobState dirtyJobState = jobInfoService.createUnknownDirtyJobState(12345L, 2);
+        JsonObject jobSummary = new JsonObject();
+
+        jobInfoService.addDirtyJobSummary(jobSummary, dirtyJobState);
+
+        JsonObject dirtyTask = jobSummary.get(RestConstant.DIRTY_TASK).asObject();
+        Assertions.assertFalse(dirtyTask.getBoolean("dirty", true));
+        Assertions.assertEquals("UNKNOWN", dirtyTask.getString("evaluationStatus", null));
+        Assertions.assertEquals(0, dirtyTask.getInt("recoveryAttemptCount", -1));
+    }
+
+    @Test
+    public void testResolveConfiguredDirtyJobStateAcceptsCurrentExecution() {
+        JobImmutableInformation jobInformation = createDirtyJobInformation(12345L, 200L, 2);
+        DirtyJobState persistedState = DirtyJobState.create(12345L, 200L, 2, 10, 600_000L, 0L);
+
+        DirtyJobState resolvedState =
+                jobInfoService.resolveConfiguredDirtyJobState(jobInformation, persistedState);
+
+        Assertions.assertSame(persistedState, resolvedState);
+        Assertions.assertEquals(
+                DirtyJobEvaluationStatus.CLEAN, resolvedState.getEvaluationStatus());
+    }
+
+    @Test
+    public void testResolveConfiguredDirtyJobStateRejectsPreviousExecution() {
+        JobImmutableInformation jobInformation = createDirtyJobInformation(12345L, 200L, 2);
+        DirtyJobState persistedState = DirtyJobState.create(12345L, 100L, 2, 10, 600_000L, 0L);
+        persistedState.processMemberEvent(
+                1L,
+                "member-1",
+                "10.0.0.1:5801",
+                MemberLeaveClassification.UNCLASSIFIED,
+                Collections.singletonList(1),
+                100L);
+        String attemptId = persistedState.prepareRecoveryAttempt(1, 110L);
+        persistedState.confirmRecoveryAttempt(1, attemptId, 120L);
+
+        DirtyJobState resolvedState =
+                jobInfoService.resolveConfiguredDirtyJobState(jobInformation, persistedState);
+
+        Assertions.assertNotSame(persistedState, resolvedState);
+        Assertions.assertEquals(200L, resolvedState.getJobCreateTime());
+        Assertions.assertEquals(
+                DirtyJobEvaluationStatus.UNKNOWN, resolvedState.getEvaluationStatus());
+        Assertions.assertEquals(0, resolvedState.getRecoveryAttemptCount());
+    }
+
+    @Test
     public void testMetricsToJsonObjectWithNonFiniteFloats() {
         // 1. We create an anonymous subclass of BaseService if it's abstract,
         // or just instantiate it if it's concrete.
@@ -148,5 +230,19 @@ public class BaseServiceNullSafetyTest {
         // Check the nested map
         JsonObject nestedResult = result.get("nested_map").asObject();
         Assertions.assertEquals("NaN", nestedResult.get("nested_nan").asString());
+    }
+
+    private JobImmutableInformation createDirtyJobInformation(
+            long jobId, long createTime, int threshold) {
+        JobImmutableInformation jobInformation = mock(JobImmutableInformation.class);
+        JobConfig jobConfig = mock(JobConfig.class);
+        when(jobInformation.getJobId()).thenReturn(jobId);
+        when(jobInformation.getCreateTime()).thenReturn(createTime);
+        when(jobInformation.getJobConfig()).thenReturn(jobConfig);
+        when(jobConfig.getEnvOptions())
+                .thenReturn(
+                        Collections.singletonMap(
+                                EnvCommonOptions.DIRTY_JOB_RESTORE_THRESHOLD.key(), threshold));
+        return jobInformation;
     }
 }


### PR DESCRIPTION
## Purpose of this pull request

Closes #11777.

This PR adds optional dirty-job tracking for SeaTunnel Zeta member-loss recovery attempts. A job can now expose `CLEAN`, `DIRTY`, or `UNKNOWN` evaluation metadata without changing the existing job status or retry behavior.

## What is included

- add the job option `job.dirty-task.threshold` and engine-side dirty-job tracker configuration;
- persist HA-backed dirty-job running state, member-event sequencing, and finished-job history snapshots;
- count only member-loss-driven recovery deployment generations after deployment actually starts;
- replay and reconcile pending member-loss events across active-master changes;
- expose additive dirty-job summary fields through running-job and finished-job REST responses;
- fail closed to `UNKNOWN` when tracking state is incomplete, including delayed-owner and zombie-cleanup retry paths;
- add unit and integration coverage for dirty-job state evaluation, config parsing, map config, null-safety, and coordinator recovery paths;
- document the new option in English and Chinese job configuration docs.

## Verification

- locally ran `./mvnw spotless:apply -pl seatunnel-api,seatunnel-engine/seatunnel-engine-common,seatunnel-engine/seatunnel-engine-server -nsu`
- did not run local compile/tests/E2E/package steps because this repository is under the current SeaTunnel GitHub-CI-only validation rule for functional verification

## Does this pull request potentially affect one of the following parts

- [ ] No. None of these.
- [ ] Dependency management
- [ ] Something that affects deployment
- [x] The core runtime module
- [x] The API
- [x] Default configuration values
- [ ] Introduces a breaking change
- [x] Documentations

## Documentation

- [x] This change is documented.
