### PR TITLE
[Fix][Connector-V2] Fix JDBC MERGE upsert SQL syntax for all-key tables

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialect.java
@@ -128,6 +128,11 @@ public class DmdbDialect implements JdbcDialect {
                                                 quoteIdentifier(fieldName)))
                         .collect(Collectors.joining(", "));
 
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
+
         String insertFields =
                 Arrays.stream(fieldNames)
                         .map(this::quoteIdentifier)
@@ -145,14 +150,13 @@ public class DmdbDialect implements JdbcDialect {
                         " MERGE INTO %s TARGET"
                                 + " USING (%s) SOURCE"
                                 + " ON (%s) "
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s)",
                         databaseName,
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialect.java
@@ -168,6 +168,10 @@ public class OracleDialect implements JdbcDialect {
                                                 quoteIdentifier(fieldName),
                                                 quoteIdentifier(fieldName)))
                         .collect(Collectors.joining(", "));
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
         String insertFields =
                 Arrays.stream(fieldNames)
                         .map(this::quoteIdentifier)
@@ -182,14 +186,13 @@ public class OracleDialect implements JdbcDialect {
                         " MERGE INTO %s TARGET"
                                 + " USING (%s) SOURCE"
                                 + " ON (%s) "
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s)",
                         tableIdentifier(database, tableName),
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/saphana/SapHanaDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/saphana/SapHanaDialect.java
@@ -18,6 +18,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.saphana;
 
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
@@ -93,6 +95,10 @@ public class SapHanaDialect implements JdbcDialect {
                                                 quoteIdentifier(fieldName),
                                                 quoteIdentifier(fieldName)))
                         .collect(Collectors.joining(", "));
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
         String insertFields =
                 Arrays.stream(fieldNames)
                         .map(this::quoteIdentifier)
@@ -107,14 +113,13 @@ public class SapHanaDialect implements JdbcDialect {
                         " MERGE INTO %s AS TARGET"
                                 + " USING (%s) AS SOURCE"
                                 + " ON (%s) "
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s)",
                         tableIdentifier(database, tableName),
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlServerDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlServerDialect.java
@@ -120,6 +120,10 @@ public class SqlServerDialect implements JdbcDialect {
                                                 quoteIdentifier(fieldName),
                                                 quoteIdentifier(fieldName)))
                         .collect(Collectors.joining(", "));
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
         String insertFields =
                 Arrays.stream(fieldNames)
                         .map(this::quoteIdentifier)
@@ -133,15 +137,14 @@ public class SqlServerDialect implements JdbcDialect {
                         "MERGE INTO %s.%s AS [TARGET]"
                                 + " USING (%s) AS [SOURCE]"
                                 + " ON (%s)"
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s);",
                         quoteDatabaseIdentifier(database),
                         quoteIdentifier(tableName),
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/vertica/VerticaDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/vertica/VerticaDialect.java
@@ -102,6 +102,10 @@ public class VerticaDialect implements JdbcDialect {
                                                 quoteIdentifier(fieldName),
                                                 quoteIdentifier(fieldName)))
                         .collect(Collectors.joining(", "));
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
         String insertFields =
                 Arrays.stream(fieldNames)
                         .map(this::quoteIdentifier)
@@ -116,15 +120,14 @@ public class VerticaDialect implements JdbcDialect {
                         " MERGE INTO %s.%s TARGET"
                                 + " USING (%s) SOURCE"
                                 + " ON (%s) "
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s)",
                         quoteDatabaseIdentifier(database),
                         quoteIdentifier(tableName),
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/xugu/XuguDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/xugu/XuguDialect.java
@@ -20,7 +20,6 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.xugu;
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
 import org.apache.seatunnel.api.table.catalog.TablePath;
-import org.apache.seatunnel.common.utils.SeaTunnelException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
@@ -103,10 +102,6 @@ public class XuguDialect implements JdbcDialect {
                 Arrays.stream(fieldNames)
                         .filter(fieldName -> !Arrays.asList(pkNames).contains(fieldName))
                         .collect(Collectors.toList());
-        if (nonUniqueKeyFields.isEmpty()) {
-            throw new SeaTunnelException(
-                    "The non-primary key field cannot be empty. Please set other fields");
-        }
         String valuesBinding =
                 Arrays.stream(fieldNames)
                         .map(fieldName -> ":" + fieldName + " " + quoteIdentifier(fieldName))
@@ -131,6 +126,10 @@ public class XuguDialect implements JdbcDialect {
                                                 quoteIdentifier(fieldName),
                                                 quoteIdentifier(fieldName)))
                         .collect(Collectors.joining(", "));
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
         String insertFields =
                 Arrays.stream(fieldNames)
                         .map(this::quoteIdentifier)
