### PR TITLE
[Improve][Connector-V2][RabbitMQ] Migrate source config validation to OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqSingleTableValidator.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqSingleTableValidator.java
@@ -20,21 +20,30 @@ package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
-import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 
+/**
+ * Validates the RabbitMQ source single-table configuration.
+ *
+ * <p>This validator is invoked by {@code ConfigValidator} through {@code
+ * Conditions.extension(QUEUE_NAME, ...)} before {@code RabbitmqSource} is constructed.
+ */
 public class RabbitmqSingleTableValidator implements ConditionExtension<String> {
+
+    private static final String SCHEMA_KEY = RabbitmqBaseOptions.SCHEMA.key();
+    private static final String QUEUE_NAME_KEY = RabbitmqBaseOptions.QUEUE_NAME.key();
+
     @Override
     public String description() {
-        return "'schema' must be configured when 'queue_name' is used.";
+        return "requires '" + SCHEMA_KEY + "' to be configured";
     }
 
     @Override
     public boolean evaluate(ReadonlyConfig config, String queueName)
             throws OptionValidationException {
 
-        if (!config.getOptional(ConnectorCommonOptions.SCHEMA).isPresent()) {
+        if (!config.getOptional(RabbitmqBaseOptions.SCHEMA).isPresent()) {
             throw new OptionValidationException(
-                    "'schema' must be configured when 'queue_name' is used");
+                    "'%s' must be configured when '%s' is used", SCHEMA_KEY, QUEUE_NAME_KEY);
         }
 
         return true;

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqSingleTableValidator.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqSingleTableValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+
+public class RabbitmqSingleTableValidator implements ConditionExtension<String> {
+    @Override
+    public String description() {
+        return "'schema' must be configured when 'queue_name' is used.";
+    }
+
+    @Override
+    public boolean evaluate(ReadonlyConfig config, String queueName)
+            throws OptionValidationException {
+
+        if (!config.getOptional(ConnectorCommonOptions.SCHEMA).isPresent()) {
+            throw new OptionValidationException(
+                    "'schema' must be configured when 'queue_name' is used");
+        }
+
+        return true;
+    }
+}

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqTableConfigsValidator.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqTableConfigsValidator.java
@@ -1,0 +1,59 @@
+package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+
+import java.util.List;
+import java.util.Map;
+
+public class RabbitmqTableConfigsValidator
+        implements ConditionExtension<List<Map<String, Object>>> {
+
+    @Override
+    public String description() {
+        return "when 'table_configs' is configured, root-level 'schema' must not be configured "
+                + "and each 'table_configs' entry must declare a non-blank 'queue_name' and a 'schema'";
+    }
+
+    @Override
+    public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> entries)
+            throws OptionValidationException {
+        if (config.getOptional(RabbitmqBaseOptions.SCHEMA).isPresent()) {
+            throw new OptionValidationException(
+                    "Cannot specify both 'table_configs' and root-level 'schema'.");
+        }
+        for (int i = 0; i < entries.size(); i++) {
+            ReadonlyConfig entry = ReadonlyConfig.fromMap(entries.get(i));
+            String queueName = entry.getOptional(RabbitmqBaseOptions.QUEUE_NAME).orElse(null);
+            if (queueName == null || queueName.trim().isEmpty()) {
+                throw new OptionValidationException(
+                        "table_configs[%d]: 'queue_name' must be configured and non-blank", i);
+            }
+
+            if (!entry.getOptional(ConnectorCommonOptions.SCHEMA).isPresent()) {
+                throw new OptionValidationException(
+                        "table_configs[%d]: 'schema' must be configured", i);
+            }
+        }
+
+        return true;
+    }
+}

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqTableConfigsValidator.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqTableConfigsValidator.java
@@ -20,18 +20,33 @@ package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
-import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Validates the RabbitMQ source multi-table configuration.
+ *
+ * <p>This validator is invoked by {@code ConfigValidator} through {@code
+ * Conditions.extension(TABLE_CONFIGS, ...)} before {@code RabbitmqSource} is constructed. It
+ * validates each {@code tables_configs} entry and rejects a root-level {@code schema}.
+ */
 public class RabbitmqTableConfigsValidator
         implements ConditionExtension<List<Map<String, Object>>> {
 
+    private static final String TABLE_CONFIGS_KEY = RabbitmqBaseOptions.TABLE_CONFIGS.key();
+    private static final String QUEUE_NAME_KEY = RabbitmqBaseOptions.QUEUE_NAME.key();
+    private static final String SCHEMA_KEY = RabbitmqBaseOptions.SCHEMA.key();
+
     @Override
     public String description() {
-        return "when 'table_configs' is configured, root-level 'schema' must not be configured "
-                + "and each 'table_configs' entry must declare a non-blank 'queue_name' and a 'schema'";
+        return "requires each entry to declare a non-blank '"
+                + QUEUE_NAME_KEY
+                + "' and a '"
+                + SCHEMA_KEY
+                + "', and forbids a root-level '"
+                + SCHEMA_KEY
+                + "'";
     }
 
     @Override
@@ -39,19 +54,20 @@ public class RabbitmqTableConfigsValidator
             throws OptionValidationException {
         if (config.getOptional(RabbitmqBaseOptions.SCHEMA).isPresent()) {
             throw new OptionValidationException(
-                    "Cannot specify both 'table_configs' and root-level 'schema'.");
+                    "Cannot specify both '%s' and root-level '%s'.", TABLE_CONFIGS_KEY, SCHEMA_KEY);
         }
         for (int i = 0; i < entries.size(); i++) {
             ReadonlyConfig entry = ReadonlyConfig.fromMap(entries.get(i));
             String queueName = entry.getOptional(RabbitmqBaseOptions.QUEUE_NAME).orElse(null);
             if (queueName == null || queueName.trim().isEmpty()) {
                 throw new OptionValidationException(
-                        "table_configs[%d]: 'queue_name' must be configured and non-blank", i);
+                        "%s[%d]: '%s' must be configured and non-blank",
+                        TABLE_CONFIGS_KEY, i, QUEUE_NAME_KEY);
             }
 
-            if (!entry.getOptional(ConnectorCommonOptions.SCHEMA).isPresent()) {
+            if (!entry.getOptional(RabbitmqBaseOptions.SCHEMA).isPresent()) {
                 throw new OptionValidationException(
-                        "table_configs[%d]: 'schema' must be configured", i);
+                        "%s[%d]: '%s' must be configured", TABLE_CONFIGS_KEY, i, SCHEMA_KEY);
             }
         }
 

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqTableConfigsValidator.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/config/RabbitmqTableConfigsValidator.java
@@ -1,4 +1,3 @@
-package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.seatunnel.connectors.seatunnel.rabbitmq.config;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConditionExtension;

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSource.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSource.java
@@ -74,13 +74,6 @@ public class RabbitmqSource
                 config.getOptional(ConnectorCommonOptions.TABLE_CONFIGS).isPresent();
         boolean hasSchema = config.getOptional(ConnectorCommonOptions.SCHEMA).isPresent();
 
-        // Mutually exclusive check: Users cannot define both root-level schema and table_configs
-        if (hasTableConfigs && hasSchema) {
-            throw new RabbitmqConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    "Cannot specify both 'table_configs' and 'schema'.");
-        }
-
         if (hasTableConfigs) {
             // Multi-Table Mode: Parse multiple queue configurations
             List<Map<String, Object>> tableConfigList =
@@ -90,17 +83,8 @@ public class RabbitmqSource
                 CatalogTable table = CatalogTableUtil.buildWithConfig(tableConfig);
                 String queueName = tableConfig.get(RabbitmqBaseOptions.QUEUE_NAME);
 
-                // Ensure queue_name is explicitly defined
-                if (queueName == null || queueName.trim().isEmpty()) {
-                    throw new RabbitmqConnectorException(
-                            SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                            "The 'queue_name' is missing or empty inside one of the 'table_configs' items.");
-                }
-
-                String splitId = queueName;
-
                 this.catalogTables.add(table);
-                this.queueToTableMap.put(splitId, table);
+                this.queueToTableMap.put(queueName, table);
             }
         } else if (hasSchema) {
             CatalogTable table = CatalogTableUtil.buildWithConfig(config);
@@ -110,10 +94,6 @@ public class RabbitmqSource
             }
             this.catalogTables.add(table);
             this.queueToTableMap.put(queueName, table);
