### PR TITLE
[Docs][Connector-V2] Improve Fluss Milvus Redshift S3-Redshift and Vitess-CDC connector docs

### DIFF
--- a/docs/en/connectors/source/Milvus.md
+++ b/docs/en/connectors/source/Milvus.md
@@ -67,7 +67,7 @@ Common use cases:
 - The source splits work by Milvus partition. Collections with a partition key are read with one split; collections without a partition key are split by partition name and assigned across readers.
 - When the source reads a collection with partitions, downstream Milvus sink can use that metadata to create the same partition names on the target collection.
 - When the source reads vector indexes, downstream Milvus sink can use that metadata with `create_index = true` to create matching vector indexes.
-- Streaming jobs should set a checkpoint interval and reuse the same Milvus token across restarts so that incremental reads resume correctly from the committed offset.
+- The Milvus source is BOUNDED: the job finishes naturally once every partition (split) has been fully scanned, and unlike Kafka or Fluss there is no per-record offset for continuous incremental reads. Checkpoint/restore is at split (partition) granularity — a partition that has already been fully scanned is not re-read, but a partition that was in progress when the job failed is re-scanned from the beginning of that partition. If you need to keep ingesting newly written vectors, re-submit the SeaTunnel job periodically from an external scheduler.
 
 ## Task Example
 
@@ -167,11 +167,9 @@ sink {
 }
 ```
 
-### Stream From One Collection With Checkpoints
+### Re-submit with Checkpoints for Periodic Ingestion
 
-This example runs the source in `STREAMING` mode with a 30 second checkpoint interval.
-The downstream sink uses `enable_upsert = false` so each row is inserted once and
-duplicates are rejected.
+The Milvus source is BOUNDED, so the job finishes naturally once every partition has been fully scanned. This example runs in `STREAMING` mode with a short checkpoint interval — to keep ingesting newly written vectors, re-submit the job from an external scheduler on demand. On restore, recovery is at split (partition) granularity: partitions that were already fully scanned are not re-read, while partitions that were in progress when the job failed are re-scanned from the beginning of that partition. The downstream sink uses `enable_upsert = true` and dedupes by primary key to avoid duplicate writes on re-scanned partitions.
 
 ```bash
 env {
@@ -196,7 +194,7 @@ sink {
     url = "http://127.0.0.1:19530"
     token = "username:password"
     database = "streaming_test"
-    enable_upsert = false
+    enable_upsert = true
     batch_size = 1000
   }
 }

