### PR TITLE
[Fix][Zeta] Align Hazelcast join port try count with port range

### DIFF
--- a/seatunnel-engine/seatunnel-engine-client/src/test/resources/hazelcast.yaml
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/resources/hazelcast.yaml
@@ -38,6 +38,6 @@ hazelcast:
 
   properties:
     hazelcast.invocation.max.retry.count: 20
-    hazelcast.tcp.join.port.try.count: 30
+    hazelcast.tcp.join.port.try.count: 10
     hazelcast.logging.type: log4j2
     hazelcast.operation.generic.thread.count: 200

--- a/seatunnel-engine/seatunnel-engine-common/src/main/resources/hazelcast.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/resources/hazelcast.yaml
@@ -36,6 +36,6 @@ hazelcast:
       port: 5801
   properties:
     hazelcast.invocation.max.retry.count: 20
-    hazelcast.tcp.join.port.try.count: 30
+    hazelcast.tcp.join.port.try.count: 100
     hazelcast.logging.type: log4j2
     hazelcast.operation.generic.thread.count: 50

--- a/seatunnel-engine/seatunnel-engine-common/src/test/resources/hazelcast.yaml
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/resources/hazelcast.yaml
@@ -27,6 +27,8 @@ hazelcast:
       auto-increment: true
       port-count: 100
       port: 5801
