### PR TITLE
[Fix][API] Fix IndexOutOfBoundsException when primary key hash is Integer.MIN_VALUE

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriter.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriter.java
@@ -563,8 +563,8 @@ public class MultiTableSinkWriter
      *
      * <ul>
      *   <li>If the table's primary key information is present and the primary key field value is
-     *       non-null, the row is routed by {@code Math.abs(primaryKeyValue.hashCode()) %
-     *       queueSize}, guaranteeing that rows with the same primary key always go to the same
+     *       non-null, the row is routed by {@code (primaryKeyValue.hashCode() & Integer.MAX_VALUE)
+     *       % queueSize}, guaranteeing that rows with the same primary key always go to the same
      *       queue for ordered delivery.
      *   <li>If the table's primary key information is present but the actual field value is {@code
      *       null}, the row is routed to queue 0.
@@ -616,7 +616,7 @@ public class MultiTableSinkWriter
             Object object = element.getField(primaryKey.get());
             int index = 0;
             if (object != null) {
-                index = Math.abs(object.hashCode()) % blockingQueues.size();
+                index = (object.hashCode() & Integer.MAX_VALUE) % blockingQueues.size();
             }
             offerRowElement(index, element);
         }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriterTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/sink/multitablesink/MultiTableSinkWriterTest.java
@@ -927,6 +927,31 @@ public class MultiTableSinkWriterTest {
         Assertions.assertTrue(restored.getFailedTables().isEmpty());
     }
 
+    @Test
+    public void testHashRoutingWithIntegerMinValuePrimaryKey() throws IOException {
+        // Verifies that when primary key hashCode() returns Integer.MIN_VALUE,
+        // the hash-based routing does not produce a negative index.
+        // Math.abs(Integer.MIN_VALUE) overflows to a negative value,
+        // but (hashCode & Integer.MAX_VALUE) always yields a non-negative result.
+        int queueSize = 3; // non-power-of-two, triggers negative index with Math.abs
+        Map<SinkIdentifier, SinkWriter<SeaTunnelRow, ?, ?>> sinkWriters = new HashMap<>();
+        Map<SinkIdentifier, SinkWriter.Context> sinkWritersContext = new HashMap<>();
+        RecordingSinkWriter writer = new RecordingSinkWriter(false);
+        SinkIdentifier sinkIdentifier = SinkIdentifier.of(TablePath.DEFAULT.toString(), 0);
+        sinkWriters.put(sinkIdentifier, writer);
+        sinkWritersContext.put(sinkIdentifier, new TestSinkWriterContext());
+
+        MultiTableSinkWriter multiTableSinkWriter =
+                new MultiTableSinkWriter(sinkWriters, queueSize, sinkWritersContext);
+
+        // Integer.MIN_VALUE.hashCode() == Integer.MIN_VALUE
+        SeaTunnelRow row = buildRow(TablePath.DEFAULT.toString(), Integer.MIN_VALUE);
+
+        // Should not throw IndexOutOfBoundsException
+        Assertions.assertDoesNotThrow(() -> multiTableSinkWriter.write(row));
+        multiTableSinkWriter.close();
+    }
+
     private SeaTunnelRow buildRow(String tableId, int value) {
         SeaTunnelRow row = new SeaTunnelRow(new Object[] {value});
         row.setTableId(tableId);


### PR DESCRIPTION
## Purpose

Fix IndexOutOfBoundsException in multi-table sink when primary key hashCode() returns Integer.MIN_VALUE.

## Root Cause

`MultiTableSinkWriter.write()` uses `Math.abs(object.hashCode()) % blockingQueues.size()` for hash-based routing. When `hashCode()` returns `Integer.MIN_VALUE`, `Math.abs(Integer.MIN_VALUE)` overflows and returns `Integer.MIN_VALUE` (still negative), causing `ArrayIndexOutOfBoundsException` when `blockingQueues.size()` is not a power of two.

## Fix

Replace `Math.abs(object.hashCode())` with `(object.hashCode() & Integer.MAX_VALUE)`, following the same pattern already used in 12 other places across the codebase (Paimon, Kafka, DynamoDB, HBase, Fluss, Typesense, TiDB CDC, MongoDB, Iceberg, JDBC, Easysearch, Hazelcast).

## Changes

- `seatunnel-api/src/main/java/.../MultiTableSinkWriter.java`: Replace `Math.abs()` with `& Integer.MAX_VALUE` in hash routing
- `seatunnel-api/src/test/java/.../MultiTableSinkWriterTest.java`: Add regression test with Integer.MIN_VALUE primary key and queueSize=3

## Verification

- All 27 MultiTableSinkWriterTest tests pass
- Spotless formatting applied
- Closes #11720