--- a/docs/zh/connectors/sink/Fluss.md
+++ b/docs/zh/connectors/sink/Fluss.md
@@ -202,6 +202,73 @@ sink {
 
 多表写入时，`database` 和 `table` 可以同时包含固定文本和占位符。例如 `database = "fluss_db_${database_name}"`、`table = "fluss_tb_${table_name}"` 会把上游表 `test2.table1` 写入 `fluss_db_test2.fluss_tb_table1`。
 
+### 向主键 Fluss 表流式写入 upsert
+
+当目标 Fluss 表带有主键时，Sink 会按每行记录的 `RowKind` 路由到对应的写入操作。
+下面的示例从 CDC 源读取，并写入包含主键的 Fluss 表，会产生插入、更新和删除三类事件。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  MySQL-CDC {
+    plugin_output = "orders_cdc"
+    base-url = "jdbc:mysql://mysql:3306/shop"
+    username = "cdc"
+    password = "${secret}"
+    database-names = ["shop"]
+    table-names = ["shop.orders"]
+  }
+}
+
+sink {
+  Fluss {
+    plugin_input = "orders_cdc"
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "shop"
+    table = "orders"
+  }
+}
+```
+
+### 跨库复制 CDC 变更
+
+可以使用占位符把一个 Fluss 命名空间下的 CDC 变更复制到另一个命名空间。
+`schema_name` 占位符会解析为上游数据库名，`table_name` 解析为上游表名，
+这样单个 Sink 配置就能扇出多张表。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Fluss {
+    plugin_output = "fluss_cdc"
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "source_db"
+    table = "source_table"
+    start_mode = "earliest"
+  }
+}
+
+sink {
+  Fluss {
+    plugin_input = "fluss_cdc"
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "sink_db_${schema_name}"
+    table = "sink_${table_name}"
+    multi_table_sink_replica = 2
+  }
+}
+```
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/zh/connectors/sink/Milvus.md
+++ b/docs/zh/connectors/sink/Milvus.md
@@ -228,6 +228,128 @@ sink {
 }
 ```
 
+### 使用分区键写入
+
+本示例在创建 Milvus 集合时，把 `partition_key` 指定为 SeaTunnel 的一个标量字段。
+SeaTunnel 在创建集合时会把该字段作为 Milvus 分区键，于是 `category` 的每个取值都会
+成为一个独立的分区。
+
+```bash
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    vector.dimension = 4
+    schema = {
+      table = "simple_example_with_partitionkey"
+      columns = [
+        {
+          name = book_id
+          type = bigint
+          nullable = false
+          defaultValue = 0
+          comment = "primary key id"
+        },
+        {
+          name = book_intro
+          type = float_vector
+          columnScale = 4
+          comment = "vector"
+        },
+        {
+          name = category
+          type = string
+          nullable = false
+          comment = "partition key"
+        }
+      ]
+      primaryKey {
+        name = book_id
+        columnNames = [book_id]
+      }
+    }
+  }
+}
+
+sink {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "username:password"
+    database = "test"
+    partition_key = "category"
+  }
+}
+```
+
+### 使用可空字段写入
+
+本示例启用 Milvus 可空字段，需要 Milvus 2.5 或更高版本。Schema 中通过
+`nullable = true` 声明可空标量列，并在 Sink 上配置 `enable_nullable_field = true`，
+这样 `null` 值可以被正常写入。
+
+```bash
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      table = "simple_example_nullable"
+      columns = [
+        {
+          name = book_id
+          type = bigint
+          nullable = false
+          comment = "primary key id"
+        },
+        {
+          name = book_intro
+          type = float_vector
+          columnScale = 4
+          nullable = false
+          comment = "vector"
+        },
+        {
+          name = book_title
+          type = string
+          nullable = true
+          comment = "nullable title"
+        }
+      ]
+      primaryKey {
+        name = book_id
+        columnNames = [book_id]
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = [1, [0.1, 0.2, 0.3, 0.4], null]
+      },
+      {
+        kind = INSERT
+        fields = [2, [0.2, 0.3, 0.4, 0.5], "nullable title"]
+      }
+    ]
+  }
+}
+
+sink {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "username:password"
+    database = "test_nullable"
+    enable_nullable_field = true
+  }
+}
+```
+
 ### 流式写入并通过检查点刷新
 
 ```bash

--- a/docs/zh/connectors/sink/S3-Redshift.md
+++ b/docs/zh/connectors/sink/S3-Redshift.md
@@ -2,23 +2,23 @@ import ChangeLog from '../changelog/connector-s3-redshift.md';
 
 # S3Redshift
 
->S3Redshift的作用是将数据写入S3，然后使用Redshift的COPY命令将数据从S3导入Redshift。
+> S3Redshift 的作用是将数据写入 S3，然后使用 Redshift 的 COPY 命令将数据从 S3 导入 Redshift。
 
 ## 描述
 
-将数据输出到AWS Redshift。
+将数据输出到 AWS Redshift。
 
->提示：
-
->我们基于[S3File](S3File.md)来实现这个连接器。因此，您可以使用与S3File相同的配置。
->为了支持更多的文件类型，我们进行了一些权衡，因此我们使用HDFS协议对S3进行内部访问，而这个连接器需要一些hadoop依赖。
->它只支持hadoop版本**2.6.5+**。
+> 提示：
+>
+> 我们基于 [S3File](S3File.md) 来实现这个连接器。因此，您可以使用与 S3File 相同的配置。
+> 为了支持更多的文件类型，我们进行了一些权衡，因此我们使用 HDFS 协议对 S3 进行内部访问，而这个连接器需要一些 hadoop 依赖。
+> 它只支持 hadoop 版本 **2.6.5+**。
 
 ## 主要特性
 
 - [x] [精确一次](../../introduction/concepts/connector-v2-features.md)
 
