### PR TITLE
[Improve][Connector-V2] Validate Databend JDBC URL

### DIFF
--- a/seatunnel-connectors-v2/connector-databend/src/main/java/org/apache/seatunnel/connectors/seatunnel/databend/source/DatabendSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-databend/src/main/java/org/apache/seatunnel/connectors/seatunnel/databend/source/DatabendSourceFactory.java
@@ -39,6 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.startsWith;
 import static org.apache.seatunnel.connectors.seatunnel.databend.config.DatabendOptions.DATABASE;
 
 /** Databend source factory that creates Databend source connector. */
@@ -53,7 +54,8 @@ public class DatabendSourceFactory implements TableSourceFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(DatabendOptions.URL, DatabendOptions.USERNAME, DatabendOptions.PASSWORD)
+                .required(DatabendOptions.URL, startsWith(DatabendOptions.URL, "jdbc:databend://"))
+                .required(DatabendOptions.USERNAME, DatabendOptions.PASSWORD)
                 .optional(
                         DATABASE,
                         DatabendOptions.TABLE,
@@ -74,12 +76,6 @@ public class DatabendSourceFactory implements TableSourceFactory {
     public TableSource createSource(TableSourceFactoryContext context) {
         return () -> {
             ReadonlyConfig options = context.getOptions();
-
-            if (!options.get(DatabendOptions.URL).startsWith("jdbc:databend://")) {
-                throw new DatabendConnectorException(
-                        DatabendConnectorErrorCode.CONNECT_FAILED,
-                        "Databend URL should start with 'jdbc:databend://'");
-            }
 
             String url = options.get(DatabendOptions.URL);
             Boolean ssl = options.get(DatabendOptions.SSL);

--- a/seatunnel-connectors-v2/connector-databend/src/test/java/org/apache/seatunnel/connectors/seatunnel/databend/DatabendFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-databend/src/test/java/org/apache/seatunnel/connectors/seatunnel/databend/DatabendFactoryTest.java
@@ -18,7 +18,9 @@
 package org.apache.seatunnel.connectors.seatunnel.databend;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
@@ -28,6 +30,7 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.connectors.seatunnel.databend.config.DatabendOptions;
 import org.apache.seatunnel.connectors.seatunnel.databend.sink.DatabendSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.databend.source.DatabendSourceFactory;
 
@@ -70,6 +73,20 @@ public class DatabendFactoryTest {
     }
 
     @Test
+    public void testSourceOptionRuleWithValidDatabendUrl() {
+        Assertions.assertDoesNotThrow(() -> validateSourceOptionRule(getSourceOptions()));
+    }
+
+    @Test
+    public void testSourceOptionRuleWithInvalidDatabendUrl() {
+        Map<String, Object> options = getSourceOptions();
+        options.put(DatabendOptions.URL.key(), "jdbc:mysql://localhost:3306");
+
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validateSourceOptionRule(options));
+    }
+
+    @Test
     public void testCreateSink() {
         DatabendSinkFactory sinkFactory = new DatabendSinkFactory();
 
@@ -90,6 +107,19 @@ public class DatabendFactoryTest {
         ReadonlyConfig config = ReadonlyConfig.fromMap(options);
         return new TableSourceFactoryContext(
                 config, Thread.currentThread().getContextClassLoader());
+    }
+
+    private Map<String, Object> getSourceOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(DatabendOptions.URL.key(), "jdbc:databend://localhost:8000");
+        options.put(DatabendOptions.USERNAME.key(), "root");
+        options.put(DatabendOptions.PASSWORD.key(), "");
+        return options;
+    }
+
+    private void validateSourceOptionRule(Map<String, Object> options) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(options))
+                .validate(new DatabendSourceFactory().optionRule());
     }
 
     private TableSinkFactoryContext getTableSinkFactoryContext(Map<String, Object> options) {


### PR DESCRIPTION
## Background

`DatabendSourceFactory` currently checks whether the JDBC URL starts with `jdbc:databend://` only when the source is created. That means an invalid URL can pass the normal configuration phase and fail later with a connector-specific exception.

This is a static configuration rule, so it belongs in `optionRule()` alongside the other Databend connector options. Doing the validation there also keeps this connector aligned with the validation migration tracked in #11007.

## Changes

- Add a `Conditions.startsWith` constraint for the Databend source URL.
- Remove the now-duplicated runtime URL-prefix check from `createSource()`.
- Add regression coverage for both a valid Databend JDBC URL and an invalid JDBC URL.

The accepted configuration format is unchanged. Invalid URLs are simply rejected earlier, during the standard configuration validation step.

Related to #11007.

## Verification

- Ran `mvn spotless:apply` successfully with JDK 8.
- Added focused tests in `DatabendFactoryTest`.
- Attempted to run the Databend module test with:

  ```text
  mvn -Dskip.spotless=true -pl seatunnel-connectors-v2/connector-databend -am -Dtest=DatabendFactoryTest -Dsurefire.failIfNoSpecifiedTests=false test
  ```

  The current `dev` checkout fails before reaching the Databend module in the unrelated `seatunnel-config-shade` module, where shaded Typesafe Config classes are missing from the local source tree. The change itself should be covered by the project CI run.