### PR TITLE
[Improve][Connector-V2][HBase] Migrate timestamp validation to OptionRule

### DIFF
--- a/docs/en/connectors/source/Hbase.md
+++ b/docs/en/connectors/source/Hbase.md
@@ -114,7 +114,7 @@ End timestamp (exclusive) for scan time range. Unit: milliseconds since epoch. T
 
 **Notes:**
 
-- `start_timestamp` / `end_timestamp` must be >= 0. If both are set, `start_timestamp` must be < `end_timestamp` (time range is [start, end), so `start_timestamp == end_timestamp` produces an empty scan).
+- `start_timestamp` must be >= 0 and `end_timestamp` must be > 0. If both are set, `start_timestamp` must be < `end_timestamp` (time range is [start, end), so `start_timestamp == end_timestamp` produces an empty scan).
 - When `start_rowkey` / `end_rowkey` and `start_timestamp` / `end_timestamp` are configured together, both the rowkey range and the time range constraints are applied (intersection).
 
 ### common-options

--- a/docs/zh/connectors/source/Hbase.md
+++ b/docs/zh/connectors/source/Hbase.md
@@ -113,7 +113,7 @@ HBase 的行键既可以是文本字符串，也可以是二进制数据。在 S
 
 **说明:**
 
-- `start_timestamp` / `end_timestamp` 必须大于等于 0；若两者同时配置，需要满足 `start_timestamp < end_timestamp`（遵循 [start, end) 约定，`start_timestamp == end_timestamp` 将导致空扫描）。
+- `start_timestamp` 必须大于等于 0，`end_timestamp` 必须大于 0；若两者同时配置，需要满足 `start_timestamp < end_timestamp`（遵循 [start, end) 约定，`start_timestamp == end_timestamp` 将导致空扫描）。
 - 当 `start_rowkey` / `end_rowkey` 与 `start_timestamp` / `end_timestamp` 同时配置时，会同时应用行键范围与时间范围限制，最终返回两者的交集。
 
 ### 常用选项

--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.hbase.source;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
@@ -56,9 +57,15 @@ public class HbaseSourceFactory implements TableSourceFactory {
                         HbaseSourceOptions.START_ROW_KEY,
                         HbaseSourceOptions.END_ROW_KEY,
                         HbaseSourceOptions.START_ROW_INCLUSIVE,
-                        HbaseSourceOptions.END_ROW_INCLUSIVE,
+                        HbaseSourceOptions.END_ROW_INCLUSIVE)
+                .optional(
                         HbaseSourceOptions.START_TIMESTAMP,
-                        HbaseSourceOptions.END_TIMESTAMP)
+                        HbaseSourceOptions.END_TIMESTAMP,
+                        Conditions.greaterOrEqual(HbaseSourceOptions.START_TIMESTAMP, 0L),
+                        Conditions.greaterOrEqual(HbaseSourceOptions.END_TIMESTAMP, 0L),
+                        Conditions.lessThanField(
+                                HbaseSourceOptions.START_TIMESTAMP,
+                                HbaseSourceOptions.END_TIMESTAMP))
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceFactory.java
@@ -62,7 +62,7 @@ public class HbaseSourceFactory implements TableSourceFactory {
                         HbaseSourceOptions.START_TIMESTAMP,
                         HbaseSourceOptions.END_TIMESTAMP,
                         Conditions.greaterOrEqual(HbaseSourceOptions.START_TIMESTAMP, 0L),
-                        Conditions.greaterOrEqual(HbaseSourceOptions.END_TIMESTAMP, 0L),
+                        Conditions.greaterThan(HbaseSourceOptions.END_TIMESTAMP, 0L),
                         Conditions.lessThanField(
                                 HbaseSourceOptions.START_TIMESTAMP,
                                 HbaseSourceOptions.END_TIMESTAMP))

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/HbaseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/HbaseFactoryTest.java
@@ -17,15 +17,66 @@
 
 package org.apache.seatunnel.connectors.seatunnel.hbase;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseBaseOptions;
