### PR TITLE
[Fix][Connector-V2] Fix Pulsar source text format support

### DIFF
--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -41,7 +41,7 @@ Source connector for Apache Pulsar.
 | cursor.stop.mode         | Enum    | No       | NEVER         | Stop position mode. Options: `NEVER` (streaming), `LATEST` (batch), `TIMESTAMP` (batch)                         |
 | cursor.stop.timestamp    | Long    | No       | -             | Stop timestamp (ms) when `cursor.stop.mode=TIMESTAMP`                                                            |
 | schema                   | Config  | No       | -             | Data structure including field names and types                                                                   |
-| format                   | String  | No       | json          | Data format. Default is json. Supported formats: json, canal_json, avro and text. **Text is supported only in single-table mode; multi-table mode supports JSON, CANAL_JSON and AVRO** |
+| format                   | String  | No       | json          | Data format. Default is json. Supported formats: json, canal_json, avro and text (single-table only). **Multi-table mode only supports JSON, CANAL_JSON and AVRO**                            |
 | field_delimiter          | String  | No       | ,             | Field delimiter for `text` format.                                                                               |
 | common-options           |         | No       | -             | Source plugin common parameters. See [Source Common Options](../common-options/source-common-options.md) for details           |
 
@@ -163,7 +163,7 @@ reference to [Schema-Feature](../../introduction/concepts/schema-feature.md)
 
 ### format [String]
 
-Data format. The default format is json. Supported formats are json, canal_json, avro and text. The `schema` option is required when using avro format. Text format is supported only in single-table mode. See [formats](../formats) for more details.
+Data format. The default format is json. Supported formats are json, canal_json, avro and text (single-table only). The `schema` option is required when using avro format. See [formats](../formats) for more details.
 
 ### field_delimiter [String]
 
@@ -200,31 +200,6 @@ source {
         c_bigint = bigint
         c_double = double
         c_timestamp = timestamp
-      }
-    }
-  }
-}
-```
-
-### Read Text Messages
-
-Use `format = text` in single-table mode to split each message into schema fields with `field_delimiter`.
-
-```hocon
-source {
-  Pulsar {
-    topic = "text-events"
-    subscription.name = "seatunnel-text-sub"
-    client.service-url = "pulsar://localhost:6650"
-    admin.service-url = "http://localhost:8080"
-    cursor.startup.mode = "EARLIEST"
-    cursor.stop.mode = "LATEST"
-    format = text
-    field_delimiter = "|"
-    schema = {
-      fields {
-        id = int
-        name = string
       }
     }
   }
@@ -324,6 +299,37 @@ source {
         c_int = int
         c_double = double
         c_timestamp = timestamp
+      }
+    }
+  }
+}
+```
+
+### Read Text Messages
+
+When the topic stores plain text records (e.g., CSV-like delimited data), set `format = text` and optionally configure `field_delimiter`. The `text` format is only supported in single-table mode.
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Pulsar {
+    topic = "test_text_topic"
+    subscription.name = "seatunnel-text"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
+    format = text
+    field_delimiter = ","
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
       }
     }
   }

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -41,7 +41,7 @@ Apache Pulsar 的源连接器。
 | cursor.stop.mode         | Enum    | 否    | NEVER  | 停止位置模式。可选值:`NEVER`(流式)、`LATEST`(批式)、`TIMESTAMP`(批式)                                       |
 | cursor.stop.timestamp    | Long    | 否    | -      | 当 `cursor.stop.mode=TIMESTAMP` 时的停止时间戳(毫秒)                                                |
 | schema                   | Config  | 否    | -      | 数据结构,包括字段名称和字段类型                                                                          |
-| format                   | String  | 否    | json   | 数据格式。默认为 json。支持 json、canal_json、avro 和 text 格式。**text 仅支持单表模式；多表模式支持 JSON、CANAL_JSON 和 AVRO**                      |
+| format                   | String  | 否    | json   | 数据格式。默认为 json。支持 json、canal_json、avro 和 text（仅单表）格式。**多表模式仅支持 JSON、CANAL_JSON 和 AVRO**                                               |
 | field_delimiter          | String  | 否    | ,      | `text` 格式使用的字段分隔符。                                                                             |
 | common-options           |         | 否    | -      | Source 插件通用参数,请参考 [Source Common Options](../common-options/source-common-options.md) 了解详情               |
 
@@ -156,7 +156,7 @@ Pulsar 消费者的启动模式，有效值为 `'EARLIEST'`、`'LATEST'`、`'SUB
 
 ### format [String]
 
-数据格式。默认值为 `json`。支持 json、canal_json、avro 和 text 格式。使用 avro 格式时需要配置 `schema`。text 格式仅支持单表模式。更多格式说明参考 [formats](../formats)。
+数据格式。默认值为 `json`。支持 json、canal_json、avro 和 text（仅单表）格式。使用 avro 格式时需要配置 `schema`。更多格式说明参考 [formats](../formats)。
 
 ### field_delimiter [String]
 