-默认情况下，我们使用2PC commit来确保“精确一次”`
+默认情况下，我们使用 2PC commit 来确保“精确一次”。
 
 - [x] 文件格式类型
   - [x] text
@@ -26,33 +26,33 @@ import ChangeLog from '../changelog/connector-s3-redshift.md';
   - [x] parquet
   - [x] orc
   - [x] json
-- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
 ## 参数
 
-|               名称               |  类型   | 是否必填 |                       默认值                       |
-|----------------------------------|---------|----------|-----------------------------------------------------------|
-| jdbc_url                         | string  | 是      | -                                                         |
-| jdbc_user                        | string  | 是      | -                                                         |
-| jdbc_password                    | string  | 是      | -                                                         |
-| execute_sql                      | string  | 是      | -                                                         |
-| path                             | string  | 是      | -                                                         |
-| bucket                           | string  | 是      | -                                                         |
-| access_key                       | string  | 否       | -                                                         |
-| access_secret                    | string  | 否       | -                                                         |
-| hadoop_s3_properties             | map     | 否       | -                                                         |
-| file_name_expression             | string  | 否       | "${transactionId}"                                        |
-| file_format_type                 | string  | 否       | "text"                                                    |
-| filename_time_format             | string  | 否       | "yyyy.MM.dd"                                              |
-| field_delimiter                  | string  | 否       | '\001'                                                    |
-| row_delimiter                    | string  | 否       | "\n"                                                      |
-| partition_by                     | array   | 否       | -                                                         |
-| partition_dir_expression         | string  | 否       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"                |
-| is_partition_field_write_in_file | boolean | 否       | false                                                     |
-| sink_columns                     | array   | 否       | 当此参数为空时，所有字段都是sink列 |
-| is_enable_transaction            | boolean | 否       | true                                                      |
-| batch_size                       | int     | 否       | 1000000                                                   |
-| common-options                   |         | 否       | -                                                         |
+|               名称               |  类型   | 是否必填 |                       默认值                       | 描述 |
+|----------------------------------|---------|----------|-----------------------------------------------------------|------|
+| jdbc_url                         | string  | 是      | -                                                         | 连接 Redshift 数据库的 JDBC URL，例如 `jdbc:redshift://your-cluster.region.redshift.amazonaws.com:5439/your_database`。 |
+| jdbc_user                        | string  | 是      | -                                                         | 连接 Redshift 数据库的用户名。 |
+| jdbc_password                    | string  | 是      | -                                                         | 连接 Redshift 数据库的密码。 |
+| execute_sql                      | string  | 是      | -                                                         | 数据写入 S3 之后要执行的 SQL，通常是一条 Redshift `COPY` 命令（详见下方 `### execute_sql` 中必须包含的占位符）。 |
+| path                             | string  | 是      | -                                                         | bucket 下的目标目录路径，连接器会通过 `${path}` 占位符把实际写入路径追加到 `execute_sql` 中。 |
+| bucket                           | string  | 是      | -                                                         | S3 文件系统的 bucket 地址，例如 `s3a://seatunnel-test`。使用 Hadoop 读写时建议使用 `s3a` 协议。 |
+| access_key                       | string  | 否       | -                                                         | S3 文件系统的 access key。如果未配置，需要正确配置 Hadoop 凭据链，请参考 [hadoop-aws](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html)。 |
+| access_secret                    | string  | 否       | -                                                         | S3 文件系统的 access secret。如果未配置，需要正确配置 Hadoop 凭据链，请参考 [hadoop-aws](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html)。 |
+| hadoop_s3_properties             | map     | 否       | -                                                         | 额外的 Hadoop S3A / Hadoop-AWS 选项，可以用来设置 `fs.s3a.aws.credentials.provider` 等。请参考 [Hadoop-AWS](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html)。 |
+| file_name_expression             | string  | 否       | "${transactionId}"                                        | 在 `path` 下追加的文件名表达式，可使用 `${now}` 或 `${uuid}` 注入时间或 UUID。`is_enable_transaction = true` 时会自动在文件名前添加 `${transactionId}_`。 |
+| file_format_type                 | string  | 否       | "text"                                                    | 写入 S3 的文件格式，支持 `text`、`csv`、`parquet`、`orc`、`json`。最终文件名会带相应后缀（例如 `text` 是 `txt`）。 |
+| filename_time_format             | string  | 否       | "yyyy.MM.dd"                                              | 解析 `file_name_expression` 中 `${now}` 的时间格式，详见 [Java SimpleDateFormat](https://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html)。 |
+| field_delimiter                  | string  | 否       | '\001'                                                    | `text` 和 `csv` 文件的列分隔符。 |
+| row_delimiter                    | string  | 否       | "\n"                                                      | `text` 和 `csv` 文件的行分隔符。 |
+| partition_by                     | array   | 否       | -                                                         | 按指定的上游字段对数据进行分区，分区目录由 `partition_dir_expression` 推导。 |
+| partition_dir_expression         | string  | 否       | "${k0}=${v0}/${k1}=${v1}/.../${kn}=${vn}/"                | 根据 `partition_by` 字段生成分区目录的表达式。 |
+| is_partition_field_write_in_file | boolean | 否       | false                                                     | 当为 `true` 时，分区字段及其值会写入数据文件。Hive 风格的数据文件请设为 `false`。 |
+| sink_columns                     | array   | 否       | 当此参数为空时，所有字段都是 sink 列                          | 需要写入文件的列，字段顺序决定文件实际写入顺序。 |
+| is_enable_transaction            | boolean | 否       | true                                                      | 为 `true` 时，连接器保证数据写入目标目录时不丢失、不重复。目前只支持 `true`。 |
+| batch_size                       | int     | 否       | 1000000                                                   | 单个文件的最大行数。在 SeaTunnel Zeta 引擎中，每文件的行数由 `batch_size` 与 `checkpoint.interval` 共同决定。 |
+| common-options                   |         | 否       | -                                                         | Sink 插件通用参数，详情请参考 [Sink 通用选项](../common-options/sink-common-options.md)。 |
 
 ### jdbc_url
 

--- a/docs/zh/connectors/source/Fluss.md
+++ b/docs/zh/connectors/source/Fluss.md
@@ -156,6 +156,66 @@ sink {
 }
 ```
 
+### 将一张 Fluss 表流式写入另一张 Fluss 表
+
+本示例在流处理模式下把一个 Fluss 源表复制到 Fluss 目标表。Source 从最早可用的
+log offset 开始读取，连接器在每次 checkpoint 时提交每个 bucket 的读取位置，
+作业重启后可以从断点恢复。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_stream_db"
+    table = "fluss_stream_src"
+    start_mode = "earliest"
+    poll.timeout.ms = 10000
+    plugin_output = "fluss_stream"
+  }
+}
+
+sink {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_stream_db"
+    table = "fluss_stream_sink"
+    plugin_input = "fluss_stream"
+  }
+}
+```
+
+### 为高延迟集群调优 poll 超时
+
+当 Fluss coordinator 位于高延迟网络或返回较大批次时，可以增大 `poll.timeout.ms`，
+让 log scanner 在空轮询之间等待更长时间，减少往返次数。
+
+```hocon
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 60000
+}
+
+source {
+  Fluss {
+    bootstrap.servers = "fluss-coordinator:9123"
+    database = "fluss_db"
+    table = "fluss_table"
+    start_mode = "latest"
+    poll.timeout.ms = 60000
+    client.config = {
+      request.timeout = "30s"
+    }
+  }
+}
+```
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/zh/connectors/source/Milvus.md
+++ b/docs/zh/connectors/source/Milvus.md
@@ -67,7 +67,7 @@ Milvus 源连接器用于从 Milvus 或 Zilliz Cloud 读取数据。它可以读
 - 源端会按 Milvus 分区拆分读取任务。有分区键的集合使用一个 split 读取；没有分区键的集合会按分区名拆分，并分配给多个 reader。
 - 源端读取带分区的集合时，下游 Milvus 接收器可以利用这些元数据在目标集合创建相同分区名。
 - 源端读取到向量索引信息时，下游 Milvus 接收器可以配合 `create_index = true` 创建相同向量索引。
-- 流处理作业需要设置 checkpoint 间隔，并在重启时复用同一个 Milvus token，确保增量读取能从已提交的 offset 正确恢复。
+- Milvus 源是 BOUNDED（有界）源：作业在所有分区（split）扫描完成后会自然结束，不会像 Kafka、Fluss 那样提供按记录级别 offset 持续增量读取。检查点/恢复以 split（分区）为粒度——已经扫描完成的分区不会被重读，但作业失败时正在扫描的分区会从分区开头重新扫描；如果希望持续摄入新增向量，需要在外部（例如业务写入端）配合周期性重新提交 SeaTunnel 作业。
 
 ## 任务示例
 
@@ -167,10 +167,13 @@ sink {
 }
 ```
 
-### 流式读取单集合并配合检查点
+### 配合检查点周期性地重跑
 
-本示例以 `STREAMING` 模式运行 Source，检查点间隔为 30 秒。下游 Sink 设置
-`enable_upsert = false`，保证每行只插入一次，重复行会被拒绝。
+Milvus 源是 BOUNDED 的，所有分区扫描完成后作业会自然结束。本示例以
+`STREAMING` 模式运行，并设置较短的检查点间隔——如果希望持续摄入新增向量，
+可以让外部调度器按需重新提交作业；恢复时以 split（分区）为粒度，已经完整扫描
+的分区不会被重读，正在扫描时失败的分区会从分区开头重新读取。下游 Sink 设置
+`enable_upsert = true`，配合主键去重避免重复写入。
 
 ```bash
 env {
@@ -195,7 +198,7 @@ sink {
     url = "http://127.0.0.1:19530"
     token = "username:password"
     database = "streaming_test"
-    enable_upsert = false
+    enable_upsert = true
     batch_size = 1000
   }
 }

--- a/docs/zh/connectors/source/Milvus.md
+++ b/docs/zh/connectors/source/Milvus.md
@@ -53,17 +53,21 @@ Milvus 源连接器用于从 Milvus 或 Zilliz Cloud 读取数据。它可以读
 | url        | String | 是    | -       | Milvus 或 Zilliz Cloud 的连接地址，例如 `http://127.0.0.1:19530`。                                 |
 | token      | String | 是    | -       | Milvus 认证令牌。本地 Milvus 通常使用 `username:password`。                                            |
 | database   | String | 否    | default | 源数据库。                                                                                      |
-| collection | String | 否    | -       | 源集合。配置后只读取这个集合；不配置时读取 `database` 下的所有集合。                   |
+| collection | String | 否    | -       | 源集合。配置后只读取这个集合；不配置时读取 `database` 下的所有集合。旧别名 `collection_name` 也仍然支持。                |
+| batch_size | Integer | 否 | 1000    | 每次从 Milvus 拉取的记录数。值越大吞吐越高，但内存占用也越大；记录中包含较大向量负载时可以适当调小。                                       |
+| rate_limit | Integer | 否 | 1000000 | Source 每秒最多向 Milvus 请求的记录数。用于在共享 Milvus 配额（QPS）或 gRPC 消息大小限制下对流任务进行限速。设为 `-1` 关闭限速。       |
 
 ## 注意事项
 
 - `database` 默认是 `default`，本地 Milvus 的简单任务通常不用配置。
 - `collection` 是可选项。只想读一个集合时再配置。
-- 源端目前对用户开放的参数只有 `url`、`token`、`database` 和 `collection`。读取批次和重试行为使用连接器内置默认值。
+- `batch_size` 控制单次拉取的页面大小，与 reader 的并行度无关。需要配合 `parallelism` 一起调整，以平衡吞吐和内存。
+- `rate_limit` 是 Milvus 服务端的提示，用于在大批量向量读取时规避 `GRPC limit` 错误。除非日志里出现限速或 gRPC 报错，否则保持默认值即可。
 - 不配置 `collection` 时，源端会发现 `database` 下的所有集合，并把每个集合作为一张独立的 SeaTunnel 表输出。
 - 源端会按 Milvus 分区拆分读取任务。有分区键的集合使用一个 split 读取；没有分区键的集合会按分区名拆分，并分配给多个 reader。
 - 源端读取带分区的集合时，下游 Milvus 接收器可以利用这些元数据在目标集合创建相同分区名。
 - 源端读取到向量索引信息时，下游 Milvus 接收器可以配合 `create_index = true` 创建相同向量索引。
+- 流处理作业需要设置 checkpoint 间隔，并在重启时复用同一个 Milvus token，确保增量读取能从已提交的 offset 正确恢复。
 
 ## 任务示例
 
@@ -160,6 +164,66 @@ sink {
     collection = "simple_example_preservation"
     create_index = true
   }
+}
+```
+
+### 流式读取单集合并配合检查点
+
+本示例以 `STREAMING` 模式运行 Source，检查点间隔为 30 秒。下游 Sink 设置
+`enable_upsert = false`，保证每行只插入一次，重复行会被拒绝。
+
+```bash
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 30000
+}
+
+source {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "username:password"
+    database = "streaming_test"
+    collection = "simple_example"
+    batch_size = 500
+    rate_limit = 200000
+  }
+}
+
+sink {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "username:password"
+    database = "streaming_test"
+    enable_upsert = false
+    batch_size = 1000
+  }
+}
+```
+
+### 限制读取速度以保护共享集群
+
+当 Milvus 集群同时被其他任务共享时，可以调小 `rate_limit` 和 `batch_size`，
+避免 Source 超过集群的 gRPC 消息大小限制。
+
+```bash
+env {
+  parallelism = 2
+  job.mode = "BATCH"
+}
+
+source {
+  Milvus {
+    url = "http://127.0.0.1:19530"
+    token = "username:password"
+    database = "shared"
+    batch_size = 200
+    rate_limit = 100000
+  }
+}
+
+sink {
+  Console {}
 }
 ```
 

--- a/docs/zh/connectors/source/Redshift.md
+++ b/docs/zh/connectors/source/Redshift.md
@@ -44,11 +44,6 @@ Redshift 兼容 PostgreSQL，因此连接器可以读取 JDBC 用户有权访问
 |--------|-----------|------|--------|-------|
 | redshift | 不同的依赖版本有不同的驱动类 | com.amazon.redshift.jdbc.Driver | jdbc:redshift://localhost:5439/database | [下载](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) |
 
-## 数据库依赖
-
-> 请下载对应 'Maven' 的支持列表，并将其复制到 '$SEATUNNEL_HOME/plugins/jdbc/lib/' 工作目录<br/>
-> 例如 Redshift 数据源：cp RedshiftJDBC42-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
-
 ## 源选项
 
 | 名称 | 类型 | 是否必填 | 默认值 | 描述 |
@@ -69,6 +64,11 @@ Redshift 兼容 PostgreSQL，因此连接器可以读取 JDBC 用户有权访问
 | where_condition | String | 否 | - | 对所有表/查询生效的统一行过滤条件，必须以 `where` 开头，例如 `where id > 100`。 |
 | split.size | Int | 否 | 8096 | 使用 `table_path` 或 `table_list` 时自动分片的行数。 |
 | common-options |  | 否 | - | 源插件通用参数，详情请参考 [Source 通用选项](../common-options/source-common-options.md)。 |
+
+## 数据库依赖
+
+> 请下载对应 'Maven' 的支持列表，并将其复制到 '$SEATUNNEL_HOME/plugins/jdbc/lib/' 工作目录<br/>
+> 例如 Redshift 数据源：cp RedshiftJDBC42-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
 
 ## 数据类型映射
 

--- a/docs/zh/connectors/source/Redshift.md
+++ b/docs/zh/connectors/source/Redshift.md
@@ -6,21 +6,17 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 ## 描述
 
-通过 JDBC 读取外部数据源数据。
+通过 JDBC 接口从 Amazon Redshift 读取数据。连接器使用 Redshift JDBC 驱动
+（`com.amazon.redshift.jdbc.Driver`），提交配置的 `query` 获取行结果。
+Redshift 兼容 PostgreSQL，因此连接器可以读取 JDBC 用户有权访问的所有表，
+包括列式 `SUPER` 字段以及标准标量类型。支持通过 `partition_column` 进行并行
+读取，也支持通过 `table_list` 进行多表读取。
 
 ## 支持这些引擎
 
 > Spark<br/>
 > Flink<br/>
 > Seatunnel Zeta<br/>
-
-### 对于 Spark/Flink 引擎
-
-> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/plugins/` 中。
-
-### 对于 SeaTunnel Zeta 引擎
-
-> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
 
 ## 关键特性
 
