### PR TITLE
[Fix][Connector-V2] Support YashanDB VARCHAR2 and NVARCHAR2 type conversion

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverter.java
@@ -73,10 +73,12 @@ public class YashanDbTypeConverter implements TypeConverter<BasicTypeDefine> {
     // CHAR: [1,8000] bytes; VARCHAR: [1,65534] bytes
     public static final String CHAR = "CHAR";
     public static final String VARCHAR = "VARCHAR";
+    public static final String VARCHAR2 = "VARCHAR2";
 
     // NCHAR: [1,4000]; NVARCHAR: [1,32767] (Unicode)
     public static final String NCHAR = "NCHAR";
     public static final String NVARCHAR = "NVARCHAR";
+    public static final String NVARCHAR2 = "NVARCHAR2";
 
     // ============================ Date & Time Data Types ============================
 
@@ -213,11 +215,13 @@ public class YashanDbTypeConverter implements TypeConverter<BasicTypeDefine> {
                 // ====================== Character types ======================
             case CHAR:
             case VARCHAR:
+            case VARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));
                 break;
             case NCHAR:
             case NVARCHAR:
+            case NVARCHAR2:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(
                         TypeDefineUtils.doubleByteTo4ByteLength(typeDefine.getLength()));

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/yashandb/YashanDbTypeConverterTest.java
@@ -257,6 +257,32 @@ public class YashanDbTypeConverterTest {
         column = INSTANCE.convert(typeDefine);
         Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
         Assertions.assertEquals(200L, column.getColumnLength());
+
+        // VARCHAR2(100) -> STRING with columnLength = 100 * 4 (byte-length semantics, same as
+        // VARCHAR)
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("VARCHAR2(100)")
+                        .dataType("VARCHAR2")
+                        .length(100L)
+                        .build();
+        column = INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(400L, column.getColumnLength());
+
+        // NVARCHAR2(100) -> STRING with columnLength = 100 * 2 (char-length semantics, same as
+        // NVARCHAR)
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
+                        .columnType("NVARCHAR2(100)")
+                        .dataType("NVARCHAR2")
+                        .length(100L)
+                        .build();
+        column = INSTANCE.convert(typeDefine);
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(200L, column.getColumnLength());
     }
 
     @Test


### PR DESCRIPTION
## Purpose

Fixes #11685.

`YashanDbTypeConverter` has cases for `CHAR`/`VARCHAR` and `NCHAR`/`NVARCHAR`, but not for the Oracle-compatible synonyms `VARCHAR2` and `NVARCHAR2`. Reading a YashanDB table containing such columns falls through to the `default` branch and fails:

```
ErrorCode:[COMMON-17], ErrorDescription:['YashanDB' unsupported convert type 'VARCHAR2' of 'test' to SeaTunnel data type.]
```

## Changes

- Added `VARCHAR2` and `NVARCHAR2` constants in `YashanDbTypeConverter`
- Added `case VARCHAR2:` to the `CHAR`/`VARCHAR` branch (byte-length semantics)
- Added `case NVARCHAR2:` to the `NCHAR`/`NVARCHAR` branch (char-length semantics)
- Added unit tests for `VARCHAR2` and `NVARCHAR2` in `YashanDbTypeConverterTest`

## Testing

```
./mvnw test -pl seatunnel-connectors-v2/connector-jdbc -Dtest=YashanDbTypeConverterTest
Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
```