-        } else {
-            throw new RabbitmqConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    "No 'schema' or 'table_configs' found.");
         }
     }
 

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSourceFactory.java
@@ -77,6 +77,7 @@ public class RabbitmqSourceFactory implements TableSourceFactory {
                         RabbitmqSourceOptions.REQUESTED_HEARTBEAT,
                         RabbitmqSourceOptions.PREFETCH_COUNT,
                         RabbitmqSourceOptions.DELIVERY_TIMEOUT,
+                        RabbitmqSourceOptions.SCHEMA,
                         RabbitmqSourceOptions.USE_CORRELATION_ID)
                 .build();
     }

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSourceFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.rabbitmq.source;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
@@ -24,8 +25,10 @@ import org.apache.seatunnel.api.table.connector.TableSource;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.rabbitmq.config.RabbitmqSingleTableValidator;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.config.RabbitmqSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.config.RabbitmqSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.rabbitmq.config.RabbitmqTableConfigsValidator;
 
 import com.google.auto.service.AutoService;
 
@@ -45,6 +48,18 @@ public class RabbitmqSourceFactory implements TableSourceFactory {
                 .bundled(RabbitmqSourceOptions.USERNAME, RabbitmqSourceOptions.PASSWORD)
                 .exclusive(RabbitmqSourceOptions.TABLE_CONFIGS, RabbitmqSourceOptions.QUEUE_NAME)
                 .optional(
+                        RabbitmqSourceOptions.QUEUE_NAME,
+                        Conditions.notBlank(RabbitmqSourceOptions.QUEUE_NAME),
+                        Conditions.extension(
+                                RabbitmqSourceOptions.QUEUE_NAME,
+                                new RabbitmqSingleTableValidator()))
+                .optional(
+                        RabbitmqSourceOptions.TABLE_CONFIGS,
+                        Conditions.notEmpty(RabbitmqSourceOptions.TABLE_CONFIGS),
+                        Conditions.extension(
+                                RabbitmqSourceOptions.TABLE_CONFIGS,
+                                new RabbitmqTableConfigsValidator()))
+                .optional(
                         RabbitmqSourceOptions.VIRTUAL_HOST,
                         RabbitmqSourceOptions.URL,
                         RabbitmqSourceOptions.ROUTING_KEY,
@@ -62,7 +77,6 @@ public class RabbitmqSourceFactory implements TableSourceFactory {
                         RabbitmqSourceOptions.REQUESTED_HEARTBEAT,
                         RabbitmqSourceOptions.PREFETCH_COUNT,
                         RabbitmqSourceOptions.DELIVERY_TIMEOUT,
-                        RabbitmqSourceOptions.SCHEMA,
                         RabbitmqSourceOptions.USE_CORRELATION_ID)
                 .build();
     }

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSourceFactoryTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.seatunnel.connectors.seatunnel.rabbitmq;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.configuration.util.RequiredOption;
 import org.apache.seatunnel.api.options.table.TableSchemaOptions;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.config.RabbitmqSourceOptions;
@@ -26,7 +29,10 @@ import org.apache.seatunnel.connectors.seatunnel.rabbitmq.source.RabbitmqSourceF
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class RabbitmqSourceFactoryTest {
 
@@ -104,5 +110,190 @@ public class RabbitmqSourceFactoryTest {
                 "The Factory must explicitly register the '"
                         + TableSchemaOptions.TABLE_CONFIGS.key()
                         + "' option.");
+    }
+
+    private void validate(Map<String, Object> configMap) {
+        RabbitmqSourceFactory rabbitmqSourceFactory = new RabbitmqSourceFactory();
+        ConfigValidator.of(ReadonlyConfig.fromMap(configMap))
+                .validate(rabbitmqSourceFactory.optionRule());
+    }
+
+    @Test
+    public void testValidSingleTableConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+        config.put(RabbitmqSourceOptions.QUEUE_NAME.key(), "test_queue");
+
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "int");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+
+        config.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
+
+        Assertions.assertDoesNotThrow(() -> validate(config));
+    }
+
+    @Test
+    public void testSingleTableMissingSchema() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+        config.put(RabbitmqSourceOptions.QUEUE_NAME.key(), "queue_1");
+
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(optionValidationException.getMessage().contains("schema"));
+    }
+
+    @Test
+    public void testSingleTableBlankQueueName() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+        config.put(RabbitmqSourceOptions.QUEUE_NAME.key(), "   ");
+
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "int");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+
+        config.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
+
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    private Map<String, Object> createValidMultiTableConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "int");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+
+        Map<String, Object> table = new HashMap<>();
+        table.put(RabbitmqSourceOptions.QUEUE_NAME.key(), "queue_1");
+        table.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
+
+        config.put(RabbitmqSourceOptions.TABLE_CONFIGS.key(), Collections.singletonList(table));
+        return config;
+    }
+
+    @Test
+    public void testValidMultiTableConfig() {
+        Map<String, Object> config = createValidMultiTableConfig();
+        Assertions.assertDoesNotThrow(() -> validate(config));
+    }
+
+    @Test
+    public void testSchemaAndTableConfigsAreExclusive() {
+        Map<String, Object> config = createValidMultiTableConfig();
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "int");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+
+        config.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
+
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @Test
+    public void testQueueNameAndTableConfigsAreExclusive() {
+        Map<String, Object> config = createValidMultiTableConfig();
+        config.put(RabbitmqSourceOptions.QUEUE_NAME.key(), "root_queue");
+
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @Test
+    public void testMissingSingleAndMultiTableConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @Test
+    public void testTableConfigsMissingQueueName() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "int");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+
+        Map<String, Object> table = new HashMap<>();
+        table.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
+
+        config.put(RabbitmqSourceOptions.TABLE_CONFIGS.key(), Collections.singletonList(table));
+
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(optionValidationException.getMessage().contains("queue_name"));
+    }
+
+    @Test
+    public void testTableConfigsBlankQueueName() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("id", "int");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+
+        Map<String, Object> table = new HashMap<>();
+        table.put(RabbitmqSourceOptions.QUEUE_NAME.key(), " ");
+        table.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
+
+        config.put(RabbitmqSourceOptions.TABLE_CONFIGS.key(), Collections.singletonList(table));
+
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+        Assertions.assertTrue(optionValidationException.getMessage().contains("queue_name"));
+    }
+
+    @Test
+    public void testTableConfigsMissingSchema() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+
+        Map<String, Object> table = new HashMap<>();
+        table.put(RabbitmqSourceOptions.QUEUE_NAME.key(), "queue_1");
+
+        config.put(RabbitmqSourceOptions.TABLE_CONFIGS.key(), Collections.singletonList(table));
+
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(optionValidationException.getMessage().contains("schema"));
+    }
+
+    @Test
+    public void testEmptyTableConfigs() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(RabbitmqSourceOptions.HOST.key(), "localhost");
+        config.put(RabbitmqSourceOptions.PORT.key(), 5672);
+
+        config.put(RabbitmqSourceOptions.TABLE_CONFIGS.key(), Collections.emptyList());
+
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
     }
 }

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSourceFactoryTest.java
@@ -146,7 +146,10 @@ public class RabbitmqSourceFactoryTest {
         OptionValidationException optionValidationException =
                 Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
 
-        Assertions.assertTrue(optionValidationException.getMessage().contains("schema"));
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.SCHEMA.key()));
     }
 
     @Test
