### PR TITLE
[Fix][Connector-V2] Fix Postgres-CDC committed-offset recovery skipping rows after savepoint

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
@@ -270,7 +270,7 @@ public class IncrementalSourceStreamFetcher implements Fetcher<SourceRecords, So
                 log.trace(
                         "The table {} is not support exactly-once, so ignore the watermark check",
                         tableId);
-                return position.isAfter(splitStartWatermark);
+                return position.isAtOrAfter(splitStartWatermark);
             }
             // check whether the pure binlog mode has been entered
             if (hasEnterPureBinlogPhase(tableId, position)) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
@@ -270,6 +270,10 @@ public class IncrementalSourceStreamFetcher implements Fetcher<SourceRecords, So
                 log.trace(
                         "The table {} is not support exactly-once, so ignore the watermark check",
                         tableId);
+                log.debug(
+                        "Non-exactly-once boundary check: position={} vs splitStartWatermark={}",
+                        position,
+                        splitStartWatermark);
                 return position.isAtOrAfter(splitStartWatermark);
             }
             // check whether the pure binlog mode has been entered

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcherTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/org/apache/seatunnel/connectors/cdc/base/source/reader/external/IncrementalSourceStreamFetcherTest.java
@@ -392,6 +392,42 @@ public class IncrementalSourceStreamFetcherTest {
         return record;
     }
 
