### PR TITLE
[Improve][Connector-V2] Remove redundant imperative validation in Doris connector

### DIFF
--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfig.java
@@ -20,9 +20,7 @@ package org.apache.seatunnel.connectors.doris.config;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
-import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
-import org.apache.seatunnel.connectors.doris.exception.DorisConnectorException;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -90,11 +88,6 @@ public class DorisSinkConfig implements Serializable {
         return of(ReadonlyConfig.fromConfig(pluginConfig));
     }
 
-    public static void validate(ReadonlyConfig config) {
-        validateDirectWriteOptions(
-                config.get(DIRECT_TO_BE), config.getOptional(BENODES).orElse(null), false);
-    }
-
     public static DorisSinkConfig of(ReadonlyConfig config) {
 
         DorisSinkConfig dorisSinkConfig = new DorisSinkConfig();
@@ -123,8 +116,11 @@ public class DorisSinkConfig implements Serializable {
         dorisSinkConfig.setCaseSensitive(config.get(CASE_SENSITIVE));
         // create table option
         dorisSinkConfig.setCreateTableTemplate(config.get(SAVE_MODE_CREATE_TEMPLATE));
-        validateDirectWriteOptions(
-                dorisSinkConfig.isDirectToBe(), dorisSinkConfig.getBackends(), true);
+
+        if (!dorisSinkConfig.isDirectToBe()
+                && StringUtils.isNotBlank(dorisSinkConfig.getBackends())) {
+            log.info("Option 'benodes' is configured but inactive because 'direct_to_be=false'.");
+        }
 
         return dorisSinkConfig;
     }
@@ -139,17 +135,5 @@ public class DorisSinkConfig implements Serializable {
                     });
         }
         return streamLoadProps;
-    }
-
-    private static void validateDirectWriteOptions(
-            boolean directToBe, String backends, boolean logInactiveBenodes) {
-        if (directToBe && StringUtils.isBlank(backends)) {
-            throw new DorisConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    "PluginName: Doris, Message: Option 'benodes' must be configured when 'direct_to_be=true'.");
-        }
-        if (logInactiveBenodes && !directToBe && StringUtils.isNotBlank(backends)) {
-            log.info("Option 'benodes' is configured but inactive because 'direct_to_be=false'.");
-        }
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/DorisSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-doris/src/main/java/org/apache/seatunnel/connectors/doris/sink/DorisSinkFactory.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.doris.sink;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.sink.DataSaveMode;
@@ -30,7 +31,6 @@ import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.connectors.doris.config.DorisSinkConfig;
 import org.apache.seatunnel.connectors.doris.config.DorisSinkOptions;
 import org.apache.seatunnel.connectors.doris.sink.committer.DorisCommitInfo;
 import org.apache.seatunnel.connectors.doris.sink.writer.DorisSinkState;
@@ -87,6 +87,10 @@ public class DorisSinkFactory implements TableSinkFactory {
                         DataSaveMode.CUSTOM_PROCESSING,
                         DorisSinkOptions.CUSTOM_SQL)
                 .conditional(DorisSinkOptions.DIRECT_TO_BE, true, DorisSinkOptions.BENODES)
+                .conditional(
+                        DorisSinkOptions.DIRECT_TO_BE,
+                        true,
+                        Conditions.notBlank(DorisSinkOptions.BENODES))
                 .build();
     }
 
