### PR TITLE
[Test][E2E] Retry Couchbase container startup and capture server logs

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-couchbase-e2e/src/test/java/org/apache/seatunnel/e2e/connector/couchbase/CouchbaseIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-couchbase-e2e/src/test/java/org/apache/seatunnel/e2e/connector/couchbase/CouchbaseIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestTemplate;
 import org.testcontainers.containers.Container;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.couchbase.BucketDefinition;
 import org.testcontainers.couchbase.CouchbaseContainer;
 import org.testcontainers.couchbase.CouchbaseService;
@@ -95,7 +96,18 @@ public class CouchbaseIT extends TestSuiteBase implements TestResource {
                         // that point, causing a Connection reset / unexpected end of stream error.
                         // A 3-minute startup timeout gives the HttpWaitStrategy enough retry
                         // budget to ride out the transient unavailability window.
-                        .withStartupTimeout(Duration.ofMinutes(3));
+                        .withStartupTimeout(Duration.ofMinutes(3))
+                        // The startup timeout above only governs the wait strategy; the
+                        // containerIsStarting REST bootstrap has no retry of its own, and its
+                        // Connection reset failures kept killing the single default start attempt
+                        // on CI (seen repeatedly on ubuntu-latest since 2026-08-15, including on
+                        // apache/dev push builds). Whole-container retries cover that window with
+                        // a fresh server each attempt.
+                        .withStartupAttempts(3)
+                        // Surface the server's own stdout/stderr in the CI job log; without it a
+                        // bootstrap failure only shows the client-side socket error and gives no
+                        // way to see why the couchbase daemon dropped the connection.
+                        .withLogConsumer(new Slf4jLogConsumer(log).withPrefix("couchbase-server"));
         couchbaseContainer.start();
 
         cluster =


### PR DESCRIPTION
### Purpose of this pull request

Stabilize `CouchbaseIT`, which has been failing `all-connectors-it-1 (8, ubuntu-latest)` since 2026-08-15 across unrelated PR branches, job reruns, and apache/dev push builds (e.g. dev run 32011043377, PR runs 31993137762 attempts 1 and 2, 31792627420), always with the same ~19s signature:

```
ContainerLaunchException: Could not create/start container
Caused by: RuntimeException: Could not perform request against couchbase HTTP endpoint
Caused by: java.net.SocketException: Connection reset   (or: unexpected end of stream)
```

### Why the existing mitigation does not cover this

The connector shipped with `withStartupTimeout(Duration.ofMinutes(3))`, but that budget only governs the wait strategy. The failing REST bootstrap (`renameNode` etc.) runs earlier, inside testcontainers 1.17.6's `containerIsStarting`, has no retry of its own, and aborts the entire start on the first `IOException`. With the default single start attempt, the job dies immediately.

### What this PR changes (test-only, no assertion or timeout changes)

- `withStartupAttempts(3)`: retries the whole container start with a fresh server, covering the un-retried `containerIsStarting` window.
- `Slf4jLogConsumer` with prefix `couchbase-server`: streams the server's stdout/stderr into the CI job log, so if startup still fails the log shows why the couchbase daemon dropped the connection instead of only the client-side socket error.

### Check list

- [x] Test-only change under `seatunnel-e2e`; no production code touched.
- [x] `./mvnw spotless:apply -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-couchbase-e2e` run.
- [ ] Functional validation via GitHub CI (`all-connectors-it-1` / `updated-modules` shard containing CouchbaseIT).