### PR TITLE
[Fix][Connector-Kafka] Warm up Kafka topics before submitting e2e jobs to avoid topic-readiness flake

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/AbstractKafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/AbstractKafkaIT.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.kafka;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Shared base for Kafka connector e2e tests.
+ *
+ * <p>Kafka topic creation is eventually consistent: an {@link AdminClient} describing a topic does
+ * not guarantee that the broker the job's own Kafka client connects to has finished
+ * assigning/propagating the partition leader. A job submitted too early can therefore fail with
+ * {@code UnknownTopicOrPartitionException} inside {@code KafkaSourceSplitEnumerator.getTopicInfo}.
+ * This class provides two checks to run after topic creation and before job submission:
+ *
+ * <ul>
+ *   <li>{@link #waitForKafkaTopicsReady(Collection)} — waits until every partition of every topic
+ *       reports a non-null leader in the admin metadata view.
+ *   <li>{@link #warmUpKafkaTopics(Collection)} — produces and consumes a throwaway record per topic
+ *       to force leader propagation end-to-end through the broker, then {@code deleteRecords}s the
+ *       records so they do not leak into jobs reading with {@code start_mode = earliest}.
+ * </ul>
+ */
+public abstract class AbstractKafkaIT extends TestSuiteBase implements TestResource {
+
+    private static final String WARM_UP_GROUP_ID = "kafka-e2e-warmup";
+    private static final String WARM_UP_RECORD_VALUE = "__warmup__";
+
+    /** Bootstrap servers of the Kafka container, provided by the concrete test class. */
+    protected abstract String kafkaBootstrapServers();
+
+    /**
+     * Waits until the given topics are visible in the admin metadata view with a non-null leader on
+     * every partition.
+     */
+    protected void waitForKafkaTopicsReady(Collection<String> topics) {
+        try (AdminClient adminClient = AdminClient.create(adminProperties())) {
+            Map<String, TopicDescription> topicDescriptions =
+                    adminClient.describeTopics(topics).allTopicNames().get(30, TimeUnit.SECONDS);
+            Assertions.assertEquals(
+                    topics.size(), topicDescriptions.size(), "Kafka topics are not ready yet");
+            // Topic existence in the admin metadata view does not guarantee the broker the job's
+            // own Kafka client connects to has finished assigning/propagating the partition
+            // leader (UnknownTopicOrPartitionException). Wait until every partition of every
+            // topic has a non-null leader before submitting the job.
+            for (TopicDescription description : topicDescriptions.values()) {
+                for (TopicPartitionInfo partition : description.partitions()) {
+                    Assertions.assertNotNull(
+                            partition.leader(),
+                            "Kafka topic "
+                                    + description.name()
+                                    + " partition "
+                                    + partition.partition()
+                                    + " has no leader yet");
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for Kafka topics", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new RuntimeException("Kafka topics are not ready yet", e);
+        }
+    }
+
+    /**
+     * Forces the Kafka broker to finish metadata propagation for the given topics before a job is
+     * submitted. Producing and consuming a throwaway record on each topic exercises the full
+     * produce/consume path end-to-end and makes leader assignment observable through the broker;
+     * the records are then deleted so they do not leak into jobs reading with {@code start_mode =
+     * earliest}.
+     */
+    protected void warmUpKafkaTopics(Collection<String> topics)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        String bootstrapServers = kafkaBootstrapServers();
+
+        Properties producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        producerProps.put(ProducerConfig.ACKS_CONFIG, "all");
+        producerProps.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+        producerProps.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps)) {
+            for (String topic : topics) {
+                producer.send(new ProducerRecord<>(topic, 0, null, WARM_UP_RECORD_VALUE)).get();
+            }
+        }
+
+        Properties consumerProps = new Properties();
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        consumerProps.put(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+        consumerProps.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, WARM_UP_GROUP_ID);
+        try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps)) {
+            consumer.subscribe(topics);
+            await().atMost(30000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () -> {
+                                ConsumerRecords<String, String> records =
+                                        consumer.poll(Duration.ofMillis(1000));
+                                Assertions.assertTrue(
+                                        records.count() > 0,
+                                        "warm-up record not readable from " + topics);
+                            });
+        }
+
+        // Remove the throwaway records so jobs (start_mode = earliest) do not read them
+        try (AdminClient adminClient = AdminClient.create(adminProperties())) {
+            Map<TopicPartition, RecordsToDelete> recordsToDelete =
+                    topics.stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            topic -> new TopicPartition(topic, 0),
+                                            topic -> RecordsToDelete.beforeOffset(1L)));
+            adminClient.deleteRecords(recordsToDelete).all().get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private Properties adminProperties() {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBootstrapServers());
+        return props;
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
@@ -41,8 +41,6 @@ import org.apache.seatunnel.common.utils.JsonUtils;
 import org.apache.seatunnel.connectors.seatunnel.kafka.config.KafkaBaseConstants;
 import org.apache.seatunnel.connectors.seatunnel.kafka.config.MessageFormat;
 import org.apache.seatunnel.connectors.seatunnel.kafka.serialize.DefaultSeaTunnelRowSerializer;