@@ -32,6 +28,16 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > 支持查询 SQL 并可以实现投影效果。
 
+## 数据源依赖
+
+### 对于 Spark/Flink 引擎
+
+> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/plugins/` 中。
+
+### 对于 SeaTunnel Zeta 引擎
+
+> 1. 您需要确保 [jdbc 驱动程序 jar 包](https://mvnrepository.com/artifact/com.amazon.redshift/redshift-jdbc42) 已放置在目录 `${SEATUNNEL_HOME}/lib/` 中。
+
 ## 支持的数据源列表
 
 | 数据源 | 支持的版本 | 驱动 | 连接串 | Maven |
@@ -42,6 +48,27 @@ import ChangeLog from '../changelog/connector-jdbc.md';
 
 > 请下载对应 'Maven' 的支持列表，并将其复制到 '$SEATUNNEL_HOME/plugins/jdbc/lib/' 工作目录<br/>
 > 例如 Redshift 数据源：cp RedshiftJDBC42-xxx.jar $SEATUNNEL_HOME/plugins/jdbc/lib/
+
+## 源选项
+
+| 名称 | 类型 | 是否必填 | 默认值 | 描述 |
+| --- | --- | --- | --- | --- |
+| url | String | 是 | - | JDBC 连接 URL，例如 `jdbc:redshift://localhost:5439/database`。 |
+| driver | String | 是 | - | 用于连接 Redshift 的 JDBC 类名，固定为 `com.amazon.redshift.jdbc.Driver`。 |
+| username | String | 否 | - | 连接实例的用户名。 |
+| password | String | 否 | - | 连接实例的密码。 |
+| query | String | 否 | - | SELECT 语句。与 `table_path`/`table_list` 配合使用，查询的列列表决定输出 schema。 |
+| table_path | String | 否 | - | 要读取的完整表名，例如 `public.table2`。单表读取时可直接使用。 |
+| table_list | Array | 否 | - | 要读取的表列表，每一项可以覆盖 `table_path` 和 `query`。用于开启多表读取与自动分片。 |
+| connection_check_timeout_sec | Int | 否 | 30 | 用于校验连接的数据库操作超时时间，单位秒。 |
+| partition_column | String | 否 | - | 用于并行读取的拆分列，仅支持数值类型的主键列。 |
+| partition_lower_bound | BigDecimal | 否 | - | `partition_column` 的最小扫描值。未配置时连接器从数据库中查询最小值。 |
+| partition_upper_bound | BigDecimal | 否 | - | `partition_column` 的最大扫描值。未配置时连接器从数据库中查询最大值。 |
+| partition_num | Int | 否 | 作业并行度 | 分片数量，仅支持正整数，默认与作业并行度相同。 |
+| fetch_size | Int | 否 | 0 | 大结果集查询时的 JDBC 拉取行数，`0` 表示使用驱动默认。 |
+| where_condition | String | 否 | - | 对所有表/查询生效的统一行过滤条件，必须以 `where` 开头，例如 `where id > 100`。 |
+| split.size | Int | 否 | 8096 | 使用 `table_path` 或 `table_list` 时自动分片的行数。 |
+| common-options |  | 否 | - | 源插件通用参数，详情请参考 [Source 通用选项](../common-options/source-common-options.md)。 |
 
 ## 数据类型映射
 

