### PR TITLE
[Fix][Transform-V2] Support decimal range bounds

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/rule/RangeValidationRule.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/rule/RangeValidationRule.java
@@ -26,6 +26,8 @@ import org.apache.seatunnel.transform.validator.ValidationResult;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 /** Validation rule to check if a numeric value is within a specified range. */
 @Data
 @NoArgsConstructor
@@ -62,7 +64,7 @@ public class RangeValidationRule implements ValidationRule {
 
         // Check minimum value
         if (minValue != null) {
-            int minComparison = comparableValue.compareTo(minValue);
+            int minComparison = compare(comparableValue, minValue);
             if (minInclusive ? minComparison < 0 : minComparison <= 0) {
                 return ValidationResult.failure(
                         customMessage != null
@@ -73,7 +75,7 @@ public class RangeValidationRule implements ValidationRule {
 
         // Check maximum value
         if (maxValue != null) {
-            int maxComparison = comparableValue.compareTo(maxValue);
+            int maxComparison = compare(comparableValue, maxValue);
             if (maxInclusive ? maxComparison > 0 : maxComparison >= 0) {
                 return ValidationResult.failure(
                         customMessage != null
@@ -83,6 +85,13 @@ public class RangeValidationRule implements ValidationRule {
         }
 
         return ValidationResult.success();
+    }
+
+    private int compare(Comparable value, Comparable bound) {
+        if (value instanceof BigDecimal && bound instanceof Number) {
+            return ((BigDecimal) value).compareTo(new BigDecimal(bound.toString()));
+        }
+        return value.compareTo(bound);
     }
 
     @Override

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
@@ -23,12 +23,14 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
@@ -139,5 +141,35 @@ public class DataValidatorTransformTest {
         assertEquals(2, producedTables.size());
         assertEquals("db1.source", producedTables.get(0).getTablePath().toString());
         assertEquals("db2.ffp", producedTables.get(1).getTablePath().toString());
+    }
+
+    @Test
+    void rangeRuleShouldValidateDecimalFieldAgainstIntegerBounds() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"amount"}, new SeaTunnelDataType[] {new DecimalType(10, 2)});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        ImmutableMap.of(
+                                "field_rules",
+                                Arrays.asList(
+                                        ImmutableMap.of(
+                                                "field_name",
+                                                "amount",
+                                                "rules",
+                                                Arrays.asList(
+                                                        ImmutableMap.of(
+                                                                "rule_type",
+                                                                "RANGE",
+                                                                "min_value",
+                                                                0,
+                                                                "max_value",
+                                                                1000))))));
+        DataValidatorTransform transform = new DataValidatorTransform(config, inputCatalogTable);
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {new BigDecimal("99.99")});
+
+        assertEquals(row, transform.map(row));
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #11804 by comparing `BigDecimal` field values with numeric range bounds as `BigDecimal` values. This prevents `ClassCastException` when a DECIMAL field uses integer `min_value` or `max_value` settings.

## Tests

- Adds a DataValidator regression test covering a DECIMAL field with integer range bounds.
- Ran the focused DECIMAL/integer-bound regression successfully.
- `./mvnw spotless:apply` completed successfully.
- Maven module and full verification could not complete because the current `upstream/dev` checkout is missing required `seatunnel-config-shade` source classes (unrelated to this change).