### PR TITLE
[Improve][Connector-V2] Migrate email validation to declarative OptionRule

### DIFF
--- a/docs/en/connectors/sink/Email.md
+++ b/docs/en/connectors/sink/Email.md
@@ -64,7 +64,7 @@ password. When set to `false`, the connector sends mail over plain SMTP without 
 
 ### email_smtp_port [int]
 
-SMTP server port. The value must be greater than `0`. The default `465` is the SMTPS port and is used together with
+SMTP server port. The value must be between `1` and `65535`, inclusive. The default `465` is the SMTPS port and is used together with
 `email_smtp_auth = true`. For plain SMTP without authentication, set the port that matches the
 server (for example `25` or `3025`).
 

--- a/docs/en/connectors/sink/Email.md
+++ b/docs/en/connectors/sink/Email.md
@@ -64,7 +64,7 @@ password. When set to `false`, the connector sends mail over plain SMTP without 
 
 ### email_smtp_port [int]
 
-SMTP server port. The default `465` is the SMTPS port and is used together with
+SMTP server port. The value must be greater than `0`. The default `465` is the SMTPS port and is used together with
 `email_smtp_auth = true`. For plain SMTP without authentication, set the port that matches the
 server (for example `25` or `3025`).
 

--- a/docs/zh/connectors/sink/Email.md
+++ b/docs/zh/connectors/sink/Email.md
@@ -62,7 +62,7 @@ import ChangeLog from '../changelog/connector-email.md';
 
 ### email_smtp_port [int]
 
-SMTP 服务器端口。默认值 `465` 为 SMTPS 端口，需与 `email_smtp_auth = true` 配合使用。如果使用不带认证的普通 SMTP，请填写与服务匹配的端口（例如 `25` 或 `3025`）。
+SMTP 服务器端口，取值必须大于 `0`。默认值 `465` 为 SMTPS 端口，需与 `email_smtp_auth = true` 配合使用。如果使用不带认证的普通 SMTP，请填写与服务匹配的端口（例如 `25` 或 `3025`）。
 
 ### email_authorization_code [string]
 

--- a/docs/zh/connectors/sink/Email.md
+++ b/docs/zh/connectors/sink/Email.md
@@ -62,7 +62,7 @@ import ChangeLog from '../changelog/connector-email.md';
 
 ### email_smtp_port [int]
 
-SMTP 服务器端口，取值必须大于 `0`。默认值 `465` 为 SMTPS 端口，需与 `email_smtp_auth = true` 配合使用。如果使用不带认证的普通 SMTP，请填写与服务匹配的端口（例如 `25` 或 `3025`）。
+SMTP 服务器端口，取值必须在 `1` 到 `65535` 之间（包含边界值）。默认值 `465` 为 SMTPS 端口，需与 `email_smtp_auth = true` 配合使用。如果使用不带认证的普通 SMTP，请填写与服务匹配的端口（例如 `25` 或 `3025`）。
 
 ### email_authorization_code [string]
 

--- a/seatunnel-connectors-v2/connector-email/src/main/java/org/apache/seatunnel/connectors/seatunnel/email/sink/EmailSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-email/src/main/java/org/apache/seatunnel/connectors/seatunnel/email/sink/EmailSinkFactory.java
@@ -27,12 +27,16 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.greaterThan;
+import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_ATTACHMENT_NAME;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_AUTHORIZATION_CODE;
+import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_FIELD_DELIMITER;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_FROM_ADDRESS;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_HOST;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_MESSAGE_CONTENT;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_MESSAGE_HEADLINE;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_SMTP_AUTH;
+import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_SMTP_PORT;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_TO_ADDRESS;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_TRANSPORT_PROTOCOL;
 
@@ -61,7 +65,11 @@ public class EmailSinkFactory implements TableSinkFactory {
                         EMAIL_AUTHORIZATION_CODE,
                         EMAIL_MESSAGE_HEADLINE,
                         EMAIL_MESSAGE_CONTENT)
-                .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
+                .optional(EMAIL_SMTP_PORT, greaterThan(EMAIL_SMTP_PORT, 0))
+                .optional(
+                        EMAIL_ATTACHMENT_NAME,
+                        EMAIL_FIELD_DELIMITER,
+                        SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .build();
     }
 }

