### PR TITLE
[Fix][Connector-V2] Support text format in Pulsar source

### DIFF
--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -41,7 +41,7 @@ Source connector for Apache Pulsar.
 | cursor.stop.mode         | Enum    | No       | NEVER         | Stop position mode. Options: `NEVER` (streaming), `LATEST` (batch), `TIMESTAMP` (batch)                         |
 | cursor.stop.timestamp    | Long    | No       | -             | Stop timestamp (ms) when `cursor.stop.mode=TIMESTAMP`                                                            |
 | schema                   | Config  | No       | -             | Data structure including field names and types                                                                   |
-| format                   | String  | No       | json          | Data format. Default is json. Supported formats: json, canal_json and avro. **Multi-table mode only supports JSON, CANAL_JSON and AVRO**                            |
+| format                   | String  | No       | json          | Data format. Default is json. Supported formats: json, canal_json, avro and text. **Text is supported only in single-table mode; multi-table mode supports JSON, CANAL_JSON and AVRO** |
 | field_delimiter          | String  | No       | ,             | Field delimiter for `text` format.                                                                               |
 | common-options           |         | No       | -             | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md) for details           |
 
@@ -163,7 +163,7 @@ reference to [Schema-Feature](../../introduction/concepts/schema-feature.md)
 
 ### format [String]
 
-Data format. The default format is json. Supported formats are json, canal_json and avro. The `schema` option is required when using avro format. See [formats](../formats) for more details.
+Data format. The default format is json. Supported formats are json, canal_json, avro and text. The `schema` option is required when using avro format. Text format is supported only in single-table mode. See [formats](../formats) for more details.
 
 ### field_delimiter [String]
 
