### PR TITLE
[Fix][CI] Add fail-fast: false to backend.yml matrix jobs

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -478,6 +478,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || (needs.changes.outputs.api == 'false' && needs.changes.outputs.ut-modules != '')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest', 'windows-latest' ]
@@ -544,6 +545,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -575,6 +577,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -606,6 +609,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -637,6 +641,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -667,6 +672,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -697,6 +703,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -727,6 +734,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -758,6 +766,7 @@ jobs:
     if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != ''
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -789,6 +798,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.engine-e2e == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -814,6 +824,7 @@ jobs:
     if: needs.changes.outputs.edge-agent == 'true' || needs.changes.outputs.edge-agent-e2e == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -839,6 +850,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || contains(needs.changes.outputs.it-modules, 'seatunnel-engine-k8s-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -876,6 +888,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -904,6 +917,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -932,6 +946,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -963,6 +978,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -994,6 +1010,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1025,6 +1042,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1056,6 +1074,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1087,6 +1106,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1118,6 +1138,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1149,6 +1170,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1178,6 +1200,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1206,6 +1229,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1234,6 +1258,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1262,6 +1287,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1290,6 +1316,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1318,6 +1345,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1346,6 +1374,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1374,6 +1403,7 @@ jobs:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
       RUN_ZETA_CONTAINER: ${{ needs.changes.outputs.engine }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1399,6 +1429,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-kudu-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1425,6 +1456,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-amazonsqs-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1450,6 +1482,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-kafka-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1475,6 +1508,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-rocketmq-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1500,6 +1534,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-elasticsearch-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1525,6 +1560,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-cdc-mysql-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1551,6 +1587,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-doris-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1576,6 +1613,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-paimon-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1601,6 +1639,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-cdc-oracle-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1631,6 +1670,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-file-local-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1656,6 +1696,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-file-sftp-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1681,6 +1722,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-redis-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
@@ -1706,6 +1748,7 @@ jobs:
     if: needs.changes.outputs.api == 'true' || contains(needs.changes.outputs.it-modules, 'connector-sensorsdata-e2e')
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]


### PR DESCRIPTION
### Purpose of this pull request

Fixes #11854.

`backend.yml` defines 44 matrix jobs. Exactly one — `benchmark-test` — sets `fail-fast: false`. The other 43 inherit the GitHub Actions default of `fail-fast: true`, so the first leg to fail cancels every sibling leg in the same matrix.

Because these matrices exist specifically to compare **JDK 8 against JDK 11** (and, for `unit-test`, **ubuntu against windows**), cancelling the siblings destroys the one thing the matrix was built to tell us. A single infrastructure flake on one leg produces a red job with no way to tell whether the failure was platform-specific, and the only recovery is to rerun the whole matrix.

That `benchmark-test` sets the flag 30 lines below `unit-test` while `unit-test` does not suggests an oversight rather than a deliberate policy.

### Evidence

Two runs from 2026-08-18, on two unrelated PRs, both on this repository's own CI:

| PR | Run | Failing leg | Actual cause | Siblings cancelled |
|---|---|---|---|---|
| #11721 | [`32100301798`](https://github.com/SEPURI-SAI-KRISHNA/seatunnel/actions/runs/32100301798/attempts/1) | [`unit-test (8, ubuntu-latest)`](https://github.com/SEPURI-SAI-KRISHNA/seatunnel/actions/runs/32100301798/job/95601487349) | Maven Central `Connection reset` fetching `com.clickhouse:clickhouse-client:0.3.2-patch11` — **zero test failures in the entire 18,544-line log** | 3 |
| #11724 | [`32101324858`](https://github.com/SEPURI-SAI-KRISHNA/seatunnel/actions/runs/32101324858/attempts/1) | [`unit-test (11, windows-latest)`](https://github.com/SEPURI-SAI-KRISHNA/seatunnel/actions/runs/32101324858/job/95634437084) | `AbstractSeaTunnelServerTest.before` → `IllegalStateException: Node failed to start!` (Hazelcast bootstrap) | 3 |

Neither underlying cause had anything to do with the JDK or OS of the legs that were cancelled. In both cases the six cancelled legs were rerun and passed without a code change.

This also matches analysis already recorded in the CI umbrella #11513:

> Across all 113 timed completed first attempts, successful attempts had p50/p90 of 79/285 minutes, while failed attempts had p50/p90 of 317/736 minutes. Scope and defect type are confounders, but the data contradicts the desired fail-fast behavior: failures are generally discovered later, not earlier.

and, on a single run of #10306:

> Its latest attempt failed in about 20 minutes, but still produced 25 failed and **25 cancelled** lanes.

### On runner minutes

The obvious objection is that `fail-fast: false` burns more runner time. In practice it usually saves it:

- On a **green** run — the large majority — the flag changes nothing at all. It only takes effect once a leg has already failed.
- On a **red** run, the cost is bounded by letting the remaining legs of one matrix finish. The alternative is a rerun of the *entire* matrix, because a cancelled leg yields no information about whether the failure was platform-specific. Both PRs above needed exactly that rerun.

### Relationship to #11513

#11513 includes the task *"Cancel queued/running expensive jobs when a required fast gate fails."* That is a different axis and this PR does not conflict with it:

- **Cross-job cancellation on a meaningful signal** (a cheap required gate fails ⇒ stop the expensive jobs) — what #11513 proposes, and worth doing.
- **Intra-matrix sibling cancellation on an arbitrary first failure** — what this PR removes, because the sibling legs are precisely the comparison being asked for.

Removing the second does not prevent the first, and the fast-gate design is strictly more useful when each matrix reports its full result.

### Does this PR introduce _any_ user-facing change?

No. The change is confined to `.github/workflows/backend.yml` and affects CI behaviour only. No runtime code, configuration option, default value, or public API is touched.

### How was this patch tested?

- The diff consists of exactly 43 insertions of the single line `      fail-fast: false`, one per matrix job that lacked it, at the same indentation as the existing `benchmark-test` entry. No other line in the file changes.
- The result parses as valid YAML, and a check over the parsed document confirms all 44 jobs carrying a `strategy:` block now resolve `fail-fast` to `false`, with none missed.
- The edit was applied by an idempotent script that fails loudly if any `strategy:` block does not have the expected shape, so a future restructuring of the file cannot silently corrupt it.
- **This PR's own CI cannot exercise the change, and I want to be explicit about that rather than imply otherwise.** `backend.yml` is not matched by any path filter in the `changes` job, so `api` resolves to `false` and `ut-modules` to empty, and all 43 modified jobs are gated off. Only `changes`, `sanity-check`, `License header`, `Code style` and `Dead links` execute on this run; a green result here says nothing about the flag.
- The strongest available evidence that the inserted lines are well-formed in this file is `benchmark-test`, which has carried `fail-fast: false` at the same indentation and nesting for a long time. The 43 insertions are byte-identical to it.
- The behavioural effect will first be observable on the next PR that touches `seatunnel-api/**`, `seatunnel-engine/**` or a connector module after this merges — at which point a single failing leg should leave its siblings running instead of cancelling them.

Jobs receiving the flag (43): `unit-test`, `updated-modules-integration-test-part-1` … `-part-8`, `engine-v2-it`, `edge-agent-it`, `engine-k8s-it`, `transform-v2-it-part-1`, `transform-v2-it-part-2`, `all-connectors-it-1` … `-it-8`, `jdbc-connectors-it-part-1` … `-part-7`, `jdbc-connectors-it-ddl`, `kudu-connector-it`, `amazonSqs-connector-it`, `kafka-connector-it`, `rocketmq-connector-it`, `elasticsearch-connector-it`, `mysql-cdc-connector-it`, `doris-connector-it`, `paimon-connector-it`, `oracle-cdc-connector-it`, `connector-file-local-it`, `connector-file-sftp-it`, `connector-redis-it`, `connector-sensorsdata-it`.

If maintainers prefer a narrower first step, applying the flag to `unit-test` alone captures most of the diagnostic value, since that is the only job spanning two operating systems; the remaining 42 can then follow under #11513. I am happy to reduce the scope on request.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — N/A, no binaries added.
* [x] If necessary, please update the documentation to describe the new feature. — N/A, CI-only change with no user-facing behaviour.
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR. — N/A, no incompatible change.
* [x] If you are contributing the connector code, please check that the following files are updated — N/A, no connector code.