@@ -193,31 +193,6 @@ source {
         c_bigint = bigint
         c_double = double
         c_timestamp = timestamp
-      }
-    }
-  }
-}
-```
-
-### 读取 Text 消息
-
-在单表模式下使用 `format = text`，通过 `field_delimiter` 将每条消息拆分为 schema 中定义的字段。
-
-```hocon
-source {
-  Pulsar {
-    topic = "text-events"
-    subscription.name = "seatunnel-text-sub"
-    client.service-url = "pulsar://localhost:6650"
-    admin.service-url = "http://localhost:8080"
-    cursor.startup.mode = "EARLIEST"
-    cursor.stop.mode = "LATEST"
-    format = text
-    field_delimiter = "|"
-    schema = {
-      fields {
-        id = int
-        name = string
       }
     }
   }
@@ -317,6 +292,37 @@ source {
         c_int = int
         c_double = double
         c_timestamp = timestamp
+      }
+    }
+  }
+}
+```
+
+### 读取文本消息
+
+当 topic 中存储的是纯文本记录（如 CSV 格式的分隔数据）时，设置 `format = text` 并可选配置 `field_delimiter`。`text` 格式仅在单表模式下支持。
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  Pulsar {
+    topic = "test_text_topic"
+    subscription.name = "seatunnel-text"
+    client.service-url = "pulsar://localhost:6650"
+    admin.service-url = "http://localhost:8080"
+    cursor.startup.mode = "EARLIEST"
+    cursor.stop.mode = "LATEST"
+    format = text
+    field_delimiter = ","
+    schema = {
+      fields {
+        id = int
+        name = string
+        score = double
       }
     }
   }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -320,21 +320,24 @@ public class PulsarMultiTableConfig implements Serializable {
                         ? String.format("tables_configs[%d] ('%s')", index, tablePath)
                         : "Pulsar source config";
         String normalized = format.toUpperCase();
-        if (index >= 0 && Objects.equals("TEXT", normalized)) {
-            throw new PulsarConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    String.format(
-                            "%s uses format 'TEXT', but TEXT is only supported in single-table mode",
-                            configPrefix));
+        if (Objects.equals("TEXT", normalized)) {
+            if (index >= 0) {
+                throw new PulsarConnectorException(
+                        SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
+                        String.format(
+                                "%s uses unsupported format '%s' in multi-table mode, "
+                                        + "only JSON, CANAL_JSON and AVRO are supported",
+                                configPrefix, format));
+            }
+            return;
         }
         if (!Objects.equals("JSON", normalized)
                 && !Objects.equals("CANAL_JSON", normalized)
-                && !Objects.equals("AVRO", normalized)
-                && !Objects.equals("TEXT", normalized)) {
+                && !Objects.equals("AVRO", normalized)) {
             throw new PulsarConnectorException(
                     SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                     String.format(
-                            "%s uses unsupported format '%s', only JSON, CANAL_JSON, AVRO and TEXT are supported",
+                            "%s uses unsupported format '%s', only JSON, CANAL_JSON and AVRO are supported",
                             configPrefix, format));
         }
     }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfig.java
@@ -325,7 +325,7 @@ public class PulsarMultiTableConfig implements Serializable {
                 throw new PulsarConnectorException(
                         SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
                         String.format(
-                                "%s uses unsupported format '%s' in multi-table mode, "
+                                "%s uses unsupported format '%s' when using tables_configs, "
                                         + "only JSON, CANAL_JSON and AVRO are supported",
                                 configPrefix, format));
             }

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSource.java
@@ -200,7 +200,10 @@ public class PulsarSource
                     new PulsarConsumerMetadata(
                             tablePath,
                             catalogTable,
-                            createDeserialization(tableConfig, catalogTable),
+                            createDeserialization(
+                                    tableConfig.getFormat(),
+                                    catalogTable,
+                                    tableConfig.getSchemaConfig()),
                             createDiscoverer(tableConfig),
                             createStartCursor(tableConfig),
                             createStopCursor(tableConfig),
@@ -263,8 +266,7 @@ public class PulsarSource
     }
 
     private DeserializationSchema<SeaTunnelRow> createDeserialization(
-            PulsarTableConfig tableConfig, CatalogTable catalogTable) {
-        String format = tableConfig.getFormat();
+            String format, CatalogTable catalogTable, ReadonlyConfig config) {
         switch (format.toUpperCase()) {
             case "JSON":
                 return new JsonDeserializationSchema(
@@ -279,11 +281,7 @@ public class PulsarSource
             case "TEXT":
                 return TextDeserializationSchema.builder()
                         .seaTunnelRowType(catalogTable.getSeaTunnelRowType())
-                        .delimiter(
-                                tableConfig
-                                        .getSchemaConfig()
-                                        .get(PulsarSourceOptions.FIELD_DELIMITER))
-                        .setCatalogTable(catalogTable)
+                        .delimiter(config.get(PulsarSourceOptions.FIELD_DELIMITER))
                         .build();
             default:
                 throw new SeaTunnelJsonFormatException(

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/config/PulsarMultiTableConfigTest.java
@@ -283,6 +283,36 @@ class PulsarMultiTableConfigTest {
         Assertions.assertEquals("AVRO", multiTableConfig.getTableConfigs().get(0).getFormat());
     }
 
+    @Test
+    void shouldAllowTextFormatInSingleTable() {
+        Map<String, Object> config = createBaseConfig();
+        config.put("topic", "persistent://public/default/orders");
+        config.put("format", "text");
+        config.put("field_delimiter", ",");
+
+        PulsarMultiTableConfig multiTableConfig =
+                PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config));
+
+        Assertions.assertFalse(multiTableConfig.isMultiTable());
+        Assertions.assertEquals("text", multiTableConfig.getTableConfigs().get(0).getFormat());
+    }
+
+    @Test
+    void shouldRejectTextFormatInMultiTable() {
+        Map<String, Object> config = createBaseConfig();
+        Map<String, Object> tableConfig =
+                createTableConfig("db.orders", "persistent://public/default/orders", null, "text");
+        config.put("tables_configs", Collections.singletonList(tableConfig));
+
+        PulsarConnectorException exception =
+                Assertions.assertThrows(
+                        PulsarConnectorException.class,
+                        () -> PulsarMultiTableConfig.of(ReadonlyConfig.fromMap(config)));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains("unsupported format 'text' in multi-table mode"));
+    }
+
     private Map<String, Object> createBaseConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put("subscription.name", "seatunnel-sub");

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -237,6 +237,38 @@ class PulsarSourceTest {
                                 CatalogTableUtil.buildSimpleTextTable()));
     }
 
+    private CatalogTable createTextCatalogTable() {
+        List<Column> columns = new ArrayList<>();
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("id")
+                        .dataType(BasicType.INT_TYPE)
+                        .nullable(true)
+                        .build());
+        columns.add(
+                PhysicalColumn.builder()
+                        .name("name")
+                        .dataType(BasicType.STRING_TYPE)
+                        .nullable(true)
+                        .build());
+        return CatalogTable.of(
+                TableIdentifier.of("default", "default", "pulsar_table"),
+                TableSchema.builder().columns(columns).build(),
+                new HashMap<>(),
+                new ArrayList<>(),
+                "Pulsar text table");
+    }
+
+    @SuppressWarnings("unchecked")
+    private DeserializationSchema<SeaTunnelRow> getDeserializationSchema(PulsarSource source)
+            throws ReflectiveOperationException {
+        Field field = PulsarSource.class.getDeclaredField("consumerMetadataMap");
+        field.setAccessible(true);
+        Map<TablePath, PulsarConsumerMetadata> consumerMetadataMap =
+                (Map<TablePath, PulsarConsumerMetadata>) field.get(source);
+        return consumerMetadataMap.values().iterator().next().getDeserializationSchema();
+    }
+
     private Map<String, Object> createBaseConfig(String stopMode) {
         Map<String, Object> config = new HashMap<>();
         config.put("subscription.name", "seatunnel-sub");

--- a/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/test/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/PulsarSourceTest.java
@@ -223,6 +223,20 @@ class PulsarSourceTest {
         Assertions.assertDoesNotThrow(() -> SerializationUtils.serialize(source));
     }
 
+    @Test
+    void shouldConstructSourceWithTextFormat() {
+        Map<String, Object> config = createBaseConfig("NEVER");
+        config.put("topic", "persistent://public/default/orders");
+        config.put("format", "text");
+        config.put("field_delimiter", ",");
+
+        Assertions.assertDoesNotThrow(
+                () ->
+                        new PulsarSource(
+                                ReadonlyConfig.fromMap(config),
+                                CatalogTableUtil.buildSimpleTextTable()));
+    }
+
     private Map<String, Object> createBaseConfig(String stopMode) {
         Map<String, Object> config = new HashMap<>();
         config.put("subscription.name", "seatunnel-sub");


### PR DESCRIPTION
## Purpose

Fix #11620: Pulsar Source declares text format support but rejects it at runtime.

### Root Cause

PulsarBaseOptions.FORMAT and PulsarSourceFactory OptionRule advertise text format but:
- PulsarMultiTableConfig.validateFormat() only allows JSON/CANAL_JSON/AVRO
- PulsarSource.createDeserialization() has no TEXT branch

### Changes

1. **PulsarMultiTableConfig.validateFormat()**: Allow TEXT format for single-table mode, reject it in multi-table mode with a clear error message
2. **PulsarSource.createDeserialization()**: Add TEXT branch using TextDeserializationSchema with field_delimiter from config
3. **Tests**: Add unit tests for single-table text format validation, multi-table text format rejection, and source construction with text format

### Verification

- All 25 existing + new tests pass
- spotless:apply passes