### PR TITLE
[Chore] Replace inactive collaborator with goutamadwant

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,7 +41,7 @@ github:
     - LeonYoah
     - heye1005
     - SEZ9
-    - boy-xiaozhang
+    - goutamadwant
     - nzw921rx
   dependabot_updates: false
   enabled_merge_buttons:


### PR DESCRIPTION
## What does this PR do?

Replace inactive collaborator `boy-xiaozhang` with active contributor `goutamadwant` in `.asf.yaml`.

## Why is this needed?

- `boy-xiaozhang` shows no recent PR or issue activity in the last 90 days.
- `goutamadwant` is an active contributor based on recent contribution activity.

## Does this PR introduce any user-facing change?

No.

## How was this verified?

- Updated `.asf.yaml` only
- Ran `./mvnw -nsu -Dmaven.gitcommitid.skip=true -T 3C -pl '!seatunnel-engine/seatunnel-engine-ui' spotless:apply`