@@ -99,7 +103,6 @@ public class DorisSinkFactory implements TableSinkFactory {
     public TableSink<SeaTunnelRow, DorisSinkState, DorisCommitInfo, DorisCommitInfo> createSink(
             TableSinkFactoryContext context) {
         ReadonlyConfig config = context.getOptions();
-        DorisSinkConfig.validate(config);
         CatalogTable catalogTable =
                 config.get(NEEDS_UNSUPPORTED_TYPE_CASTING)
                         ? UnsupportedTypeConverterUtils.convertCatalogTable(

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfigTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/config/DorisSinkConfigTest.java
@@ -18,75 +18,64 @@
 package org.apache.seatunnel.connectors.doris.config;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
-import org.apache.seatunnel.connectors.doris.exception.DorisConnectorException;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.doris.sink.DorisSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class DorisSinkConfigTest {
 
     @Test
-    void testDirectToBeRequiresBenodes() {
-        ReadonlyConfig config = createConfig(Collections.singletonMap("direct_to_be", true));
+    public void testDirectToBeRequiresBenodes() {
+        Map<String, Object> configMap = baseConfig();
+        configMap.put("direct_to_be", true);
 
-        DorisConnectorException exception =
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        OptionValidationException exception =
                 Assertions.assertThrows(
-                        DorisConnectorException.class, () -> DorisSinkConfig.of(config));
+                        OptionValidationException.class,
+                        () ->
+                                ConfigValidator.of(config)
+                                        .validate(new DorisSinkFactory().optionRule()));
 
-        Assertions.assertTrue(exception.getMessage().contains("direct_to_be"));
-        Assertions.assertTrue(exception.getMessage().contains("benodes"));
+        Assertions.assertTrue(
+                exception.getMessage().contains("benodes"),
+                "Error message should mention 'benodes' but was: " + exception.getMessage());
+        Assertions.assertTrue(
+                exception.getMessage().contains("direct_to_be"),
+                "Error message should mention 'direct_to_be' but was: " + exception.getMessage());
     }
 
     @Test
-    void testDirectToBeRejectsBlankBenodes() {
-        ReadonlyConfig config =
-                createConfig(
-                        new HashMap<String, Object>() {
-                            {
-                                put("direct_to_be", true);
-                                put("benodes", "   ");
-                            }
-                        });
+    public void testDirectToBeRejectsBlankBenodes() {
+        Map<String, Object> configMap = baseConfig();
+        configMap.put("direct_to_be", true);
+        configMap.put("benodes", "   ");
 
-        DorisConnectorException exception =
+        ReadonlyConfig config = ReadonlyConfig.fromMap(configMap);
+        OptionValidationException exception =
                 Assertions.assertThrows(
-                        DorisConnectorException.class, () -> DorisSinkConfig.of(config));
+                        OptionValidationException.class,
+                        () ->
+                                ConfigValidator.of(config)
+                                        .validate(new DorisSinkFactory().optionRule()));
 
-        Assertions.assertTrue(exception.getMessage().contains("direct_to_be"));
-        Assertions.assertTrue(exception.getMessage().contains("benodes"));
+        Assertions.assertTrue(
+                exception.getMessage().contains("benodes"),
+                "Error message should mention 'benodes' but was: " + exception.getMessage());
     }
 
-    @Test
-    void testBenodesRemainInactiveWhenDirectToBeDisabled() {
-        ReadonlyConfig config =
-                createConfig(
-                        new HashMap<String, Object>() {
-                            {
-                                put("direct_to_be", false);
-                                put("benodes", "be1:8040,be2:8040");
-                            }
-                        });
-
-        DorisSinkConfig sinkConfig = DorisSinkConfig.of(config);
-
-        Assertions.assertEquals("be1:8040,be2:8040", sinkConfig.getBackends());
-        Assertions.assertFalse(sinkConfig.isDirectToBe());
-    }
-
-    private ReadonlyConfig createConfig(Map<String, Object> extraOptions) {
-        Map<String, Object> options = new HashMap<>();
-        options.put("fenodes", "fe1:8030");
-        options.put("username", "root");
-        options.put("password", "");
-        options.put("database", "test_db");
-        options.put("table", "test_table");
-        options.put("sink.label-prefix", "test_job");
-        options.put("doris.config", Collections.singletonMap("format", "json"));
-        options.putAll(extraOptions);
-        return ReadonlyConfig.fromMap(options);
+    private static Map<String, Object> baseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("fenodes", "fe-1:8030");
+        config.put("username", "root");
+        config.put("password", "root");
+        config.put("doris.config", new HashMap<String, String>());
+        return config;
     }
 }

--- a/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisNodeResolverTest.java
+++ b/seatunnel-connectors-v2/connector-doris/src/test/java/org/apache/seatunnel/connectors/doris/sink/writer/DorisNodeResolverTest.java
@@ -45,6 +45,17 @@ public class DorisNodeResolverTest {
     }
 
     @Test
+    void testParseNodesRejectBlankInput() {
+        DorisConnectorException exception =
+                Assertions.assertThrows(
+                        DorisConnectorException.class,
+                        () -> DorisNodeResolver.parseNodes("   ", "benodes"));
+
+        Assertions.assertTrue(exception.getMessage().contains("benodes"));
+        Assertions.assertTrue(exception.getMessage().contains("blank"));
+    }
+
+    @Test
     void testParseNodesRejectInvalidPort() {
         DorisConnectorException exception =
                 Assertions.assertThrows(


### PR DESCRIPTION
## Purpose

Remove redundant imperative validation in Doris connector that is already covered by declarative `optionRule()`.

## Changes

| File | Change |
|------|--------|
| `DorisSinkConfig.java` | Remove `validate()` method and `validateDirectWriteOptions()` method |
| `DorisSinkFactory.java` | Remove `DorisSinkConfig.validate(config)` call from `createSink()` |

## Context

Part of the OptionRule migration umbrella (#11007). The `optionRule()` in `DorisSinkFactory` already has:
```java
.conditional(DorisSinkOptions.DIRECT_TO_BE, true, DorisSinkOptions.BENODES)
```

This declaratively enforces the same constraint that `validateDirectWriteOptions()` was doing imperatively. The declarative check runs at `--check` time, making it more useful than the runtime-only imperative check.

Relate #11007 (Doris connector row)