@@ -203,7 +206,18 @@ public class RabbitmqSourceFactoryTest {
 
         config.put(RabbitmqSourceOptions.SCHEMA.key(), schema);
 
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.SCHEMA.key()));
+
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.TABLE_CONFIGS.key()));
     }
 
     @Test
@@ -243,7 +257,10 @@ public class RabbitmqSourceFactoryTest {
         OptionValidationException optionValidationException =
                 Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
 
-        Assertions.assertTrue(optionValidationException.getMessage().contains("queue_name"));
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.QUEUE_NAME.key()));
     }
 
     @Test
@@ -266,7 +283,10 @@ public class RabbitmqSourceFactoryTest {
 
         OptionValidationException optionValidationException =
                 Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
-        Assertions.assertTrue(optionValidationException.getMessage().contains("queue_name"));
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.QUEUE_NAME.key()));
     }
 
     @Test
@@ -283,7 +303,10 @@ public class RabbitmqSourceFactoryTest {
         OptionValidationException optionValidationException =
                 Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
 
-        Assertions.assertTrue(optionValidationException.getMessage().contains("schema"));
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.SCHEMA.key()));
     }
 
     @Test
@@ -294,6 +317,24 @@ public class RabbitmqSourceFactoryTest {
 
         config.put(RabbitmqSourceOptions.TABLE_CONFIGS.key(), Collections.emptyList());
 
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+        OptionValidationException optionValidationException =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        Assertions.assertTrue(
+                optionValidationException
+                        .getMessage()
+                        .contains(RabbitmqSourceOptions.TABLE_CONFIGS.key()));
+    }
+
+    @Test
+    public void testSchemaIsRegisteredAsOptionalOption() {
+        RabbitmqSourceFactory factory = new RabbitmqSourceFactory();
+
+        boolean hasSchema =
+                factory.optionRule().getOptionalOptions().stream()
+                        .anyMatch(
+                                option -> option.key().equals(RabbitmqSourceOptions.SCHEMA.key()));
+
+        Assertions.assertTrue(hasSchema, "SCHEMA should be registered as an optional option");
     }
 }

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSourceTest.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSourceTest.java
@@ -34,7 +34,6 @@ import org.apache.seatunnel.connectors.seatunnel.rabbitmq.split.RabbitmqSplit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -116,43 +115,6 @@ public class RabbitmqSourceTest {
     }
 
     /**
-     * Test Validation: If a user accidentally provides BOTH 'table_configs' and 'schema', the
-     * connector should fail-fast and throw a validation exception.
-     */
-    @Test
-    public void testMixedConfigThrowsException() {
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put(RabbitmqBaseOptions.HOST.key(), "localhost");
-
-        // Define Table Configs
-        Map<String, Object> table1 = new HashMap<>();
-        table1.put("queue_name", "q1");
-        table1.put(
-                "schema",
-                Collections.singletonMap("fields", Collections.singletonMap("col1", "string")));
-        configMap.put(TableSchemaOptions.TABLE_CONFIGS.key(), Collections.singletonList(table1));
-
-        // Define Root Schema (Conflict)
-        Map<String, Object> rootSchema = new HashMap<>();
-        rootSchema.put("fields", Collections.singletonMap("legacy_col", "boolean"));
-        configMap.put(ConnectorCommonOptions.SCHEMA.key(), rootSchema);
-        configMap.put(RabbitmqBaseOptions.QUEUE_NAME.key(), "global_q");
-
-        // Expect the validation to fail and throw our new RabbitmqConnectorException
-        RabbitmqConnectorException exception =
-                Assertions.assertThrows(
-                        RabbitmqConnectorException.class,
-                        () -> new RabbitmqSource(ReadonlyConfig.fromMap(configMap)),
-                        "Should throw an exception when both table_configs and schema are provided");
-
-        // Verify the error message is the one we expect
-        Assertions.assertTrue(
-                exception
-                        .getMessage()
-                        .contains("Cannot specify both 'table_configs' and 'schema'"));
-    }
-
-    /**
      * Tests that the Source throws an exception if configured for BATCH mode, as RabbitMQ is
      * inherently unbounded (Streaming) unless specific for_e2e_testing flag is true.
      */
