### PR TITLE
[Fix][Connector-V2] Restore legacy RabbitMQ checkpoint state

### DIFF
--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSourceState.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSourceState.java
@@ -17,7 +17,25 @@
 
 package org.apache.seatunnel.connectors.seatunnel.rabbitmq.source;
 
-import java.io.Serializable;
+import org.apache.seatunnel.connectors.seatunnel.rabbitmq.split.RabbitmqSplitEnumeratorState;
 
-/** State for RabbitMQ source reader. */
-public class RabbitmqSourceState implements Serializable {}
+import java.util.Collections;
+
+/**
+ * Legacy checkpoint state created by RabbitMQ sources before the split enumerator state fix.
+ *
+ * @deprecated only used to restore checkpoints written by older connector versions
+ */
+@Deprecated
+public class RabbitmqSourceState extends RabbitmqSplitEnumeratorState {
+    private static final long serialVersionUID = -1143819030309308746L;
+
+    public RabbitmqSourceState() {
+        super(Collections.emptyMap());
+    }
+
+    /** Restores fields from the current superclass that are absent from legacy streams. */
+    private Object readResolve() {
+        return new RabbitmqSourceState();
+    }
+}

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/source/RabbitmqSplitEnumerator.java
@@ -84,6 +84,9 @@ public class RabbitmqSplitEnumerator
             RabbitmqSplitEnumeratorState checkpointState) {
         this(context, rabbitmqConfig, queues);
 
+        if (checkpointState instanceof RabbitmqSourceState) {
+            log.info("Restoring RabbitMQ source from legacy checkpoint state");
+        }
         if (checkpointState != null && checkpointState.getAssignedSplits() != null) {
             this.assignedSplits.putAll(checkpointState.getAssignedSplits());
             for (String assignedSplitId : checkpointState.getAssignedSplits().keySet()) {

--- a/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-rabbitmq/src/test/java/org/apache/seatunnel/connectors/seatunnel/rabbitmq/RabbitmqSplitEnumeratorTest.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.rabbitmq;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.config.RabbitmqConfig;
+import org.apache.seatunnel.connectors.seatunnel.rabbitmq.source.RabbitmqSourceState;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.source.RabbitmqSplitEnumerator;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.split.RabbitmqSplit;
 import org.apache.seatunnel.connectors.seatunnel.rabbitmq.split.RabbitmqSplitEnumeratorState;
@@ -28,7 +29,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +45,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RabbitmqSplitEnumeratorTest {
+    private static final long LEGACY_STATE_SERIAL_VERSION_UID = -1143819030309308746L;
+
+    // Serialized by RabbitmqSourceState from SeaTunnel 2.3.13.
+    private static final String LEGACY_CHECKPOINT_STATE =
+            "rO0ABXNyAE1vcmcuYXBhY2hlLnNlYXR1bm5lbC5jb25uZWN0b3JzLnNlYXR1bm5lbC5yYWJiaXRtcS5zb3VyY2UuUmFiYml0bXFTb3VyY2VTdGF0ZfAgVqbzFPa2AgAAeHA=";
+
     /**
      * Tests the split assignment logic of the {@link RabbitmqSplitEnumerator} in a Multi-Table
      * scenario.
@@ -156,5 +167,35 @@ public class RabbitmqSplitEnumeratorTest {
         Assertions.assertEquals(2, newState.getAssignedSplits().size());
         Assertions.assertTrue(newState.getAssignedSplits().containsKey("queue_A"));
         Assertions.assertTrue(newState.getAssignedSplits().containsKey("queue_B"));
+    }
+
+    @Test
+    public void testRestoreLegacySourceState() throws Exception {
+        Assertions.assertEquals(
+                LEGACY_STATE_SERIAL_VERSION_UID,
+                ObjectStreamClass.lookup(RabbitmqSourceState.class).getSerialVersionUID());
+
+        RabbitmqSplitEnumeratorState legacyState;
+        try (ObjectInputStream input =
+                new ObjectInputStream(
+                        new ByteArrayInputStream(
+                                Base64.getDecoder().decode(LEGACY_CHECKPOINT_STATE)))) {
+            Object state = input.readObject();
+            Assertions.assertInstanceOf(RabbitmqSourceState.class, state);
+            legacyState = Assertions.assertInstanceOf(RabbitmqSplitEnumeratorState.class, state);
+        }
+        Assertions.assertNotNull(legacyState.getAssignedSplits());
+        Assertions.assertTrue(legacyState.getAssignedSplits().isEmpty());
+
+        @SuppressWarnings("unchecked")
+        SourceSplitEnumerator.Context<RabbitmqSplit> context =
+                mock(SourceSplitEnumerator.Context.class);
+        List<String> queues = Arrays.asList("queue_A", "queue_B");
+
+        RabbitmqSplitEnumerator enumerator =
+                new RabbitmqSplitEnumerator(
+                        context, mock(RabbitmqConfig.class), queues, legacyState);
+
+        Assertions.assertEquals(queues.size(), enumerator.currentUnassignedSplitSize());
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fixes #9533.

RabbitMQ checkpoints written by released SeaTunnel versions before the split-enumerator state fix contain `RabbitmqSourceState`, while the current source declares `RabbitmqSplitEnumeratorState`. During restore, the generated bridge method casts the deserialized state before invoking `restoreEnumerator`, which causes:

`RabbitmqSourceState cannot be cast to RabbitmqSplitEnumeratorState`

This patch preserves the legacy class's original `serialVersionUID` and makes it a compatibility subtype of `RabbitmqSplitEnumeratorState`. Legacy streams do not contain the current superclass or assigned-split data, and Java serialization does not invoke Serializable constructors while reading them. A private `readResolve` therefore rebuilds a fully initialized legacy subtype with an empty assignment map after deserialization. Retaining the legacy subtype also lets the enumerator log when the compatibility path is used. New checkpoints continue to use `RabbitmqSplitEnumeratorState`.

The regression test embeds checkpoint state serialized by SeaTunnel 2.3.13, deserializes it with the current code, verifies that the inherited assignment map is non-null and empty, and restores the current enumerator from it.

### Does this PR introduce _any_ user-facing change?

Yes. Streaming jobs using the RabbitMQ source can restore checkpoints created by older connector versions instead of failing with `ClassCastException`. Operators receive an INFO log when a legacy checkpoint is restored. New checkpoint behavior and connector configuration are unchanged.

### How was this patch tested?

- Rebased onto the latest `dev` and built the required reactor modules with Java 8:
  `./mvnw -B -pl seatunnel-connectors-v2/connector-rabbitmq -am -DskipTests install`
- Ran the complete RabbitMQ connector test suite:
  `./mvnw -B -pl seatunnel-connectors-v2/connector-rabbitmq test`
- Result: 26 tests, 0 failures, 0 errors, 0 skipped.
- Spotless passed for the reactor build and connector test run.
- `testRestoreLegacySourceState` deserializes a real 2.3.13 checkpoint-state fixture, verifies the restored assignment map, and restores the current split enumerator.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation changes are not required because this restores checkpoint compatibility without changing configuration.
* [x] `incompatible-changes.md` does not need an update because this removes an incompatibility.
* [x] Connector registration and distribution files do not change because this is an internal state compatibility fix.