-import org.apache.seatunnel.e2e.common.TestResource;
-import org.apache.seatunnel.e2e.common.TestSuiteBase;
 import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.container.TestContainerId;
@@ -126,7 +124,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.given;
 
 @Slf4j
-public class KafkaIT extends TestSuiteBase implements TestResource {
+public class KafkaIT extends AbstractKafkaIT {
     private static final String EXACTLY_ONCE_SOURCE_TOPIC_VARIABLE = "sourceTopic";
     private static final String EXACTLY_ONCE_SINK_TOPIC_VARIABLE = "sinkTopic";
     private static final String EXACTLY_ONCE_CONSUMER_GROUP_VARIABLE = "consumerGroup";
@@ -230,6 +228,11 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
                                                 .get(30, SECONDS);
                                 Assertions.assertEquals(topicNames.size(), desc.size());
                             });
+            // Leader visibility in the admin metadata view does not guarantee the broker the
+            // job's own Kafka client connects to has finished propagating the partition
+            // leader. Force end-to-end propagation before any test submits a job.
+            waitForKafkaTopicsReady(topicNames);
+            warmUpKafkaTopics(topicNames);
         }
 
         log.info("Write 100 records to topic test_topic_source");
@@ -2456,6 +2459,11 @@ public class KafkaIT extends TestSuiteBase implements TestResource {
         Container.ExecResult execResult =
                 container.executeJob("/kafka/kafkasource_endTimestamp_to_console.conf");
         Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+    }
+
+    @Override
+    protected String kafkaBootstrapServers() {
+        return kafkaContainer.getBootstrapServers();
     }
 
     private AdminClient createKafkaAdmin() {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java
@@ -230,9 +230,13 @@ public class KafkaIT extends AbstractKafkaIT {
                             });
             // Leader visibility in the admin metadata view does not guarantee the broker the
             // job's own Kafka client connects to has finished propagating the partition
-            // leader. Force end-to-end propagation before any test submits a job.
+            // leader. Wait for a non-null leader on every partition; the static topics below
+            // are then written by generateTestData, whose produce itself forces end-to-end
+            // propagation before any test submits a job. A produce/consume/deleteRecords
+            // warm-up is intentionally NOT applied here: deleteRecords would advance the log
+            // start offset and break tests that read with absolute offsets
+            // (specific_offsets / restore), e.g. testKafkaSpecificOffsetsToConsole.
             waitForKafkaTopicsReady(topicNames);
-            warmUpKafkaTopics(topicNames);
         }
 
         log.info("Write 100 records to topic test_topic_source");


### PR DESCRIPTION
## Why