--- a/seatunnel-connectors-v2/connector-email/src/main/java/org/apache/seatunnel/connectors/seatunnel/email/sink/EmailSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-email/src/main/java/org/apache/seatunnel/connectors/seatunnel/email/sink/EmailSinkFactory.java
@@ -28,6 +28,7 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import com.google.auto.service.AutoService;
 
 import static org.apache.seatunnel.api.configuration.util.Conditions.greaterThan;
+import static org.apache.seatunnel.api.configuration.util.Conditions.lessOrEqual;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_ATTACHMENT_NAME;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_AUTHORIZATION_CODE;
 import static org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions.EMAIL_FIELD_DELIMITER;
@@ -65,7 +66,10 @@ public class EmailSinkFactory implements TableSinkFactory {
                         EMAIL_AUTHORIZATION_CODE,
                         EMAIL_MESSAGE_HEADLINE,
                         EMAIL_MESSAGE_CONTENT)
-                .optional(EMAIL_SMTP_PORT, greaterThan(EMAIL_SMTP_PORT, 0))
+                // Fail fast during option validation instead of when the writer sends the email.
+                .optional(
+                        EMAIL_SMTP_PORT,
+                        greaterThan(EMAIL_SMTP_PORT, 0).and(lessOrEqual(EMAIL_SMTP_PORT, 65535)))
                 .optional(
                         EMAIL_ATTACHMENT_NAME,
                         EMAIL_FIELD_DELIMITER,

--- a/seatunnel-connectors-v2/connector-email/src/test/java/org/apache/seatunnel/connectors/seatunnel/email/EmailFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-email/src/test/java/org/apache/seatunnel/connectors/seatunnel/email/EmailFactoryTest.java
@@ -75,7 +75,9 @@ public class EmailFactoryTest {
     }
 
     private void validate(Map<String, Object> config) {
-        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(optionRule);
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "EmailSink");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
     }
 
     private Map<String, Object> requiredConfig() {

--- a/seatunnel-connectors-v2/connector-email/src/test/java/org/apache/seatunnel/connectors/seatunnel/email/EmailFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-email/src/test/java/org/apache/seatunnel/connectors/seatunnel/email/EmailFactoryTest.java
@@ -36,26 +36,41 @@ public class EmailFactoryTest {
 
     @Test
     void testValidSmtpPorts() {
-        Map<String, Object> config = validConfig();
+        Map<String, Object> config = requiredConfig();
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 1);
+        Assertions.assertDoesNotThrow(() -> validate(config));
+
         config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 465);
         Assertions.assertDoesNotThrow(() -> validate(config));
 
-        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 1);
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 65535);
         Assertions.assertDoesNotThrow(() -> validate(config));
     }
 
     @Test
-    void testDefaultSmtpPort() {
-        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    void testDefaultOptionalOptions() {
+        Assertions.assertDoesNotThrow(() -> validate(requiredConfig()));
     }
 
     @Test
-    void testNonPositiveSmtpPorts() {
-        Map<String, Object> config = validConfig();
+    void testExplicitOptionalOptions() {
+        Map<String, Object> config = requiredConfig();
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 465);
+        config.put(EmailSinkOptions.EMAIL_ATTACHMENT_NAME.key(), "report.csv");
+        config.put(EmailSinkOptions.EMAIL_FIELD_DELIMITER.key(), "|");
+        Assertions.assertDoesNotThrow(() -> validate(config));
+    }
+
+    @Test
+    void testInvalidSmtpPorts() {
+        Map<String, Object> config = requiredConfig();
         config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 0);
         Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
 
         config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), -1);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 65536);
         Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
     }
 
@@ -63,7 +78,7 @@ public class EmailFactoryTest {
         ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(optionRule);
     }
 
-    private Map<String, Object> validConfig() {
+    private Map<String, Object> requiredConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put(EmailSinkOptions.EMAIL_FROM_ADDRESS.key(), "sender@example.com");
         config.put(EmailSinkOptions.EMAIL_TO_ADDRESS.key(), "receiver@example.com");
@@ -73,8 +88,6 @@ public class EmailFactoryTest {
         config.put(EmailSinkOptions.EMAIL_AUTHORIZATION_CODE.key(), "code");
         config.put(EmailSinkOptions.EMAIL_MESSAGE_HEADLINE.key(), "subject");
         config.put(EmailSinkOptions.EMAIL_MESSAGE_CONTENT.key(), "content");
-        config.put(EmailSinkOptions.EMAIL_ATTACHMENT_NAME.key(), "report.csv");
-        config.put(EmailSinkOptions.EMAIL_FIELD_DELIMITER.key(), "|");
         return config;
     }
 }

