### PR TITLE
[Improve][Connector-V2] Migrate IoTDBv2 SQL dialect validation to OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-iotdb-v2/src/main/java/org/apache/seatunnel/connectors/seatunnel/iotdbv2/sink/IoTDBv2SinkFactory.java
+++ b/seatunnel-connectors-v2/connector-iotdb-v2/src/main/java/org/apache/seatunnel/connectors/seatunnel/iotdbv2/sink/IoTDBv2SinkFactory.java
@@ -18,15 +18,14 @@
 package org.apache.seatunnel.connectors.seatunnel.iotdbv2.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
-import org.apache.seatunnel.common.exception.CommonErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.iotdbv2.config.IoTDBv2SinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.iotdbv2.constant.SinkConstants;
-import org.apache.seatunnel.connectors.seatunnel.iotdbv2.exception.IotdbConnectorException;
 
 import com.google.auto.service.AutoService;
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +49,8 @@ public class IoTDBv2SinkFactory implements TableSinkFactory {
                         IoTDBv2SinkOptions.KEY_DEVICE)
                 .optional(
                         IoTDBv2SinkOptions.SQL_DIALECT,
+                        Conditions.matches(IoTDBv2SinkOptions.SQL_DIALECT, "(?i)^(tree|table)$"))
+                .optional(
                         IoTDBv2SinkOptions.KEY_TIMESTAMP,
                         IoTDBv2SinkOptions.KEY_TAG_FIELDS,
                         IoTDBv2SinkOptions.KEY_ATTRIBUTE_FIELDS,
@@ -69,22 +70,11 @@ public class IoTDBv2SinkFactory implements TableSinkFactory {
     @Override
     public TableSink createSink(TableSinkFactoryContext context) {
         ReadonlyConfig conf = context.getOptions();
-        String targetSqlDialect;
-        if (conf.get(IoTDBv2SinkOptions.SQL_DIALECT) != null) {
-            String sqlDialect = conf.get(IoTDBv2SinkOptions.SQL_DIALECT);
-            if (SinkConstants.TABLE.equalsIgnoreCase(sqlDialect)) {
-                targetSqlDialect = SinkConstants.TABLE;
-            } else {
-                if (SinkConstants.TREE.equalsIgnoreCase(sqlDialect)) {
-                    targetSqlDialect = SinkConstants.TREE;
-                } else {
-                    throw new IotdbConnectorException(
-                            CommonErrorCode.ILLEGAL_ARGUMENT, "Sql dialect not supported");
-                }
-            }
-        } else {
-            targetSqlDialect = SinkConstants.TREE;
-        }
+        String sqlDialect = conf.get(IoTDBv2SinkOptions.SQL_DIALECT);
+        String targetSqlDialect =
+                SinkConstants.TABLE.equalsIgnoreCase(sqlDialect)
+                        ? SinkConstants.TABLE
+                        : SinkConstants.TREE;
         return () ->
                 new IoTDBv2Sink(context.getOptions(), context.getCatalogTable(), targetSqlDialect);
     }

--- a/seatunnel-connectors-v2/connector-iotdb-v2/src/main/java/org/apache/seatunnel/connectors/seatunnel/iotdbv2/source/IoTDBv2SourceFactory.java
+++ b/seatunnel-connectors-v2/connector-iotdb-v2/src/main/java/org/apache/seatunnel/connectors/seatunnel/iotdbv2/source/IoTDBv2SourceFactory.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.iotdbv2.source;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
@@ -28,10 +29,8 @@ import org.apache.seatunnel.api.table.connector.TableSource;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactory;
 import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
-import org.apache.seatunnel.common.exception.CommonErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.iotdbv2.config.IoTDBv2SourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.iotdbv2.constant.SourceConstants;
-import org.apache.seatunnel.connectors.seatunnel.iotdbv2.exception.IotdbConnectorException;
 
 import com.google.auto.service.AutoService;
 
@@ -55,6 +54,8 @@ public class IoTDBv2SourceFactory implements TableSourceFactory {
                         ConnectorCommonOptions.SCHEMA)
                 .optional(
                         IoTDBv2SourceOptions.SQL_DIALECT,
+                        Conditions.matches(IoTDBv2SourceOptions.SQL_DIALECT, "(?i)^(tree|table)$"))
+                .optional(
                         IoTDBv2SourceOptions.DATABASE,
                         IoTDBv2SourceOptions.FETCH_SIZE,
                         IoTDBv2SourceOptions.DEFAULT_THRIFT_BUFFER_SIZE,
@@ -71,22 +72,11 @@ public class IoTDBv2SourceFactory implements TableSourceFactory {
             TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
         CatalogTable catalogTable = CatalogTableUtil.buildWithConfig(context.getOptions());
         ReadonlyConfig conf = context.getOptions();
-        String targetSqlDialect;
-        if (conf.get(IoTDBv2SourceOptions.SQL_DIALECT) != null) {
-            String sqlDialect = conf.get(IoTDBv2SourceOptions.SQL_DIALECT);
-            if (SourceConstants.TABLE.equalsIgnoreCase(sqlDialect)) {
-                targetSqlDialect = SourceConstants.TABLE;
-            } else {
-                if (SourceConstants.TREE.equalsIgnoreCase(sqlDialect)) {
-                    targetSqlDialect = SourceConstants.TREE;
-                } else {
-                    throw new IotdbConnectorException(
-                            CommonErrorCode.ILLEGAL_ARGUMENT, "Sql dialect not supported");
-                }
-            }
-        } else {
-            targetSqlDialect = SourceConstants.TREE;
-        }
+        String sqlDialect = conf.get(IoTDBv2SourceOptions.SQL_DIALECT);
+        String targetSqlDialect =
+                SourceConstants.TABLE.equalsIgnoreCase(sqlDialect)
+                        ? SourceConstants.TABLE
+                        : SourceConstants.TREE;
         return () ->
                 (SeaTunnelSource<T, SplitT, StateT>)
                         new IoTDBv2Source(catalogTable, context.getOptions(), targetSqlDialect);

--- a/seatunnel-connectors-v2/connector-iotdb-v2/src/test/java/org/apache/seatunnel/connectors/seatunnel/iotdbv2/IoTDBFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-iotdb-v2/src/test/java/org/apache/seatunnel/connectors/seatunnel/iotdbv2/IoTDBFactoryTest.java
@@ -17,17 +17,98 @@
 
 package org.apache.seatunnel.connectors.seatunnel.iotdbv2;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.iotdbv2.config.IoTDBv2CommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.iotdbv2.config.IoTDBv2SinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.iotdbv2.config.IoTDBv2SourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.iotdbv2.sink.IoTDBv2SinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.iotdbv2.source.IoTDBv2SourceFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 class IoTDBFactoryTest {
+
+    private final OptionRule sourceRule = new IoTDBv2SourceFactory().optionRule();
+    private final OptionRule sinkRule = new IoTDBv2SinkFactory().optionRule();
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new IoTDBv2SourceFactory()).optionRule());
-        Assertions.assertNotNull((new IoTDBv2SinkFactory()).optionRule());
+        Assertions.assertNotNull(sourceRule);
+        Assertions.assertNotNull(sinkRule);
+    }
+
+    @Test
+    void omittedSqlDialectIsAccepted() {
+        Assertions.assertDoesNotThrow(() -> validate(validSourceConfig(), sourceRule));
+        Assertions.assertDoesNotThrow(() -> validate(validSinkConfig(), sinkRule));
+    }
+
+    @Test
+    void supportedSqlDialectsAreAcceptedCaseInsensitively() {
+        for (String dialect : Arrays.asList("tree", "table", "TrEe", "TaBlE")) {
+            Map<String, Object> sourceConfig = validSourceConfig();
+            sourceConfig.put(IoTDBv2CommonOptions.SQL_DIALECT.key(), dialect);
+            Assertions.assertDoesNotThrow(() -> validate(sourceConfig, sourceRule));
+
+            Map<String, Object> sinkConfig = validSinkConfig();
+            sinkConfig.put(IoTDBv2CommonOptions.SQL_DIALECT.key(), dialect);
+            Assertions.assertDoesNotThrow(() -> validate(sinkConfig, sinkRule));
+        }
+    }
+
+    @Test
+    void unsupportedSqlDialectIsRejected() {
+        Map<String, Object> sourceConfig = validSourceConfig();
+        sourceConfig.put(IoTDBv2CommonOptions.SQL_DIALECT.key(), "unsupported");
+        OptionValidationException sourceException =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validate(sourceConfig, sourceRule));
+        Assertions.assertTrue(
+                sourceException.getMessage().contains(IoTDBv2CommonOptions.SQL_DIALECT.key()));
+
+        Map<String, Object> sinkConfig = validSinkConfig();
+        sinkConfig.put(IoTDBv2CommonOptions.SQL_DIALECT.key(), "unsupported");
+        OptionValidationException sinkException =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validate(sinkConfig, sinkRule));
+        Assertions.assertTrue(
+                sinkException.getMessage().contains(IoTDBv2CommonOptions.SQL_DIALECT.key()));
+    }
+
+    private void validate(Map<String, Object> config, OptionRule rule) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(rule);
+    }
+
+    private Map<String, Object> validSourceConfig() {
+        Map<String, Object> config = commonConfig();
+        config.put(IoTDBv2SourceOptions.SQL.key(), "select * from root.test");
+        config.put(ConnectorCommonOptions.SCHEMA.key(), Collections.emptyMap());
+        return config;
+    }
+
+    private Map<String, Object> validSinkConfig() {
+        Map<String, Object> config = commonConfig();
+        config.put(IoTDBv2SinkOptions.STORAGE_GROUP.key(), "root.test");
+        config.put(IoTDBv2SinkOptions.KEY_DEVICE.key(), "device");
+        return config;
+    }
+
+    private Map<String, Object> commonConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(
+                IoTDBv2CommonOptions.NODE_URLS.key(), Collections.singletonList("127.0.0.1:6667"));
+        config.put(IoTDBv2CommonOptions.USERNAME.key(), "root");
+        config.put(IoTDBv2CommonOptions.PASSWORD.key(), "root");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Part of #11007.