@@ -201,73 +163,6 @@ public class RabbitmqSourceTest {
         Assertions.assertEquals("RabbitMQ", source.getPluginName());
     }
 
-    /** Test Fallback Scenario: Missing 'queue_name' in table config. */
-    @Test
-    public void testTableConfigWithoutQueueName() {
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put(RabbitmqBaseOptions.HOST.key(), "localhost");
-        configMap.put(RabbitmqBaseOptions.PORT.key(), 5672);
-
-        // Define a Global Queue
-        configMap.put(RabbitmqBaseOptions.QUEUE_NAME.key(), "global_default_queue");
-
-        // Define a Table Config without queue_name
-        Map<String, Object> table1 = new HashMap<>();
-
-        // Setup Schema
-        Map<String, Object> schema1 = new HashMap<>();
-        schema1.put("table", "fallback_table");
-        schema1.put("fields", Collections.singletonMap("id", "int"));
-        table1.put("schema", schema1);
-
-        // Add to config
-        configMap.put(TableSchemaOptions.TABLE_CONFIGS.key(), Collections.singletonList(table1));
-
-        // Create Source (Περιμένουμε να πετάξει Exception αμέσως!)
-        Assertions.assertThrows(
-                Exception.class,
-                () -> new RabbitmqSource(ReadonlyConfig.fromMap(configMap)),
-                "Should fail when table_configs is missing the queue_name");
-    }
-
-    @Test
-    public void testTableConfigMissingSchemaThrowsException() {
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put(RabbitmqBaseOptions.HOST.key(), "localhost");
-
-        Map<String, Object> table1 = new HashMap<>();
-        table1.put("queue_name", "q1");
-        // table1.put("schema", ...) is purposefully missing
-
-        configMap.put(TableSchemaOptions.TABLE_CONFIGS.key(), Collections.singletonList(table1));
-
-        Assertions.assertThrows(
-                Exception.class,
-                () -> new RabbitmqSource(ReadonlyConfig.fromMap(configMap)),
-                "Should fail when table_configs is missing the schema block");
-    }
-    /**
-     * Verifies that if a user configures BOTH 'schema' and 'tables_configs', the code fails-fast
-     * instead of silently prioritizing one over the other.
-     */
-    @Test
-    public void testExclusiveConfigValidation() {
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("host", "localhost");
-        configMap.put(ConnectorCommonOptions.SCHEMA.key(), new HashMap<>());
-        configMap.put(ConnectorCommonOptions.TABLE_CONFIGS.key(), new ArrayList<>());
-
-        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
-
-        RabbitmqConnectorException exception =
-                Assertions.assertThrows(
-                        RabbitmqConnectorException.class, () -> new RabbitmqSource(config));
-        Assertions.assertTrue(
-                exception
-                        .getMessage()
-                        .contains("Cannot specify both 'table_configs' and 'schema'"));
-    }
-
     /**
      * Verifies that the 'splitId' correctly represents the physical 'queue_name' and is NOT
      * overwritten by the virtual 'plugin_output' table identifier, ensuring connection stability.
@@ -295,39 +190,5 @@ public class RabbitmqSourceTest {
         Assertions.assertEquals(1, enumerator.currentUnassignedSplitSize());
 
         Assertions.assertTrue(source.getProducedCatalogTables().size() == 1);
-    }
-
-    /**
-     * Verifies that if a user defines a 'table_configs' block but forgets to include the
-     * 'queue_name' key inside it, the system throws a fail-fast validation exception instead of
-     * throwing a NullPointerException during source initialization.
-     */
-    @Test
-    public void testMissingQueueNameInTableConfigsThrowsException() {
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put(RabbitmqBaseOptions.HOST.key(), "localhost");
-
-        Map<String, Object> table1 = new HashMap<>();
-        table1.put("plugin_output", "my_table");
-        // PURPOSEFULLY MISSING: table1.put("queue_name", "q1");
-
-        Map<String, Object> schema1 = new HashMap<>();
-        schema1.put("fields", Collections.singletonMap("col1", "string"));
-        table1.put("schema", schema1);
-
-        configMap.put(TableSchemaOptions.TABLE_CONFIGS.key(), Collections.singletonList(table1));
-
-        RabbitmqConnectorException exception =
-                Assertions.assertThrows(
-                        RabbitmqConnectorException.class,
-                        () -> new RabbitmqSource(ReadonlyConfig.fromMap(configMap)),
-                        "Should fail-fast when 'queue_name' is omitted inside a table_configs item");
-
-        Assertions.assertTrue(
-                exception
-                        .getMessage()
-                        .contains(
-                                "The 'queue_name' is missing or empty inside one of the 'table_configs' items."),
-                "Error message should clearly state that queue_name is missing");
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Migrate RabbitMQ source configuration validation from runtime checks to the declarative `OptionRule` validation framework.

### Changes

- Add declarative validation for single-table mode:
  - require non-blank `queue_name`
  - require `schema` when `queue_name` is configured
- Add declarative validation for multi-table mode:
  - require non-empty `tables_configs`
  - reject root-level `schema` when `tables_configs` is configured
  - require each `tables_configs` entry to contain a non-blank `queue_name`
  - require each `tables_configs` entry to contain `schema`
- Remove duplicate runtime validation from `RabbitmqSource`
- Move related validation tests to `RabbitmqSourceFactoryTest`

### Tests

- `mvnw.cmd -pl seatunnel-connectors-v2/connector-rabbitmq test`
  - Tests run: 32
  - Failures: 0
  - Errors: 0
- `mvnw.cmd -pl seatunnel-connectors-v2/connector-rabbitmq spotless:check`
  - BUILD SUCCESS
- `git diff --cached --check`
  - passed

### User-facing change

Invalid RabbitMQ source configurations are now rejected during factory option validation, before `RabbitmqSource` is constructed. As a result, these invalid configurations now fail with `OptionValidationException` instead of `RabbitmqConnectorException`.

Related to #11007