@@ -144,14 +143,13 @@ public class XuguDialect implements JdbcDialect {
                         " MERGE INTO %s TARGET"
                                 + " USING (%s) SOURCE"
                                 + " ON (%s) "
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s)",
                         tableIdentifier(database, tableName),
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbDialect.java
@@ -144,19 +144,23 @@ public class YashanDbDialect implements JdbcDialect {
                         .map(fieldName -> "SOURCE." + quoteIdentifier(fieldName))
                         .collect(Collectors.joining(", "));
 
+        String matchedClause =
+                StringUtils.isNotBlank(updateSetClause)
+                        ? String.format(" WHEN MATCHED THEN UPDATE SET %s", updateSetClause)
+                        : "";
+
         String upsertSQL =
                 String.format(
                         " MERGE INTO %s TARGET"
                                 + " USING (%s) SOURCE"
                                 + " ON (%s) "
-                                + " WHEN MATCHED THEN"
-                                + " UPDATE SET %s"
+                                + "%s"
                                 + " WHEN NOT MATCHED THEN"
                                 + " INSERT (%s) VALUES (%s)",
                         tableIdentifier(database, tableName),
                         usingClause,
                         onConditions,
-                        updateSetClause,
+                        matchedClause,
                         insertFields,
                         insertValues);
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/dm/DmdbDialectTest.java
@@ -159,4 +159,25 @@ public class DmdbDialectTest {
                         () -> DmdbDialect.normalizeTablespaceForDdl("MAIN\tTS"));
         Assertions.assertTrue(tabCharacter.getMessage().contains("illegal characters"));
     }
