### PR TITLE
[Feature][Connector-V2] Add Splunk sink connector

### DIFF
--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -375,3 +375,13 @@ nats-jetstream:
           - all-globs-to-all-files:
               - '!seatunnel-connectors-v2/connector-!(nats-jetstream)/**'
               - '!seatunnel-e2e/seatunnel-connector-v2-e2e/connector-!(nats-jetstream)-e2e/**'
+
+splunk:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - seatunnel-connectors-v2/connector-splunk/**
+              - seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/**
+          - all-globs-to-all-files:
+              - '!seatunnel-connectors-v2/connector-!(splunk)/**'
+              - '!seatunnel-e2e/seatunnel-connector-v2-e2e/connector-!(splunk)-e2e/**'

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -107,3 +107,4 @@ connector-lance
 connector-mqtt
 connector-bigquery
 connector-nats-jetstream
+connector-splunk

--- a/docs/en/connectors/changelog/connector-splunk.md
+++ b/docs/en/connectors/changelog/connector-splunk.md
@@ -1,0 +1,26 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+# Changelog
+
+## next version
+
+### Sink
+
+- Add Splunk Sink Connector

--- a/docs/en/connectors/sink/Splunk.md
+++ b/docs/en/connectors/sink/Splunk.md
@@ -37,6 +37,17 @@ endpoint, and this connector does not send an idempotency key.
 
 :::
 
+:::caution Row kinds
+
+Splunk indexes an append-only event stream, so this sink does not interpret CDC row kinds. Only
+`UPDATE_BEFORE` rows are dropped, because indexing a pre-image would store a second, misleading
+copy of the record. `INSERT`, `UPDATE_AFTER` and `DELETE` rows are all indexed as ordinary events
+and are indistinguishable from one another once in Splunk — a `DELETE` does **not** remove
+anything. If you point a CDC-capable source at this sink, expect every change to land as a new
+event rather than as a mutation of an existing one.
+
+:::
+
 ## Options
 
 | Name                     | Type    | Required | Default | Description                                                                                     |
@@ -70,6 +81,17 @@ The HTTP Event Collector address. Both forms are accepted:
 
 Trailing slashes are stripped. The address must be an absolute `http` or `https` URL including a
 host, otherwise the job fails at startup with a message naming the option.
+
+:::caution
+
+Any address already containing `/services/collector` is used **verbatim** — the `/event` suffix is
+never appended to it. Some Splunk UI screens show the collector path as
+`https://splunk-host:8088/services/collector`, without the suffix; pasting that form sends the JSON
+event envelopes to Splunk's **raw** ingestion endpoint, which expects a different payload. Either
+configure the base address on its own (`https://splunk-host:8088`) and let the sink append the
+path, or give the full endpoint including `/event`.
+
+:::
 
 ### token [string]
 

--- a/docs/en/connectors/sink/Splunk.md
+++ b/docs/en/connectors/sink/Splunk.md
@@ -1,0 +1,223 @@
+import ChangeLog from '../changelog/connector-splunk.md';
+
+# Splunk
+
+> Splunk sink connector
+
+## Support Those Engines
+
+> SeaTunnel Zeta<br/>
+> Flink<br/>
+> Spark<br/>
+
+## Description
+
+Writes SeaTunnel rows to a Splunk index through the [HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector).
+
+Each row is serialized into one HEC event envelope: the row itself is written under `event`, and the
+Splunk metadata fields (`index`, `source`, `sourcetype`, `host`, `time`) are taken from the sink
+options. Events are buffered and POSTed to `/services/collector/event` in batches.
+
+## Key Features
+
+- [ ] [Exactly Once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [x] [Multiple Table Sink](../../introduction/concepts/connector-v2-features.md)
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
+- [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+:::caution Delivery semantics
+
+This sink provides **at-least-once** delivery.
+
+A batch that fails after the collector already indexed it is retried in full, so events can be
+duplicated. Splunk's HEC has no server-side deduplication for the `/services/collector/event`
+endpoint, and this connector does not send an idempotency key.
+
+:::
+
+## Options
+
+| Name                     | Type    | Required | Default | Description                                                                                     |
+|--------------------------|---------|----------|---------|-------------------------------------------------------------------------------------------------|
+| url                      | string  | Yes      | -       | Splunk HTTP Event Collector address.                                                            |
+| token                    | string  | Yes      | -       | HTTP Event Collector token.                                                                     |
+| index                    | string  | No       | -       | Target Splunk index.                                                                            |
+| source                   | string  | No       | -       | Value written to the Splunk `source` metadata field.                                            |
+| sourcetype               | string  | No       | -       | Value written to the Splunk `sourcetype` metadata field.                                        |
+| host                     | string  | No       | -       | Static value written to the Splunk `host` metadata field.                                       |
+| host_field               | string  | No       | -       | Upstream field whose value populates the Splunk `host` metadata field.                          |
+| time_field               | string  | No       | -       | Upstream field whose value populates the Splunk `time` metadata field.                          |
+| max_batch_size           | int     | No       | 100     | Maximum number of events sent in one collector request.                                         |
+| max_retry_count          | int     | No       | 3       | Maximum number of attempts for one batch request.                                               |
+| retry_backoff_ms         | int     | No       | 200     | Base backoff in milliseconds between two attempts of the same batch.                            |
+| connect_timeout_ms       | int     | No       | 10000   | Timeout in milliseconds for establishing a connection to the collector.                         |
+| socket_timeout_ms        | int     | No       | 60000   | Timeout in milliseconds waiting for collector response data between packets.                    |
+| tls_verify_certificate   | boolean | No       | true    | Whether to verify the collector TLS certificate.                                                |
+| tls_verify_hostname      | boolean | No       | true    | Whether to verify the collector TLS certificate hostname.                                       |
+| multi_table_sink_replica | int     | No       | 1       | Number of sink replicas used by the common multi-table sink routing mechanism.                  |
+| common-options           |         | No       | -       | Common sink options.                                                                            |
+
+### url [string]
+
+The HTTP Event Collector address. Both forms are accepted:
+
+- the collector base address, for example `https://splunk-host:8088`, in which case
+  `/services/collector/event` is appended;
+- the full endpoint address, for example `https://splunk-host:8088/services/collector/event`,
+  which is used as-is.
+
+Trailing slashes are stripped. The address must be an absolute `http` or `https` URL including a
+host, otherwise the job fails at startup with a message naming the option.
+
+### token [string]
+
+The HTTP Event Collector token of the target collector, sent as the
+`Authorization: Splunk <token>` request header. Treat this value as a secret and prefer passing it
+through a job secret or environment variable rather than committing it to a job file.
+
+### index [string]
+
+The Splunk index to write to. When it is not set, the option is omitted from the event envelope and
+the collector falls back to the index configured on the HEC token. A token that is not allowed to
+write to the configured index makes the collector reject the batch with HTTP 400; the sink treats
+this as a permanent failure and fails the task without retrying.
+
+### source [string] / sourcetype [string]
+
+Values written to the Splunk `source` and `sourcetype` event metadata fields. When they are not set,
+they are omitted from the envelope and the collector falls back to the values configured on the HEC
+token.
+
+### host [string] / host_field [string]
+
+`host` writes a fixed value into the Splunk `host` metadata field for every event. `host_field`
+instead names an upstream field whose value is used per event, and takes precedence over `host`.
+When `host_field` is set but the row carries a null in that field, the sink falls back to `host`, or
+omits the metadata field when `host` is not set either.
+
+The field named by `host_field` also stays in the event body. Drop it upstream with a transform if
+you do not want it duplicated.
+
+### time_field [string]
+
+Names an upstream field whose value populates the Splunk `time` metadata field. Supported types:
+
+- `TIMESTAMP` — interpreted as **UTC**, since a SeaTunnel `TIMESTAMP` carries no zone;
+- `TIMESTAMP_TZ` — its own offset is used;
+- `BIGINT` — interpreted as **epoch milliseconds**.
+
+Any other type fails at startup with a message naming the field and its type. When `time_field` is
+not set, or the row carries a null in that field, `time` is omitted and Splunk stamps the event with
+its ingest time.
+
+The value is sent as epoch seconds with millisecond precision, which is the representation the
+collector expects.
+
+### max_batch_size [int]
+
+The maximum number of events buffered before a collector request is sent. Larger batches reduce
+request overhead but increase the number of events replayed when a batch fails.
+
+### max_retry_count [int] / retry_backoff_ms [int]
+
+`max_retry_count` bounds the number of attempts for one batch. Only failures that can clear on
+their own are retried: transport errors, HTTP 429 (the collector queue is full) and HTTP 5xx. Every
+other response — a bad token, a forbidden index, a malformed payload — fails the task immediately
+rather than burning retries on an error that cannot resolve itself.
+
+The backoff grows exponentially from `retry_backoff_ms` and is capped at 20 seconds. The buffer is
+cleared only after the collector has accepted the batch, so a failed attempt never silently drops
+events.
+
+### tls_verify_certificate [boolean] / tls_verify_hostname [boolean]
+
+Splunk deployments frequently expose the collector behind the self-signed certificate generated at
+install time. Set these to `false` to accept it. This disables the protection against
+man-in-the-middle attacks and is not recommended outside of test environments; prefer installing a
+trusted certificate on the collector.
+
+### common options
+
+Common parameters for Sink plugins. Refer to [Common Sink Options](../common-options/sink-common-options.md) for more details.
+
+## Periodic Flush
+
+The sink flushes its buffer when it reaches `max_batch_size`, on checkpoint, and on close. To also
+flush on a timer, set the engine-level `sink.flush.interval` option in the job `env` block:
+
+```hocon
+env {
+  sink.flush.interval = 3000
+}
+```
+
+Timer flush is implemented by the Zeta engine only. On Spark and Flink there is no periodic flush,
+so tune `max_batch_size` instead.
+
+## Task Example
+
+### Simple
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "splunk_test_table"
+    schema = {
+      fields {
+        id = bigint
+        message = string
+        hostname = string
+        event_time = timestamp
+      }
+    }
+    rows = [
+      {fields = [1, "seatunnel event one", "web-01", "2026-08-17T12:30:45"], kind = INSERT},
+      {fields = [2, "seatunnel event two", "web-02", "2026-08-17T12:30:46"], kind = INSERT}
+    ]
+  }
+}
+
+sink {
+  Splunk {
+    plugin_input = "splunk_test_table"
+    url = "https://splunk-host:8088"
+    token = "00000000-0000-0000-0000-0000000000ff"
+    index = "main"
+    source = "seatunnel"
+    sourcetype = "seatunnel_events"
+    host_field = "hostname"
+    time_field = "event_time"
+    max_batch_size = 100
+    max_retry_count = 3
+  }
+}
+```
+
+A row of that job is sent to the collector as:
+
+```json
+{"time":1786969845.000,"host":"web-01","source":"seatunnel","sourcetype":"seatunnel_events","index":"main","event":{"id":1,"message":"seatunnel event one","hostname":"web-01","event_time":"2026-08-17T12:30:45"}}
+```
+
+### Self-Signed Collector Certificate
+
+```hocon
+sink {
+  Splunk {
+    url = "https://splunk-host:8088"
+    token = "00000000-0000-0000-0000-0000000000ff"
+    index = "main"
+    tls_verify_certificate = false
+    tls_verify_hostname = false
+  }
+}
+```
+
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-splunk.md
+++ b/docs/zh/connectors/changelog/connector-splunk.md
@@ -1,0 +1,26 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+# Changelog
+
+## next version
+
+### Sink
+
+- Add Splunk Sink Connector

--- a/docs/zh/connectors/sink/Splunk.md
+++ b/docs/zh/connectors/sink/Splunk.md
@@ -36,6 +36,16 @@ Splunk HEC 的 `/services/collector/event` 端点没有服务端去重能力，�
 
 :::
 
+:::caution 行类型（RowKind）
+
+Splunk 索引的是仅追加（append-only）的事件流，因此该 Sink 不会解释 CDC 行类型。只有
+`UPDATE_BEFORE` 行会被丢弃，因为写入更新前镜像会在 Splunk 中留下一条具有误导性的重复记录。
+`INSERT`、`UPDATE_AFTER` 与 `DELETE` 行都会作为普通事件写入，进入 Splunk 后彼此无法区分 ——
+`DELETE` **不会**删除任何数据。如果将支持 CDC 的 Source 接入该 Sink，请预期每一次变更都会
+作为一条新事件写入，而不是对既有事件的修改。
+
+:::
+
 ## 配置项
 
 | 名称                       | 类型      | 是否必填 | 默认值   | 描述                                       |
@@ -67,6 +77,16 @@ HTTP Event Collector 地址，支持以下两种形式：
 
 末尾的斜杠会被去除。该地址必须是包含主机名的绝对 `http` 或 `https` URL，否则任务会在启动时失败，
 并给出包含该配置项名称的错误信息。
+
+:::caution
+
+任何已经包含 `/services/collector` 的地址都会被**原样使用**，不会再追加 `/event` 后缀。部分
+Splunk 界面显示的 Collector 路径形如 `https://splunk-host:8088/services/collector`（不带后缀），
+若直接粘贴该形式，JSON 事件信封会被发送到 Splunk 的 **raw** 摄取端点，而该端点期望的是不同的
+载荷格式。请只配置基础地址（`https://splunk-host:8088`）由 Sink 自动追加路径，或者给出包含
+`/event` 的完整端点地址。
+
+:::
 
 ### token [string]
 

--- a/docs/zh/connectors/sink/Splunk.md
+++ b/docs/zh/connectors/sink/Splunk.md
@@ -1,0 +1,207 @@
+import ChangeLog from '../changelog/connector-splunk.md';
+
+# Splunk
+
+> Splunk 数据接收器
+
+## 支持的引擎
+
+> SeaTunnel Zeta<br/>
+> Flink<br/>
+> Spark<br/>
+
+## 描述
+
+通过 [HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector) 将 SeaTunnel 数据行写入 Splunk 索引。
+
+每一行数据会被序列化为一个 HEC 事件信封：数据行本身写入 `event` 字段，Splunk 元数据字段
+（`index`、`source`、`sourcetype`、`host`、`time`）则取自 Sink 配置项。事件会先缓冲，再以批次的形式
+POST 到 `/services/collector/event`。
+
+## 主要特性
+
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [x] [多表写入](../../introduction/concepts/connector-v2-features.md)
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+:::caution 投递语义
+
+该 Sink 提供 **至少一次（at-least-once）** 投递语义。
+
+如果某个批次在 Splunk 已经完成索引之后才失败，该批次会被整体重试，因此可能产生重复事件。
+Splunk HEC 的 `/services/collector/event` 端点没有服务端去重能力，且本连接器不会发送幂等键。
+
+:::
+
+## 配置项
+
+| 名称                       | 类型      | 是否必填 | 默认值   | 描述                                       |
+|--------------------------|---------|------|-------|------------------------------------------|
+| url                      | string  | 是    | -     | Splunk HTTP Event Collector 地址。          |
+| token                    | string  | 是    | -     | HTTP Event Collector 令牌。                 |
+| index                    | string  | 否    | -     | 目标 Splunk 索引。                            |
+| source                   | string  | 否    | -     | 写入 Splunk `source` 元数据字段的值。              |
+| sourcetype               | string  | 否    | -     | 写入 Splunk `sourcetype` 元数据字段的值。          |
+| host                     | string  | 否    | -     | 写入 Splunk `host` 元数据字段的固定值。              |
+| host_field               | string  | 否    | -     | 用于填充 Splunk `host` 元数据字段的上游字段名。          |
+| time_field               | string  | 否    | -     | 用于填充 Splunk `time` 元数据字段的上游字段名。          |
+| max_batch_size           | int     | 否    | 100   | 单次 Collector 请求发送的最大事件数。                 |
+| max_retry_count          | int     | 否    | 3     | 单个批次请求的最大尝试次数。                           |
+| retry_backoff_ms         | int     | 否    | 200   | 同一批次两次尝试之间的基础退避时间（毫秒）。                   |
+| connect_timeout_ms       | int     | 否    | 10000 | 与 Collector 建立连接的超时时间（毫秒）。               |
+| socket_timeout_ms        | int     | 否    | 60000 | 等待 Collector 响应数据包之间的超时时间（毫秒）。           |
+| tls_verify_certificate   | boolean | 否    | true  | 是否校验 Collector 的 TLS 证书。                 |
+| tls_verify_hostname      | boolean | 否    | true  | 是否校验 Collector TLS 证书的主机名。               |
+| multi_table_sink_replica | int     | 否    | 1     | 通用多表 Sink 路由机制使用的 Sink 副本数。              |
+| common-options           |         | 否    | -     | Sink 通用配置项。                              |
+
+### url [string]
+
+HTTP Event Collector 地址，支持以下两种形式：
+
+- Collector 基础地址，例如 `https://splunk-host:8088`，此时会自动追加 `/services/collector/event`；
+- 完整端点地址，例如 `https://splunk-host:8088/services/collector/event`，此时按原样使用。
+
+末尾的斜杠会被去除。该地址必须是包含主机名的绝对 `http` 或 `https` URL，否则任务会在启动时失败，
+并给出包含该配置项名称的错误信息。
+
+### token [string]
+
+目标 Collector 的 HTTP Event Collector 令牌，会以 `Authorization: Splunk <token>` 请求头发送。
+请将该值视为机密信息，优先通过作业密钥或环境变量传入，而不要直接提交到作业配置文件中。
+
+### index [string]
+
+要写入的 Splunk 索引。未配置时该字段不会出现在事件信封中，Collector 会回退到 HEC 令牌上配置的索引。
+如果令牌没有写入所配置索引的权限，Collector 会以 HTTP 400 拒绝该批次；Sink 将其视为永久性失败，
+不会重试并直接让任务失败。
+
+### source [string] / sourcetype [string]
+
+写入 Splunk `source` 与 `sourcetype` 事件元数据字段的值。未配置时不会出现在事件信封中，
+Collector 会回退到 HEC 令牌上配置的值。
+
+### host [string] / host_field [string]
+
+`host` 为所有事件写入固定的 Splunk `host` 元数据值。`host_field` 则指定一个上游字段，
+按事件逐条取值，其优先级高于 `host`。当配置了 `host_field` 但该行对应字段为 null 时，
+Sink 会回退到 `host`；若 `host` 也未配置，则省略该元数据字段。
+
+`host_field` 指定的字段同时仍保留在事件体中。如果不希望重复，请在上游使用 transform 将其删除。
+
+### time_field [string]
+
+指定用于填充 Splunk `time` 元数据字段的上游字段。支持的类型：
+
+- `TIMESTAMP` —— 按 **UTC** 解释，因为 SeaTunnel 的 `TIMESTAMP` 不携带时区信息；
+- `TIMESTAMP_TZ` —— 使用其自带的时区偏移；
+- `BIGINT` —— 按 **epoch 毫秒** 解释。
+
+其他类型会在启动时失败，并给出包含字段名与类型的错误信息。当未配置 `time_field`，
+或该行对应字段为 null 时，`time` 会被省略，由 Splunk 使用其摄取时间作为事件时间。
+
+该值以 epoch 秒（保留毫秒精度）发送，这是 Collector 期望的表示形式。
+
+### max_batch_size [int]
+
+发送 Collector 请求前缓冲的最大事件数。批次越大，请求开销越小，但批次失败时需要重放的事件也越多。
+
+### max_retry_count [int] / retry_backoff_ms [int]
+
+`max_retry_count` 限制单个批次的尝试次数。只有可自行恢复的失败才会重试：传输错误、
+HTTP 429（Collector 队列已满）以及 HTTP 5xx。其他响应 —— 令牌错误、索引无权限、载荷格式错误 ——
+会立即让任务失败，而不是把重试次数浪费在无法自行恢复的错误上。
+
+退避时间从 `retry_backoff_ms` 开始指数增长，上限为 20 秒。只有在 Collector 接受该批次之后
+才会清空缓冲区，因此失败的尝试不会静默丢弃事件。
+
+### tls_verify_certificate [boolean] / tls_verify_hostname [boolean]
+
+Splunk 部署经常使用安装时生成的自签名证书来暴露 Collector。将这两项设置为 `false` 即可接受该证书。
+这会失去对中间人攻击的防护，因此不建议在测试环境之外使用；更推荐在 Collector 上安装受信任的证书。
+
+### 通用配置项
+
+Sink 插件通用参数，详情请参考 [Sink 通用配置](../common-options/sink-common-options.md)。
+
+## 定时刷新
+
+Sink 会在缓冲区达到 `max_batch_size`、检查点以及关闭时刷新。若还需要按时间定时刷新，
+请在作业的 `env` 块中设置引擎级配置项 `sink.flush.interval`：
+
+```hocon
+env {
+  sink.flush.interval = 3000
+}
+```
+
+定时刷新仅由 Zeta 引擎实现。在 Spark 与 Flink 上没有周期性刷新，请改为调整 `max_batch_size`。
+
+## 任务示例
+
+### 简单示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "splunk_test_table"
+    schema = {
+      fields {
+        id = bigint
+        message = string
+        hostname = string
+        event_time = timestamp
+      }
+    }
+    rows = [
+      {fields = [1, "seatunnel event one", "web-01", "2026-08-17T12:30:45"], kind = INSERT},
+      {fields = [2, "seatunnel event two", "web-02", "2026-08-17T12:30:46"], kind = INSERT}
+    ]
+  }
+}
+
+sink {
+  Splunk {
+    plugin_input = "splunk_test_table"
+    url = "https://splunk-host:8088"
+    token = "00000000-0000-0000-0000-0000000000ff"
+    index = "main"
+    source = "seatunnel"
+    sourcetype = "seatunnel_events"
+    host_field = "hostname"
+    time_field = "event_time"
+    max_batch_size = 100
+    max_retry_count = 3
+  }
+}
+```
+
+上述作业中的一行数据会以如下形式发送给 Collector：
+
+```json
+{"time":1786969845.000,"host":"web-01","source":"seatunnel","sourcetype":"seatunnel_events","index":"main","event":{"id":1,"message":"seatunnel event one","hostname":"web-01","event_time":"2026-08-17T12:30:45"}}
+```
+
+### 自签名 Collector 证书
+
+```hocon
+sink {
+  Splunk {
+    url = "https://splunk-host:8088"
+    token = "00000000-0000-0000-0000-0000000000ff"
+    index = "main"
+    tls_verify_certificate = false
+    tls_verify_hostname = false
+  }
+}
+```
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -167,6 +167,7 @@ seatunnel.sink.Fluss = connector-fluss
 seatunnel.sink.Lance = connector-lance
 seatunnel.sink.BigQuery = connector-bigquery
 seatunnel.sink.NatsJetStream = connector-nats-jetstream
+seatunnel.sink.Splunk = connector-splunk
 
 # For custom transforms, make sure to use the seatunnel.transform.[PluginIdentifier]=[JarPerfix] naming convention. For example:
 # seatunnel.transform.Sql = seatunnel-transforms-v2

--- a/seatunnel-connectors-v2/connector-splunk/pom.xml
+++ b/seatunnel-connectors-v2/connector-splunk/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-splunk</artifactId>
+    <name>SeaTunnel : Connectors V2 : Splunk</name>
+
+    <properties>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpcore.version>4.4.16</httpcore.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/client/SplunkHecClient.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/client/SplunkHecClient.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.client;
+
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.util.EntityUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.net.ssl.SSLContext;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Minimal client for the Splunk HTTP Event Collector.
+ *
+ * <p>This connector does not reuse {@code connector-http-base}'s {@code HttpClientProvider} because
+ * that provider always builds a default client and offers no hook for TLS configuration. Splunk
+ * deployments commonly expose the collector behind the self-signed certificate created at install
+ * time, so configurable certificate and hostname verification is a requirement here.
+ */
+@Slf4j
+public class SplunkHecClient implements Closeable {
+
+    private static final String AUTHORIZATION_PREFIX = "Splunk ";
+
+    /** HTTP status returned by Splunk when the collector is saturated. */
+    private static final int STATUS_TOO_MANY_REQUESTS = 429;
+
+    private final String endpoint;
+    private final String authorizationHeader;
+    private final CloseableHttpClient httpClient;
+
+    public SplunkHecClient(SplunkSinkConfig config) {
+        this.endpoint = config.getEndpoint();
+        this.authorizationHeader = AUTHORIZATION_PREFIX + config.getToken();
+        this.httpClient = buildHttpClient(config);
+    }
+
+    /**
+     * Sends one batch of newline-delimited HEC event envelopes.
+     *
+     * @param body concatenated event envelopes
+     * @throws SplunkHecRetryableException when the failure is worth retrying (transport error, 429
+     *     or 5xx)
+     * @throws SplunkConnectorException when the collector rejected the batch permanently
+     */
+    public void send(String body) throws SplunkHecRetryableException {
+        HttpPost httpPost = new HttpPost(endpoint);
+        httpPost.setHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+        httpPost.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+
+        int statusCode;
+        String responseBody;
+        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+            statusCode = response.getStatusLine().getStatusCode();
+            responseBody =
+                    response.getEntity() == null
+                            ? ""
+                            : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new SplunkHecRetryableException(
+                    String.format("Failed to reach the Splunk HEC endpoint '%s'", endpoint), e);
+        }
+
+        if (statusCode == HttpStatus.SC_OK) {
+            return;
+        }
+
+        String message =
+                String.format(
+                        "Splunk HEC endpoint '%s' rejected the batch with HTTP status %d, response: %s",
+                        endpoint, statusCode, responseBody);
+        if (isRetryable(statusCode)) {
+            throw new SplunkHecRetryableException(message, null);
+        }
+        throw new SplunkConnectorException(SplunkConnectorErrorCode.SEND_EVENTS_FAILED, message);
+    }
+
+    /**
+     * A 429 means the collector queue is full and a 5xx means the indexer is unhealthy; both clear
+     * on their own. Every other status reflects a bad token, a bad index or a malformed payload,
+     * none of which a retry can fix.
+     */
+    private static boolean isRetryable(int statusCode) {
+        return statusCode == STATUS_TOO_MANY_REQUESTS
+                || statusCode >= HttpStatus.SC_INTERNAL_SERVER_ERROR;
+    }
+
+    private static CloseableHttpClient buildHttpClient(SplunkSinkConfig config) {
+        RequestConfig requestConfig =
+                RequestConfig.custom()
+                        .setConnectTimeout(config.getConnectTimeoutMs())
+                        .setSocketTimeout(config.getSocketTimeoutMs())
+                        .setConnectionRequestTimeout(config.getConnectTimeoutMs())
+                        .build();
+
+        HttpClientBuilder builder =
+                HttpClients.custom()
+                        .setDefaultRequestConfig(requestConfig)
+                        .disableAutomaticRetries();
+
+        if (!config.isTlsVerifyCertificate()) {
+            try {
+                SSLContext sslContext =
+                        SSLContexts.custom().loadTrustMaterial(new TrustAllStrategy()).build();
+                builder.setSSLContext(sslContext);
+            } catch (Exception e) {
+                throw new SplunkConnectorException(
+                        SplunkConnectorErrorCode.SSL_CONTEXT_FAILED,
+                        "Failed to build a trust-all TLS context for the Splunk HEC client",
+                        e);
+            }
+            log.warn(
+                    "Splunk sink TLS certificate verification is disabled - not recommended for production");
+        }
+        if (!config.isTlsVerifyHostname()) {
+            builder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+            log.warn(
+                    "Splunk sink TLS hostname verification is disabled - not recommended for production");
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpClient.close();
+    }
+
+    /** Signals a collector failure that is worth another attempt. */
+    public static class SplunkHecRetryableException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public SplunkHecRetryableException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkConfig.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.config;
+
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Resolved and validated configuration of the Splunk HEC sink.
+ *
+ * <p>Presence of the required options is enforced declaratively by the factory {@code OptionRule}.
+ * This class carries the semantic validation that a rule cannot express, so a misconfigured job
+ * fails during sink construction rather than on the first flush.
+ */
+@Getter
+public class SplunkSinkConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Path of the HEC endpoint that accepts events in the JSON event envelope format. */
+    static final String EVENT_ENDPOINT_PATH = "/services/collector/event";
+
+    /** Marker used to detect a URL that already points at a collector endpoint. */
+    private static final String COLLECTOR_PATH_MARKER = "/services/collector";
+
+    private final String endpoint;
+    private final String token;
+    private final String index;
+    private final String source;
+    private final String sourceType;
+    private final String host;
+    private final String hostField;
+    private final String timeField;
+    private final int maxBatchSize;
+    private final int maxRetryCount;
+    private final int retryBackoffMs;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+    private final boolean tlsVerifyCertificate;
+    private final boolean tlsVerifyHostname;
+
+    public SplunkSinkConfig(ReadonlyConfig config) {
+        this.endpoint = resolveEndpoint(config.get(SplunkSinkOptions.URL));
+        this.token = requireToken(config.get(SplunkSinkOptions.TOKEN));
+        this.index = config.get(SplunkSinkOptions.INDEX);
+        this.source = config.get(SplunkSinkOptions.SOURCE);
+        this.sourceType = config.get(SplunkSinkOptions.SOURCE_TYPE);
+        this.host = config.get(SplunkSinkOptions.HOST);
+        this.hostField = config.get(SplunkSinkOptions.HOST_FIELD);
+        this.timeField = config.get(SplunkSinkOptions.TIME_FIELD);
+        this.maxBatchSize =
+                requirePositive(
+                        config.get(SplunkSinkOptions.MAX_BATCH_SIZE),
+                        SplunkSinkOptions.MAX_BATCH_SIZE.key());
+        this.maxRetryCount =
+                requirePositive(
+                        config.get(SplunkSinkOptions.MAX_RETRY_COUNT),
+                        SplunkSinkOptions.MAX_RETRY_COUNT.key());
+        this.retryBackoffMs =
+                requireNonNegative(
+                        config.get(SplunkSinkOptions.RETRY_BACKOFF_MS),
+                        SplunkSinkOptions.RETRY_BACKOFF_MS.key());
+        this.connectTimeoutMs =
+                requirePositive(
+                        config.get(SplunkSinkOptions.CONNECT_TIMEOUT_MS),
+                        SplunkSinkOptions.CONNECT_TIMEOUT_MS.key());
+        this.socketTimeoutMs =
+                requirePositive(
+                        config.get(SplunkSinkOptions.SOCKET_TIMEOUT_MS),
+                        SplunkSinkOptions.SOCKET_TIMEOUT_MS.key());
+        this.tlsVerifyCertificate = config.get(SplunkSinkOptions.TLS_VERIFY_CERTIFICATE);
+        this.tlsVerifyHostname = config.get(SplunkSinkOptions.TLS_VERIFY_HOSTNAME);
+    }
+
+    /**
+     * Normalizes the configured address into a full HEC event endpoint.
+     *
+     * <p>Accepts both the collector base address and a full endpoint address so that operators can
+     * paste either form out of the Splunk UI.
+     */
+    private static String resolveEndpoint(String url) {
+        if (StringUtils.isBlank(url)) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format(
+                            "Option '%s' is required and must not be blank. Configure the Splunk HTTP "
+                                    + "Event Collector address, for example 'https://splunk-host:8088'.",
+                            SplunkSinkOptions.URL.key()));
+        }
+
+        String trimmed = StringUtils.stripEnd(url.trim(), "/");
+        URI uri;
+        try {
+            uri = new URI(trimmed);
+        } catch (URISyntaxException e) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format(
+                            "Option '%s' is not a valid URL: '%s'.",
+                            SplunkSinkOptions.URL.key(), url),
+                    e);
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null
+                || !("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+                || uri.getHost() == null) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format(
+                            "Option '%s' must be an absolute http or https URL including a host, but was '%s'. "
+                                    + "For example 'https://splunk-host:8088'.",
+                            SplunkSinkOptions.URL.key(), url));
+        }
+
+        if (trimmed.contains(COLLECTOR_PATH_MARKER)) {
+            return trimmed;
+        }
+        return trimmed + EVENT_ENDPOINT_PATH;
+    }
+
+    private static String requireToken(String token) {
+        if (StringUtils.isBlank(token)) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format(
+                            "Option '%s' is required and must not be blank. Configure the Splunk HTTP "
+                                    + "Event Collector token of the target collector.",
+                            SplunkSinkOptions.TOKEN.key()));
+        }
+        return token.trim();
+    }
+
+    private static int requirePositive(int value, String key) {
+        if (value < 1) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format("Option '%s' must be greater than 0, but was %d.", key, value));
+        }
+        return value;
+    }
+
+    private static int requireNonNegative(int value, String key) {
+        if (value < 0) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format("Option '%s' must not be negative, but was %d.", key, value));
+        }
+        return value;
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkOptions.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+/** Configuration options of the Splunk HTTP Event Collector (HEC) sink. */
+public class SplunkSinkOptions {
+
+    public static final Option<String> URL =
+            Options.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Splunk HTTP Event Collector address. Either the collector base address "
+                                    + "(for example https://splunk-host:8088), in which case "
+                                    + "/services/collector/event is appended, or the full endpoint address.");
+
+    public static final Option<String> TOKEN =
+            Options.key("token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "HTTP Event Collector token, sent as the 'Authorization: Splunk <token>' header.");
+
+    public static final Option<String> INDEX =
+            Options.key("index")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Target Splunk index. When unset, the index configured on the HEC token is used.");
+
+    public static final Option<String> SOURCE =
+            Options.key("source")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Value written to the Splunk 'source' event metadata field. "
+                                    + "When unset, the source configured on the HEC token is used.");
+
+    public static final Option<String> SOURCE_TYPE =
+            Options.key("sourcetype")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Value written to the Splunk 'sourcetype' event metadata field. "
+                                    + "When unset, the sourcetype configured on the HEC token is used.");
+
+    public static final Option<String> HOST =
+            Options.key("host")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Static value written to the Splunk 'host' event metadata field. "
+                                    + "Ignored when 'host_field' is set.");
+
+    public static final Option<String> HOST_FIELD =
+            Options.key("host_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of an upstream field whose value populates the Splunk 'host' event "
+                                    + "metadata field. Takes precedence over the static 'host' option.");
+
+    public static final Option<String> TIME_FIELD =
+            Options.key("time_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of an upstream field whose value populates the Splunk 'time' event "
+                                    + "metadata field. Must be of type TIMESTAMP (interpreted as UTC) or "
+                                    + "BIGINT (interpreted as epoch milliseconds). When unset, Splunk "
+                                    + "stamps events with their ingest time.");
+
+    public static final Option<Integer> MAX_BATCH_SIZE =
+            Options.key("max_batch_size")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription(
+                            "Maximum number of events sent in one HTTP Event Collector request.");
+
+    public static final Option<Integer> MAX_RETRY_COUNT =
+            Options.key("max_retry_count")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Maximum number of attempts for one batch request. Only transport failures "
+                                    + "and retryable HTTP responses (429 and 5xx) are retried.");
+
+    public static final Option<Integer> RETRY_BACKOFF_MS =
+            Options.key("retry_backoff_ms")
+                    .intType()
+                    .defaultValue(200)
+                    .withDescription(
+                            "Base backoff in milliseconds between two attempts of the same batch. "
+                                    + "The backoff grows linearly with the attempt number.");
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription(
+                            "Timeout in milliseconds for establishing a connection to the collector.");
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription(
+                            "Timeout in milliseconds waiting for collector response data between packets.");
+
+    public static final Option<Boolean> TLS_VERIFY_CERTIFICATE =
+            Options.key("tls_verify_certificate")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to verify the collector TLS certificate. Set to false only for "
+                                    + "Splunk deployments still using the default self-signed certificate.");
+
+    public static final Option<Boolean> TLS_VERIFY_HOSTNAME =
+            Options.key("tls_verify_hostname")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether to verify the collector TLS certificate hostname.");
+
+    private SplunkSinkOptions() {}
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkOptions.java
@@ -28,9 +28,14 @@ public class SplunkSinkOptions {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Splunk HTTP Event Collector address. Either the collector base address "
-                                    + "(for example https://splunk-host:8088), in which case "
-                                    + "/services/collector/event is appended, or the full endpoint address.");
+                            "Splunk HTTP Event Collector address. When the address does not already "
+                                    + "contain a collector path (for example https://splunk-host:8088), "
+                                    + "/services/collector/event is appended. An address that already "
+                                    + "contains /services/collector is used verbatim, so pass the full "
+                                    + "endpoint including the /event suffix: a bare "
+                                    + "https://host:8088/services/collector targets the raw ingestion "
+                                    + "endpoint, which does not accept the JSON event envelopes this "
+                                    + "sink sends.");
 
     public static final Option<String> TOKEN =
             Options.key("token")
