### PR TITLE
[Fix][Connector-V2] Fix CDC comment schema-change event routing

### DIFF
--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -5,6 +5,18 @@ You need to check this document before you upgrade to related version.
 
 ## dev
 
+### MySQL CDC Schema-Change Parsing
+
+- **Behavior change: DDL parser listener errors are propagated**
+  - **Affected component**: `connector-cdc-mysql`
+  - **Description**: Errors raised while processing a parsed DDL are no longer swallowed and
+    treated as a no-op. They are now propagated as parsing failures so that a CDC job cannot
+    silently skip a schema change.
+  - **Impact**: A job may fail on a DDL statement that was previously ignored after an internal
+    parser/listener error. Review the source DDL and update it to syntax supported by the
+    connector before restarting the job. This change does not alter checkpoint or savepoint
+    formats.
+
 ### JDBC Connector
 
 - **Breaking Change: Mapping of timezone-aware timestamp columns to `TIMESTAMP_TZ` type**

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -4,6 +4,13 @@
 
 ## dev
 
+### MySQL CDC Schema-Change 解析
+
+- **行为变更：向上传播 DDL 解析监听器错误**
+  - **影响范围**：`connector-cdc-mysql`
+  - **变更说明**：处理已解析 DDL 时发生的错误不再被吞掉并当作无操作处理，而是作为解析失败向上抛出，避免 CDC 作业静默跳过 schema 变更。
+  - **影响**：某些过去在内部解析器或监听器出错后被忽略的 DDL，升级后可能导致作业失败。请检查源端 DDL，修改为连接器支持的语法后再重启作业。本变更不修改 checkpoint 或 savepoint 格式。
+
 ### JDBC Connector
 
 - **破坏性变更：带时区的时间戳列映射为 `TIMESTAMP_TZ` 类型**

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/schema/handler/AlterTableEventHandler.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/schema/handler/AlterTableEventHandler.java
@@ -18,10 +18,12 @@
 package org.apache.seatunnel.api.table.schema.handler;
 
 import org.apache.seatunnel.api.table.catalog.Column;