@@ -200,6 +200,31 @@ source {
         c_bigint = bigint
         c_double = double
         c_timestamp = timestamp
+      }
+    }
+  }
+}
+```
+
+### Read Text Messages
+
+Use `format = text` in single-table mode to split each message into schema fields with `field_delimiter`.
+
+```hocon
+source {
+  Pulsar {
+    topic = "text-events"
+    subscription.name = "seatunnel-text-sub"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
+    format = text
+    field_delimiter = "|"
+    schema = {
+      fields {
+        id = int
+        name = string
       }
     }
   }

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -41,7 +41,7 @@ Apache Pulsar 的源连接器。
 | cursor.stop.mode         | Enum    | 否    | NEVER  | 停止位置模式。可选值:`NEVER`(流式)、`LATEST`(批式)、`TIMESTAMP`(批式)                                       |
 | cursor.stop.timestamp    | Long    | 否    | -      | 当 `cursor.stop.mode=TIMESTAMP` 时的停止时间戳(毫秒)                                                |
 | schema                   | Config  | 否    | -      | 数据结构,包括字段名称和字段类型                                                                          |
-| format                   | String  | 否    | json   | 数据格式。默认为 json。支持 json、canal_json 和 avro 格式。**多表模式仅支持 JSON、CANAL_JSON 和 AVRO**                                               |
+| format                   | String  | 否    | json   | 数据格式。默认为 json。支持 json、canal_json、avro 和 text 格式。**text 仅支持单表模式；多表模式支持 JSON、CANAL_JSON 和 AVRO**                      |
 | field_delimiter          | String  | 否    | ,      | `text` 格式使用的字段分隔符。                                                                             |
 | common-options           |         | 否    | -      | Source 插件通用参数,请参考 [Source Common Options](../common-options/source-common-options.md) 了解详情               |
 
@@ -156,7 +156,7 @@ Pulsar 消费者的启动模式，有效值为 `'EARLIEST'`、`'LATEST'`、`'SUB
 
 ### format [String]
 
-数据格式。默认值为 `json`。支持 json、canal_json 和 avro 格式。使用 avro 格式时需要配置 `schema`。更多格式说明参考 [formats](../formats)。
+数据格式。默认值为 `json`。支持 json、canal_json、avro 和 text 格式。使用 avro 格式时需要配置 `schema`。text 格式仅支持单表模式。更多格式说明参考 [formats](../formats)。
 
 ### field_delimiter [String]
 
@@ -193,6 +193,31 @@ source {
         c_bigint = bigint
         c_double = double
         c_timestamp = timestamp
+      }
+    }
+  }
+}
+```
+
+### 读取 Text 消息
+
+在单表模式下使用 `format = text`，通过 `field_delimiter` 将每条消息拆分为 schema 中定义的字段。
+
+```hocon
+source {
+  Pulsar {
+    topic = "text-events"
+    subscription.name = "seatunnel-text-sub"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
+    format = text
+    field_delimiter = "|"
+    schema = {
+      fields {
+        id = int
+        name = string
       }
     }
   }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -320,13 +320,21 @@ public class PulsarMultiTableConfig implements Serializable {
                         ? String.format("tables_configs[%d] ('%s')", index, tablePath)
                         : "Pulsar source config";
         String normalized = format.toUpperCase();
-        if (!Objects.equals("JSON", normalized)
-                && !Objects.equals("CANAL_JSON", normalized)
-                && !Objects.equals("AVRO", normalized)) {
+        if (index >= 0 && Objects.equals("TEXT", normalized)) {
             throw new PulsarConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                     String.format(
-                            "%s uses unsupported format '%s', only JSON, CANAL_JSON and AVRO are supported",
+                            "%s uses format 'TEXT', but TEXT is only supported in single-table mode",
+                            configPrefix));
+        }
+        if (!Objects.equals("JSON", normalized)
+                && !Objects.equals("CANAL_JSON", normalized)
+                && !Objects.equals("AVRO", normalized)
+                && !Objects.equals("TEXT", normalized)) {
+            throw new PulsarConnectorException(
+                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                    String.format(
+                            "%s uses unsupported format '%s', only JSON, CANAL_JSON, AVRO and TEXT are supported",
                             configPrefix, format));
         }
     }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -56,6 +56,7 @@ import org.apache.seatunnel.format.avro.AvroDeserializationSchema;
 import org.apache.seatunnel.format.json.JsonDeserializationSchema;
 import org.apache.seatunnel.format.json.canal.CanalJsonDeserializationSchema;
 import org.apache.seatunnel.format.json.exception.SeaTunnelJsonFormatException;
+import org.apache.seatunnel.format.text.TextDeserializationSchema;
 
 import org.apache.pulsar.shade.org.apache.commons.lang3.StringUtils;
 
@@ -199,7 +200,7 @@ public class PulsarSource
                     new PulsarConsumerMetadata(
                             tablePath,
                             catalogTable,
-                            createDeserialization(tableConfig.getFormat(), catalogTable),
+                            createDeserialization(tableConfig, catalogTable),
                             createDiscoverer(tableConfig),
                             createStartCursor(tableConfig),
                             createStopCursor(tableConfig),
@@ -262,7 +263,8 @@ public class PulsarSource
     }
 
     private DeserializationSchema<SeaTunnelRow> createDeserialization(
-            String format, CatalogTable catalogTable) {
+            PulsarTableConfig tableConfig, CatalogTable catalogTable) {
+        String format = tableConfig.getFormat();
         switch (format.toUpperCase()) {
             case "JSON":
                 return new JsonDeserializationSchema(
@@ -274,6 +276,15 @@ public class PulsarSource
                                 .build());
             case "AVRO":
                 return new AvroDeserializationSchema(catalogTable);
+            case "TEXT":
+                return TextDeserializationSchema.builder()
+                        .seaTunnelRowType(catalogTable.getSeaTunnelRowType())
+                        .delimiter(
+                                tableConfig
+                                        .getSchemaConfig()
+                                        .get(PulsarSourceOptions.FIELD_DELIMITER))
+                        .setCatalogTable(catalogTable)
+                        .build();
             default:
                 throw new SeaTunnelJsonFormatException(
                         CommonErrorCode.UNSUPPORTED_DATA_TYPE, "Unsupported format: " + format);

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
@@ -74,6 +74,42 @@ class PulsarMultiTableConfigTest {
     }
 
     @Test
+    void shouldAllowTextFormatInSingleTable() {
+        Map<String, Object> config = createBaseConfig();
+        config.put("topic", "persistent://public/default/events");
+        config.put("format", "text");
+        config.put("field_delimiter", "|");
+
+        PulsarMultiTableConfig multiTableConfig =
+                PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config));
+
+        PulsarTableConfig tableConfig = multiTableConfig.getTableConfigs().get(0);
+        Assertions.assertEquals("text", tableConfig.getFormat());
+        Assertions.assertEquals(
+                "|", tableConfig.getSchemaConfig().get(PulsarSourceOptions.FIELD_DELIMITER));
+    }
+
+    @Test
+    void shouldRejectTextFormatInTablesConfigs() {
+        Map<String, Object> config = createBaseConfig();
+        config.put(
+                "tables_configs",
+                Collections.singletonList(
+                        createTableConfig(
+                                "db.events", "persistent://public/default/events", null, "text")));
+
+        PulsarConnectorException exception =
+                Assertions.assertThrows(
+                        PulsarConnectorException.class,
+                        () -> PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config)));
+
+        Assertions.assertEquals(
+                SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED, exception.getSeaTunnelErrorCode());
+        Assertions.assertTrue(
+                exception.getMessage().contains("TEXT is only supported in single-table mode"));
+    }
+
+    @Test
     void shouldRejectOverlappingTopicDeclarations() {
         Map<String, Object> config = createBaseConfig();
         config.put(

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -19,21 +19,54 @@ package org.apache.seatunnel.connectors.seatunnel.pulsar.source;
 
 import org.apache.seatunnel.api.common.JobContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
 import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.constants.JobMode;
 import org.apache.seatunnel.common.utils.SerializationUtils;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
+import org.apache.seatunnel.format.text.TextDeserializationSchema;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 class PulsarSourceTest {
+
+    @Test
+    void shouldDeserializeTextWithConfiguredFieldDelimiter() throws Exception {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put("topic", "persistent://public/default/events");
+        config.put("format", "text");
+        config.put("field_delimiter", "|");
+
+        PulsarSource source =
+                new PulsarSource(ReadonlyConfig.fromMap(config), createTextCatalogTable());
+        DeserializationSchema<SeaTunnelRow> deserializationSchema =
+                getDeserializationSchema(source);
+
+        Assertions.assertTrue(deserializationSchema instanceof TextDeserializationSchema);
+        SeaTunnelRow row =
+                deserializationSchema.deserialize("1|Alice".getBytes(StandardCharsets.UTF_8));
+        Assertions.assertEquals(1, row.getField(0));
+        Assertions.assertEquals("Alice", row.getField(1));
+    }
 
     @Test
     void shouldExposeProducedCatalogTablesForTablesConfigs() {
@@ -200,6 +233,38 @@ class PulsarSourceTest {
         config.put("cursor.stop.mode", stopMode);
         config.put("cursor.reset.mode", "EARLIEST");
         return config;
+    }
+
+    private CatalogTable createTextCatalogTable() {
+        List<Column> columns = new ArrayList<>();
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("id")
+                        .dataType(BasicType.INT_TYPE)
+                        .nullable(true)
+                        .build());
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("name")
+                        .dataType(BasicType.STRING_TYPE)
+                        .nullable(true)
+                        .build());
+        return CatalogTable.of(
+                TableIdentifier.of("default", "default", "pulsar_table"),
+                TableSchema.builder().columns(columns).build(),
+                new HashMap<>(),
+                new ArrayList<>(),
+                "Pulsar text table");
+    }
+
+    @SuppressWarnings("unchecked")
+    private DeserializationSchema<SeaTunnelRow> getDeserializationSchema(PulsarSource source)
+            throws ReflectiveOperationException {
+        Field field = PulsarSource.class.getDeclaredField("consumerMetadataMap");
+        field.setAccessible(true);
+        Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap =
+                (Map<TablePath, PulsarConsumerMetadata>) field.get(source);
+        return consumerMetadataMap.values().iterator().next().getDeserializationSchema();
     }
 
     private Map<String, Object> createTableConfig(String tablePath, String topic) {


### PR DESCRIPTION
### Purpose of this pull request

Fixes #11620.

Pulsar Source advertises `format = text`, but its runtime validation and deserialization path reject it. This patch:

- allows `text` in single-table source configuration;
- builds `TextDeserializationSchema` with the configured `field_delimiter`;
- keeps the multi-table restriction explicit;
- updates the English and Chinese Pulsar Source documentation and examples.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, a single-table Pulsar Source configured with `format = text` failed validation (and would also fail during deserializer creation). After this change, text messages are deserialized according to the configured schema and `field_delimiter`. Multi-table mode continues to support only JSON, CANAL_JSON, and AVRO.

### How was this patch tested?

- Added a positive regression test for single-table text deserialization with a custom `|` delimiter.
- Added configuration tests that allow text in single-table mode and explicitly reject it in `tables_configs`.
- Ran all 9 Pulsar unit test classes: **46 tests, 0 failures, 0 errors, 0 skipped**.
- Ran the Reactor build with Spotless checks enabled:

```shell
mvn -B -pl seatunnel-connectors-v2/connector-pulsar -am verify   "-Dtest=PulsarConfigUtilTest,PulsarMultiTableConfigTest,PulsarSinkFactoryTest,PulsarSinkWriterTest,MultiTablePartitionDiscovererTest,PulsarCanalDecoratorTest,PulsarSourceFactoryTest,PulsarSourceTest,PulsarSourceReaderRestoreTest"   "-Dsurefire.failIfNoSpecifiedTests=false"   "-DskipIT=true"   "-Dlicense.skipAddThirdParty=true"   "-Dskip.ui=true"
```

### Check list

* [x] No new JAR binary package is added.
* [x] Updated the English and Chinese connector documentation.
* [x] This change does not introduce an incompatibility.
* [x] This is an existing connector bug fix; new connector registration steps are not applicable.