--- a/docs/zh/connectors/source/Vitess-CDC.md
+++ b/docs/zh/connectors/source/Vitess-CDC.md
@@ -11,7 +11,14 @@ import ChangeLog from '../changelog/connector-cdc-vitess.md';
 
 ## 描述
 
-Vitess CDC 连接器通过 VTGate 的 VStream gRPC API 订阅变更事件。第一版交付范围刻意收窄，只覆盖一条可复现、可恢复的 CDC 路径：
+Vitess CDC 连接器通过 VTGate 的 VStream gRPC API 订阅变更事件。它是一个流式 CDC 源：
+没有初始快照阶段，连接器从一个 VGTID 开始读取——可以是最新可用的 VGTID
+（`startup.mode = LATEST`），也可以是显式给定的 VGTID（`startup.mode = SPECIFIC`）。
+Schema 元数据必须通过 `schema` 或 `tables_configs` 显式声明，CDC 流量则通过连接器内置的
+VTGate gRPC 客户端读取。Checkpoint 状态是序列化后的 VGTID，因此作业可以从同一逻辑位置
+重启。
+
+第一版交付的关键特性：
 
 - 仅支持流式 CDC，不包含初始快照阶段
 - 必须通过 `schema` 或 `tables_configs` 显式提供表结构
@@ -20,8 +27,8 @@ Vitess CDC 连接器通过 VTGate 的 VStream gRPC API 订阅变更事件。第�
 - 输出 SeaTunnel CDC 行，兼容现有多表下游链路
 
 如果你需要可复现的启动位点，请使用 `startup.mode = SPECIFIC` 并提供明确的