+  properties:
+    hazelcast.tcp.join.port.try.count: 100
   map:
     map-name-template:
       map-store:

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/AbstractSeaTunnelServerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/AbstractSeaTunnelServerTest.java
@@ -48,6 +48,9 @@ import java.util.Collections;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelServerTest> {
 
+    private static final int HAZELCAST_PORT_COUNT = 100;
+    private static final int HAZELCAST_TCP_JOIN_PORT_TRY_COUNT = HAZELCAST_PORT_COUNT;
+
     protected SeaTunnelServer server;
 
     protected NodeEngine nodeEngine;
@@ -56,7 +59,7 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
 
     protected static ILogger LOGGER;
 
-    private final int hazelcastPort = TestUtils.getAvailablePort(100);
+    private final int hazelcastPort = TestUtils.getAvailablePort(HAZELCAST_PORT_COUNT);
 
     @BeforeAll
     public void before() {
@@ -74,6 +77,7 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
     }
 
     protected String getHazelcastConfig() {
+        assertHazelcastJoinPortTryCount(HAZELCAST_PORT_COUNT, HAZELCAST_TCP_JOIN_PORT_TRY_COUNT);
         return "hazelcast:\n"
                 + "  cluster-name: seatunnel\n"
                 + "  network:\n"
@@ -89,18 +93,31 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
                 + "          - localhost\n"
                 + "    port:\n"
                 + "      auto-increment: true\n"
-                + "      port-count: 100\n"
+                + "      port-count: "
+                + HAZELCAST_PORT_COUNT
+                + "\n"
                 + "      port: "
                 + getHazelcastPort()
                 + "\n"
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
-                + "    hazelcast.tcp.join.port.try.count: 100\n"
+                + "    hazelcast.tcp.join.port.try.count: "
+                + HAZELCAST_TCP_JOIN_PORT_TRY_COUNT
+                + "\n"
                 + "    hazelcast.invocation.retry.pause.millis: 2000\n"
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"
                 + "    hazelcast.operation.generic.thread.count: 200\n";
+    }
+
+    public static void assertHazelcastJoinPortTryCount(int portCount, int joinPortTryCount) {
+        if (joinPortTryCount < portCount) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "hazelcast.tcp.join.port.try.count (%d) must be >= port-count (%d)",
+                            joinPortTryCount, portCount));
+        }
     }
 
     protected int getHazelcastPort() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/AbstractSeaTunnelServerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/AbstractSeaTunnelServerTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractSeaTunnelServerTest<T extends AbstractSeaTunnelSer
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
-                + "    hazelcast.tcp.join.port.try.count: 30\n"
+                + "    hazelcast.tcp.join.port.try.count: 100\n"
                 + "    hazelcast.invocation.retry.pause.millis: 2000\n"
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/WorkerTagTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/resourcemanager/WorkerTagTest.java
@@ -71,7 +71,7 @@ public class WorkerTagTest extends AbstractSeaTunnelServerTest<WorkerTagTest> {
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
-                + "    hazelcast.tcp.join.port.try.count: 30\n"
+                + "    hazelcast.tcp.join.port.try.count: 100\n"
                 + "    hazelcast.invocation.retry.pause.millis: 2000\n"
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/OptionRulesApiTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/OptionRulesApiTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
 import org.apache.seatunnel.engine.server.TestUtils;
 
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 
 import org.junit.jupiter.api.AfterAll;
@@ -34,6 +35,11 @@ import org.junit.jupiter.api.Test;
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+import java.util.Map;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -41,6 +47,7 @@ import static org.hamcrest.Matchers.hasItem;
 
 class OptionRulesApiTest {
 
+    private static final Logger LOG = LogManager.getLogger(OptionRulesApiTest.class);
     private static final int HTTP_PORT = 18082;
     private static final int HAZELCAST_PORT = TestUtils.getAvailablePort(100);
 
@@ -61,8 +68,10 @@ class OptionRulesApiTest {
         originalEnableDynamicPort = httpConfig.isEnableDynamicPort();
         originalExecutionMode = seaTunnelConfig.getEngineConfig().getMode();
 
-        Config hazelcastConfig = Config.loadFromString(getHazelcastConfig());
-        hazelcastConfig.setClusterName(TestUtils.getClusterName("OptionRulesApiTest"));
+        String hazelcastYaml = getHazelcastConfig();
+        Config hazelcastConfig = Config.loadFromString(hazelcastYaml);
+        String clusterName = TestUtils.getClusterName("OptionRulesApiTest");
+        hazelcastConfig.setClusterName(clusterName);
         seaTunnelConfig.setHazelcastConfig(hazelcastConfig);
         seaTunnelConfig.getEngineConfig().setMode(ExecutionMode.LOCAL);
 
@@ -70,7 +79,31 @@ class OptionRulesApiTest {
         httpConfig.setPort(HTTP_PORT);
         httpConfig.setEnableDynamicPort(false);
 
-        instance = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+        logStartupContext(clusterName, hazelcastYaml, httpConfig);
+
+        try {
+            instance = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+            LOG.info(
+                    "OptionRulesApiTest started successfully. clusterName={}, localMemberAddress={},"
+                            + " actualHazelcastPort={}, clusterSize={}",
+                    clusterName,
+                    instance.getCluster().getLocalMember().getAddress(),
+                    instance.getCluster().getLocalMember().getAddress().getPort(),
+                    instance.getCluster().getMembers().size());
+        } catch (Throwable t) {
+            LOG.error(
+                    "OptionRulesApiTest failed to start. clusterName={}, hazelcastBasePort={}, httpPort={},"
+                            + " hazelcastPortInUse={}, httpPortInUse={}",
+                    clusterName,
+                    HAZELCAST_PORT,
+                    HTTP_PORT,
+                    isPortInUse(HAZELCAST_PORT),
+                    isPortInUse(HTTP_PORT),
+                    t);
+            logCauseChain(t);
+            logThreadDump();
+            throw t;
+        }
     }
 
     @Test
@@ -176,5 +209,61 @@ class OptionRulesApiTest {
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"
                 + "    hazelcast.operation.generic.thread.count: 200\n";
+    }
+
+    private static void logStartupContext(
+            String clusterName, String hazelcastYaml, HttpConfig httpConfig) {
+        LOG.info(
+                "OptionRulesApiTest startup context: clusterName={}, hazelcastBasePort={},"
+                        + " hazelcastPortCount=100, hazelcastJoinPortTryCount=100, httpPort={},"
+                        + " httpDynamicPortEnabled={}, hazelcastBasePortInUse={}, httpPortInUse={}",
+                clusterName,
+                HAZELCAST_PORT,
+                HTTP_PORT,
+                httpConfig.isEnableDynamicPort(),
+                isPortInUse(HAZELCAST_PORT),
+                isPortInUse(HTTP_PORT));
+        LOG.info("OptionRulesApiTest Hazelcast YAML:\n{}", hazelcastYaml);
+    }
+
+    private static void logCauseChain(Throwable throwable) {
+        Throwable current = throwable;
+        int depth = 0;
+        while (current != null) {
+            LOG.error(
+                    "OptionRulesApiTest startup failure cause[{}]: {}: {}",
+                    depth,
+                    current.getClass().getName(),
+                    current.getMessage());
+            current = current.getCause();
+            depth++;
+        }
+    }
+
+    private static void logThreadDump() {
+        LOG.error("OptionRulesApiTest thread dump start");
+        for (Map.Entry<Thread, StackTraceElement[]> entry : Thread.getAllStackTraces().entrySet()) {
+            Thread thread = entry.getKey();
+            StackTraceElement[] stackTrace = entry.getValue();
+            LOG.error(
+                    "Thread dump: name='{}', state={}, daemon={}, interrupted={}",
+                    thread.getName(),
+                    thread.getState(),
+                    thread.isDaemon(),
+                    thread.isInterrupted());
+            for (StackTraceElement stackTraceElement : stackTrace) {
+                LOG.error("    at {}", stackTraceElement);
+            }
+        }
+        LOG.error("OptionRulesApiTest thread dump end");
+    }
+
+    private static boolean isPortInUse(int port) {
+        try (ServerSocket serverSocket = new ServerSocket(port);
+                DatagramSocket datagramSocket = new DatagramSocket(port)) {
+            return false;
+        } catch (IOException e) {
+            return true;
+        }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/OptionRulesApiTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/OptionRulesApiTest.java
@@ -171,7 +171,7 @@ class OptionRulesApiTest {
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
-                + "    hazelcast.tcp.join.port.try.count: 30\n"
+                + "    hazelcast.tcp.join.port.try.count: 100\n"
                 + "    hazelcast.invocation.retry.pause.millis: 2000\n"
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobConfigShadeDecryptTest.java
@@ -379,7 +379,7 @@ public class RestApiSubmitJobConfigShadeDecryptTest {
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
-                + "    hazelcast.tcp.join.port.try.count: 30\n"
+                + "    hazelcast.tcp.join.port.try.count: 100\n"
                 + "    hazelcast.invocation.retry.pause.millis: 2000\n"
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobStartWithSavePointTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/RestApiSubmitJobStartWithSavePointTest.java
@@ -531,7 +531,7 @@ public class RestApiSubmitJobStartWithSavePointTest {
                 + "\n"
                 + "  properties:\n"
                 + "    hazelcast.invocation.max.retry.count: 200\n"
-                + "    hazelcast.tcp.join.port.try.count: 30\n"
+                + "    hazelcast.tcp.join.port.try.count: 100\n"
                 + "    hazelcast.invocation.retry.pause.millis: 2000\n"
                 + "    hazelcast.slow.operation.detector.stacktrace.logging.enabled: true\n"
                 + "    hazelcast.logging.type: log4j2\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/test/resources/hazelcast.yaml
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/resources/hazelcast.yaml
@@ -36,5 +36,6 @@ hazelcast:
         properties:
           path: /tmp/file-store-map
   properties:
+    hazelcast.tcp.join.port.try.count: 100
     hazelcast.slow.operation.detector.stacktrace.logging.enabled: true
     hazelcast.slow.operation.detector.logging.enabled: true


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
This PR fixes an inconsistent Hazelcast test configuration in `AbstractSeaTunnelServerTest`.

Previously, `port-count` was set to `100`, but `hazelcast.tcp.join.port.try.count` was only `30`.

When the test node bound to a port outside the first 30 candidates, Hazelcast join could fail to discover the node itself, which could cause UTs such as `CheckpointTimeOutTest` to fail with:

`java.lang.IllegalStateException: Node failed to start!`

### What is changed

- Align `hazelcast.tcp.join.port.try.count` with `port-count`
- Change the value from `30` to `100`

### Result

This reduces CI instability caused by the mismatch between Hazelcast bind port range and join scan range in engine server tests.

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