@@ -84,9 +89,10 @@ public class SplunkSinkOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Name of an upstream field whose value populates the Splunk 'time' event "
-                                    + "metadata field. Must be of type TIMESTAMP (interpreted as UTC) or "
-                                    + "BIGINT (interpreted as epoch milliseconds). When unset, Splunk "
-                                    + "stamps events with their ingest time.");
+                                    + "metadata field. Must be of type TIMESTAMP (interpreted as UTC), "
+                                    + "TIMESTAMP_TZ (its own offset is used), or BIGINT (interpreted as "
+                                    + "epoch milliseconds). When unset, Splunk stamps events with their "
+                                    + "ingest time.");
 
     public static final Option<Integer> MAX_BATCH_SIZE =
             Options.key("max_batch_size")
@@ -109,7 +115,8 @@ public class SplunkSinkOptions {
                     .defaultValue(200)
                     .withDescription(
                             "Base backoff in milliseconds between two attempts of the same batch. "
-                                    + "The backoff grows linearly with the attempt number.");
+                                    + "The backoff doubles on each subsequent attempt and is capped "
+                                    + "at 20 seconds.");
 
     public static final Option<Integer> CONNECT_TIMEOUT_MS =
             Options.key("connect_timeout_ms")

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/exception/SplunkConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/exception/SplunkConnectorErrorCode.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+
+public enum SplunkConnectorErrorCode implements SeaTunnelErrorCode {
+    INVALID_CONFIG("SPLUNK-01", "Invalid Splunk sink configuration"),
+    SSL_CONTEXT_FAILED("SPLUNK-02", "Failed to build the TLS context for the Splunk HEC client"),
+    SEND_EVENTS_FAILED("SPLUNK-03", "Failed to send events to the Splunk HTTP Event Collector"),
+    SERIALIZE_EVENT_FAILED("SPLUNK-04", "Failed to serialize a row into a Splunk HEC event"),
+    ;
+
+    private final String code;
+
+    private final String description;
+
+    SplunkConnectorErrorCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/exception/SplunkConnectorException.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/exception/SplunkConnectorException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+public class SplunkConnectorException extends SeaTunnelRuntimeException {
+
+    public SplunkConnectorException(SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage) {
+        super(seaTunnelErrorCode, errorMessage);
+    }
+
+    public SplunkConnectorException(
+            SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage, Throwable cause) {
+        super(seaTunnelErrorCode, errorMessage, cause);
+    }
+
+    public SplunkConnectorException(SeaTunnelErrorCode seaTunnelErrorCode, Throwable cause) {
+        super(seaTunnelErrorCode, cause);
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/serialize/SplunkEventSerializer.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/serialize/SplunkEventSerializer.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.serialize;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+import org.apache.seatunnel.format.json.JsonSerializationSchema;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Serializes a {@link SeaTunnelRow} into a single Splunk HTTP Event Collector event envelope.
+ *
+ * <p>The envelope carries the Splunk metadata fields ({@code time}, {@code host}, {@code source},
+ * {@code sourcetype}, {@code index}) alongside the row itself under {@code event}. Metadata fields
+ * that are not configured are omitted so that the collector falls back to the defaults of the HEC
+ * token rather than being overridden with nulls.
+ */
+public class SplunkEventSerializer implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String FIELD_TIME = "time";
+    private static final String FIELD_HOST = "host";
+    private static final String FIELD_SOURCE = "source";
+    private static final String FIELD_SOURCE_TYPE = "sourcetype";
+    private static final String FIELD_INDEX = "index";
+    private static final String FIELD_EVENT = "event";
+
+    /** Scale that turns epoch milliseconds into epoch seconds without losing precision. */
+    private static final int EPOCH_SECONDS_SCALE = 3;
+
+    /** Upstream types accepted for {@code time_field}. */
+    private static final Set<SqlType> SUPPORTED_TIME_TYPES =
+            EnumSet.of(SqlType.TIMESTAMP, SqlType.TIMESTAMP_TZ, SqlType.BIGINT);
+
+    private final SplunkSinkConfig config;
+    private final JsonSerializationSchema jsonSerializationSchema;
+    private final ObjectMapper objectMapper;
+
+    /** Index of the row field feeding the Splunk {@code host} metadata, or -1 when unconfigured. */
+    private final int hostFieldIndex;
+
+    /** Index of the row field feeding the Splunk {@code time} metadata, or -1 when unconfigured. */
+    private final int timeFieldIndex;
+
+    private final SqlType timeFieldType;
+
+    public SplunkEventSerializer(SeaTunnelRowType rowType, SplunkSinkConfig config) {
+        this.config = config;
+        this.jsonSerializationSchema = new JsonSerializationSchema(rowType);
+        this.objectMapper = new ObjectMapper();
+        // The collector reads `time` as epoch seconds. Written as a double, any realistic epoch
+        // renders in scientific notation (1.786969845123E9), which Splunk does not accept, so the
+        // value is carried as a BigDecimal and written in plain notation.
+        this.objectMapper.configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
+        this.hostFieldIndex = resolveFieldIndex(rowType, config.getHostField(), "host_field");
+        this.timeFieldIndex = resolveFieldIndex(rowType, config.getTimeField(), "time_field");
+        this.timeFieldType =
+                timeFieldIndex < 0 ? null : rowType.getFieldType(timeFieldIndex).getSqlType();
+
+        if (timeFieldType != null && !SUPPORTED_TIME_TYPES.contains(timeFieldType)) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format(
+                            "Option 'time_field' refers to field '%s' of type %s, which cannot be used as "
+                                    + "a Splunk event timestamp. Supported types are TIMESTAMP, TIMESTAMP_TZ "
+                                    + "and BIGINT (epoch milliseconds).",
+                            config.getTimeField(), timeFieldType));
+        }
+    }
+
+    /** Serializes one row into the HEC event envelope, ready to be concatenated into a batch. */
+    public String serialize(SeaTunnelRow row) {
+        ObjectNode envelope = objectMapper.createObjectNode();
+
+        BigDecimal time = extractTime(row);
+        if (time != null) {
+            envelope.put(FIELD_TIME, time);
+        }
+
+        String host = extractHost(row);
+        if (StringUtils.isNotEmpty(host)) {
+            envelope.put(FIELD_HOST, host);
+        }
+        if (StringUtils.isNotEmpty(config.getSource())) {
+            envelope.put(FIELD_SOURCE, config.getSource());
+        }
+        if (StringUtils.isNotEmpty(config.getSourceType())) {
+            envelope.put(FIELD_SOURCE_TYPE, config.getSourceType());
+        }
+        if (StringUtils.isNotEmpty(config.getIndex())) {
+            envelope.put(FIELD_INDEX, config.getIndex());
+        }
+
+        // JsonSerializationSchema reuses its internal node, so the envelope must be written out
+        // before the next row is converted. serialize() does exactly that, one row at a time.
+        envelope.set(FIELD_EVENT, jsonSerializationSchema.convert(row));
+
+        try {
+            return objectMapper.writeValueAsString(envelope);
+        } catch (JsonProcessingException e) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.SERIALIZE_EVENT_FAILED,
+                    "Failed to write the Splunk HEC event envelope as JSON",
+                    e);
+        }
+    }
+
+    /**
+     * Converts the configured time field into the epoch-seconds representation the collector
+     * expects, keeping millisecond precision. Returns {@code null} when no time field is configured
+     * or the row carries no value, in which case Splunk stamps the event on ingest.
+     */
+    private BigDecimal extractTime(SeaTunnelRow row) {
+        if (timeFieldIndex < 0) {
+            return null;
+        }
+        Object value = row.getField(timeFieldIndex);
+        if (value == null) {
+            return null;
+        }
+        switch (timeFieldType) {
+            case TIMESTAMP:
+                return epochSeconds(
+                        ((LocalDateTime) value).toInstant(ZoneOffset.UTC).toEpochMilli());
+            case TIMESTAMP_TZ:
+                return epochSeconds(((OffsetDateTime) value).toInstant().toEpochMilli());
+            case BIGINT:
+                return epochSeconds(((Number) value).longValue());
+            default:
+                // Unreachable: the constructor rejects every other type.
+                throw new SplunkConnectorException(
+                        SplunkConnectorErrorCode.SERIALIZE_EVENT_FAILED,
+                        "Unsupported time field type: " + timeFieldType);
+        }
+    }
+
+    /** Rescales epoch milliseconds to epoch seconds, keeping the milliseconds as decimals. */
+    private static BigDecimal epochSeconds(long epochMillis) {
+        return BigDecimal.valueOf(epochMillis, EPOCH_SECONDS_SCALE);
+    }
+
+    private String extractHost(SeaTunnelRow row) {
+        if (hostFieldIndex < 0) {
+            return config.getHost();
+        }
+        Object value = row.getField(hostFieldIndex);
+        return value == null ? config.getHost() : value.toString();
+    }
+
+    /** Resolves a configured field name to its row index, failing with the available names. */
+    private static int resolveFieldIndex(
+            SeaTunnelRowType rowType, String fieldName, String optionKey) {
+        if (StringUtils.isBlank(fieldName)) {
+            return -1;
+        }
+        int index = rowType.indexOf(fieldName, false);
+        if (index < 0) {
+            throw new SplunkConnectorException(
+                    SplunkConnectorErrorCode.INVALID_CONFIG,
+                    String.format(
+                            "Option '%s' refers to field '%s', which does not exist upstream. "
+                                    + "Available fields are %s.",
+                            optionKey, fieldName, Arrays.toString(rowType.getFieldNames())));
+        }
+        return index;
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSink.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSink.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.sink;
+
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.SupportMultiTableSink;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSimpleSink;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+
+import java.util.Optional;
+
+/** Sink writing SeaTunnel rows to a Splunk index through the HTTP Event Collector. */
+public class SplunkSink extends AbstractSimpleSink<SeaTunnelRow, Void>
+        implements SupportMultiTableSink {
+
+    public static final String PLUGIN_NAME = "Splunk";
+
+    private final SplunkSinkConfig config;
+    private final CatalogTable catalogTable;
+    private final SeaTunnelRowType seaTunnelRowType;
+
+    public SplunkSink(SplunkSinkConfig config, CatalogTable catalogTable) {
+        this.config = config;
+        this.catalogTable = catalogTable;
+        this.seaTunnelRowType = catalogTable.getSeaTunnelRowType();
+    }
+
+    @Override
+    public String getPluginName() {
+        return PLUGIN_NAME;
+    }
+
+    @Override
+    public SplunkSinkWriter createWriter(SinkWriter.Context context) {
+        return new SplunkSinkWriter(seaTunnelRowType, config, context);
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.ofNullable(catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.sink;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.connector.TableSink;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkOptions;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(Factory.class)
+public class SplunkSinkFactory implements TableSinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return SplunkSink.PLUGIN_NAME;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(SplunkSinkOptions.URL, SplunkSinkOptions.TOKEN)
+                .optional(
+                        SplunkSinkOptions.INDEX,
+                        SplunkSinkOptions.SOURCE,
+                        SplunkSinkOptions.SOURCE_TYPE,
+                        SplunkSinkOptions.HOST,
+                        SplunkSinkOptions.HOST_FIELD,
+                        SplunkSinkOptions.TIME_FIELD,
+                        SplunkSinkOptions.MAX_BATCH_SIZE,
+                        SplunkSinkOptions.MAX_RETRY_COUNT,
+                        SplunkSinkOptions.RETRY_BACKOFF_MS,
+                        SplunkSinkOptions.CONNECT_TIMEOUT_MS,
+                        SplunkSinkOptions.SOCKET_TIMEOUT_MS,
+                        SplunkSinkOptions.TLS_VERIFY_CERTIFICATE,
+                        SplunkSinkOptions.TLS_VERIFY_HOSTNAME,
+                        SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
+                .build();
+    }
+
+    @Override
+    public TableSink createSink(TableSinkFactoryContext context) {
+        SplunkSinkConfig config = new SplunkSinkConfig(context.getOptions());
+        CatalogTable catalogTable = context.getCatalogTable();
+        return () -> new SplunkSink(config, catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/main/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkWriter.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.sink;
+
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.utils.RetryUtils;
+import org.apache.seatunnel.common.utils.RetryUtils.RetryMaterial;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
+import org.apache.seatunnel.connectors.seatunnel.splunk.client.SplunkHecClient;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.splunk.serialize.SplunkEventSerializer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Buffers rows as Splunk HEC event envelopes and POSTs them in batches to the collector.
+ *
+ * <p>A batch is flushed when it reaches {@code max_batch_size}, when the engine delivers a periodic
+ * flush signal, on checkpoint, and on close.
+ */
+@Slf4j
+public class SplunkSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
+        implements SupportMultiTableSinkWriter<Void> {
+
+    private final SplunkSinkConfig config;
+    private final SplunkEventSerializer serializer;
+    private final SplunkHecClient client;
+    private final RetryMaterial retryMaterial;
+
+    /** Serialized event envelopes awaiting the next flush. */
+    private final List<String> batchBuffer;
+
+    public SplunkSinkWriter(
+            SeaTunnelRowType rowType, SplunkSinkConfig config, SinkWriter.Context context) {
+        this(rowType, config, context, new SplunkHecClient(config));
+    }
+
+    @VisibleForTesting
+    SplunkSinkWriter(
+            SeaTunnelRowType rowType,
+            SplunkSinkConfig config,
+            SinkWriter.Context context,
+            SplunkHecClient client) {
+        this.config = config;
+        this.serializer = new SplunkEventSerializer(rowType, config);
+        this.client = client;
+        this.batchBuffer = new ArrayList<>(config.getMaxBatchSize());
+        this.retryMaterial =
+                new RetryMaterial(
+                        config.getMaxRetryCount(),
+                        true,
+                        e -> e instanceof SplunkHecClient.SplunkHecRetryableException,
+                        config.getRetryBackoffMs(),
+                        true);
+
+        // Opt in to engine-level timer flush, driven by the env option `sink.flush.interval`. Only
+        // Zeta implements it; on Spark and Flink the Context keeps the interface's no-op default,
+        // so there the buffer is flushed on max_batch_size, on checkpoint and on close.
+        if (context != null) {
+            context.registerFlushAction(this::flush);
+        }
+    }
+
+    @Override
+    public void write(SeaTunnelRow element) {
+        // Splunk indexes an append-only event stream, so an UPDATE_BEFORE row would be indexed as
+        // a second, misleading copy of the pre-image rather than retracting anything.
+        if (RowKind.UPDATE_BEFORE.equals(element.getRowKind())) {
+            return;
+        }
+
+        String event = serializer.serialize(element);
+        synchronized (batchBuffer) {
+            batchBuffer.add(event);
+            if (batchBuffer.size() >= config.getMaxBatchSize()) {
+                flush();
+            }
+        }
+    }
+
+    @Override
+    public Optional<Void> prepareCommit() {
+        flush();
+        return Optional.empty();
+    }
+
+    /**
+     * Sends the buffered events, retrying transient collector failures.
+     *
+     * <p>The buffer is cleared only after the collector has accepted the batch, so a failed attempt
+     * never silently drops events.
+     */
+    @VisibleForTesting
+    void flush() {
+        synchronized (batchBuffer) {
+            if (batchBuffer.isEmpty()) {
+                return;
+            }
+            int eventCount = batchBuffer.size();
+            String body = String.join("\n", batchBuffer);
+            try {
+                RetryUtils.retryWithException(
+                        () -> {
+                            client.send(body);
+                            return null;
+                        },
+                        retryMaterial);
+            } catch (SplunkConnectorException e) {
+                // RetryUtils rethrows a non-retryable failure unchanged, so this batch was rejected
+                // permanently on the first attempt. Claiming a retry count here would be wrong.
+                throw new SplunkConnectorException(
+                        SplunkConnectorErrorCode.SEND_EVENTS_FAILED,
+                        String.format(
+                                "Failed to send a batch of %d event(s) to the Splunk HTTP Event "
+                                        + "Collector: the collector rejected it permanently, so it was not retried",
+                                eventCount),
+                        e);
+            } catch (Exception e) {
+                throw new SplunkConnectorException(
+                        SplunkConnectorErrorCode.SEND_EVENTS_FAILED,
+                        String.format(
+                                "Failed to send a batch of %d event(s) to the Splunk HTTP Event Collector "
+                                        + "after %d attempt(s)",
+                                eventCount, config.getMaxRetryCount()),
+                        e);
+            }
+            batchBuffer.clear();
+            log.debug("Sent {} event(s) to the Splunk HTTP Event Collector", eventCount);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            flush();
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkConfigTest.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/config/SplunkSinkConfigTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class SplunkSinkConfigTest {
+
+    private static Map<String, Object> validOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("url", "https://splunk-host:8088");
+        options.put("token", "00000000-0000-0000-0000-000000000000");
+        return options;
+    }
+
+    private static SplunkSinkConfig configOf(Map<String, Object> options) {
+        return new SplunkSinkConfig(ReadonlyConfig.fromMap(options));
+    }
+
+    @Test
+    void defaultsAreApplied() {
+        SplunkSinkConfig config = configOf(validOptions());
+
+        Assertions.assertEquals(
+                "https://splunk-host:8088/services/collector/event", config.getEndpoint());
+        Assertions.assertEquals("00000000-0000-0000-0000-000000000000", config.getToken());
+        Assertions.assertEquals(100, config.getMaxBatchSize());
+        Assertions.assertEquals(3, config.getMaxRetryCount());
+        Assertions.assertEquals(200, config.getRetryBackoffMs());
+        Assertions.assertTrue(config.isTlsVerifyCertificate());
+        Assertions.assertTrue(config.isTlsVerifyHostname());
+        Assertions.assertNull(config.getIndex());
+        Assertions.assertNull(config.getSourceType());
+    }
+
+    @Test
+    void collectorPathIsAppendedToBaseUrlOnlyOnce() {
+        Map<String, Object> options = validOptions();
+        options.put("url", "https://splunk-host:8088/services/collector/event");
+        Assertions.assertEquals(
+                "https://splunk-host:8088/services/collector/event",
+                configOf(options).getEndpoint());
+
+        options.put("url", "https://splunk-host:8088/services/collector");
+        Assertions.assertEquals(
+                "https://splunk-host:8088/services/collector", configOf(options).getEndpoint());
+    }
+
+    @Test
+    void trailingSlashesAreStripped() {
+        Map<String, Object> options = validOptions();
+        options.put("url", "https://splunk-host:8088/");
+        Assertions.assertEquals(
+                "https://splunk-host:8088/services/collector/event",
+                configOf(options).getEndpoint());
+    }
+
+    @Test
+    void missingUrlFailsWithActionableMessage() {
+        Map<String, Object> options = validOptions();
+        options.remove("url");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertEquals(
+                SplunkConnectorErrorCode.INVALID_CONFIG.getCode(),
+                exception.getSeaTunnelErrorCode().getCode());
+        Assertions.assertTrue(
+                exception.getMessage().contains("'url' is required"), exception.getMessage());
+    }
+
+    @Test
+    void blankUrlFailsWithActionableMessage() {
+        Map<String, Object> options = validOptions();
+        options.put("url", "   ");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertTrue(
+                exception.getMessage().contains("'url' is required"), exception.getMessage());
+    }
+
+    @Test
+    void relativeUrlFailsWithActionableMessage() {
+        Map<String, Object> options = validOptions();
+        options.put("url", "splunk-host:8088");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertTrue(
+                exception.getMessage().contains("must be an absolute http or https URL"),
+                exception.getMessage());
+    }
+
+    @Test
+    void nonHttpSchemeFailsWithActionableMessage() {
+        Map<String, Object> options = validOptions();
+        options.put("url", "ftp://splunk-host:8088");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertTrue(
+                exception.getMessage().contains("must be an absolute http or https URL"),
+                exception.getMessage());
+    }
+
+    @Test
+    void missingTokenFailsWithActionableMessage() {
+        Map<String, Object> options = validOptions();
+        options.remove("token");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertEquals(
+                SplunkConnectorErrorCode.INVALID_CONFIG.getCode(),
+                exception.getSeaTunnelErrorCode().getCode());
+        Assertions.assertTrue(
+                exception.getMessage().contains("'token' is required"), exception.getMessage());
+    }
+
+    @Test
+    void blankTokenFailsWithActionableMessage() {
+        Map<String, Object> options = validOptions();
+        options.put("token", " ");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertTrue(
+                exception.getMessage().contains("'token' is required"), exception.getMessage());
+    }
+
+    @Test
+    void nonPositiveBatchSizeFails() {
+        Map<String, Object> options = validOptions();
+        options.put("max_batch_size", 0);
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertTrue(
+                exception.getMessage().contains("'max_batch_size' must be greater than 0"),
+                exception.getMessage());
+    }
+
+    @Test
+    void negativeRetryBackoffFails() {
+        Map<String, Object> options = validOptions();
+        options.put("retry_backoff_ms", -1);
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> configOf(options));
+        Assertions.assertTrue(
+                exception.getMessage().contains("'retry_backoff_ms' must not be negative"),
+                exception.getMessage());
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/serialize/SplunkEventSerializerTest.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/serialize/SplunkEventSerializerTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.serialize;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+class SplunkEventSerializerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final SeaTunnelRowType ROW_TYPE =
+            new SeaTunnelRowType(
+                    new String[] {"id", "message", "hostname", "event_time", "epoch_millis"},
+                    new SeaTunnelDataType<?>[] {
+                        BasicType.LONG_TYPE,
+                        BasicType.STRING_TYPE,
+                        BasicType.STRING_TYPE,
+                        LocalTimeType.LOCAL_DATE_TIME_TYPE,
+                        BasicType.LONG_TYPE
+                    });
+
+    private static SeaTunnelRow row() {
+        return new SeaTunnelRow(
+                new Object[] {
+                    1L,
+                    "hello splunk",
+                    "web-01",
+                    LocalDateTime.of(2026, 8, 17, 12, 30, 45, 123_000_000),
+                    1_755_432_645_123L
+                });
+    }
+
+    private static SplunkSinkConfig configOf(Map<String, Object> extraOptions) {
+        Map<String, Object> options = new HashMap<>();
+        options.put("url", "https://splunk-host:8088");
+        options.put("token", "test-token");
+        options.putAll(extraOptions);
+        return new SplunkSinkConfig(ReadonlyConfig.fromMap(options));
+    }
+
+    private static JsonNode serialize(Map<String, Object> extraOptions) throws Exception {
+        SplunkSinkConfig config = configOf(extraOptions);
+        SplunkEventSerializer serializer = new SplunkEventSerializer(ROW_TYPE, config);
+        return MAPPER.readTree(serializer.serialize(row()));
+    }
+
+    @Test
+    void writesRowUnderEventAndOmitsUnconfiguredMetadata() throws Exception {
+        JsonNode envelope = serialize(new HashMap<>());
+
+        Assertions.assertFalse(envelope.has("index"));
+        Assertions.assertFalse(envelope.has("source"));
+        Assertions.assertFalse(envelope.has("sourcetype"));
+        Assertions.assertFalse(envelope.has("host"));
+        Assertions.assertFalse(envelope.has("time"));
+
+        JsonNode event = envelope.get("event");
+        Assertions.assertEquals(1L, event.get("id").asLong());
+        Assertions.assertEquals("hello splunk", event.get("message").asText());
+        Assertions.assertEquals("web-01", event.get("hostname").asText());
+    }
+
+    @Test
+    void writesConfiguredMetadataFields() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("index", "main");
+        options.put("source", "seatunnel");
+        options.put("sourcetype", "_json");
+        options.put("host", "static-host");
+
+        JsonNode envelope = serialize(options);
+
+        Assertions.assertEquals("main", envelope.get("index").asText());
+        Assertions.assertEquals("seatunnel", envelope.get("source").asText());
+        Assertions.assertEquals("_json", envelope.get("sourcetype").asText());
+        Assertions.assertEquals("static-host", envelope.get("host").asText());
+    }
+
+    @Test
+    void hostFieldOverridesStaticHost() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("host", "static-host");
+        options.put("host_field", "hostname");
+
+        Assertions.assertEquals("web-01", serialize(options).get("host").asText());
+    }
+
+    @Test
+    void hostFieldFallsBackToStaticHostWhenRowValueIsNull() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("host", "static-host");
+        options.put("host_field", "hostname");
+
+        SplunkEventSerializer serializer = new SplunkEventSerializer(ROW_TYPE, configOf(options));
+        SeaTunnelRow rowWithNullHost = row();
+        rowWithNullHost.setField(2, null);
+
+        Assertions.assertTrue(
+                serializer.serialize(rowWithNullHost).contains("\"host\":\"static-host\""));
+    }
+
+    @Test
+    void timestampTimeFieldIsConvertedToEpochSecondsWithMillisPrecision() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("time_field", "event_time");
+
+        // 2026-08-17T12:30:45.123 read as UTC == 1786969845.123 epoch seconds
+        Assertions.assertEquals(
+                1786969845.123d, serialize(options).get("time").asDouble(), 0.0005d);
+    }
+
+    @Test
+    void bigintTimeFieldIsInterpretedAsEpochMillis() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("time_field", "epoch_millis");
+
+        Assertions.assertEquals(
+                1755432645.123d, serialize(options).get("time").asDouble(), 0.0005d);
+    }
+
+    @Test
+    void timeIsWrittenInPlainNotation() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("time_field", "event_time");
+
+        SplunkEventSerializer serializer = new SplunkEventSerializer(ROW_TYPE, configOf(options));
+        String event = serializer.serialize(row());
+
+        // Splunk rejects a scientific-notation timestamp such as 1.786969845123E9.
+        Assertions.assertTrue(event.contains("\"time\":1786969845.123"), event);
+    }
+
+    @Test
+    void timeIsOmittedWhenTheRowValueIsNull() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("time_field", "event_time");
+
+        SplunkEventSerializer serializer = new SplunkEventSerializer(ROW_TYPE, configOf(options));
+        SeaTunnelRow rowWithNullTime = row();
+        rowWithNullTime.setField(3, null);
+
+        Assertions.assertFalse(MAPPER.readTree(serializer.serialize(rowWithNullTime)).has("time"));
+    }
+
+    @Test
+    void unknownHostFieldFailsWithAvailableFields() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("host_field", "does_not_exist");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(
+                        SplunkConnectorException.class,
+                        () -> new SplunkEventSerializer(ROW_TYPE, configOf(options)));
+        Assertions.assertTrue(
+                exception.getMessage().contains("does not exist upstream"), exception.getMessage());
+        Assertions.assertTrue(exception.getMessage().contains("hostname"), exception.getMessage());
+    }
+
+    @Test
+    void unsupportedTimeFieldTypeFails() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("time_field", "message");
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(
+                        SplunkConnectorException.class,
+                        () -> new SplunkEventSerializer(ROW_TYPE, configOf(options)));
+        Assertions.assertTrue(
+                exception.getMessage().contains("cannot be used as a Splunk event timestamp"),
+                exception.getMessage());
+    }
+
+    @Test
+    void consecutiveRowsDoNotLeakStateBetweenEnvelopes() throws Exception {
+        SplunkEventSerializer serializer =
+                new SplunkEventSerializer(ROW_TYPE, configOf(new HashMap<>()));
+
+        SeaTunnelRow second = row();
+        second.setField(0, 2L);
+        second.setField(1, "second event");
+
+        JsonNode first = MAPPER.readTree(serializer.serialize(row()));
+        JsonNode secondEnvelope = MAPPER.readTree(serializer.serialize(second));
+
+        Assertions.assertEquals(1L, first.get("event").get("id").asLong());
+        Assertions.assertEquals("hello splunk", first.get("event").get("message").asText());
+        Assertions.assertEquals(2L, secondEnvelope.get("event").get("id").asLong());
+        Assertions.assertEquals(
+                "second event", secondEnvelope.get("event").get("message").asText());
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkFactoryTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.sink;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SplunkSinkFactoryTest {
+
+    @Test
+    void factoryIdentifierMatchesThePluginMappingEntry() {
+        Assertions.assertEquals("Splunk", new SplunkSinkFactory().factoryIdentifier());
+    }
+
+    @Test
+    void urlAndTokenAreDeclaredRequired() {
+        OptionRule optionRule = new SplunkSinkFactory().optionRule();
+
+        Assertions.assertTrue(
+                optionRule.getRequiredOptions().stream()
+                        .anyMatch(option -> option.getOptions().contains(SplunkSinkOptions.URL)));
+        Assertions.assertTrue(
+                optionRule.getRequiredOptions().stream()
+                        .anyMatch(option -> option.getOptions().contains(SplunkSinkOptions.TOKEN)));
+    }
+
+    @Test
+    void batchingAndTlsOptionsAreDeclaredOptional() {
+        OptionRule optionRule = new SplunkSinkFactory().optionRule();
+
+        Assertions.assertTrue(optionRule.getOptionalOptions().contains(SplunkSinkOptions.INDEX));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(SplunkSinkOptions.MAX_BATCH_SIZE));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(SplunkSinkOptions.MAX_RETRY_COUNT));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(SplunkSinkOptions.TLS_VERIFY_CERTIFICATE));
+    }
+}

