### PR TITLE
Revert "[Fix][Connector-V2] Upgrade shaded Doris thrift-service to 1.0.1" (#11703)

### DIFF
--- a/seatunnel-shade/seatunnel-thrift-service/pom.xml
+++ b/seatunnel-shade/seatunnel-thrift-service/pom.xml
@@ -26,7 +26,7 @@
     <name>SeaTunnel : Shade : Thrift-Service</name>
 
     <properties>
-        <thrift-service.version>1.0.1</thrift-service.version>
+        <thrift-service.version>1.0.0</thrift-service.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Reverts apache/seatunnel#11703.

The shade module is currently being released (rc3), and #11703 was merged prematurely (see the maintainer comment on #11703). This PR rolls the shaded `org.apache.doris:thrift-service` dependency back from 1.0.1 to 1.0.0.

Scope is limited to the single version property in `seatunnel-shade/seatunnel-thrift-service/pom.xml` — a byte-exact revert with no other files touched (no E2E or CI changes).
