### PR TITLE
[Fix][Connector-V2] Close Parquet and ORC writers when rolling files

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/OrcWriteStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/OrcWriteStrategy.java
@@ -97,6 +97,12 @@ public class OrcWriteStrategy extends AbstractWriteStrategy<Writer> {
     }
 
     @Override
+    public synchronized void newFilePart() {
+        finishAndCloseFile();
+        super.newFilePart();
+    }
+
+    @Override
     public void finishAndCloseFile() {
         List<FileConnectorException> closeErrors = new ArrayList<>();
         this.beingWrittenWriter.forEach(

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/ParquetWriteStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/sink/writer/ParquetWriteStrategy.java
@@ -141,6 +141,12 @@ public class ParquetWriteStrategy extends AbstractWriteStrategy<ParquetWriter<Ge
     }
 
     @Override
+    public synchronized void newFilePart() {
+        finishAndCloseFile();
+        super.newFilePart();
+    }
+
+    @Override
     public void finishAndCloseFile() {
         List<FileConnectorException> closeErrors = new ArrayList<>();
         this.beingWrittenWriter.forEach(

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/writer/OrcWriteStrategyTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/writer/OrcWriteStrategyTest.java
@@ -51,6 +51,49 @@ public class OrcWriteStrategyTest {
 
     @DisabledOnOs(OS.WINDOWS)
     @Test
+    public void testCloseWriterWhenRollingFile() throws Exception {
+        String tmpPath = "file:///tmp/seatunnel/orc/rolling/test-" + System.nanoTime();
+        Map<String, Object> writeConfig = new HashMap<>();
+        writeConfig.put("tmp_path", tmpPath);
+        writeConfig.put("path", "file:///tmp/seatunnel/orc/rolling");
+        writeConfig.put("file_format_type", FileFormat.ORC.name());
+        writeConfig.put("batch_size", 1);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"value"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+        OrcWriteStrategy writeStrategy =
+                new OrcWriteStrategy(
+                        new FileSinkConfig(ReadonlyConfig.fromMap(writeConfig), rowType));
+        LocalFileSystemConf.LocalConf hadoopConf =
+                new LocalFileSystemConf.LocalConf(FS_DEFAULT_NAME_DEFAULT);
+        writeStrategy.setCatalogTable(
+                CatalogTableUtil.getCatalogTable("test", null, null, "test", rowType));
+        writeStrategy.init(hadoopConf, "rolling-test", "rolling-test", 0);
+        writeStrategy.beginTransaction(1L);
+
+        writeStrategy.write(new SeaTunnelRow(new Object[] {"first"}));
+        writeStrategy.write(new SeaTunnelRow(new Object[] {"second"}));
+
+        OrcReadStrategy readStrategy = new OrcReadStrategy();
+        readStrategy.init(hadoopConf);
+        List<String> readFiles = readStrategy.getFileNamesByPath(tmpPath);
+        Assertions.assertEquals(1, readFiles.size());
+        String rolledFile = readFiles.get(0);
+        Assertions.assertTrue(rolledFile.endsWith("_0.orc"));
+        readStrategy.getSeaTunnelRowTypeInfo(rolledFile);
+        List<String> values = new ArrayList<>();
+        readStrategy.read(rolledFile, "test", collectorForFirstField(values));
+        Assertions.assertEquals(java.util.Arrays.asList("first"), values);
+
+        writeStrategy.finishAndCloseFile();
+        writeStrategy.close();
+        Assertions.assertEquals(2, readStrategy.getFileNamesByPath(tmpPath).size());
+        readStrategy.close();
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
     public void testOrcWriteWithBatch() throws Exception {
         Map<String, Object> writeConfig = new HashMap<>();
         writeConfig.put("tmp_path", TMP_PATH);
@@ -105,5 +148,19 @@ public class OrcWriteStrategyTest {
         readStrategy.read(readFilePath, "test", readCollector);
         Assertions.assertEquals(ORC_WRITE_NUMBER, readRows.size());
         readStrategy.close();
+    }
+
+    private static Collector<SeaTunnelRow> collectorForFirstField(List<String> values) {
+        return new Collector<SeaTunnelRow>() {
+            @Override
+            public void collect(SeaTunnelRow record) {
+                values.add((String) record.getField(0));
+            }
+
+            @Override
+            public Object getCheckpointLock() {
+                return null;
+            }
+        };
     }
 }

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/writer/ParquetWriteStrategyTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/writer/ParquetWriteStrategyTest.java
@@ -62,6 +62,49 @@ public class ParquetWriteStrategyTest {
 
     @DisabledOnOs(OS.WINDOWS)
     @Test
+    public void testCloseWriterWhenRollingFile() throws Exception {
+        String tmpPath = "file:///tmp/seatunnel/parquet/rolling/test-" + System.nanoTime();
+        Map<String, Object> writeConfig = new HashMap<>();
+        writeConfig.put("tmp_path", tmpPath);
+        writeConfig.put("path", "file:///tmp/seatunnel/parquet/rolling");
+        writeConfig.put("file_format_type", FileFormat.PARQUET.name());
+        writeConfig.put("batch_size", 1);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"value"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+        ParquetWriteStrategy writeStrategy =
+                new ParquetWriteStrategy(
+                        new FileSinkConfig(ReadonlyConfig.fromMap(writeConfig), rowType));
+        LocalFileSystemConf.LocalConf hadoopConf =
+                new LocalFileSystemConf.LocalConf(FS_DEFAULT_NAME_DEFAULT);
+        writeStrategy.setCatalogTable(
+                CatalogTableUtil.getCatalogTable("test", null, null, "test", rowType));
+        writeStrategy.init(hadoopConf, "rolling-test", "rolling-test", 0);
+        writeStrategy.beginTransaction(1L);
+
+        writeStrategy.write(new SeaTunnelRow(new Object[] {"first"}));
+        writeStrategy.write(new SeaTunnelRow(new Object[] {"second"}));
+
+        ParquetReadStrategy readStrategy = new ParquetReadStrategy();
+        readStrategy.init(hadoopConf);
+        List<String> readFiles = readStrategy.getFileNamesByPath(tmpPath);
+        Assertions.assertEquals(1, readFiles.size());
+        String rolledFile = readFiles.get(0);
+        Assertions.assertTrue(rolledFile.endsWith("_0.parquet"));
+        readStrategy.getSeaTunnelRowTypeInfo(rolledFile);
+        List<String> values = new ArrayList<>();
+        readStrategy.read(rolledFile, "test", collectorForFirstField(values));
+        Assertions.assertEquals(Arrays.asList("first"), values);
+
+        writeStrategy.finishAndCloseFile();
+        writeStrategy.close();
+        Assertions.assertEquals(2, readStrategy.getFileNamesByPath(tmpPath).size());
+        readStrategy.close();
+    }
+
+    @DisabledOnOs(OS.WINDOWS)
+    @Test
     public void testParquetWriteInt96() throws Exception {
         Map<String, Object> writeConfig = new HashMap<>();
         writeConfig.put("tmp_path", TMP_PATH);
@@ -192,5 +235,19 @@ public class ParquetWriteStrategyTest {
                     createTimeType.asPrimitiveType().getPrimitiveTypeName());
         }
         readStrategy.close();
+    }
+
+    private static Collector<SeaTunnelRow> collectorForFirstField(List<String> values) {
+        return new Collector<SeaTunnelRow>() {
+            @Override
+            public void collect(SeaTunnelRow record) {
+                values.add((String) record.getField(0));
+            }
+
+            @Override
+            public Object getCheckpointLock() {
+                return null;
+            }
+        };
     }
 }


### PR DESCRIPTION
 ### Purpose

  Close Parquet and ORC writers when `batch_size` triggers file rolling, preventing old writers and their buffers from being retained until the batch job finishes.

 Fixes #11830

  ### Changes

  - Close and release current writers before creating a new file part.
  - Flush pending ORC row batches during file rolling.
  - Add tests to verify rolled files are closed and readable immediately.

  ### Verification

  - `./mvnw spotless:apply`
  - `./mvnw -q -DskipTests verify`
  - Parquet and ORC writer unit tests