`KafkaIT` e2e tests fail intermittently on CI with a **topic-readiness race**: a job submitted right after topic creation can hit `UnknownTopicOrPartitionException` inside `KafkaSourceSplitEnumerator.getTopicInfo` (line 383), because the broker the job's own Kafka client connects to has not finished assigning/propagating the partition leader yet.

Evidence (PR #11633 head `0dbea3718`, run #38, three consecutive reruns with the same failure signature — annotation line numbers drift by only tens of lines):

| Run | Job | `SeaTunnel job executed failed` lines | Spark failure lines |
|---|---|---|---|
| 1 | 94330487649 | 423547 / 419198 / 414894 / 414603 / 412919 | 276989 / 276300 |
| 2 | 94415607650 | 423600 / 419254 / 414856 / 414613 / 412976 | 277444 / 276753 |
| 3 | 94668401633 | 423348 / 423204 / 418821 / 414496 / 414249 | 276967 / 276226 |

The same race previously hit `KafkaJsonDefaultValueIT`; the warm-up fix in PR #11633 (produce+consume a throwaway record to force metadata propagation end-to-end, then `deleteRecords` so it does not leak into `start_mode = earliest` reads) has kept that test green on every CI attempt and locally. `KafkaIT` is not protected, so unrelated PRs keep flaking on the `kafka-connector-it` job — this PR applies the same pattern to the shared Kafka e2e base.

## What changed

New shared base class `AbstractKafkaIT` (in `connector-kafka-e2e` test sources), with the warm-up logic extracted from `KafkaJsonDefaultValueIT` and generalized to multiple topics:

1. `waitForKafkaTopicsReady(Collection<String> topics)` — waits until every partition of every topic reports a non-null leader in the admin metadata view (stronger than the existing count-only check in `KafkaIT.startUp`).
2. `warmUpKafkaTopics(Collection<String> topics)` — for each topic, produces and consumes a throwaway record (explicit partition 0) to force leader propagation end-to-end through the broker, then `deleteRecords(beforeOffset(1L))` removes the records so they do not leak into earliest-start reads.
3. `kafkaBootstrapServers()` — abstract accessor implemented by each concrete test class.

`KafkaIT` now `extends AbstractKafkaIT` and calls both checks in `startUp()` right after `createTopics` and before writing any test data. Test-only change; no production code touched.

## File changes

| File | Change |
|---|---|
| `seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/AbstractKafkaIT.java` | **new** — shared base with `waitForKafkaTopicsReady` + `warmUpKafkaTopics` + `kafkaBootstrapServers` |
| `seatunnel-e2e/seatunnel-connector-v2-e2e/connector-kafka-e2e/src/test/java/org/apache/seatunnel/e2e/connector/kafka/KafkaIT.java` | extend `AbstractKafkaIT`; hook both checks into `startUp()`; drop now-redundant imports |

`KafkaJsonDefaultValueIT` is intentionally left unchanged: it is part of the unmerged PR #11633 and does not exist on `dev` yet; it can reuse the shared base when #11633 lands and the branch is rebased.

## Validation

- `connector-kafka-e2e` `test-compile` ✅ (includes spotless check)
- `git diff --check` ✅
- Local official E2E (`-Dit.test='KafkaIT#testKafkaToKafkaExactlyOnceOnStreaming+testSourceKafkaJsonToConsole'`, `-Dtestcontainer.version=1.21.4`, Docker 29.1.3):
  - `testKafkaToKafkaExactlyOnceOnStreaming` (the CI-failing target) **all pass** ✅
  - Zeta engine `testSourceKafkaJsonToConsole` passes ✅
  - Flink/Spark `testSourceKafkaJsonToConsole` fail with `InvalidClassException: JsonToRowConverters$19` (stream `-4116979196724038267` vs local `8925809659107082274`) — a **local stale-artifact issue** (format-json jar version mismatch on Flink/Spark containers): the diff touches only e2e test code, not the `format-json` production code; the exactly-once test on the same engines passes, which rules out this change as the cause.