--- a/seatunnel-connectors-v2/connector-email/src/test/java/org/apache/seatunnel/connectors/seatunnel/email/EmailFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-email/src/test/java/org/apache/seatunnel/connectors/seatunnel/email/EmailFactoryTest.java
@@ -17,15 +17,64 @@
 
 package org.apache.seatunnel.connectors.seatunnel.email;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.email.config.EmailSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.email.sink.EmailSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class EmailFactoryTest {
 
+    private final OptionRule optionRule = new EmailSinkFactory().optionRule();
+
     @Test
-    void optionRule() {
-        Assertions.assertNotNull((new EmailSinkFactory()).optionRule());
+    void testValidSmtpPorts() {
+        Map<String, Object> config = validConfig();
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 465);
+        Assertions.assertDoesNotThrow(() -> validate(config));
+
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 1);
+        Assertions.assertDoesNotThrow(() -> validate(config));
+    }
+
+    @Test
+    void testDefaultSmtpPort() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testNonPositiveSmtpPorts() {
+        Map<String, Object> config = validConfig();
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), 0);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+
+        config.put(EmailSinkOptions.EMAIL_SMTP_PORT.key(), -1);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(optionRule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(EmailSinkOptions.EMAIL_FROM_ADDRESS.key(), "sender@example.com");
+        config.put(EmailSinkOptions.EMAIL_TO_ADDRESS.key(), "receiver@example.com");
+        config.put(EmailSinkOptions.EMAIL_HOST.key(), "smtp.example.com");
+        config.put(EmailSinkOptions.EMAIL_TRANSPORT_PROTOCOL.key(), "smtp");
+        config.put(EmailSinkOptions.EMAIL_SMTP_AUTH.key(), true);
+        config.put(EmailSinkOptions.EMAIL_AUTHORIZATION_CODE.key(), "code");
+        config.put(EmailSinkOptions.EMAIL_MESSAGE_HEADLINE.key(), "subject");
+        config.put(EmailSinkOptions.EMAIL_MESSAGE_CONTENT.key(), "content");
+        config.put(EmailSinkOptions.EMAIL_ATTACHMENT_NAME.key(), "report.csv");
+        config.put(EmailSinkOptions.EMAIL_FIELD_DELIMITER.key(), "|");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Part of #11007.

This PR completes the Email sink declarative option rule by:

- declaring the SMTP port, attachment name, and field delimiter options;
- validating the complete `email_smtp_port` range (`1..65535`) with declarative `Conditions`;
- failing fast during option validation instead of failing later when the writer sends the email;
- adding focused tests for valid boundaries, defaults, explicit optional options, invalid ports, and the CLI-facing unknown-key validation path;
- documenting the SMTP port constraint in English and Chinese.

### Scope clarification

The SMTP port constraint is new fail-fast validation rather than a migration of an existing imperative check. Invalid port values previously reached the writer and failed later during email delivery. Maintainer confirmation that this validation should remain in this PR has been requested in the review discussion.

### Does this PR introduce _any_ user-facing change?

Yes. `email_smtp_port` values outside the valid TCP port range (`1..65535`) are now rejected during option validation. The default value and valid configurations remain unchanged.

### How was this patch tested?

- `./mvnw -pl seatunnel-connectors-v2/connector-email -DskipITs test`
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`

The connector-email module passed all 6 tests with no failures or errors, including 4 focused `EmailFactoryTest` cases and the 2 existing writer tests. The factory-test helper runs `validateUnknownKeys()` before normal option validation, directly protecting the option declarations used by the CLI validation path. The full `./mvnw test` command was also attempted earlier, but the reactor stopped in the unrelated `seatunnel-config-shade` module because shaded `ConfigFactory` classes were unavailable in its test classpath.

### Check list

* [x] No new Jar binary package is added.
* [x] English and Chinese Email connector documentation is updated.
* [x] No incompatible-change entry is required; valid configurations and defaults are unchanged.
* [x] Existing connector packaging, mapping, labels, and E2E wiring are unchanged.
