### PR TITLE
[Bug][Connector-V2][Prometheus] Apply batch_size default in loadConfig

### DIFF
--- a/seatunnel-connectors-v2/connector-prometheus/src/main/java/org/apache/seatunnel/connectors/seatunnel/prometheus/config/PrometheusSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-prometheus/src/main/java/org/apache/seatunnel/connectors/seatunnel/prometheus/config/PrometheusSinkConfig.java
@@ -51,10 +51,11 @@ public class PrometheusSinkConfig extends HttpConfig {
         if (pluginConfig.getOptional(PrometheusSinkOptions.KEY_TIMESTAMP).isPresent()) {
             sinkConfig.setKeyTimestamp(pluginConfig.get(PrometheusSinkOptions.KEY_TIMESTAMP));
         }
-        if (pluginConfig.getOptional(PrometheusSinkOptions.BATCH_SIZE).isPresent()) {
-            int batchSize = checkIntArgument(pluginConfig.get(PrometheusSinkOptions.BATCH_SIZE));
-            sinkConfig.setBatchSize(batchSize);
-        }
+        // Use get() (not getOptional().isPresent()) so the option's declared default is applied
+        // when batch_size is not configured; getOptional() does not fall back to the default, which
+        // would leave batchSize at 0 and disable the size-based flush trigger.
+        int batchSize = checkIntArgument(pluginConfig.get(PrometheusSinkOptions.BATCH_SIZE));
+        sinkConfig.setBatchSize(batchSize);
         if (pluginConfig.getOptional(PrometheusSinkOptions.FLUSH_INTERVAL).isPresent()) {
             long flushInterval = pluginConfig.get(PrometheusSinkOptions.FLUSH_INTERVAL);
             sinkConfig.setFlushInterval(flushInterval);

--- a/seatunnel-connectors-v2/connector-prometheus/src/test/java/org/apache/seatunnel/connectors/seatunnel/prometheus/PrometheusSinkConfigTest.java
+++ b/seatunnel-connectors-v2/connector-prometheus/src/test/java/org/apache/seatunnel/connectors/seatunnel/prometheus/PrometheusSinkConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.prometheus;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.prometheus.config.PrometheusSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.prometheus.config.PrometheusSinkOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class PrometheusSinkConfigTest {
+
+    @Test
+    void shouldApplyBatchSizeDefaultWhenNotConfigured() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("url", "http://localhost:9090/api/v1/write");
+        map.put("key_label", "c_map");
+        map.put("key_value", "c_double");
+
+        PrometheusSinkConfig config = PrometheusSinkConfig.loadConfig(ReadonlyConfig.fromMap(map));
+
+        Assertions.assertEquals(
+                PrometheusSinkOptions.BATCH_SIZE.defaultValue().intValue(), config.getBatchSize());
+    }
+
+    @Test
+    void shouldUseConfiguredBatchSize() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("url", "http://localhost:9090/api/v1/write");
+        map.put("key_label", "c_map");
+        map.put("key_value", "c_double");
+        map.put("batch_size", 5);
+
+        PrometheusSinkConfig config = PrometheusSinkConfig.loadConfig(ReadonlyConfig.fromMap(map));
+
+        Assertions.assertEquals(5, config.getBatchSize());
+    }
+
+    @Test
+    void shouldRejectNonPositiveBatchSize() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("url", "http://localhost:9090/api/v1/write");
+        map.put("key_label", "c_map");
+        map.put("key_value", "c_double");
+        map.put("batch_size", 0);
+
+        Assertions.assertThrows(
+                Exception.class,
+                () -> PrometheusSinkConfig.loadConfig(ReadonlyConfig.fromMap(map)));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Follow-up to the review discussion on #11778 (raised by @nzw921rx and @DanielLeens).

`PrometheusSinkConfig.loadConfig()` set `batch_size` only when the key was present, guarded by
`getOptional(BATCH_SIZE).isPresent()`. `ReadonlyConfig.getOptional()` does not fall back to the
option's declared default (only `get()` does, via `getOptional(option).orElseGet(option::defaultValue)`).
So a job that omits `batch_size` ended up with `batchSize = 0`, and the size-based flush trigger in
the writer (`batchSize > 0 && batchList.size() >= batchSize`) never fired. The declared default of
`1024` in `PrometheusSinkOptions.BATCH_SIZE` was effectively ignored.

This PR uses `get()` so the declared default is applied when `batch_size` is not configured.

### Does this PR introduce _any_ user-facing change?

Yes, a bug fix. A `Prometheus` sink that does not set `batch_size` now buffers up to the documented
default of `1024` rows before a size-based flush, instead of never flushing by size (`batchSize = 0`).
Jobs that explicitly set `batch_size` are unaffected.

### How was this patch tested?

Added `PrometheusSinkConfigTest` with three cases:

- `batch_size` not configured -> `loadConfig` returns the declared default (`1024`);
- `batch_size` configured -> that value is used;
- `batch_size` non-positive -> rejected by the existing `checkArgument` guard.

```
./mvnw -pl seatunnel-connectors-v2/connector-prometheus test
=> Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

### Check list

* [x] Code changed are covered with tests.
* [ ] If any new Jar binary package adding in your PR, please add License Notice — N/A.