--- a/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-splunk/src/test/java/org/apache/seatunnel/connectors/seatunnel/splunk/sink/SplunkSinkWriterTest.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.splunk.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.splunk.client.SplunkHecClient;
+import org.apache.seatunnel.connectors.seatunnel.splunk.client.SplunkHecClient.SplunkHecRetryableException;
+import org.apache.seatunnel.connectors.seatunnel.splunk.config.SplunkSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.splunk.exception.SplunkConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class SplunkSinkWriterTest {
+
+    private static final SeaTunnelRowType ROW_TYPE =
+            new SeaTunnelRowType(
+                    new String[] {"id", "message"},
+                    new SeaTunnelDataType<?>[] {BasicType.LONG_TYPE, BasicType.STRING_TYPE});
+
+    private static SeaTunnelRow row(long id) {
+        return new SeaTunnelRow(new Object[] {id, "message-" + id});
+    }
+
+    private static SplunkSinkConfig config(Map<String, Object> extraOptions) {
+        Map<String, Object> options = new HashMap<>();
+        options.put("url", "https://splunk-host:8088");
+        options.put("token", "test-token");
+        options.put("retry_backoff_ms", 0);
+        options.putAll(extraOptions);
+        return new SplunkSinkConfig(ReadonlyConfig.fromMap(options));
+    }
+
+    private static SplunkSinkConfig configWithBatchSize(int batchSize) {
+        Map<String, Object> options = new HashMap<>();
+        options.put("max_batch_size", batchSize);
+        return config(options);
+    }
+
+    @Test
+    void batchIsNotSentBeforeTheThresholdIsReached() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        SplunkSinkWriter writer =
+                new SplunkSinkWriter(ROW_TYPE, configWithBatchSize(3), null, client);
+
+        writer.write(row(1));
+        writer.write(row(2));
+
+        Mockito.verify(client, Mockito.never()).send(Mockito.anyString());
+    }
+
+    @Test
+    void batchIsSentExactlyWhenTheThresholdIsReached() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        SplunkSinkWriter writer =
+                new SplunkSinkWriter(ROW_TYPE, configWithBatchSize(3), null, client);
+
+        writer.write(row(1));
+        writer.write(row(2));
+        writer.write(row(3));
+
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client, Mockito.times(1)).send(body.capture());
+        Assertions.assertEquals(3, body.getValue().split("\n").length);
+        Assertions.assertTrue(body.getValue().contains("message-1"));
+        Assertions.assertTrue(body.getValue().contains("message-3"));
+
+        // The buffer is reset after a successful flush, so the next rows start a fresh batch.
+        writer.write(row(4));
+        Mockito.verify(client, Mockito.times(1)).send(Mockito.anyString());
+    }
+
+    @Test
+    void prepareCommitFlushesAPartialBatch() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        SplunkSinkWriter writer =
+                new SplunkSinkWriter(ROW_TYPE, configWithBatchSize(100), null, client);
+
+        writer.write(row(1));
+        writer.prepareCommit();
+
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client, Mockito.times(1)).send(body.capture());
+        Assertions.assertEquals(1, body.getValue().split("\n").length);
+    }
+
+    @Test
+    void closeFlushesAPartialBatchAndClosesTheClient() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        SplunkSinkWriter writer =
+                new SplunkSinkWriter(ROW_TYPE, configWithBatchSize(100), null, client);
+
+        writer.write(row(1));
+        writer.close();
+
+        Mockito.verify(client, Mockito.times(1)).send(Mockito.anyString());
+        Mockito.verify(client, Mockito.times(1)).close();
+    }
+
+    @Test
+    void flushOnAnEmptyBufferSendsNothing() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        SplunkSinkWriter writer =
+                new SplunkSinkWriter(ROW_TYPE, configWithBatchSize(100), null, client);
+
+        writer.prepareCommit();
+        writer.close();
+
+        Mockito.verify(client, Mockito.never()).send(Mockito.anyString());
+    }
+
+    @Test
+    void updateBeforeRowsAreSkipped() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        SplunkSinkWriter writer =
+                new SplunkSinkWriter(ROW_TYPE, configWithBatchSize(100), null, client);
+
+        SeaTunnelRow updateBefore = row(1);
+        updateBefore.setRowKind(RowKind.UPDATE_BEFORE);
+        writer.write(updateBefore);
+        writer.prepareCommit();
+
+        Mockito.verify(client, Mockito.never()).send(Mockito.anyString());
+    }
+
+    @Test
+    void retryableFailuresAreRetriedUpToMaxRetryCount() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        Mockito.doThrow(new SplunkHecRetryableException("collector busy", null))
+                .doThrow(new SplunkHecRetryableException("collector busy", null))
+                .doNothing()
+                .when(client)
+                .send(Mockito.anyString());
+
+        Map<String, Object> options = new HashMap<>();
+        options.put("max_batch_size", 1);
+        options.put("max_retry_count", 3);
+        SplunkSinkWriter writer = new SplunkSinkWriter(ROW_TYPE, config(options), null, client);
+
+        writer.write(row(1));
+
+        Mockito.verify(client, Mockito.times(3)).send(Mockito.anyString());
+    }
+
+    @Test
+    void exhaustedRetriesFailTheTaskAndKeepTheBuffer() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        Mockito.doThrow(new SplunkHecRetryableException("collector busy", null))
+                .when(client)
+                .send(Mockito.anyString());
+
+        Map<String, Object> options = new HashMap<>();
+        options.put("max_batch_size", 1);
+        options.put("max_retry_count", 2);
+        SplunkSinkWriter writer = new SplunkSinkWriter(ROW_TYPE, config(options), null, client);
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> writer.write(row(1)));
+        Assertions.assertEquals(
+                SplunkConnectorErrorCode.SEND_EVENTS_FAILED.getCode(),
+                exception.getSeaTunnelErrorCode().getCode());
+        Mockito.verify(client, Mockito.times(2)).send(Mockito.anyString());
+
+        // The events were never accepted, so they must still be buffered rather than dropped.
+        Mockito.clearInvocations(client);
+        Mockito.doNothing().when(client).send(Mockito.anyString());
+        writer.prepareCommit();
+
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client, Mockito.times(1)).send(body.capture());
+        Assertions.assertTrue(body.getValue().contains("message-1"));
+    }
+
+    @Test
+    void permanentFailuresAreNotRetried() throws Exception {
+        SplunkHecClient client = Mockito.mock(SplunkHecClient.class);
+        Mockito.doThrow(
+                        new SplunkConnectorException(
+                                SplunkConnectorErrorCode.SEND_EVENTS_FAILED, "invalid token"))
+                .when(client)
+                .send(Mockito.anyString());
+
+        Map<String, Object> options = new HashMap<>();
+        options.put("max_batch_size", 1);
+        options.put("max_retry_count", 5);
+        SplunkSinkWriter writer = new SplunkSinkWriter(ROW_TYPE, config(options), null, client);
+
+        SplunkConnectorException exception =
+                Assertions.assertThrows(SplunkConnectorException.class, () -> writer.write(row(1)));
+        Mockito.verify(client, Mockito.times(1)).send(Mockito.anyString());
+
+        // The batch was never retried, so the message must not claim an attempt count.
+        Assertions.assertTrue(
+                exception.getMessage().contains("rejected it permanently, so it was not retried"),
+                exception.getMessage());
+        Assertions.assertFalse(
+                exception.getMessage().contains("attempt(s)"), exception.getMessage());
+    }
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -98,6 +98,7 @@
         <module>connector-bigquery</module>
         <module>connector-edge-socket</module>
         <module>connector-nats-jetstream</module>