+import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.hbase.sink.HbaseSinkFactory;
+import org.apache.seatunnel.connectors.seatunnel.hbase.source.HbaseSourceFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class HbaseFactoryTest {
 
     @Test
     public void optionRuleTest() {
         Assertions.assertNotNull((new HbaseSinkFactory()).optionRule());
+        Assertions.assertNotNull((new HbaseSourceFactory()).optionRule());
+    }
+
+    @Test
+    void testValidTimestampRanges() {
+        Assertions.assertDoesNotThrow(() -> validateTimestampRange(null, null));
+        Assertions.assertDoesNotThrow(() -> validateTimestampRange(0L, null));
+        Assertions.assertDoesNotThrow(() -> validateTimestampRange(null, 1000L));
+        Assertions.assertDoesNotThrow(() -> validateTimestampRange(0L, 1000L));
+    }
+
+    @Test
+    void testNegativeTimestampFails() {
+        assertInvalidTimestampRange(-1L, null);
+        assertInvalidTimestampRange(null, -1L);
+    }
+
+    @Test
+    void testInvalidTimestampRangeFails() {
+        assertInvalidTimestampRange(1000L, 1000L);
+        assertInvalidTimestampRange(2000L, 1000L);
+    }
+
+    private void assertInvalidTimestampRange(Long startTimestamp, Long endTimestamp) {
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> validateTimestampRange(startTimestamp, endTimestamp));
+    }
+
+    private void validateTimestampRange(Long startTimestamp, Long endTimestamp) {
+        Map<String, Object> config = new HashMap<>();
+        config.put(HbaseBaseOptions.ZOOKEEPER_QUORUM.key(), "127.0.0.1:2181");
+        config.put(HbaseBaseOptions.TABLE.key(), "test_table");
+        if (startTimestamp != null) {
+            config.put(HbaseSourceOptions.START_TIMESTAMP.key(), startTimestamp);
+        }
+        if (endTimestamp != null) {
+            config.put(HbaseSourceOptions.END_TIMESTAMP.key(), endTimestamp);
+        }
+
+        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                .validate(new HbaseSourceFactory().optionRule());
     }
 }

--- a/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/HbaseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/test/java/org/apache/seatunnel/connectors/seatunnel/hbase/HbaseFactoryTest.java
@@ -31,6 +31,10 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Tests factory option rules, including the half-open {@code [start_timestamp, end_timestamp)}
+ * range.
+ */
 public class HbaseFactoryTest {
 
     @Test
@@ -44,6 +48,7 @@ public class HbaseFactoryTest {
         Assertions.assertDoesNotThrow(() -> validateTimestampRange(null, null));
         Assertions.assertDoesNotThrow(() -> validateTimestampRange(0L, null));
         Assertions.assertDoesNotThrow(() -> validateTimestampRange(null, 1000L));
+        Assertions.assertDoesNotThrow(() -> validateTimestampRange(0L, 1L));
         Assertions.assertDoesNotThrow(() -> validateTimestampRange(0L, 1000L));
     }
 
@@ -51,10 +56,12 @@ public class HbaseFactoryTest {
     void testNegativeTimestampFails() {
         assertInvalidTimestampRange(-1L, null);
         assertInvalidTimestampRange(null, -1L);
+        assertInvalidTimestampRange(null, 0L);
     }
 
     @Test
     void testInvalidTimestampRangeFails() {
+        // Equal bounds describe an empty half-open range and are rejected before source creation.
         assertInvalidTimestampRange(1000L, 1000L);
         assertInvalidTimestampRange(2000L, 1000L);
     }


### PR DESCRIPTION
### Purpose of this pull request

Part of #11007.

HBase source timestamp constraints were validated only when `HbaseClient` created the scan. This PR adds the same constraints to `HbaseSourceFactory#optionRule()` so invalid connector configuration is rejected during factory validation.

The change:

- requires `start_timestamp` to be non-negative and an explicitly configured `end_timestamp` to be positive
- requires `start_timestamp` to be less than `end_timestamp` when both are configured
- preserves the existing runtime checks for direct or programmatic construction of `HbaseClient`
- adds focused factory validation coverage for optional, valid, negative, equal and reversed timestamp ranges

### Does this PR introduce _any_ user-facing change?

Yes.

Invalid HBase timestamp configurations are now rejected during connector option validation instead of failing later while the HBase scan is created. Valid configurations keep the existing behavior.

The English and Chinese HBase documentation now distinguish the non-negative start bound from the positive end bound and retain the `start_timestamp < end_timestamp` constraint.

### How was this patch tested?

Added factory validation tests covering:

- neither timestamp configured
- only `start_timestamp` configured
- only `end_timestamp` configured
- a valid timestamp range
- negative start and end timestamps
- a zero end timestamp
- the minimum valid `[0, 1)` range
- equal start and end timestamps
- a start timestamp greater than the end timestamp

Focused verification:

```shell
./mvnw -pl seatunnel-connectors-v2/connector-hbase -Dtest=HbaseFactoryTest test
```

The full `connector-hbase` package was also run locally. All 43 tests passed.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)

No checklist item applies to this change. It does not add a binary, dependency, connector, packaging entry or incompatible behavior. The existing English and Chinese HBase documentation was updated to match the validated bounds.