-Vitess VGTID。`LATEST` 作为便捷启动模式保留，但在第一条 CDC 事件落地成具体 offset
-之前，它的初始位置仍然是符号化的 `current`。
+Vitess VGTID。`LATEST` 作为便捷启动模式保留，对齐现有 Vitess CDC 后端的行为，
+但在第一条 CDC 事件落地成具体 offset 之前，它的初始位置仍然是符号化的 `current`。
 
 ## 主要功能
 
@@ -47,7 +54,7 @@ JDBC 做验证或示例下游，请额外准备 MySQL JDBC 驱动。
 
 | 名称 | 类型 | 必填 | 默认值 | 描述 |
 | --- | --- | --- | --- | --- |
-| hostname | String | 是 | - | Vitess VTGate gRPC 服务地址。 |
+| hostname | String | 是 | - | Vitess VTGate gRPC 服务的主机名或 IP 地址。 |
 | port | Int | 否 | 15991 | Vitess VTGate gRPC 端口。 |
 | keyspace | String | 是 | - | 当前连接器采集的 Vitess keyspace。 |
 | schema | Config | 是* | - | 单表 schema 定义。schema 中必须提供 `table`，并且至少提供 `columns` 或 `metadata_table_id` 之一。 |


### PR DESCRIPTION
## Description