+        <module>connector-splunk</module>
     </modules>
 
     <dependencyManagement>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -810,6 +810,13 @@
 
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-splunk</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-bigquery</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connector-v2-e2e</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-splunk-e2e</artifactId>
+    <name>SeaTunnel : E2E : Connector V2 : Splunk</name>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- SeaTunnel connectors -->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-fake</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-splunk</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/src/test/java/org/apache/seatunnel/e2e/connector/splunk/SplunkIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/src/test/java/org/apache/seatunnel/e2e/connector/splunk/SplunkIT.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.splunk;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * Verifies that a FakeSource to Splunk sink job actually lands its events in the target index,
+ * including the configured HEC metadata mapping.
+ */
+@Slf4j
+public class SplunkIT extends TestSuiteBase implements TestResource {
+
+    private static final String SPLUNK_DOCKER_IMAGE = "splunk/splunk:9.3.2";
+    private static final String SPLUNK_HOST = "splunk-e2e";
+    private static final int HEC_PORT = 8088;
+    private static final int MANAGEMENT_PORT = 8089;
+
+    private static final String SPLUNK_PASSWORD = "SeaTunnel@2026";
+    /** Must match the token configured in fake_to_splunk.conf. */
+    private static final String HEC_TOKEN = "00000000-0000-0000-0000-0000000000ff";
+
+    private static final String INDEX = "main";
+    private static final String SOURCE = "seatunnel";
+    private static final String SOURCE_TYPE = "seatunnel_e2e";
+
+    /** Number of rows produced by fake_to_splunk.conf. */
+    private static final int EXPECTED_EVENT_COUNT = 5;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private GenericContainer<?> splunkContainer;
+
+    @BeforeAll
+    @Override
+    public void startUp() throws Exception {
+        splunkContainer =
+                new GenericContainer<>(DockerImageName.parse(SPLUNK_DOCKER_IMAGE))
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(SPLUNK_HOST)
+                        .withExposedPorts(HEC_PORT, MANAGEMENT_PORT)
+                        .withEnv("SPLUNK_START_ARGS", "--accept-license")
+                        .withEnv("SPLUNK_PASSWORD", SPLUNK_PASSWORD)
+                        .withEnv("SPLUNK_HEC_TOKEN", HEC_TOKEN)
+                        .withStartupAttempts(2)
+                        .withStartupTimeout(Duration.ofMinutes(10))
+                        // The collector runs behind the self-signed certificate generated at
+                        // install time, which is exactly the deployment shape the sink's
+                        // tls_verify_certificate option exists for.
+                        .waitingFor(
+                                Wait.forHttp("/services/collector/health")
+                                        .forPort(HEC_PORT)
+                                        .usingTls()
+                                        .allowInsecure()
+                                        .forStatusCode(200)
+                                        .withStartupTimeout(Duration.ofMinutes(10)))
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger(SPLUNK_DOCKER_IMAGE)));
+        Startables.deepStart(Stream.of(splunkContainer)).join();
+        log.info("Splunk container started");
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        if (splunkContainer != null) {
+            splunkContainer.close();
+        }
+    }
+
+    @TestTemplate
+    public void testFakeSourceToSplunkSink(TestContainer container) throws Exception {
+        // The suite runs once per engine container against the same index, so the assertion is on
+        // the delta rather than on an absolute count.
+        int countBefore = searchEventCount();
+
+        Container.ExecResult execResult = container.executeJob("/fake_to_splunk.conf");
+        Assertions.assertEquals(0, execResult.getExitCode(), execResult.getStderr());
+
+        Awaitility.await()
+                .atMost(120, TimeUnit.SECONDS)
+                .pollInterval(2, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        countBefore + EXPECTED_EVENT_COUNT, searchEventCount()));
+
+        assertEventContentAndMetadata();
+    }
+
+    /** Asserts the HEC metadata mapping and the event body written by the sink. */
+    private void assertEventContentAndMetadata() throws Exception {
+        List<JsonNode> results =
+                runSearch(
+                        String.format(
+                                "search index=%s sourcetype=%s | eval epoch=_time "
+                                        + "| table id, message, host, source, sourcetype, epoch",
+                                INDEX, SOURCE_TYPE));
+        Assertions.assertFalse(results.isEmpty(), "no events were returned by the Splunk search");
+
+        Set<String> messages = new HashSet<>();
+        Set<String> hosts = new HashSet<>();
+        Set<String> epochs = new HashSet<>();
+        for (JsonNode result : results) {
+            // sourcetype and source come from the static sink options.
+            Assertions.assertEquals(SOURCE_TYPE, result.get("sourcetype").asText());
+            Assertions.assertEquals(SOURCE, result.get("source").asText());
+            messages.add(result.get("message").asText());
+            hosts.add(result.get("host").asText());
+            // Splunk reports _time in whole seconds here; the sink sends millisecond precision.
+            epochs.add(result.get("epoch").asText().split("\\.")[0]);
+        }
+
+        // The event body carries the upstream row fields.
+        Assertions.assertTrue(messages.contains("seatunnel event one"), messages.toString());
+        Assertions.assertTrue(messages.contains("seatunnel event five"), messages.toString());
+
+        // host comes from the 'hostname' row field via host_field.
+        Assertions.assertTrue(hosts.contains("web-01"), hosts.toString());
+        Assertions.assertTrue(hosts.contains("web-02"), hosts.toString());
+        Assertions.assertTrue(hosts.contains("web-03"), hosts.toString());
+
+        // _time comes from the 'event_time' row field via time_field, read as UTC.
+        Assertions.assertTrue(epochs.contains("1786969845"), epochs.toString());
+        Assertions.assertTrue(epochs.contains("1786969849"), epochs.toString());
+    }
+
+    private int searchEventCount() throws Exception {
+        List<JsonNode> results =
+                runSearch(
+                        String.format(
+                                "search index=%s sourcetype=%s | stats count", INDEX, SOURCE_TYPE));
+        if (results.isEmpty()) {
+            return 0;
+        }
+        return results.get(0).get("count").asInt();
+    }
+
+    /**
+     * Runs a Splunk search through the management API from inside the container, avoiding a
+     * dependency on a TLS-tolerant HTTP client in the test classpath.
+     */
+    private List<JsonNode> runSearch(String search) throws Exception {
+        Container.ExecResult result =
+                splunkContainer.execInContainer(
+                        "curl",
+                        "-sk",
+                        "-u",
+                        "admin:" + SPLUNK_PASSWORD,
+                        "https://localhost:" + MANAGEMENT_PORT + "/services/search/jobs/export",
+                        "--data-urlencode",
+                        "search=" + search,
+                        "-d",
+                        "output_mode=json");
+        Assertions.assertEquals(
+                0, result.getExitCode(), "splunk search failed: " + result.getStderr());
+
+        // The export endpoint streams one JSON object per line; only lines carrying a result
+        // matter.
+        List<JsonNode> results = new ArrayList<>();
+        for (String line : result.getStdout().split("\n")) {
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+            JsonNode node = OBJECT_MAPPER.readTree(line);
+            if (node.has("result")) {
+                results.add(node.get("result"));
+            }
+        }
+        return results;
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/src/test/resources/fake_to_splunk.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-splunk-e2e/src/test/resources/fake_to_splunk.conf
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    plugin_output = "splunk_test_table"
+    schema = {
+      fields {
+        id = bigint
+        message = string
+        hostname = string
+        event_time = timestamp
+      }
+    }
+    rows = [
+      {fields = [1, "seatunnel event one", "web-01", "2026-08-17T12:30:45"], kind = INSERT},
+      {fields = [2, "seatunnel event two", "web-02", "2026-08-17T12:30:46"], kind = INSERT},
+      {fields = [3, "seatunnel event three", "web-01", "2026-08-17T12:30:47"], kind = INSERT},
+      {fields = [4, "seatunnel event four", "web-03", "2026-08-17T12:30:48"], kind = INSERT},
+      {fields = [5, "seatunnel event five", "web-02", "2026-08-17T12:30:49"], kind = INSERT}
+    ]
+  }
+}
+
+sink {
+  Splunk {
+    plugin_input = "splunk_test_table"
+    url = "https://splunk-e2e:8088"
+    token = "00000000-0000-0000-0000-0000000000ff"
+    index = "main"
+    source = "seatunnel"
+    sourcetype = "seatunnel_e2e"
+    host_field = "hostname"
+    time_field = "event_time"
+    max_batch_size = 2
+    max_retry_count = 3
+    tls_verify_certificate = false
+    tls_verify_hostname = false
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
@@ -98,6 +98,7 @@
         <module>connector-bigquery-e2e</module>
         <module>connector-nats-jetstream-e2e</module>
         <module>connector-couchbase-e2e</module>
+        <module>connector-splunk-e2e</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Purpose of this pull request

Implements the **Splunk Sink** connector, the first half of #10753. The Source
will follow in a separate PR.

The sink writes SeaTunnel rows to a Splunk index through the HTTP Event
Collector. Each row becomes one HEC event envelope — the row under `event`,
with `index` / `source` / `sourcetype` / `host` / `time` populated from sink
options — and envelopes are POSTed to `/services/collector/event` in batches.

Part of #10753

### Does this PR introduce _any_ user-facing change?

Yes — a new `Splunk` sink plugin. No existing option, default, or API is
changed. Docs added at `docs/en/connectors/sink/Splunk.md` and the zh
equivalent.

### Design notes

- **Not built on `connector-http-base`.** Its `HttpClientProvider` always
  builds `HttpClients.createDefault()` with no TLS hook, and Splunk HEC
  commonly sits behind the self-signed certificate generated at install time.
  `SplunkHecClient` adds `tls_verify_certificate` / `tls_verify_hostname`
  (named to match the Elasticsearch sink).
- **Retry classification.** Only transport errors, HTTP 429 and 5xx are
  retried. A bad token, a forbidden index, or a malformed payload fails the
  task immediately instead of burning retries on an error that cannot resolve
  itself. The buffer is cleared only after the collector accepts the batch, so
  a failed attempt never silently drops events.
- **No connector-level `flush_interval`.** Periodic flushing uses the
  engine-level `sink.flush.interval` via `context.registerFlushAction`,
  consistent with the direction taken in connector-prometheus and the
  Elasticsearch/Hudi sinks. Zeta only; Spark and Flink flush on
  `max_batch_size`, checkpoint and close.
- **`time_field` accepts** `TIMESTAMP` (read as UTC), `TIMESTAMP_TZ`, and
  `BIGINT` (epoch millis). Any other type fails at startup with a message
  naming the field and its type. The value is sent as epoch seconds with
  millisecond precision, written in plain notation — Splunk rejects the
  scientific notation Jackson produces for doubles at epoch magnitude.
- **Delivery is at-least-once** and documented as such; HEC offers no
  server-side dedup for this endpoint.

### How was this patch tested?

- 34 unit tests: config validation and endpoint normalisation, HEC envelope
  serialization (metadata mapping, timestamp conversion, plain-notation wire
  format), batching and flush thresholds, retry classification, and the
  factory OptionRule.
- E2E `SplunkIT`: `splunk/splunk:9.3.2` container, FakeSource → Splunk sink,
  asserting the events land in the target index with the configured metadata.
- Additionally verified by hand against a real Splunk 9.3.2 instance using the
  built distribution: a Zeta job wrote 5 rows, and a Splunk search confirmed
  the event bodies, `host` from `host_field`, static `source`/`sourcetype`,
  and `_time` from `time_field`. An invalid-token run confirmed the fail-fast
  path.

Note: the local Docker version (29.3.0) is incompatible with this repo's
pinned Testcontainers client, so no E2E in the repo can run locally — the
pre-existing `HttpIT` fails identically. `SplunkIT` therefore runs for the
first time in CI; the manual round-trip above covers the same ground.

### Check list

* [x] Code changed are covered with tests
* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md) — no new third-party dependency; `httpclient`/`httpcore` are already in `known-dependencies.txt`
* [x] If necessary, please update the documentation to describe the new feature
* [x] Update the `plugin-mapping.properties` and add new connector information in it