The IoTDBv2 source and sink factories currently validate `sql_dialect` imperatively during `createSource` and `createSink`. Because the accepted values are a static configuration rule, this change moves that validation into each factory's declarative `OptionRule`.

- Accept only `tree` and `table`, preserving the existing case-insensitive behavior.
- Preserve the existing default value of `tree`.
- Remove the duplicate runtime unsupported-dialect checks.
- Add focused `ConfigValidator` coverage for omitted, valid, mixed-case, and unsupported values in both source and sink rules.

### Does this PR introduce _any_ user-facing change?

Yes. Invalid explicit `sql_dialect` values are now rejected earlier by standard option validation with `OptionValidationException`. The accepted values, default value, option name, and behavior of valid configurations are unchanged.

The English and Chinese connector documentation already state that the supported values are `tree` and `table` and that the default is `tree`, so no documentation update is required.

### How was this patch tested?

Test-first verification confirmed that the new invalid-value test failed against the old implementation because no `OptionValidationException` was raised.

The final change was verified with:

```shell
./mvnw spotless:apply
./mvnw -q \
  -pl seatunnel-connectors-v2/connector-iotdb-v2 \
  -am \
  -Dmaven.site.skip=true \
  -Dtest=IoTDBFactoryTest,IoTDBv2SourceSplitEnumeratorTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  verify
./mvnw -q -pl seatunnel-connectors-v2/connector-iotdb-v2 spotless:check
git diff --check origin/dev..HEAD
```

Results:

- `IoTDBFactoryTest`: 4 tests passed.
- `IoTDBv2SourceSplitEnumeratorTest`: 3 tests passed.
- Total: 7 tests passed, 0 failures, 0 errors, 0 skipped.
- Full-repository Spotless completed successfully across 288 reactor modules.

The full-repository `./mvnw -q -DskipTests verify` was also attempted twice, but Maven dependency resolution stalled on the local network proxy while resolving unrelated transitive dependencies. The scoped IoTDBv2 reactor `verify` above completed successfully.

### Check list

- [x] No new binary package or dependency is added.
- [x] Existing English and Chinese docs already describe the accepted values and default.
- [x] No incompatible option, API, or SPI change is introduced.
- [x] This updates an existing connector, so plugin mapping, distribution POM, label scope, and plugin configuration changes are not required.