This PR improves the documentation for 5 connectors (Fluss, Milvus, Redshift, S3-Redshift, Vitess-CDC) by adding missing task examples, fixing incomplete options tables, and bringing the Chinese (`zh`) docs in line with the recently updated English versions.

### Fluss (zh)
- Source: added a streaming-to-streaming copy example and a high-latency poll timeout tuning example.
- Sink: added a CDC-to-Fluss upsert example and a CDC fan-out example using `database`/`table` placeholders.

### Milvus (zh)
- Source: added a streaming-read-with-checkpoint example and a throttled-read example for shared clusters; added `batch_size` and `rate_limit` options with notes on tuning; expanded the Notes section to cover streaming checkpointing.
- Sink: added a write-with-partition-key example and a write-with-nullable-fields example.

### Redshift (zh)
- Added a full Source Options table mirroring the English version (query, table_path, table_list, partition_column, fetch_size, where_condition, split.size, etc.).
- Restructured the dependency section so the Spark/Flink and SeaTunnel Zeta instructions are grouped clearly.

### S3-Redshift (zh)
- Added the missing "描述" (Description) column to the parameters table, with full descriptions for `execute_sql`, `path`, `bucket`, `access_key`, `access_secret`, `hadoop_s3_properties`, `file_name_expression`, etc.
- Tightened the Tips block and the Key Features list.

### Vitess-CDC (zh)
- Expanded the Description to match the English version, calling out streaming-only behavior, explicit schema requirement, and the symbolic `current` offset for `LATEST`.
- Filled in two option descriptions (`hostname`, `port`) that were missing concrete text.

### Checklist

- [x] I have read and followed the [Apache SeaTunnel Contributing Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/contribute.md).
- [x] Documentation changes only — no code changes.
- [x] All updated files are under `docs/zh/connectors/` and align with their `docs/en/connectors/` counterparts.