+import org.apache.seatunnel.api.table.schema.event.AlterColumnCommentEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableChangeColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableColumnsEvent;
+import org.apache.seatunnel.api.table.schema.event.AlterTableCommentEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableDropColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableModifyColumnEvent;
@@ -58,7 +60,9 @@ public class AlterTableEventHandler implements DataTypeChangeEventHandler {
     }
 
     private SeaTunnelRowType apply(SeaTunnelRowType dataType, AlterTableEvent alterTableEvent) {
-        if (alterTableEvent instanceof AlterTableNameEvent) {
+        if (alterTableEvent instanceof AlterTableNameEvent
+                || alterTableEvent instanceof AlterTableCommentEvent
+                || alterTableEvent instanceof AlterColumnCommentEvent) {
             return dataType;
         }
         if (alterTableEvent instanceof AlterTableDropColumnEvent) {

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/schema/handler/DataTypeChangeEventDispatcher.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/table/schema/handler/DataTypeChangeEventDispatcher.java
@@ -17,9 +17,11 @@
 
 package org.apache.seatunnel.api.table.schema.handler;
 
+import org.apache.seatunnel.api.table.schema.event.AlterColumnCommentEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableAddColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableChangeColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableColumnsEvent;
+import org.apache.seatunnel.api.table.schema.event.AlterTableCommentEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableDropColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableModifyColumnEvent;
@@ -76,6 +78,8 @@ public class DataTypeChangeEventDispatcher implements DataTypeChangeEventHandler
         handlers.put(AlterTableModifyColumnEvent.class, alterTableEventHandler);
         handlers.put(AlterTableDropColumnEvent.class, alterTableEventHandler);
         handlers.put(AlterTableChangeColumnEvent.class, alterTableEventHandler);
+        handlers.put(AlterTableCommentEvent.class, alterTableEventHandler);
+        handlers.put(AlterColumnCommentEvent.class, alterTableEventHandler);
         return handlers;
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/schema/event/EventTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/table/schema/event/EventTest.java
@@ -23,10 +23,14 @@ import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.schema.handler.AlterTableSchemaEventHandler;
+import org.apache.seatunnel.api.table.schema.handler.DataTypeChangeEventDispatcher;
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 public class EventTest {
 
@@ -90,6 +94,39 @@ public class EventTest {
         TableSchema changeAfter = new AlterTableSchemaEventHandler().reset(schema).apply(event);
 
         Assertions.assertEquals("new comment", changeAfter.getColumn("description").getComment());
+    }
+
+    @Test
+    public void testDeprecatedDispatcherAcceptsCommentEvents() {
+        TableIdentifier tableIdentifier = TableIdentifier.of("", TablePath.DEFAULT);
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"description"},
+                        new org.apache.seatunnel.api.table.type.SeaTunnelDataType[] {
+                            BasicType.STRING_TYPE
+                        });
+        DataTypeChangeEventDispatcher dispatcher = new DataTypeChangeEventDispatcher();
+
+        Assertions.assertSame(
+                rowType,
+                dispatcher
+                        .reset(rowType)
+                        .apply(
+                                AlterTableCommentEvent.of(
+                                        tableIdentifier, "old table", "new table")));
+        Assertions.assertSame(
+                rowType,
+                dispatcher
+                        .reset(rowType)
+                        .apply(
+                                new AlterTableColumnsEvent(
+                                        tableIdentifier,
+                                        Collections.singletonList(
+                                                AlterColumnCommentEvent.of(
+                                                        tableIdentifier,
+                                                        "description",
+                                                        "old column",
+                                                        "new column")))));
     }
 
     private EventType getEventType(AlterTableColumnEvent event) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolver.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolver.java
@@ -33,6 +33,7 @@ import org.apache.seatunnel.api.table.schema.event.AlterTableEvent;
 import org.apache.seatunnel.api.table.schema.event.AlterTableModifyColumnEvent;
 import org.apache.seatunnel.api.table.schema.event.SchemaChangeEvent;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.connectors.cdc.base.config.JdbcSourceConfig;
 import org.apache.seatunnel.connectors.cdc.base.utils.SourceRecordUtils;
 
@@ -93,6 +94,7 @@ public abstract class AbstractSchemaChangeResolver implements SchemaChangeResolv
         // Parse DDL statement using Debezium's Antlr parser
         ddlParser.parse(ddl, tables);
         List<AlterTableEvent> parsedEvents = getAndClearParsedSchemaChangeEvents();
+        parsedEvents = normalizeTableIdentifiers(parsedEvents, tablePath);
         parsedEvents = completeSchemaChangeEvents(parsedEvents, catalogTables, tablePath);
         parsedEvents.forEach(e -> e.setSourceDialectName(getSourceDialectName()));
 
@@ -241,6 +243,30 @@ public abstract class AbstractSchemaChangeResolver implements SchemaChangeResolv
                 .collect(Collectors.toList());
     }
 
+    List<AlterTableEvent> normalizeTableIdentifiers(
+            List<AlterTableEvent> events, TablePath tablePath) {
+        TableIdentifier tableIdentifier =
+                TableIdentifier.of(
+                        StringUtils.EMPTY,
+                        tablePath.getDatabaseName(),
+                        tablePath.getSchemaName(),
+                        tablePath.getTableName());
+        return events.stream()
+                .map(
+                        event -> {
+                            if (event instanceof AlterTableCommentEvent) {
+                                AlterTableCommentEvent commentEvent =
+                                        (AlterTableCommentEvent) event;
+                                return AlterTableCommentEvent.of(
+                                        tableIdentifier,
+                                        commentEvent.getOldComment(),
+                                        commentEvent.getNewComment());
+                            }
+                            return event;
+                        })
+                .collect(Collectors.toList());
+    }
+
     private CatalogTable findCatalogTable(List<CatalogTable> catalogTables, TablePath tablePath) {
         if (tablePath == null) {
             return null;
@@ -273,12 +299,27 @@ public abstract class AbstractSchemaChangeResolver implements SchemaChangeResolv
     private boolean isSameColumnExceptComment(Column oldColumn, Column newColumn) {
         return StringUtils.equals(oldColumn.getName(), newColumn.getName())
                 && isSameDataType(oldColumn.getDataType(), newColumn.getDataType())
-                && Objects.equals(oldColumn.getColumnLength(), newColumn.getColumnLength())
+                && isSameColumnLength(oldColumn, newColumn)
                 && Objects.equals(oldColumn.getScale(), newColumn.getScale())
                 && oldColumn.isNullable() == newColumn.isNullable()
                 && Objects.equals(oldColumn.getDefaultValue(), newColumn.getDefaultValue())
                 && StringUtils.equals(oldColumn.getSourceType(), newColumn.getSourceType())
                 && Objects.equals(oldColumn.getOptions(), newColumn.getOptions());
+    }
+
+    private boolean isSameColumnLength(Column oldColumn, Column newColumn) {
+        if (Objects.equals(oldColumn.getColumnLength(), newColumn.getColumnLength())) {
+            return true;
+        }
+        // Some dialects canonicalize character lengths (for example MySQL converts character
+        // counts to a four-byte storage length). An identical source type is the stable semantic
+        // representation in that case; genuine length changes still have a different source type.
+        return oldColumn.getDataType() != null
+                && oldColumn.getDataType().getSqlType() == SqlType.STRING
+                && newColumn.getDataType() != null
+                && newColumn.getDataType().getSqlType() == SqlType.STRING
+                && StringUtils.isNotBlank(oldColumn.getSourceType())
+                && StringUtils.equals(oldColumn.getSourceType(), newColumn.getSourceType());
     }
 
     private boolean isSameDataType(

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolver.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolver.java
@@ -245,6 +245,8 @@ public abstract class AbstractSchemaChangeResolver implements SchemaChangeResolv
 
     List<AlterTableEvent> normalizeTableIdentifiers(
             List<AlterTableEvent> events, TablePath tablePath) {
+        // The parser may lose the database while walking a SourceRecord. The SourceRecord table
+        // path is authoritative because it comes from the CDC event's captured source table.
         TableIdentifier tableIdentifier =
                 TableIdentifier.of(
                         StringUtils.EMPTY,

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolverTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/schema/AbstractSchemaChangeResolverTest.java
@@ -107,6 +107,24 @@ public class AbstractSchemaChangeResolverTest {
     }
 
     @Test
+    void testNormalizeTableCommentIdentifierFromSourceRecordPath() {
+        AbstractSchemaChangeResolver resolver = createResolver();
+        AlterTableCommentEvent parsedEvent =
+                AlterTableCommentEvent.of(
+                        TableIdentifier.of(null, null, "products"), null, "new comment");
+
+        AlterTableCommentEvent normalizedEvent =
+                (AlterTableCommentEvent)
+                        resolver.normalizeTableIdentifiers(
+                                        Collections.singletonList(parsedEvent),
+                                        TablePath.of("shop", "products"))
+                                .get(0);
+
+        Assertions.assertEquals(TablePath.of("shop", "products"), normalizedEvent.tablePath());
+        Assertions.assertEquals("new comment", normalizedEvent.getNewComment());
+    }
+
+    @Test
     void testCompletionEventConvertsModifyColumnToColumnCommentEvent() {
         AbstractSchemaChangeResolver resolver = createResolver();
         AlterTableModifyColumnEvent modifyColumnEvent =
@@ -172,6 +190,90 @@ public class AbstractSchemaChangeResolverTest {
                                                 .name("description")
                                                 .dataType(BasicType.STRING_TYPE)
                                                 .columnLength(512L)
+                                                .nullable(true)
+                                                .comment("old column comment")
+                                                .build())
+                                .build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        null,
+                        null);
+
+        List<AlterTableEvent> events =
+                resolver.completeSchemaChangeEvents(
+                        Collections.singletonList(modifyColumnEvent),
+                        Collections.singletonList(catalogTable),
+                        TablePath.of("test_db", "test_table"));
+
+        Assertions.assertSame(modifyColumnEvent, events.get(0));
+    }
+
+    @Test
+    void testCompletionEventUsesCanonicalSourceTypeForColumnComment() {
+        AbstractSchemaChangeResolver resolver = createResolver();
+        AlterTableModifyColumnEvent modifyColumnEvent =
+                AlterTableModifyColumnEvent.modify(
+                        TableIdentifier.of(null, "test_db", "test_table"),
+                        PhysicalColumn.builder()
+                                .name("description")
+                                .dataType(BasicType.STRING_TYPE)
+                                .columnLength(512L)
+                                .sourceType("VARCHAR(512)")
+                                .nullable(true)
+                                .comment("new column comment")
+                                .build());
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(null, "test_db", "test_table"),
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.builder()
+                                                .name("description")
+                                                .dataType(BasicType.STRING_TYPE)
+                                                .columnLength(2048L)
+                                                .sourceType("VARCHAR(512)")
+                                                .nullable(true)
+                                                .comment("old column comment")
+                                                .build())
+                                .build(),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        null,
+                        null);
+
+        List<AlterTableEvent> events =
+                resolver.completeSchemaChangeEvents(
+                        Collections.singletonList(modifyColumnEvent),
+                        Collections.singletonList(catalogTable),
+                        TablePath.of("test_db", "test_table"));
+
+        Assertions.assertInstanceOf(AlterColumnCommentEvent.class, events.get(0));
+    }
+
+    @Test
+    void testCompletionEventKeepsSourceTypeLengthChangeStructural() {
+        AbstractSchemaChangeResolver resolver = createResolver();
+        AlterTableModifyColumnEvent modifyColumnEvent =
+                AlterTableModifyColumnEvent.modify(
+                        TableIdentifier.of(null, "test_db", "test_table"),
+                        PhysicalColumn.builder()
+                                .name("description")
+                                .dataType(BasicType.STRING_TYPE)
+                                .columnLength(1024L)
+                                .sourceType("VARCHAR(1024)")
+                                .nullable(true)
+                                .comment("new column comment")
+                                .build());
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of(null, "test_db", "test_table"),
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.builder()
+                                                .name("description")
+                                                .dataType(BasicType.STRING_TYPE)
+                                                .columnLength(2048L)
+                                                .sourceType("VARCHAR(512)")
                                                 .nullable(true)
                                                 .comment("old column comment")
                                                 .build())

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParser.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParser.java
@@ -46,7 +46,7 @@ public class CustomMySqlAntlrDdlParser extends MySqlAntlrDdlParser {
     private RelationalDatabaseConnectorConfig dbzConnectorConfig;
 
     public CustomMySqlAntlrDdlParser(RelationalDatabaseConnectorConfig dbzConnectorConfig) {
-        super(false, false, true, (MySqlValueConverters) null, Tables.TableFilter.includeAll());
+        super(true, false, true, (MySqlValueConverters) null, Tables.TableFilter.includeAll());
         this.parsedEvents = new LinkedList<>();
         this.dbzConnectorConfig = dbzConnectorConfig;
     }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParser.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParser.java
@@ -45,6 +45,10 @@ public class CustomMySqlAntlrDdlParser extends MySqlAntlrDdlParser {
 
     private RelationalDatabaseConnectorConfig dbzConnectorConfig;
 
+    /**
+     * Creates a parser that propagates listener failures instead of silently treating malformed DDL
+     * as a no-op.
+     */
     public CustomMySqlAntlrDdlParser(RelationalDatabaseConnectorConfig dbzConnectorConfig) {
         super(true, false, true, (MySqlValueConverters) null, Tables.TableFilter.includeAll());
         this.parsedEvents = new LinkedList<>();

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParserTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParserTest.java
@@ -26,9 +26,13 @@ import org.apache.seatunnel.connectors.seatunnel.cdc.mysql.config.MySqlSourceCon
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.antlr.AntlrDdlParserListener;
+import io.debezium.ddl.parser.mysql.generated.MySqlParserBaseListener;
 import io.debezium.relational.Tables;
 import io.debezium.text.ParsingException;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class CustomMySqlAntlrDdlParserTest {
@@ -89,13 +93,35 @@ public class CustomMySqlAntlrDdlParserTest {
 
     @Test
     void testParsePropagatesDdlErrors() {
-        CustomMySqlAntlrDdlParser parser = new CustomMySqlAntlrDdlParser(null);
+        CustomMySqlAntlrDdlParser parser = new ParserWithTreeWalkError();
 
         Assertions.assertThrows(
                 ParsingException.class,
                 () ->
                         parser.parse(
-                                "ALTER TABLE products MODIFY COLUMN description VARCHAR(512) DEFAULT",
+                                "ALTER TABLE products COMMENT = 'Product catalog table'",
                                 new Tables()));
+    }
+
+    private static class ParserWithTreeWalkError extends CustomMySqlAntlrDdlParser {
+        private ParserWithTreeWalkError() {
+            super(null);
+        }
+
+        @Override
+        protected AntlrDdlParserListener createParseTreeWalkerListener() {
+            return new ListenerWithError();
+        }
+    }
+
+    private static class ListenerWithError extends MySqlParserBaseListener
+            implements AntlrDdlParserListener {
+        private final Collection<ParsingException> errors =
+                Collections.singletonList(new ParsingException(null, "listener failure"));
+
+        @Override
+        public Collection<ParsingException> getErrors() {
+            return errors;
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParserTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-mysql/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/mysql/source/parser/CustomMySqlAntlrDdlParserTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.debezium.relational.Tables;
+import io.debezium.text.ParsingException;
 
 import java.util.List;
 
@@ -84,5 +85,17 @@ public class CustomMySqlAntlrDdlParserTest {
         Assertions.assertTrue(events.get(0) instanceof AlterTableCommentEvent);
         AlterTableCommentEvent event = (AlterTableCommentEvent) events.get(0);
         Assertions.assertEquals("Product catalog table", event.getNewComment());
+    }
+
+    @Test
+    void testParsePropagatesDdlErrors() {
+        CustomMySqlAntlrDdlParser parser = new CustomMySqlAntlrDdlParser(null);
+
+        Assertions.assertThrows(
+                ParsingException.class,
+                () ->
+                        parser.parse(
+                                "ALTER TABLE products MODIFY COLUMN description VARCHAR(512) DEFAULT",
+                                new Tables()));
     }
 }

--- a/seatunnel-connectors-v2/connector-databend/src/main/java/org/apache/seatunnel/connectors/seatunnel/databend/schema/SchemaChangeManager.java
+++ b/seatunnel-connectors-v2/connector-databend/src/main/java/org/apache/seatunnel/connectors/seatunnel/databend/schema/SchemaChangeManager.java
@@ -74,10 +74,7 @@ public class SchemaChangeManager implements Serializable {
                         tablePath.getFullName(),
                         event.getClass().getSimpleName());
             } else if (event instanceof AlterTableColumnsEvent) {
-                for (AlterTableColumnEvent columnEvent :
-                        ((AlterTableColumnsEvent) event).getEvents()) {
-                    applySchemaChange(connection, tablePath, columnEvent);
-                }
+                applySchemaChange(connection, tablePath, (AlterTableColumnsEvent) event);
             } else if (event instanceof AlterTableColumnEvent) {
                 applySchemaChange(connection, tablePath, (AlterTableColumnEvent) event);
             } else {
@@ -95,7 +92,13 @@ public class SchemaChangeManager implements Serializable {
     private void applySchemaChange(
             Connection connection, TablePath tablePath, AlterTableColumnEvent event)
             throws SQLException, IOException {
-        if (event instanceof AlterTableChangeColumnEvent) {
+        if (event instanceof AlterColumnCommentEvent) {
+            // Databend does not support comment synchronization, including nested column events.
+            log.info(
+                    "Ignoring comment change event for table {} - Databend sink does not support comment sync: {}",
+                    tablePath.getFullName(),
+                    event.getClass().getSimpleName());
+        } else if (event instanceof AlterTableChangeColumnEvent) {
             AlterTableChangeColumnEvent changeColumnEvent = (AlterTableChangeColumnEvent) event;
             if (!changeColumnEvent.getOldColumn().equals(changeColumnEvent.getColumn().getName())) {
                 if (!columnExists(connection, tablePath, changeColumnEvent.getOldColumn())
@@ -138,6 +141,19 @@ public class SchemaChangeManager implements Serializable {
         } else {
             throw new SeaTunnelException(
                     "Unsupported AlterTableColumnEvent type: " + event.getClass().getName());
+        }
+    }
+
+    /**
+     * Applies each column event in a grouped schema change.
+     *
+     * <p>The resolver wraps column-comment changes in {@link AlterTableColumnsEvent}, so the
+     * per-column dispatcher must handle comment events before structural column events.
+     */
+    void applySchemaChange(Connection connection, TablePath tablePath, AlterTableColumnsEvent event)
+            throws SQLException, IOException {
+        for (AlterTableColumnEvent columnEvent : event.getEvents()) {
+            applySchemaChange(connection, tablePath, columnEvent);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-databend/src/main/java/org/apache/seatunnel/connectors/seatunnel/databend/schema/SchemaChangeManager.java
+++ b/seatunnel-connectors-v2/connector-databend/src/main/java/org/apache/seatunnel/connectors/seatunnel/databend/schema/SchemaChangeManager.java
@@ -66,20 +66,20 @@ public class SchemaChangeManager implements Serializable {
                         String.format(
                                 "%s/%s", databendSinkConfig.getUrl(), tablePath.getDatabaseName()),
                         databendSinkConfig.toProperties())) {
-            if (event instanceof AlterTableColumnsEvent) {
-                for (AlterTableColumnEvent columnEvent :
-                        ((AlterTableColumnsEvent) event).getEvents()) {
-                    applySchemaChange(connection, tablePath, columnEvent);
-                }
-            } else if (event instanceof AlterTableColumnEvent) {
-                applySchemaChange(connection, tablePath, (AlterTableColumnEvent) event);
-            } else if (event instanceof AlterTableCommentEvent
+            if (event instanceof AlterTableCommentEvent
                     || event instanceof AlterColumnCommentEvent) {
                 // Comment-only changes are not supported by Databend sink, safely ignore
                 log.info(
                         "Ignoring comment change event for table {} - Databend sink does not support comment sync: {}",
                         tablePath.getFullName(),
                         event.getClass().getSimpleName());
+            } else if (event instanceof AlterTableColumnsEvent) {
+                for (AlterTableColumnEvent columnEvent :
+                        ((AlterTableColumnsEvent) event).getEvents()) {
+                    applySchemaChange(connection, tablePath, columnEvent);
+                }
+            } else if (event instanceof AlterTableColumnEvent) {
+                applySchemaChange(connection, tablePath, (AlterTableColumnEvent) event);
             } else {
                 throw new SeaTunnelException(
                         "Unsupported schemaChangeEvent: " + event.getClass().getName());

--- a/seatunnel-connectors-v2/connector-databend/src/test/java/org/apache/seatunnel/connectors/seatunnel/databend/schema/SchemaChangeManagerTest.java
+++ b/seatunnel-connectors-v2/connector-databend/src/test/java/org/apache/seatunnel/connectors/seatunnel/databend/schema/SchemaChangeManagerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.databend.schema;
+
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.schema.event.AlterColumnCommentEvent;
+import org.apache.seatunnel.api.table.schema.event.AlterTableColumnsEvent;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class SchemaChangeManagerTest {
+
+    @Test
+    void testNestedColumnCommentEventIsIgnored() {
+        TableIdentifier tableIdentifier = TableIdentifier.of(null, "test_db", "products");
+        AlterColumnCommentEvent commentEvent =
+                AlterColumnCommentEvent.of(tableIdentifier, "description", null, "Product text");
+        AlterTableColumnsEvent groupedEvent =
+                new AlterTableColumnsEvent(
+                        tableIdentifier, Collections.singletonList(commentEvent));
+
+        SchemaChangeManager manager = new SchemaChangeManager(null);
+
+        assertDoesNotThrow(
+                () ->
+                        manager.applySchemaChange(
+                                null, TablePath.of("test_db", "products"), groupedEvent));
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Close: https://github.com/apache/seatunnel/issues/11833
Comment from: https://github.com/apache/seatunnel/pull/11025

### Does this PR introduce _any_ user-facing change?
- Normalize AlterTableCommentEvent identifiers using the SourceRecord TablePath.
- Compare canonicalized string-column metadata when detecting comment-only changes.
- Preserve structural modify-column events when the column definition genuinely changes.
- Add comment-event support to the deprecated Zeta dispatcher and handler.
- Check Databend comment events and ignore them.

### How was this patch tested?
Please refer: MysqlCDCWithFlinkSchemaChangeIT

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