+
+    @Test
+    void testUpsertStatementAllKey() {
+        DmdbDialect dialect = new DmdbDialect(FieldIdeEnum.ORIGINAL.getValue());
+        String[] fieldNames = {"id", "name", "age"};
+        String[] allKeyFields = {"id", "name", "age"};
+
+        String sql =
+                dialect.getUpsertStatement("test_db", "test_table", fieldNames, allKeyFields)
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "Expected upsert SQL to be present"));
+
+        Assertions.assertFalse(
+                sql.contains("WHEN MATCHED"),
+                "All-key upsert SQL should not contain WHEN MATCHED clause");
+        Assertions.assertTrue(
+                sql.contains("WHEN NOT MATCHED"),
+                "All-key upsert SQL should contain WHEN NOT MATCHED clause");
+    }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialectSqlTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/oracle/OracleDialectSqlTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.oracle;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OracleDialectSqlTest {
+
+    @Test
+    void testUpsertStatementAllKey() {
+        OracleDialect dialect = new OracleDialect();
+        String[] fieldNames = {"id", "name", "age"};
+        String[] allKeyFields = {"id", "name", "age"};
+
+        String sql =
+                dialect.getUpsertStatement("test_schema", "test_table", fieldNames, allKeyFields)
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "Expected upsert SQL to be present"));
+
+        Assertions.assertFalse(
+                sql.contains("WHEN MATCHED"),
+                "All-key upsert SQL should not contain WHEN MATCHED clause");
+        Assertions.assertTrue(
+                sql.contains("WHEN NOT MATCHED"),
+                "All-key upsert SQL should contain WHEN NOT MATCHED clause");
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlServerDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/sqlserver/SqlServerDialectTest.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.schema.event.AlterTableChangeColumnEvent;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
@@ -32,6 +33,27 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SqlServerDialectTest {
+
+    @Test
+    void testUpsertStatementAllKey() {
+        SqlServerDialect dialect = new SqlServerDialect();
+        String[] fieldNames = {"id", "name", "age"};
+        String[] allKeyFields = {"id", "name", "age"};
+
+        String sql =
+                dialect.getUpsertStatement("test_db", "test_table", fieldNames, allKeyFields)
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "Expected upsert SQL to be present"));
+
+        Assertions.assertFalse(
+                sql.contains("WHEN MATCHED"),
+                "All-key upsert SQL should not contain WHEN MATCHED clause");
+        Assertions.assertTrue(
+                sql.contains("WHEN NOT MATCHED"),
+                "All-key upsert SQL should contain WHEN NOT MATCHED clause");
+    }
 
     @Test
     void shouldUseSchemaTableColumnForRenameWithoutDatabasePrefix() throws Exception {

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/vertica/VerticaDialectTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/vertica/VerticaDialectTest.java
@@ -120,5 +120,18 @@ public class VerticaDialectTest {
         Assertions.assertEquals(
                 upsertCreateTimeSQL,
                 " MERGE INTO test_database.\"test_table\" TARGET USING (SELECT CAST(:id AS BIGINT) AS \"id\", CAST(:name AS VARCHAR) AS \"name\", CAST(:age AS INT) AS \"age\", CAST(:createTime AS TIME) AS \"createTime\" ) SOURCE ON (TARGET.\"id\"=SOURCE.\"id\" AND TARGET.\"name\"=SOURCE.\"name\" AND TARGET.\"age\"=SOURCE.\"age\")  WHEN MATCHED THEN UPDATE SET \"createTime\"=SOURCE.\"createTime\" WHEN NOT MATCHED THEN INSERT (\"id\", \"name\", \"age\", \"createTime\") VALUES (SOURCE.\"id\", SOURCE.\"name\", SOURCE.\"age\", SOURCE.\"createTime\")");
+
+        // Test all-key table: every column is a primary key, so no WHEN MATCHED THEN UPDATE SET
+        final String[] allKeyFields = {"id", "name", "age", "createTime"};
+        String allKeySql =
+                dialect.getUpsertStatementByTableSchema(
+                                dataBaseName, tableName, tableSchema, allKeyFields)
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "Expected allKeySql String to be present"));
+        Assertions.assertEquals(
+                allKeySql,
+                " MERGE INTO test_database.\"test_table\" TARGET USING (SELECT CAST(:id AS BIGINT) AS \"id\", CAST(:name AS VARCHAR) AS \"name\", CAST(:age AS INT) AS \"age\", CAST(:createTime AS TIME) AS \"createTime\" ) SOURCE ON (TARGET.\"id\"=SOURCE.\"id\" AND TARGET.\"name\"=SOURCE.\"name\" AND TARGET.\"age\"=SOURCE.\"age\" AND TARGET.\"createTime\"=SOURCE.\"createTime\")  WHEN NOT MATCHED THEN INSERT (\"id\", \"name\", \"age\", \"createTime\") VALUES (SOURCE.\"id\", SOURCE.\"name\", SOURCE.\"age\", SOURCE.\"createTime\")");
     }
 }


### PR DESCRIPTION
## Purpose of this pull request

Fix the MERGE (upsert) SQL generation in JDBC dialects for tables whose every column is a primary/unique key (i.e. no non-key field to update). Previously `getUpsertStatement` always appended `WHEN MATCHED THEN UPDATE SET <clause>`; when `updateSetClause` is empty this yielded invalid SQL (`UPDATE SET` with an empty body) and the database threw a syntax error.

Affected dialects: DM, Oracle, SAP HANA, SQL Server, Vertica, Xugu.

This PR introduces a `matchedClause` string that is omitted entirely when there is nothing to update. When `updateSetClause` is non-empty, the behavior is identical to before.

Closes #11729

## Does this PR introduce any user-facing change?

Yes (bug fix, no API/config/schema change).

- Before: upserting into an all-key table via the above dialects failed with a SQL syntax error (empty `UPDATE SET` body).
- After: the MERGE statement is generated correctly; matched rows are left unchanged and unmatched rows inserted, so the job succeeds.

## How was this patch tested?

- Added regression test in `VerticaDialectTest` covering the all-key table scenario
- Ran `./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=VerticaDialectTest` - all tests pass

## Check list

- [x] No new Jar binary package added
- [ ] Documentation update — not needed (internal SQL generation fix)
- [ ] incompatible-changes.md — not needed (backward compatible)
- [ ] Connector checklist — not applicable, no new connector added