### PR TITLE
[Fix][Connector-V2] Add Dameng NCHAR type support in type converter

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbTypeConverter.java
@@ -205,8 +205,12 @@ public class DmdbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case DM_NCHAR:
+                builder.sourceType(String.format("%s(%s)", DM_NCHAR, typeDefine.getLength()));
+                builder.dataType(BasicType.STRING_TYPE);
+                builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
+                break;
             case DM_NVARCHAR:
-                builder.sourceType(String.format("%s(%s)", dmType, typeDefine.getLength()));
+                builder.sourceType(String.format("%s(%s)", DM_NVARCHAR, typeDefine.getLength()));
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;


### PR DESCRIPTION
## Purpose

Fixes #11688.

`DmdbTypeConverter` handles `CHAR`, `CHARACTER`, `VARCHAR`, `VARCHAR2` and `NVARCHAR`, but not `NCHAR`. Reading a Dameng table that contains `NCHAR` columns falls through to the `default` branch and throws:

```
ErrorCode:[COMMON-17], ErrorDescription:['Dameng' unsupported convert type 'nchar' of 'test' to SeaTunnel data type.]
```

`NCHAR` is the fixed-length national character type, and the counterpart of the already supported variable-length `NVARCHAR`. Supporting `NVARCHAR` but not `NCHAR` is an oversight.

## Changes

- Added `DM_NCHAR = "NCHAR"` constant in `DmdbTypeConverter`
- Added `case DM_NCHAR:` in the `convert` method, mapping to `STRING` type with `charTo4ByteLength` for column length (same treatment as other fixed-length character types)
- Added `testConvertNchar` unit test in `DmdbTypeConverterTest`

## Testing

```
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=DmdbTypeConverterTest
Tests run: 35, Failures: 0, Errors: 0, Skipped: 0
```

## Checklist

- [x] No new dependency added
- [x] No documentation change needed (type mapping is internal)
- [x] Backward compatible
- [x] Spotless formatting applied