+    static SourceRecord createDataEventWithSource() {
+        Schema sourceSchema =
+                SchemaBuilder.struct()
+                        .name("io.debezium.connector.postgresql.Source")
+                        .field("db", Schema.STRING_SCHEMA)
+                        .field("schema", Schema.STRING_SCHEMA)
+                        .field("table", Schema.STRING_SCHEMA)
+                        .field(DEBEZIUM_CONNECTOR_KEY, Schema.STRING_SCHEMA)
+                        .build();
+        Struct sourceStruct = new Struct(sourceSchema);
+        sourceStruct.put("db", "testdb");
+        sourceStruct.put("schema", "public");
+        sourceStruct.put("table", "test_table");
+        sourceStruct.put(DEBEZIUM_CONNECTOR_KEY, "postgresql");
+
+        Schema valueSchema =
+                SchemaBuilder.struct()
+                        .field(Envelope.FieldName.SOURCE, sourceSchema)
+                        .field(Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA)
+                        .build();
+        Struct value = new Struct(valueSchema);
+        value.put(Envelope.FieldName.SOURCE, sourceStruct);
+        value.put(Envelope.FieldName.OPERATION, "c");
+        SourceRecord record =
+                new SourceRecord(
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        "testdb.public.test_table",
+                        null,
+                        null,
+                        valueSchema,
+                        value);
+        Assertions.assertTrue(SourceRecordUtils.isDataChangeRecord(record));
+        return record;
+    }
+
     static SourceRecord createHeartbeatEvent() throws InterruptedException {
         TestConnectorConfig testConnectorConfig = new TestConnectorConfig(dezConf, "test", 1000);
         HeartbeatFactory<TableId> heartbeatFactory =
@@ -516,6 +552,50 @@ public class IncrementalSourceStreamFetcherTest {
         IncrementalSourceStreamFetcher spy = spy(fetcher);
         doReturn(true).when(spy).shouldEmit(any());
         return spy;
+    }
+
+    static IncrementalSourceStreamFetcher createPlainFetcher() {
+        return new IncrementalSourceStreamFetcher(null, 0, null);
+    }
+
+    @Test
+    public void testShouldEmitAtOrAfterWatermark() throws Exception {
+        IncrementalSourceStreamFetcher fetcher = createPlainFetcher();
+
+        FetchTask.Context taskContext = mock(FetchTask.Context.class);
+        when(taskContext.isDataChangeRecord(any())).thenReturn(true);
+        when(taskContext.isExactlyOnce()).thenReturn(false);
+
+        Offset splitStartWatermark = mock(Offset.class);
+        Offset position = mock(Offset.class);
+        when(position.isAtOrAfter(splitStartWatermark)).thenReturn(true);
+        when(taskContext.getStreamOffset(any())).thenReturn(position);
+
+        setField(fetcher, "taskContext", taskContext);
+        setField(fetcher, "splitStartWatermark", splitStartWatermark);
+
+        SourceRecord record = createDataEventWithSource();
+        Assertions.assertTrue(fetcher.shouldEmit(record));
+    }
+
+    @Test
+    public void testShouldEmitBeforeWatermarkFiltered() throws Exception {
+        IncrementalSourceStreamFetcher fetcher = createPlainFetcher();
+
+        FetchTask.Context taskContext = mock(FetchTask.Context.class);
+        when(taskContext.isDataChangeRecord(any())).thenReturn(true);
+        when(taskContext.isExactlyOnce()).thenReturn(false);
+
+        Offset splitStartWatermark = mock(Offset.class);
+        Offset position = mock(Offset.class);
+        when(position.isAtOrAfter(splitStartWatermark)).thenReturn(false);
+        when(taskContext.getStreamOffset(any())).thenReturn(position);
+
+        setField(fetcher, "taskContext", taskContext);
+        setField(fetcher, "splitStartWatermark", splitStartWatermark);
+
+        SourceRecord record = createDataEventWithSource();
+        Assertions.assertFalse(fetcher.shouldEmit(record));
     }
 
     public static class TestConnectorConfig extends CommonConnectorConfig {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffset.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffset.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset;
 
 import org.apache.seatunnel.connectors.cdc.base.source.offset.Offset;
 
+import io.debezium.connector.postgresql.PostgresOffsetContext;
 import io.debezium.connector.postgresql.SourceInfo;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.time.Conversions;
@@ -59,6 +60,11 @@ public class LsnOffset extends Offset {
         Map<String, String> offsetMap = new HashMap<>();
         // keys are from io.debezium.connector.postgresql.PostgresOffsetContext.Loader.load
         offsetMap.put(SourceInfo.LSN_KEY, lsn.toString());
+        // Store LAST_COMMIT_LSN_KEY as a fallback so that savepoint recovery
+        // has a valid commit LSN even before the first commitCurrentOffset call.
+        // This is safe because at the start of streaming, the committed LSN
+        // equals the current LSN.
+        offsetMap.put(PostgresOffsetContext.LAST_COMMIT_LSN_KEY, lsn.toString());
         if (txId != null) {
             offsetMap.put(SourceInfo.TXID_KEY, txId.toString());
         }
@@ -85,9 +91,7 @@ public class LsnOffset extends Offset {
     }
 
     public Lsn getLsnCommit() {
-        String lsnCommitStr =
-                offset.get(
-                        io.debezium.connector.postgresql.PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
+        String lsnCommitStr = offset.get(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
         if (lsnCommitStr != null) {
             return Lsn.valueOf(Long.valueOf(lsnCommitStr));
         }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffset.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffset.java
@@ -84,6 +84,16 @@ public class LsnOffset extends Offset {
         return Lsn.valueOf(Long.valueOf(offset.get(SourceInfo.LSN_KEY)));
     }
 
+    public Lsn getLsnCommit() {
+        String lsnCommitStr =
+                offset.get(
+                        io.debezium.connector.postgresql.PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
+        if (lsnCommitStr != null) {
+            return Lsn.valueOf(Long.valueOf(lsnCommitStr));
+        }
+        return getLsn();
+    }
+
     public Long getTxId() {
         return Long.parseLong(offset.get(SourceInfo.TXID_KEY));
     }

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
@@ -73,13 +73,18 @@ public class PostgresWalFetchTask implements FetchTask<SourceSplitBase> {
                 split.getStartupOffset().toString());
         streamingChangeEventSource.execute(
                 changeEventSourceContext, sourceFetchContext.getPartition(), offsetContext);
+
+        Throwable producerThrowable = sourceFetchContext.getErrorHandler().getProducerThrowable();
+        if (producerThrowable != null) {
+            throw new RuntimeException("Postgres WAL streaming failed", producerThrowable);
+        }
     }
 
     public void commitCurrentOffset(LsnOffset offset) {
         if (streamingChangeEventSource != null && offset != null) {
 
             // only extracting and storing the lsn of the last commit
-            Long commitLsn = offset.getLsn().asLong();
+            Long commitLsn = offset.getLsnCommit().asLong();
             if (commitLsn != null
                     && (lastCommitLsn == null
                             || Lsn.valueOf(commitLsn).compareTo(Lsn.valueOf(lastCommitLsn)) > 0)) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/main/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/reader/wal/PostgresWalFetchTask.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class PostgresWalFetchTask implements FetchTask<SourceSplitBase> {
     private final IncrementalSplit split;
     private volatile boolean taskRunning = false;
-    private Long lastCommitLsn;
+    private volatile Long lastCommitLsn;
     private PostgresStreamingChangeEventSource streamingChangeEventSource;
     private PostgresOffsetContext offsetContext;
 
@@ -76,7 +76,12 @@ public class PostgresWalFetchTask implements FetchTask<SourceSplitBase> {
 
         Throwable producerThrowable = sourceFetchContext.getErrorHandler().getProducerThrowable();
         if (producerThrowable != null) {
-            throw new RuntimeException("Postgres WAL streaming failed", producerThrowable);
+            throw new RuntimeException(
+                    "Postgres WAL streaming failed for split "
+                            + split.splitId()
+                            + ", last committed LSN: "
+                            + (lastCommitLsn != null ? Lsn.valueOf(lastCommitLsn) : "none"),
+                    producerThrowable);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffsetTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-postgres/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/postgres/source/offset/LsnOffsetTest.java
@@ -20,11 +20,49 @@ package org.apache.seatunnel.connectors.seatunnel.cdc.postgres.source.offset;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.SourceInfo;
+import io.debezium.connector.postgresql.connection.Lsn;
+
+import java.util.HashMap;
+import java.util.Map;
+
 class LsnOffsetTest {
 
     @Test
     void testNoStoppingOffsetIsNeverStop() {
         Assertions.assertTrue(LsnOffset.NO_STOPPING_OFFSET.isNeverStop());
         Assertions.assertFalse(LsnOffset.INITIAL_OFFSET.isNeverStop());
+    }
+
+    @Test
+    void testGetLsnCommitWhenLsnCommitKeyExists() {
+        Map<String, String> offsetMap = new HashMap<>();
+        offsetMap.put(SourceInfo.LSN_KEY, "12345");
+        offsetMap.put(PostgresOffsetContext.LAST_COMMIT_LSN_KEY, "67890");
+        LsnOffset offset = new LsnOffset(offsetMap);
+
+        Lsn lsnCommit = offset.getLsnCommit();
+        Assertions.assertEquals(Lsn.valueOf(67890L), lsnCommit);
+    }
+
+    @Test
+    void testGetLsnCommitFallbackToLsnWhenLsnCommitKeyMissing() {
+        Map<String, String> offsetMap = new HashMap<>();
+        offsetMap.put(SourceInfo.LSN_KEY, "12345");
+        LsnOffset offset = new LsnOffset(offsetMap);
+
+        Lsn lsnCommit = offset.getLsnCommit();
+        Assertions.assertEquals(Lsn.valueOf(12345L), lsnCommit);
+    }
+
+    @Test
+    void testConstructorStoresLastCommitLsnKey() {
+        // Verify that the (Long, Long, Instant) constructor stores
+        // LAST_COMMIT_LSN_KEY so that savepoint recovery has a valid
+        // commit LSN even before the first commitCurrentOffset call.
+        LsnOffset offset = new LsnOffset(12345L, null, null);
+        Lsn lsnCommit = offset.getLsnCommit();
+        Assertions.assertEquals(Lsn.valueOf(12345L), lsnCommit);
     }
 }


### PR DESCRIPTION
## Purpose

Fix three issues that cause Postgres-CDC to silently skip rows after savepoint recovery, as described in issue #11847.

## Brief change log

1. **PostgresWalFetchTask.commitCurrentOffset used wrong LSN key**
   - `commitCurrentOffset` was reading the LSN via `offset.getLsn()` which uses `SourceInfo.LSN_KEY` ("lsn"), but Debezium's `commitOffset` expects the `LAST_COMMIT_LSN_KEY` ("lsn_commit") field.
   - Added `getLsnCommit()` to `LsnOffset` that reads from `LAST_COMMIT_LSN_KEY` with fallback to `LSN_KEY`, and updated `commitCurrentOffset` to use the committed LSN.

2. **IncrementalSourceStreamFetcher.shouldEmit used strict greater-than comparison**
   - In non-exactly-once mode, `shouldEmit` used `isAfter(splitStartWatermark)` (strict greater-than), so after recovery the first event with the same LSN as `splitStartWatermark` was filtered out.
   - Changed to `isAtOrAfter(splitStartWatermark)` to include the watermark-position event.

3. **PostgresWalFetchTask.execute missing error handler check**
   - `execute()` did not check `errorHandler.getProducerThrowable()` after the streaming loop completed, so streaming failures could be silently swallowed.
   - Added error handler check to surface streaming errors.

## Verify this pull request

- [ ] This change is already covered by existing tests, such as `LsnOffsetFactoryTest`.
- [ ] Manual verification: run Postgres-CDC with savepoint and verify no rows are skipped after recovery.

## Does this PR potentially affect the following other parts of the project?

- [x] Connector-CDC
- [x] Connector-CDC-Postgres