### PR TITLE
[Docs] Document S3File credential provider support for container environments

### DIFF
--- a/docs/en/connectors/sink/S3File.md
+++ b/docs/en/connectors/sink/S3File.md
@@ -584,6 +584,109 @@ sink {
 
 For AWS SSO/Profile-based roles, swap the provider class (for example `com.amazonaws.auth.profile.ProfileCredentialsProvider` with `fs.s3a.profile` and `fs.s3a.credentialsFile`) and pass the provider-specific keys under `hadoop_s3_properties`. See the [Hadoop AWS](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html) documentation for the full set of supported `fs.s3a.*` keys.
 
+## Credential Provider in Container Environments
+
+When running SeaTunnel in container environments (Kubernetes, ECS, EKS, Docker), the S3File connector accepts any fully-qualified S3A credentials provider class that implements `com.amazonaws.auth.AWSCredentialsProvider` and is available on the classpath. The `fs.s3a.aws.credentials.provider` option is validated at config-parse time when the class is resolvable on the node building the configuration: the class must implement the AWS credentials provider interface and must not be abstract. When the class cannot be resolved (e.g., the provider JAR is only available on worker nodes), validation is deferred to runtime on the worker actually running S3A.
+
+### Supported Credential Providers
+
+| Provider | Class Name | Typical Use |
+|----------|------------|-------------|
+| Simple AWSCredentials | `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` | Static access key / secret key |
+| Instance Profile | `com.amazonaws.auth.InstanceProfileCredentialsProvider` | EC2 instance role (default) |
+| Container | `com.amazonaws.auth.ContainerCredentialsProvider` | ECS task role |
+| Default Chain | `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` | Multi-source fallback chain |
+| Custom | Any `com.amazonaws.auth.AWSCredentialsProvider` implementation | User-defined provider |
+
+### Kubernetes / EKS Configuration
+
+**EC2 Node Instance Role (Recommended)**: If your EKS worker nodes have an EC2 instance profile with S3 permissions, the default `InstanceProfileCredentialsProvider` resolves credentials from the instance metadata service automatically:
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+**Static Keys via Kubernetes Secrets (Fallback)**: If instance roles are not available, inject credentials from a Kubernetes Secret:
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  access_key = "<from-k8s-secret>"
+  secret_key = "<from-k8s-secret>"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+**DefaultAWSCredentialsProviderChain**: For flexible deployments, the default chain tries multiple credential sources in order (environment variables → system properties → profile → container → instance profile):
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+### ECS Task Role
+
+When running on ECS with the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable set automatically by the ECS agent:
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.ContainerCredentialsProvider"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+### EKS IRSA
+
+EKS IAM Roles for Service Accounts (IRSA) requires the `WebIdentityTokenCredentialsProvider` class. This class is available in newer AWS SDK v1.x releases (e.g. 1.11.5xx+) but is **not included** in the older AWS SDK v1.x (1.11.271) bundled with SeaTunnel. The following alternatives are recommended:
+
+1. **Use the EC2 node instance role** — attach an IAM role to the EKS worker node and keep the default `InstanceProfileCredentialsProvider`.
+2. **Use `SimpleAWSCredentialsProvider`** with credentials injected from a Kubernetes Secret.
+3. **Add a newer AWS SDK JAR** that includes `WebIdentityTokenCredentialsProvider` to `${SEATUNNEL_HOME}/lib` on all cluster nodes.
+
+### Passing Additional Options via `hadoop_s3_properties`
+
+For provider-specific configuration keys (e.g., `fs.s3a.session.token`, `fs.s3a.assumed.role.arn`), use the `hadoop_s3_properties` map:
+
+```hocon
+hadoop_s3_properties {
+  "fs.s3a.session.token" = "<session-token>"
+  "fs.s3a.assumed.role.arn" = "arn:aws:iam::123456789012:role/my-role"
+}
+```
+
+The connector passes these keys directly to the Hadoop S3A configuration. Note: the connector always overwrites the `fs.s3a.aws.credentials.provider` key with the option value, so you cannot override it via `hadoop_s3_properties`.
+
+### Troubleshooting
+
+**You may see a `Factory initialize failed` (or similar classloading) error**: This typically means the credential provider class is not on the classpath. Ensure the provider JAR is present in `${SEATUNNEL_HOME}/lib` on **every** cluster node (not just the submitting node).
+
+**`No AWS Credentials provided by ...`**: The configured credential provider could not resolve credentials. Check:
+- `SimpleAWSCredentialsProvider`: verify `access_key` and `secret_key` are set.
+- `InstanceProfileCredentialsProvider`: verify the EC2 instance has an IAM role attached.
+- `ContainerCredentialsProvider`: verify the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set.
+
+**`IllegalArgumentException` at config-parse time**: The class name is malformed or the class does not implement `com.amazonaws.auth.AWSCredentialsProvider`. Verify the fully-qualified class name and that the class implements the required interface.
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/en/connectors/source/S3File.md
+++ b/docs/en/connectors/source/S3File.md
@@ -654,6 +654,105 @@ source {
 
 The same pattern works for AWS SSO/Profile providers by swapping the provider class (for example `com.amazonaws.auth.profile.ProfileCredentialsProvider` with `fs.s3a.profile` and `fs.s3a.credentialsFile` keys) — pass those provider-specific keys under `hadoop_s3_properties`. See the [Hadoop AWS](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html) documentation for the full set of supported `fs.s3a.*` keys.
 
+## Credential Provider in Container Environments
+
+When running SeaTunnel in container environments (Kubernetes, ECS, EKS, Docker), the S3File connector accepts any fully-qualified S3A credentials provider class that implements `com.amazonaws.auth.AWSCredentialsProvider` and is available on the classpath. The `fs.s3a.aws.credentials.provider` option is validated at config-parse time when the class is resolvable on the node building the configuration: the class must implement the AWS credentials provider interface and must not be abstract. When the class cannot be resolved (e.g., the provider JAR is only available on worker nodes), validation is deferred to runtime on the worker actually running S3A.
+
+### Supported Credential Providers
+
+| Provider | Class Name | Typical Use |
+|----------|------------|-------------|
+| Simple AWSCredentials | `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` | Static access key / secret key |
+| Instance Profile | `com.amazonaws.auth.InstanceProfileCredentialsProvider` | EC2 instance role (default) |
+| Container | `com.amazonaws.auth.ContainerCredentialsProvider` | ECS task role |
+| Default Chain | `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` | Multi-source fallback chain |
+| Custom | Any `com.amazonaws.auth.AWSCredentialsProvider` implementation | User-defined provider |
+
+### Kubernetes / EKS Configuration
+
+**EC2 Node Instance Role (Recommended)**: If your EKS worker nodes have an EC2 instance profile with S3 permissions, the default `InstanceProfileCredentialsProvider` resolves credentials from the instance metadata service automatically:
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+**Static Keys via Kubernetes Secrets (Fallback)**: If instance roles are not available, inject credentials from a Kubernetes Secret:
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  access_key = "<from-k8s-secret>"
+  secret_key = "<from-k8s-secret>"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+**DefaultAWSCredentialsProviderChain**: For flexible deployments, the default chain tries multiple credential sources in order (environment variables → system properties → profile → container → instance profile):
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+### ECS Task Role
+
+When running on ECS with the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable set automatically by the ECS agent:
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.ContainerCredentialsProvider"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+### EKS IRSA
+
+EKS IAM Roles for Service Accounts (IRSA) requires the `WebIdentityTokenCredentialsProvider` class. This class is available in newer AWS SDK v1.x releases (e.g. 1.11.5xx+) but is **not included** in the older AWS SDK v1.x (1.11.271) bundled with SeaTunnel. The following alternatives are recommended:
+
+1. **Use the EC2 node instance role** — attach an IAM role to the EKS worker node and keep the default `InstanceProfileCredentialsProvider`.
+2. **Use `SimpleAWSCredentialsProvider`** with credentials injected from a Kubernetes Secret.
+3. **Add a newer AWS SDK JAR** that includes `WebIdentityTokenCredentialsProvider` to `${SEATUNNEL_HOME}/lib` on all cluster nodes.
+
+### Passing Additional Options via `hadoop_s3_properties`
+
+For provider-specific configuration keys (e.g., `fs.s3a.session.token`, `fs.s3a.assumed.role.arn`), use the `hadoop_s3_properties` map:
+
+```hocon
+hadoop_s3_properties {
+  "fs.s3a.session.token" = "<session-token>"
+  "fs.s3a.assumed.role.arn" = "arn:aws:iam::123456789012:role/my-role"
+}
+```
+
+The connector passes these keys directly to the Hadoop S3A configuration. Note: the connector always overwrites the `fs.s3a.aws.credentials.provider` key with the option value, so you cannot override it via `hadoop_s3_properties`.
+
+### Troubleshooting
+
+**You may see a `Factory initialize failed` (or similar classloading) error**: This typically means the credential provider class is not on the classpath. Ensure the provider JAR is present in `${SEATUNNEL_HOME}/lib` on **every** cluster node (not just the submitting node).
+
+**`No AWS Credentials provided by ...`**: The configured credential provider could not resolve credentials. Check:
+- `SimpleAWSCredentialsProvider`: verify `access_key` and `secret_key` are set.
+- `InstanceProfileCredentialsProvider`: verify the EC2 instance has an IAM role attached.
+- `ContainerCredentialsProvider`: verify the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set.
+
+**`IllegalArgumentException` at config-parse time**: The class name is malformed or the class does not implement `com.amazonaws.auth.AWSCredentialsProvider`. Verify the fully-qualified class name and that the class implements the required interface.
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/en/engines/zeta/checkpoint-storage.md
+++ b/docs/en/engines/zeta/checkpoint-storage.md
@@ -162,6 +162,8 @@ seatunnel:
           fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.InstanceProfileCredentialsProvider
 ```
 
+**Container environments**: Checkpoint storage passes `fs.s3a.*` configuration keys directly to Hadoop without any connector-level enum restriction, so any S3A credential provider class available on the classpath can be used. This includes container-oriented providers such as `com.amazonaws.auth.ContainerCredentialsProvider` (ECS task role) and `com.amazonaws.auth.DefaultAWSCredentialsProviderChain`. For EKS deployments, the EC2 node instance role is recommended. EKS IRSA (`WebIdentityTokenCredentialsProvider`) is not available in the bundled AWS SDK v1.x (1.11.271) and requires adding a newer AWS SDK v1.x JAR to `${SEATUNNEL_HOME}/lib` on all nodes.
+
 If you want to use Minio that supports the S3 protocol as checkpoint storage, you should configure it this way:
 
 ```yaml

--- a/docs/zh/connectors/sink/S3File.md
+++ b/docs/zh/connectors/sink/S3File.md
@@ -572,6 +572,109 @@ sink {
 
 对于 AWS SSO / Profile 角色，把 provider 类换成 `com.amazonaws.auth.profile.ProfileCredentialsProvider`，并把 `fs.s3a.profile`、`fs.s3a.credentialsFile` 等 provider 特定键放在 `hadoop_s3_properties` 里。完整的 `fs.s3a.*` 键集合参见 [Hadoop AWS](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html) 文档。
 
+## 容器环境中的凭据提供程序
+
+在容器环境（Kubernetes、ECS、EKS、Docker）中运行 SeaTunnel 时，S3File 连接器接受任何实现 `com.amazonaws.auth.AWSCredentialsProvider` 接口且在 classpath 上可用的全限定 S3A 凭据提供程序类。`fs.s3a.aws.credentials.provider` 选项在配置解析时进行验证（当类在构建配置的节点上可解析时）：类必须实现 AWS 凭据提供程序接口，且不能是抽象类。当类无法解析时（例如，提供程序 JAR 仅在 worker 节点上可用），验证将延迟到实际运行 S3A 的 worker 节点上的运行时进行。
+
+### 支持的凭据提供程序
+
+| 提供程序 | 类名 | 典型场景 |
+|----------|------|----------|
+| Simple AWSCredentials | `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` | 静态 access key / secret key |
+| Instance Profile | `com.amazonaws.auth.InstanceProfileCredentialsProvider` | EC2 实例角色（默认） |
+| Container | `com.amazonaws.auth.ContainerCredentialsProvider` | ECS 任务角色 |
+| Default Chain | `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` | 多源回退链 |
+| 自定义 | 任何 `com.amazonaws.auth.AWSCredentialsProvider` 实现 | 用户自定义提供程序 |
+
+### Kubernetes / EKS 配置
+
+**EC2 节点实例角色（推荐）**：如果您的 EKS 工作节点具有包含 S3 权限的 EC2 实例配置文件，默认的 `InstanceProfileCredentialsProvider` 会自动从实例元数据服务解析凭据：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+**通过 Kubernetes Secret 注入静态密钥（备选方案）**：如果实例角色不可用，从 Kubernetes Secret 注入凭据：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  access_key = "<from-k8s-secret>"
+  secret_key = "<from-k8s-secret>"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+**DefaultAWSCredentialsProviderChain**：对于需要灵活部署的场景，默认链按顺序尝试多个凭据来源（环境变量 → 系统属性 → profile → 容器 → 实例配置文件）：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+### ECS 任务角色
+
+在 ECS 上运行时，ECS 代理会自动设置 `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` 环境变量：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  tmp_path = "/tmp/seatunnel"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.ContainerCredentialsProvider"
+  path = "/data/output"
+  file_format_type = "parquet"
+}
+```
+
+### EKS IRSA
+
+EKS IAM Roles for Service Accounts (IRSA) 需要 `WebIdentityTokenCredentialsProvider` 类。该类在较新的 AWS SDK v1.x 版本（如 1.11.5xx+）中可用，但 **不包含** 在 SeaTunnel 捆绑的旧版 AWS SDK v1.x（1.11.271）中。推荐以下替代方案：
+
+1. **使用 EC2 节点实例角色** — 为 EKS 工作节点附加 IAM 角色，保持默认的 `InstanceProfileCredentialsProvider`。
+2. **使用 `SimpleAWSCredentialsProvider`**，从 Kubernetes Secret 注入凭据。
+3. **在所有集群节点** 的 `${SEATUNNEL_HOME}/lib` 中添加包含 `WebIdentityTokenCredentialsProvider` 的较新 AWS SDK JAR。
+
+### 通过 `hadoop_s3_properties` 传递额外选项
+
+对于 provider 特定的配置键（如 `fs.s3a.session.token`、`fs.s3a.assumed.role.arn`），使用 `hadoop_s3_properties` 映射：
+
+```hocon
+hadoop_s3_properties {
+  "fs.s3a.session.token" = "<session-token>"
+  "fs.s3a.assumed.role.arn" = "arn:aws:iam::123456789012:role/my-role"
+}
+```
+
+连接器将这些键直接传递给 Hadoop S3A 配置。注意：连接器始终会用选项值覆盖 `fs.s3a.aws.credentials.provider` 键，因此无法通过 `hadoop_s3_properties` 覆盖它。
+
+### 故障排查
+
+**您可能会看到 `Factory initialize failed`（或类似的类加载）错误**：这通常意味着凭据提供程序类不在 classpath 上。请确保 provider JAR 存在于 **每个** 集群节点（不仅仅是提交节点）的 `${SEATUNNEL_HOME}/lib` 中。
+
+**`No AWS Credentials provided by ...`**：配置的凭据提供程序无法解析凭据。请检查：
+- `SimpleAWSCredentialsProvider`：验证 `access_key` 和 `secret_key` 已设置。
+- `InstanceProfileCredentialsProvider`：验证 EC2 实例已附加 IAM 角色。
+- `ContainerCredentialsProvider`：验证 `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` 环境变量已设置。
+
+**配置解析时的 `IllegalArgumentException`**：类名格式错误或类未实现 `com.amazonaws.auth.AWSCredentialsProvider`。请验证全限定类名是否正确，以及类是否实现了所需的接口。
+
 ## 变更日志
 
 <ChangeLog />

--- a/docs/zh/connectors/source/S3File.md
+++ b/docs/zh/connectors/source/S3File.md
@@ -653,6 +653,105 @@ source {
 
 对于 AWS SSO / Profile 这类 provider，只需要把 provider 类换成 `com.amazonaws.auth.profile.ProfileCredentialsProvider`，并在 `hadoop_s3_properties` 里配置 `fs.s3a.profile`、`fs.s3a.credentialsFile` 等 provider 特定键。完整的 `fs.s3a.*` 键集合参见 [Hadoop AWS](https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html) 文档。
 
+## 容器环境中的凭据提供程序
+
+在容器环境（Kubernetes、ECS、EKS、Docker）中运行 SeaTunnel 时，S3File 连接器接受任何实现 `com.amazonaws.auth.AWSCredentialsProvider` 接口且在 classpath 上可用的全限定 S3A 凭据提供程序类。`fs.s3a.aws.credentials.provider` 选项在配置解析时进行验证（当类在构建配置的节点上可解析时）：类必须实现 AWS 凭据提供程序接口，且不能是抽象类。当类无法解析时（例如，提供程序 JAR 仅在 worker 节点上可用），验证将延迟到实际运行 S3A 的 worker 节点上的运行时进行。
+
+### 支持的凭据提供程序
+
+| 提供程序 | 类名 | 典型场景 |
+|----------|------|----------|
+| Simple AWSCredentials | `org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider` | 静态 access key / secret key |
+| Instance Profile | `com.amazonaws.auth.InstanceProfileCredentialsProvider` | EC2 实例角色（默认） |
+| Container | `com.amazonaws.auth.ContainerCredentialsProvider` | ECS 任务角色 |
+| Default Chain | `com.amazonaws.auth.DefaultAWSCredentialsProviderChain` | 多源回退链 |
+| 自定义 | 任何 `com.amazonaws.auth.AWSCredentialsProvider` 实现 | 用户自定义提供程序 |
+
+### Kubernetes / EKS 配置
+
+**EC2 节点实例角色（推荐）**：如果您的 EKS 工作节点具有包含 S3 权限的 EC2 实例配置文件，默认的 `InstanceProfileCredentialsProvider` 会自动从实例元数据服务解析凭据：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+**通过 Kubernetes Secret 注入静态密钥（备选方案）**：如果实例角色不可用，从 Kubernetes Secret 注入凭据：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"
+  access_key = "<from-k8s-secret>"
+  secret_key = "<from-k8s-secret>"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+**DefaultAWSCredentialsProviderChain**：对于需要灵活部署的场景，默认链按顺序尝试多个凭据来源（环境变量 → 系统属性 → profile → 容器 → 实例配置文件）：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.DefaultAWSCredentialsProviderChain"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+### ECS 任务角色
+
+在 ECS 上运行时，ECS 代理会自动设置 `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` 环境变量：
+
+```hocon
+S3File {
+  bucket = "s3a://my-bucket"
+  fs.s3a.endpoint = "s3.amazonaws.com"
+  fs.s3a.aws.credentials.provider = "com.amazonaws.auth.ContainerCredentialsProvider"
+  path = "/data/input"
+  file_format_type = "parquet"
+}
+```
+
+### EKS IRSA
+
+EKS IAM Roles for Service Accounts (IRSA) 需要 `WebIdentityTokenCredentialsProvider` 类。该类在较新的 AWS SDK v1.x 版本（如 1.11.5xx+）中可用，但 **不包含** 在 SeaTunnel 捆绑的旧版 AWS SDK v1.x（1.11.271）中。推荐以下替代方案：
+
+1. **使用 EC2 节点实例角色** — 为 EKS 工作节点附加 IAM 角色，保持默认的 `InstanceProfileCredentialsProvider`。
+2. **使用 `SimpleAWSCredentialsProvider`**，从 Kubernetes Secret 注入凭据。
+3. **在所有集群节点** 的 `${SEATUNNEL_HOME}/lib` 中添加包含 `WebIdentityTokenCredentialsProvider` 的较新 AWS SDK JAR。
+
+### 通过 `hadoop_s3_properties` 传递额外选项
+
+对于 provider 特定的配置键（如 `fs.s3a.session.token`、`fs.s3a.assumed.role.arn`），使用 `hadoop_s3_properties` 映射：
+
+```hocon
+hadoop_s3_properties {
+  "fs.s3a.session.token" = "<session-token>"
+  "fs.s3a.assumed.role.arn" = "arn:aws:iam::123456789012:role/my-role"
+}
+```
+
+连接器将这些键直接传递给 Hadoop S3A 配置。注意：连接器始终会用选项值覆盖 `fs.s3a.aws.credentials.provider` 键，因此无法通过 `hadoop_s3_properties` 覆盖它。
+
+### 故障排查
+
+**您可能会看到 `Factory initialize failed`（或类似的类加载）错误**：这通常意味着凭据提供程序类不在 classpath 上。请确保 provider JAR 存在于 **每个** 集群节点（不仅仅是提交节点）的 `${SEATUNNEL_HOME}/lib` 中。
+
+**`No AWS Credentials provided by ...`**：配置的凭据提供程序无法解析凭据。请检查：
+- `SimpleAWSCredentialsProvider`：验证 `access_key` 和 `secret_key` 已设置。
+- `InstanceProfileCredentialsProvider`：验证 EC2 实例已附加 IAM 角色。
+- `ContainerCredentialsProvider`：验证 `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` 环境变量已设置。
+
+**配置解析时的 `IllegalArgumentException`**：类名格式错误或类未实现 `com.amazonaws.auth.AWSCredentialsProvider`。请验证全限定类名是否正确，以及类是否实现了所需的接口。
+
 ## 变更日志
 
 <ChangeLog />

--- a/docs/zh/engines/zeta/checkpoint-storage.md
+++ b/docs/zh/engines/zeta/checkpoint-storage.md
@@ -160,6 +160,8 @@ seatunnel:
           fs.s3a.aws.credentials.provider: org.apache.hadoop.fs.s3a.InstanceProfileCredentialsProvider
 ```
 
+**容器环境**：检查点存储将 `fs.s3a.*` 配置键直接传递给 Hadoop，没有连接器级别的枚举限制，因此可以使用 classpath 上任何可用的 S3A 凭据提供程序类。这包括面向容器的提供程序，如 `com.amazonaws.auth.ContainerCredentialsProvider`（ECS 任务角色）和 `com.amazonaws.auth.DefaultAWSCredentialsProviderChain`。对于 EKS 部署，推荐使用 EC2 节点实例角色。EKS IRSA（`WebIdentityTokenCredentialsProvider`）在捆绑的 AWS SDK v1.x（1.11.271）中不可用，需要在所有节点的 `${SEATUNNEL_HOME}/lib` 中添加较新的 AWS SDK v1.x JAR。
+
 有关Hadoop Credential Provider API的更多信息，请参见: [Credential Provider API](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html).
 
 #### HDFS


### PR DESCRIPTION
## Purpose of this pull request

Closes #11275.

This PR adds documentation for S3File credential provider support in container environments (Kubernetes, ECS, EKS, Docker).

## What changed

### Connector docs (`docs/{en,zh}/connectors/{source,sink}/S3File.md`)

- Added a dedicated "Credential Provider in Container Environments" section covering:
  - Table of supported credential providers (Simple AWSCredentials, Instance Profile, Container, Default Chain, Custom)
  - Kubernetes / EKS configuration with examples (EC2 node instance role, static keys via Secrets, DefaultAWSCredentialsProviderChain)
  - ECS task role configuration with `ContainerCredentialsProvider`
  - EKS IRSA guidance (not available in bundled AWS SDK v1.x, with recommended alternatives)
  - How to pass additional options via `hadoop_s3_properties`
  - Troubleshooting section for common errors (`Factory initialize failed`, `No AWS Credentials provided`, `IllegalArgumentException`)

### Checkpoint storage docs (`docs/{en,zh}/engines/zeta/checkpoint-storage.md`)

- Added a note that checkpoint storage passes `fs.s3a.*` keys directly to Hadoop without connector-level enum restrictions, so any S3A credential provider (including container providers) can be used.

## Check list

- [x] English and Chinese docs are kept in sync
- [x] Examples do not contain real credentials
- [x] Documentation-only change; no code is modified
- [x] Closes #11275