### PR TITLE
[Feature] [Connector-V2] [GooglePubSub] Add Google Pub/Sub sink connector

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1445,6 +1445,31 @@ jobs:
         env:
           MAVEN_OPTS: -Xmx4096m
 
+  google-pubsub-connector-it:
+    needs: [ changes, sanity-check ]
+    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-google-pubsub-e2e')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+        os: [ 'ubuntu-latest' ]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: free disk space
+        run: tools/github/free_disk_space.sh
+      - name: run google pubsub connector integration test
+        run: |
+          ./mvnw -B -T 1 verify -DskipUT=true -DskipIT=false -D"license.skipAddThirdParty"=true -D"skip.ui"=true --no-snapshot-updates -pl :connector-google-pubsub-e2e -am -Pci
+        env:
+          MAVEN_OPTS: -Xmx4096m
+
   kafka-connector-it:
     needs: [ changes, sanity-check ]
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(needs.changes.outputs.it-modules, 'connector-kafka-e2e')

--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -159,6 +159,11 @@ google-firestore:
       - changed-files:
           - any-glob-to-any-file: seatunnel-connectors-v2/connector-google-firestore/**
           - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(google-firestore)/**'
+google-pubsub:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: seatunnel-connectors-v2/connector-google-pubsub/**
+          - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(google-pubsub)/**'
 google-sheets:
   - all:
       - changed-files:

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -49,6 +49,7 @@ connector-file-obs
 connector-fluss
 connector-google-sheets
 connector-google-firestore
+connector-google-pubsub
 connector-google-bigtable
 connector-graphql
 connector-hive

--- a/docs/en/connectors/changelog/connector-google-pubsub.md
+++ b/docs/en/connectors/changelog/connector-google-pubsub.md
@@ -1,0 +1,7 @@
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+|[Feature][Connector-V2] Add Google Pub/Sub sink connector|-|Next|
+
+</details>

--- a/docs/en/connectors/sink/GooglePubSub.md
+++ b/docs/en/connectors/sink/GooglePubSub.md
@@ -1,0 +1,136 @@
+import ChangeLog from '../changelog/connector-google-pubsub.md';
+
+# GooglePubSub
+
+> Google Pub/Sub sink connector
+
+## Description
+
+Publishes each incoming SeaTunnel row as one message to a Google Pub/Sub topic.
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
+
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+## Options
+
+| name | type | required | default value |
+| --- | --- | --- | --- |
+| project_id | string | yes | - |
+| topic | string | yes | - |
+| credentials_path | string | no | - |
+| emulator_host | string | no | - |
+| format | enum | no | json |
+| field_delimiter | string | no | , |
+| common-options | | no | - |
+
+### project_id [string]
+
+Google Cloud project ID that owns the target topic.
+
+### topic [string]
+
+Target Pub/Sub topic ID. The topic must exist before the job starts.
+
+### credentials_path [string]
+
+Path to a Google Cloud service account JSON key file. If this option is not set, the connector uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials).
+
+### emulator_host [string]
+
+Pub/Sub emulator host and port, for example `pubsub-emulator:8085`. When set, the connector uses a plaintext connection without credentials. Do not use this option for a production Pub/Sub endpoint.
+
+### format [enum]
+
+Message payload format. Supported values:
+
+- `json`: writes the row as a JSON object.
+- `text`: joins row fields with `field_delimiter`.
+
+### field_delimiter [string]
+
+Field delimiter used when `format = text`. The default is `,`.
+
+### common options
+
+Sink plugin common parameters, please refer to [Sink Common Options](../common-options/sink-common-options.md) for details.
+
+## Delivery Semantics
+
+The connector uses the Google Pub/Sub publisher's batching, flow-control, and retry behavior. It waits for all accepted publish operations during checkpoints and shutdown and fails the task when an asynchronous publish fails.
+
+Pub/Sub publishing is at-least-once from the SeaTunnel job's perspective. A task retry can publish a message again, so downstream consumers should tolerate duplicates when required by the use case.
+
+This first sink implementation publishes only the serialized row payload. Message attributes, ordering keys, and per-row topic routing are not supported.
+
+## Task Example
+
+### Application Default Credentials
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    schema = {
+      fields {
+        event_id = string
+        event_type = string
+      }
+    }
+  }
+}
+
+sink {
+  GooglePubSub {
+    project_id = "my-gcp-project"
+    topic = "events"
+    format = json
+  }
+}
+```
+
+### Service Account Key File
+
+```hocon
+sink {
+  GooglePubSub {
+    project_id = "my-gcp-project"
+    topic = "events"
+    credentials_path = "/secrets/service-account.json"
+    format = text
+    field_delimiter = "|"
+  }
+}
+```
+
+### Pub/Sub Emulator
+
+```hocon
+sink {
+  GooglePubSub {
+    project_id = "local-project"
+    topic = "events"
+    emulator_host = "pubsub-emulator:8085"
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-google-pubsub.md
+++ b/docs/zh/connectors/changelog/connector-google-pubsub.md
@@ -1,0 +1,7 @@
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+|[Feature][Connector-V2] Add Google Pub/Sub sink connector|-|Next|
+
+</details>

--- a/docs/zh/connectors/sink/GooglePubSub.md
+++ b/docs/zh/connectors/sink/GooglePubSub.md
@@ -1,0 +1,136 @@
+import ChangeLog from '../changelog/connector-google-pubsub.md';
+
+# GooglePubSub
+
+> Google Pub/Sub Sink 连接器
+
+## 描述
+
+将每条 SeaTunnel 输入行作为一条消息发布到 Google Pub/Sub 主题。
+
+## 支持这些引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 主要特性
+
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+## 参数
+
+| 参数名 | 类型 | 是否必填 | 默认值 |
+| --- | --- | --- | --- |
+| project_id | string | 是 | - |
+| topic | string | 是 | - |
+| credentials_path | string | 否 | - |
+| emulator_host | string | 否 | - |
+| format | enum | 否 | json |
+| field_delimiter | string | 否 | , |
+| common-options | | 否 | - |
+
+### project_id [string]
+
+目标主题所属的 Google Cloud 项目 ID。
+
+### topic [string]
+
+目标 Pub/Sub 主题 ID。启动作业前必须先创建该主题。
+
+### credentials_path [string]
+
+Google Cloud 服务账号 JSON 密钥文件的路径。未配置时，连接器使用 [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)。
+
+### emulator_host [string]
+
+Pub/Sub 模拟器的主机和端口，例如 `pubsub-emulator:8085`。配置后，连接器使用无凭证的明文连接。生产环境中不要使用该选项。
+
+### format [enum]
+
+消息负载格式。支持以下值：
+
+- `json`：将行写为 JSON 对象。
+- `text`：使用 `field_delimiter` 拼接行字段。
+
+### field_delimiter [string]
+
+`format = text` 时使用的字段分隔符。默认值为 `,`。
+
+### common options
+
+Sink 插件通用参数，请参考 [Sink 通用选项](../common-options/sink-common-options.md)。
+
+## 交付语义
+
+连接器使用 Google Pub/Sub Publisher 的批处理、流量控制和重试机制。在检查点和关闭期间，连接器会等待所有已接收的发布操作完成；异步发布失败会使任务失败。
+
+从 SeaTunnel 作业角度看，Pub/Sub 发布语义为至少一次。任务重试可能再次发布消息，因此下游消费者应根据业务需要处理重复消息。
+
+当前版本只发布序列化后的行负载，不支持消息属性、排序键和按行选择主题。
+
+## 任务示例
+
+### Application Default Credentials
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 10
+    schema = {
+      fields {
+        event_id = string
+        event_type = string
+      }
+    }
+  }
+}
+
+sink {
+  GooglePubSub {
+    project_id = "my-gcp-project"
+    topic = "events"
+    format = json
+  }
+}
+```
+
+### 服务账号密钥文件
+
+```hocon
+sink {
+  GooglePubSub {
+    project_id = "my-gcp-project"
+    topic = "events"
+    credentials_path = "/secrets/service-account.json"
+    format = text
+    field_delimiter = "|"
+  }
+}
+```
+
+### Pub/Sub 模拟器
+
+```hocon
+sink {
+  GooglePubSub {
+    project_id = "local-project"
+    topic = "events"
+    emulator_host = "pubsub-emulator:8085"
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -91,6 +91,7 @@ seatunnel.source.MyHours = connector-http-myhours
 seatunnel.sink.InfluxDB = connector-influxdb
 seatunnel.source.GoogleSheets = connector-google-sheets
 seatunnel.sink.GoogleFirestore = connector-google-firestore
+seatunnel.sink.GooglePubSub = connector-google-pubsub
 seatunnel.source.GoogleBigtable = connector-google-bigtable
 seatunnel.sink.GoogleBigtable = connector-google-bigtable
 seatunnel.sink.Tablestore = connector-tablestore

--- a/seatunnel-connectors-v2/connector-google-pubsub/pom.xml
+++ b/seatunnel-connectors-v2/connector-google-pubsub/pom.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-google-pubsub</artifactId>
+    <name>SeaTunnel : Connectors V2 : Google Pub/Sub</name>
+
+    <properties>
+        <google.cloud.bom.version>26.72.0</google.cloud.bom.version>
+        <guava.version>33.5.0-jre</guava.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>${google.cloud.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-format-text</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-pubsub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>${seatunnel.shade.package}.google.pubsub.com.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>${seatunnel.shade.package}.google.pubsub.com.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.grpc</pattern>
+                                    <shadedPattern>${seatunnel.shade.package}.google.pubsub.io.grpc</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/GooglePubSubSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/GooglePubSubSinkConfig.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+@Builder
+public class GooglePubSubSinkConfig implements Serializable {
+
+    private final String projectId;
+    private final String topic;
+    private final String credentialsPath;
+    private final String emulatorHost;
+    private final MessageFormat format;
+    private final String fieldDelimiter;
+
+    public static GooglePubSubSinkConfig from(ReadonlyConfig config) {
+        String projectId = config.get(GooglePubSubSinkOptions.PROJECT_ID);
+        String topic = config.get(GooglePubSubSinkOptions.TOPIC);
+        String credentialsPath = config.get(GooglePubSubSinkOptions.CREDENTIALS_PATH);
+        String emulatorHost = config.get(GooglePubSubSinkOptions.EMULATOR_HOST);
+        MessageFormat format = config.get(GooglePubSubSinkOptions.FORMAT);
+        String fieldDelimiter = config.get(GooglePubSubSinkOptions.FIELD_DELIMITER);
+
+        requireNonBlank(projectId, GooglePubSubSinkOptions.PROJECT_ID.key());
+        requireNonBlank(topic, GooglePubSubSinkOptions.TOPIC.key());
+        requireNonBlankIfPresent(credentialsPath, GooglePubSubSinkOptions.CREDENTIALS_PATH.key());
+        requireNonBlankIfPresent(emulatorHost, GooglePubSubSinkOptions.EMULATOR_HOST.key());
+        if (credentialsPath != null && emulatorHost != null) {
+            throw new IllegalArgumentException(
+                    "Options 'credentials_path' and 'emulator_host' cannot be configured together");
+        }
+        if (format == MessageFormat.TEXT && fieldDelimiter.isEmpty()) {
+            throw new IllegalArgumentException("Option 'field_delimiter' cannot be empty");
+        }
+
+        return GooglePubSubSinkConfig.builder()
+                .projectId(projectId)
+                .topic(topic)
+                .credentialsPath(credentialsPath)
+                .emulatorHost(emulatorHost)
+                .format(format)
+                .fieldDelimiter(fieldDelimiter)
+                .build();
+    }
+
+    private static void requireNonBlank(String value, String option) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("Option '" + option + "' cannot be blank");
+        }
+    }
+
+    private static void requireNonBlankIfPresent(String value, String option) {
+        if (value != null) {
+            requireNonBlank(value, option);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/GooglePubSubSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/GooglePubSubSinkOptions.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+
+public class GooglePubSubSinkOptions extends ConnectorCommonOptions {
+
+    public static final Option<String> PROJECT_ID =
+            Options.key("project_id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Google Cloud project ID.");
+
+    public static final Option<String> TOPIC =
+            Options.key("topic")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Google Pub/Sub topic ID.");
+
+    public static final Option<String> CREDENTIALS_PATH =
+            Options.key("credentials_path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Path to a Google Cloud service account JSON key file. "
+                                    + "Application Default Credentials are used when this option is not set.");
+
+    public static final Option<String> EMULATOR_HOST =
+            Options.key("emulator_host")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Pub/Sub emulator host and port, for example pubsub-emulator:8085. "
+                                    + "Authentication and TLS are disabled when this option is set.");
+
+    public static final Option<MessageFormat> FORMAT =
+            Options.key("format")
+                    .enumType(MessageFormat.class)
+                    .defaultValue(MessageFormat.JSON)
+                    .withDescription("Message payload format. Supported values are json and text.");
+
+    public static final Option<String> FIELD_DELIMITER =
+            Options.key("field_delimiter")
+                    .stringType()
+                    .defaultValue(",")
+                    .withDescription("Field delimiter used when format is text.");
+
+    private GooglePubSubSinkOptions() {}
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/MessageFormat.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/MessageFormat.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.config;
+
+public enum MessageFormat {
+    JSON,
+    TEXT
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/exception/GooglePubSubConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/exception/GooglePubSubConnectorErrorCode.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+
+public enum GooglePubSubConnectorErrorCode implements SeaTunnelErrorCode {
+    CONNECTION_FAILED("GooglePubSub-01", "Create Google Pub/Sub publisher failed"),
+    WRITE_FAILED("GooglePubSub-02", "Publish Google Pub/Sub message failed"),
+    CLOSE_FAILED("GooglePubSub-03", "Close Google Pub/Sub publisher failed");
+
+    private final String code;
+    private final String description;
+
+    GooglePubSubConnectorErrorCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/exception/GooglePubSubConnectorException.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/exception/GooglePubSubConnectorException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+public class GooglePubSubConnectorException extends SeaTunnelRuntimeException {
+
+    public GooglePubSubConnectorException(
+            GooglePubSubConnectorErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+
+    public GooglePubSubConnectorException(
+            GooglePubSubConnectorErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubPublisher.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubPublisher.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.GooglePubSubSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception.GooglePubSubConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception.GooglePubSubConnectorException;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.TopicName;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+class GooglePubSubPublisher implements PubSubPublisher {
+
+    private static final long CLOSE_TIMEOUT_SECONDS = 60;
+
+    private final Publisher publisher;
+    private final ManagedChannel emulatorChannel;
+
+    private GooglePubSubPublisher(Publisher publisher, ManagedChannel emulatorChannel) {
+        this.publisher = publisher;
+        this.emulatorChannel = emulatorChannel;
+    }
+
+    static PubSubPublisher create(GooglePubSubSinkConfig config) {
+        ManagedChannel emulatorChannel = null;
+        try {
+            Publisher.Builder publisherBuilder =
+                    Publisher.newBuilder(TopicName.of(config.getProjectId(), config.getTopic()));
+
+            if (config.getEmulatorHost() != null) {
+                emulatorChannel =
+                        ManagedChannelBuilder.forTarget(config.getEmulatorHost())
+                                .usePlaintext()
+                                .build();
+                publisherBuilder
+                        .setChannelProvider(
+                                FixedTransportChannelProvider.create(
+                                        GrpcTransportChannel.create(emulatorChannel)))
+                        .setCredentialsProvider(NoCredentialsProvider.create());
+            } else if (config.getCredentialsPath() != null) {
+                try (FileInputStream credentialsStream =
+                        new FileInputStream(config.getCredentialsPath())) {
+                    publisherBuilder.setCredentialsProvider(
+                            FixedCredentialsProvider.create(
+                                    GoogleCredentials.fromStream(credentialsStream)
+                                            .createScoped(
+                                                    PublisherStubSettings
+                                                            .getDefaultServiceScopes())));
+                }
+            }
+
+            return new GooglePubSubPublisher(publisherBuilder.build(), emulatorChannel);
+        } catch (Exception e) {
+            if (emulatorChannel != null) {
+                emulatorChannel.shutdownNow();
+            }
+            throw new GooglePubSubConnectorException(
+                    GooglePubSubConnectorErrorCode.CONNECTION_FAILED,
+                    "Failed to create Google Pub/Sub publisher for topic " + config.getTopic(),
+                    e);
+        }
+    }
+
+    @Override
+    public ApiFuture<String> publish(PubsubMessage message) {
+        return publisher.publish(message);
+    }
+
+    @Override
+    public void publishAllOutstanding() {
+        publisher.publishAllOutstanding();
+    }
+
+    @Override
+    public void close() throws IOException {
+        Throwable failure = null;
+        publisher.shutdown();
+        try {
+            if (!publisher.awaitTermination(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                failure = new IOException("Timed out while closing the Google Pub/Sub publisher");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            failure = e;
+        }
+
+        if (emulatorChannel != null) {
+            emulatorChannel.shutdown();
+            try {
+                if (!emulatorChannel.awaitTermination(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    emulatorChannel.shutdownNow();
+                    IOException timeout =
+                            new IOException("Timed out while closing the Pub/Sub emulator channel");
+                    if (failure == null) {
+                        failure = timeout;
+                    } else {
+                        failure.addSuppressed(timeout);
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                emulatorChannel.shutdownNow();
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+
+        if (failure != null) {
+            throw new IOException("Failed to close Google Pub/Sub publisher", failure);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSink.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSink.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSimpleSink;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.GooglePubSubSinkConfig;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class GooglePubSubSink extends AbstractSimpleSink<SeaTunnelRow, Void> {
+
+    public static final String PLUGIN_NAME = "GooglePubSub";
+
+    private final GooglePubSubSinkConfig config;
+    private final CatalogTable catalogTable;
+
+    public GooglePubSubSink(GooglePubSubSinkConfig config, CatalogTable catalogTable) {
+        this.config = config;
+        this.catalogTable = catalogTable;
+    }
+
+    @Override
+    public String getPluginName() {
+        return PLUGIN_NAME;
+    }
+
+    @Override
+    public AbstractSinkWriter<SeaTunnelRow, Void> createWriter(SinkWriter.Context context)
+            throws IOException {
+        return new GooglePubSubSinkWriter(catalogTable.getSeaTunnelRowType(), config);
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.of(catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.table.connector.TableSink;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.GooglePubSubSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.GooglePubSubSinkOptions;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(Factory.class)
+public class GooglePubSubSinkFactory implements TableSinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return GooglePubSubSink.PLUGIN_NAME;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(GooglePubSubSinkOptions.PROJECT_ID, GooglePubSubSinkOptions.TOPIC)
+                .optional(
+                        GooglePubSubSinkOptions.CREDENTIALS_PATH,
+                        GooglePubSubSinkOptions.EMULATOR_HOST,
+                        GooglePubSubSinkOptions.FORMAT,
+                        GooglePubSubSinkOptions.FIELD_DELIMITER)
+                .build();
+    }
+
+    @Override
+    public TableSink createSink(TableSinkFactoryContext context) {
+        return () ->
+                new GooglePubSubSink(
+                        GooglePubSubSinkConfig.from(context.getOptions()),
+                        context.getCatalogTable());
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkWriter.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import org.apache.seatunnel.api.serialization.SerializationSchema;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.GooglePubSubSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.MessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception.GooglePubSubConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception.GooglePubSubConnectorException;
+import org.apache.seatunnel.format.json.JsonSerializationSchema;
+import org.apache.seatunnel.format.text.TextSerializationSchema;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class GooglePubSubSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void> {
+
+    private final PubSubPublisher publisher;
+    private final SerializationSchema serializationSchema;
+    private final Set<ApiFuture<String>> pendingPublishes = ConcurrentHashMap.newKeySet();
+    private final AtomicReference<Throwable> publishError = new AtomicReference<>();
+
+    GooglePubSubSinkWriter(
+            SeaTunnelRowType rowType, GooglePubSubSinkConfig config, PubSubPublisher publisher) {
+        this.publisher = publisher;
+        this.serializationSchema = createSerializationSchema(rowType, config);
+    }
+
+    public GooglePubSubSinkWriter(SeaTunnelRowType rowType, GooglePubSubSinkConfig config) {
+        this(rowType, config, GooglePubSubPublisher.create(config));
+    }
+
+    @Override
+    public void write(SeaTunnelRow row) throws IOException {
+        checkPublishError();
+
+        PubsubMessage message =
+                PubsubMessage.newBuilder()
+                        .setData(ByteString.copyFrom(serializationSchema.serialize(row)))
+                        .build();
+        ApiFuture<String> publishFuture;
+        try {
+            publishFuture = publisher.publish(message);
+        } catch (RuntimeException e) {
+            throw writeFailure(e);
+        }
+
+        pendingPublishes.add(publishFuture);
+        ApiFutures.addCallback(
+                publishFuture,
+                new ApiFutureCallback<String>() {
+                    @Override
+                    public void onSuccess(String messageId) {
+                        pendingPublishes.remove(publishFuture);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable throwable) {
+                        publishError.compareAndSet(null, throwable);
+                        pendingPublishes.remove(publishFuture);
+                    }
+                },
+                Runnable::run);
+        checkPublishError();
+    }
+
+    @Override
+    public Optional<Void> prepareCommit() {
+        flush();
+        return Optional.empty();
+    }
+
+    private void flush() {
+        checkPublishError();
+        try {
+            publisher.publishAllOutstanding();
+        } catch (RuntimeException e) {
+            throw writeFailure(e);
+        }
+        try {
+            ApiFutures.allAsList(new ArrayList<>(pendingPublishes)).get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw writeFailure(e);
+        } catch (ExecutionException e) {
+            throw writeFailure(e.getCause());
+        }
+        checkPublishError();
+    }
+
+    @Override
+    public void close() throws IOException {
+        GooglePubSubConnectorException failure = null;
+        try {
+            flush();
+        } catch (GooglePubSubConnectorException e) {
+            failure = e;
+        }
+
+        try {
+            publisher.close();
+        } catch (Exception e) {
+            if (failure == null) {
+                failure =
+                        new GooglePubSubConnectorException(
+                                GooglePubSubConnectorErrorCode.CLOSE_FAILED,
+                                "Failed to close Google Pub/Sub publisher",
+                                e);
+            } else {
+                failure.addSuppressed(e);
+            }
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void checkPublishError() {
+        Throwable failure = publishError.get();
+        if (failure != null) {
+            throw writeFailure(failure);
+        }
+    }
+
+    private GooglePubSubConnectorException writeFailure(Throwable cause) {
+        return new GooglePubSubConnectorException(
+                GooglePubSubConnectorErrorCode.WRITE_FAILED,
+                "Failed to publish message to Google Pub/Sub",
+                cause);
+    }
+
+    private static SerializationSchema createSerializationSchema(
+            SeaTunnelRowType rowType, GooglePubSubSinkConfig config) {
+        if (config.getFormat() == MessageFormat.JSON) {
+            return new JsonSerializationSchema(rowType);
+        }
+        return TextSerializationSchema.builder()
+                .seaTunnelRowType(rowType)
+                .delimiter(config.getFieldDelimiter())
+                .build();
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/PubSubPublisher.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/main/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/PubSubPublisher.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import com.google.api.core.ApiFuture;
+import com.google.pubsub.v1.PubsubMessage;
+
+import java.io.IOException;
+
+interface PubSubPublisher extends AutoCloseable {
+
+    ApiFuture<String> publish(PubsubMessage message);
+
+    void publishAllOutstanding();
+
+    @Override
+    void close() throws IOException;
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/test/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/GooglePubSubSinkConfigTest.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/test/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/config/GooglePubSubSinkConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class GooglePubSubSinkConfigTest {
+
+    @Test
+    void shouldRejectCredentialsForEmulator() {
+        Map<String, Object> options = requiredOptions();
+        options.put("credentials_path", "/tmp/service-account.json");
+        options.put("emulator_host", "localhost:8085");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> GooglePubSubSinkConfig.from(ReadonlyConfig.fromMap(options)));
+        Assertions.assertTrue(exception.getMessage().contains("cannot be configured together"));
+    }
+
+    @Test
+    void shouldRejectBlankProjectId() {
+        Map<String, Object> options = requiredOptions();
+        options.put("project_id", " ");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> GooglePubSubSinkConfig.from(ReadonlyConfig.fromMap(options)));
+        Assertions.assertTrue(exception.getMessage().contains("project_id"));
+    }
+
+    @Test
+    void shouldRejectEmptyTextDelimiter() {
+        Map<String, Object> options = requiredOptions();
+        options.put("format", "text");
+        options.put("field_delimiter", "");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> GooglePubSubSinkConfig.from(ReadonlyConfig.fromMap(options)));
+        Assertions.assertTrue(exception.getMessage().contains("field_delimiter"));
+    }
+
+    private Map<String, Object> requiredOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("project_id", "test-project");
+        options.put("topic", "test-topic");
+        return options;
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/test/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/test/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class GooglePubSubSinkFactoryTest {
+
+    @Test
+    void shouldExposeGooglePubSubIdentifierAndOptions() {
+        GooglePubSubSinkFactory factory = new GooglePubSubSinkFactory();
+
+        Assertions.assertEquals("GooglePubSub", factory.factoryIdentifier());
+        Assertions.assertNotNull(factory.optionRule());
+    }
+}

--- a/seatunnel-connectors-v2/connector-google-pubsub/src/test/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-google-pubsub/src/test/java/org/apache/seatunnel/connectors/seatunnel/google/pubsub/sink/GooglePubSubSinkWriterTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.google.pubsub.sink;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.GooglePubSubSinkConfig;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.config.MessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.google.pubsub.exception.GooglePubSubConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.pubsub.v1.PubsubMessage;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+class GooglePubSubSinkWriterTest {
+
+    private SeaTunnelRowType rowType;
+    private TestPubSubPublisher publisher;
+
+    @BeforeEach
+    void setUp() {
+        rowType =
+                new SeaTunnelRowType(
+                        new String[] {"name", "age"},
+                        new SeaTunnelDataType[] {BasicType.STRING_TYPE, BasicType.INT_TYPE});
+        publisher = new TestPubSubPublisher();
+    }
+
+    @Test
+    void shouldSerializeRowAsJson() throws IOException {
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.JSON, ",");
+
+        writer.write(row("alice", 30));
+
+        Assertions.assertEquals(
+                "{\"name\":\"alice\",\"age\":30}",
+                publisher.messages.get(0).getData().toStringUtf8());
+    }
+
+    @Test
+    void shouldUseConfiguredTextDelimiter() throws IOException {
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.TEXT, "|");
+
+        writer.write(row("alice", 30));
+
+        Assertions.assertEquals("alice|30", publisher.messages.get(0).getData().toStringUtf8());
+    }
+
+    @Test
+    void shouldFlushOutstandingMessagesBeforeCommit() throws IOException {
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.JSON, ",");
+        writer.write(row("alice", 30));
+
+        writer.prepareCommit();
+
+        Assertions.assertEquals(1, publisher.flushCount);
+    }
+
+    @Test
+    void shouldSurfaceAsynchronousPublishFailure() throws IOException {
+        SettableApiFuture<String> future = SettableApiFuture.create();
+        publisher.nextFuture = future;
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.JSON, ",");
+        writer.write(row("alice", 30));
+        future.setException(new IOException("publish failed"));
+
+        GooglePubSubConnectorException exception =
+                Assertions.assertThrows(
+                        GooglePubSubConnectorException.class, writer::prepareCommit);
+        Assertions.assertTrue(exception.getMessage().contains("Failed to publish message"));
+    }
+
+    @Test
+    void shouldSurfaceSynchronousPublishFailure() {
+        publisher.publishFailure = new IllegalStateException("publish failed");
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.JSON, ",");
+
+        GooglePubSubConnectorException exception =
+                Assertions.assertThrows(
+                        GooglePubSubConnectorException.class, () -> writer.write(row("alice", 30)));
+        Assertions.assertTrue(exception.getMessage().contains("Failed to publish message"));
+    }
+
+    @Test
+    void shouldSurfaceFlushFailure() throws IOException {
+        publisher.flushFailure = new IllegalStateException("flush failed");
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.JSON, ",");
+        writer.write(row("alice", 30));
+
+        GooglePubSubConnectorException exception =
+                Assertions.assertThrows(
+                        GooglePubSubConnectorException.class, writer::prepareCommit);
+        Assertions.assertTrue(exception.getMessage().contains("Failed to publish message"));
+    }
+
+    @Test
+    void shouldClosePublisherAfterPublishFailure() throws IOException {
+        SettableApiFuture<String> future = SettableApiFuture.create();
+        publisher.nextFuture = future;
+        GooglePubSubSinkWriter writer = createWriter(MessageFormat.JSON, ",");
+        writer.write(row("alice", 30));
+        future.setException(new IOException("publish failed"));
+
+        Assertions.assertThrows(GooglePubSubConnectorException.class, writer::close);
+        Assertions.assertTrue(publisher.closed);
+    }
+
+    private GooglePubSubSinkWriter createWriter(MessageFormat format, String delimiter) {
+        GooglePubSubSinkConfig config =
+                GooglePubSubSinkConfig.builder()
+                        .projectId("test-project")
+                        .topic("test-topic")
+                        .format(format)
+                        .fieldDelimiter(delimiter)
+                        .build();
+        return new GooglePubSubSinkWriter(rowType, config, publisher);
+    }
+
+    private SeaTunnelRow row(String name, int age) {
+        return new SeaTunnelRow(new Object[] {name, age});
+    }
+
+    private static class TestPubSubPublisher implements PubSubPublisher {
+
+        private final List<PubsubMessage> messages = new ArrayList<>();
+        private ApiFuture<String> nextFuture = ApiFutures.immediateFuture("message-id");
+        private RuntimeException publishFailure;
+        private RuntimeException flushFailure;
+        private int flushCount;
+        private boolean closed;
+
+        @Override
+        public ApiFuture<String> publish(PubsubMessage message) {
+            if (publishFailure != null) {
+                throw publishFailure;
+            }
+            messages.add(message);
+            return nextFuture;
+        }
+
+        @Override
+        public void publishAllOutstanding() {
+            flushCount++;
+            if (flushFailure != null) {
+                throw flushFailure;
+            }
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -70,6 +70,7 @@
         <module>connector-starrocks</module>
         <module>connector-google-sheets</module>
         <module>connector-google-firestore</module>
+        <module>connector-google-pubsub</module>
         <module>connector-slack</module>
         <module>connector-rabbitmq</module>
         <module>connector-openmldb</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -496,6 +496,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-google-pubsub</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-google-bigtable</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connector-v2-e2e</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-google-pubsub-e2e</artifactId>
+    <name>SeaTunnel : E2E : Connector V2 : Google Pub/Sub</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-google-pubsub</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/java/org/apache/seatunnel/e2e/connector/google/pubsub/GooglePubSubIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/java/org/apache/seatunnel/e2e/connector/google/pubsub/GooglePubSubIT.java
@@ -93,9 +93,8 @@ public class GooglePubSubIT extends TestSuiteBase implements TestResource {
 
         emulatorEndpoint =
                 "http://" + emulator.getHost() + ":" + emulator.getMappedPort(EMULATOR_PORT);
-        request("PUT", "/v1/projects/" + PROJECT_ID + "/topics/" + TOPIC_ID, "{}");
-        request(
-                "PUT",
+        createResource("/v1/projects/" + PROJECT_ID + "/topics/" + TOPIC_ID, "{}");
+        createResource(
                 "/v1/projects/" + PROJECT_ID + "/subscriptions/" + SUBSCRIPTION_ID,
                 "{\"topic\":\"projects/"
                         + PROJECT_ID
@@ -154,6 +153,13 @@ public class GooglePubSubIT extends TestSuiteBase implements TestResource {
                 "POST",
                 "/v1/projects/" + PROJECT_ID + "/subscriptions/" + SUBSCRIPTION_ID + ":acknowledge",
                 "{\"ackIds\":[\"" + ackId + "\"]}");
+    }
+
+    private void createResource(String path, String body) {
+        await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> request("PUT", path, body));
     }
 
     private String request(String method, String path, String body) throws IOException {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/java/org/apache/seatunnel/e2e/connector/google/pubsub/GooglePubSubIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/java/org/apache/seatunnel/e2e/connector/google/pubsub/GooglePubSubIT.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.google.pubsub;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.seatunnel.common.utils.JsonUtils;
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.awaitility.Awaitility.await;
+
+@Slf4j
+public class GooglePubSubIT extends TestSuiteBase implements TestResource {
+
+    private static final String EMULATOR_IMAGE =
+            "gcr.io/google.com/cloudsdktool/google-cloud-cli:573.0.0-emulators";
+    private static final String PROJECT_ID = "seatunnel-test";
+    private static final String TOPIC_ID = "events";
+    private static final String SUBSCRIPTION_ID = "events-test";
+    private static final int EMULATOR_PORT = 8085;
+    private static final String EMULATOR_HOST = "pubsub-emulator";
+    private static final String JOB_CONFIG = "/pubsub/fake_to_google_pubsub.conf";
+    private static final String EXPECTED_MESSAGE = "{\"name\":\"alice\",\"age\":30}";
+
+    private GenericContainer<?> emulator;
+    private String emulatorEndpoint;
+
+    @BeforeAll
+    @Override
+    public void startUp() throws Exception {
+        DockerImageName image = DockerImageName.parse(EMULATOR_IMAGE);
+        emulator =
+                new GenericContainer<>(image)
+                        .withCommand(
+                                "gcloud",
+                                "beta",
+                                "emulators",
+                                "pubsub",
+                                "start",
+                                "--project=" + PROJECT_ID,
+                                "--host-port=0.0.0.0:" + EMULATOR_PORT)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(EMULATOR_HOST)
+                        .withExposedPorts(EMULATOR_PORT)
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(
+                                        DockerLoggerFactory.getLogger(
+                                                image.asCanonicalNameString())));
+        Startables.deepStart(Stream.of(emulator)).join();
+
+        emulatorEndpoint =
+                "http://" + emulator.getHost() + ":" + emulator.getMappedPort(EMULATOR_PORT);
+        request("PUT", "/v1/projects/" + PROJECT_ID + "/topics/" + TOPIC_ID, "{}");
+        request(
+                "PUT",
+                "/v1/projects/" + PROJECT_ID + "/subscriptions/" + SUBSCRIPTION_ID,
+                "{\"topic\":\"projects/"
+                        + PROJECT_ID
+                        + "/topics/"
+                        + TOPIC_ID
+                        + "\",\"ackDeadlineSeconds\":10}");
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        if (emulator != null) {
+            emulator.close();
+        }
+    }
+
+    @TestTemplate
+    public void testGooglePubSubSink(TestContainer container) throws Exception {
+        Container.ExecResult result = container.executeJob(JOB_CONFIG);
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+
+        AtomicReference<ObjectNode> receivedMessage = new AtomicReference<>();
+        await().atMost(30, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .until(
+                        () -> {
+                            ObjectNode response =
+                                    JsonUtils.parseObject(
+                                            request(
+                                                    "POST",
+                                                    "/v1/projects/"
+                                                            + PROJECT_ID
+                                                            + "/subscriptions/"
+                                                            + SUBSCRIPTION_ID
+                                                            + ":pull",
+                                                    "{\"maxMessages\":1,\"returnImmediately\":true}"));
+                            JsonNode messages = response.get("receivedMessages");
+                            if (messages == null || messages.isEmpty()) {
+                                return false;
+                            }
+                            receivedMessage.set((ObjectNode) messages.get(0));
+                            return true;
+                        });
+
+        ObjectNode message = receivedMessage.get();
+        String payload =
+                new String(
+                        Base64.getDecoder().decode(message.path("message").path("data").asText()),
+                        StandardCharsets.UTF_8);
+        Assertions.assertEquals(EXPECTED_MESSAGE, payload);
+        acknowledge(message.path("ackId").asText());
+    }
+
+    private void acknowledge(String ackId) throws IOException {
+        request(
+                "POST",
+                "/v1/projects/" + PROJECT_ID + "/subscriptions/" + SUBSCRIPTION_ID + ":acknowledge",
+                "{\"ackIds\":[\"" + ackId + "\"]}");
+    }
+
+    private String request(String method, String path, String body) throws IOException {
+        HttpURLConnection connection =
+                (HttpURLConnection) new URL(emulatorEndpoint + path).openConnection();
+        try {
+            connection.setRequestMethod(method);
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(10_000);
+            connection.setDoOutput(true);
+            try (OutputStream output = connection.getOutputStream()) {
+                output.write(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            int status = connection.getResponseCode();
+            InputStream responseStream =
+                    status >= 200 && status < 300
+                            ? connection.getInputStream()
+                            : connection.getErrorStream();
+            String response = responseStream == null ? "" : readResponse(responseStream);
+            if (status < 200 || status >= 300) {
+                throw new IOException(
+                        "Pub/Sub emulator request failed with status " + status + ": " + response);
+            }
+            return response;
+        } finally {
+            connection.disconnect();
+        }
+    }
+
+    private String readResponse(InputStream input) throws IOException {
+        try (InputStream response = input;
+                ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = response.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+            return new String(output.toByteArray(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/resources/pubsub/fake_to_google_pubsub.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/resources/pubsub/fake_to_google_pubsub.conf
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 env {
   parallelism = 1
   job.mode = "BATCH"

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/resources/pubsub/fake_to_google_pubsub.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-google-pubsub-e2e/src/test/resources/pubsub/fake_to_google_pubsub.conf
@@ -1,0 +1,31 @@
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    row.num = 1
+    schema = {
+      fields {
+        name = string
+        age = int
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["alice", 30]
+      }
+    ]
+  }
+}
+
+sink {
+  GooglePubSub {
+    project_id = "seatunnel-test"
+    topic = "events"
+    emulator_host = "pubsub-emulator:8085"
+    format = json
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
@@ -67,6 +67,7 @@
         <module>connector-maxcompute-e2e</module>
         <module>connector-druid-e2e</module>
         <module>connector-google-firestore-e2e</module>
+        <module>connector-google-pubsub-e2e</module>
         <module>connector-rocketmq-e2e</module>
         <!--        <module>connector-file-obs-e2e</module>-->
         <module>connector-file-ftp-e2e</module>


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

Contributes to #10753.

This PR adds the Google Pub/Sub sink side as a focused first connector slice.

- Publishes one Pub/Sub message for each SeaTunnel row
- Supports JSON and delimited text payloads
- Supports Application Default Credentials, a service account key file, and the Pub/Sub emulator
- Waits for outstanding asynchronous publishes during checkpoints and shutdown
- Reports synchronous and asynchronous publish failures to the SeaTunnel task
- Isolates the Google client dependency stack through connector-local shading
- Registers the connector in the distribution, plugin mapping, plugin config, CI labels, and E2E workflow
- Adds English and Chinese documentation

Source support is intentionally not part of this PR because subscriber acknowledgement and checkpoint recovery need a separate source-focused design.

### Does this PR introduce _any_ user-facing change?

Yes.

Users can configure a new `GooglePubSub` sink for batch or streaming jobs. The connector publishes serialized row payloads with at-least-once delivery semantics.

Message attributes, ordering keys, and per-row topic routing are not included in this first slice.

### How was this patch tested?

Added unit coverage for:

- Required and mutually exclusive options
- JSON and delimited text serialization
- Checkpoint flush behavior
- Synchronous and asynchronous publish failures
- Publisher cleanup after a failed publish
- Factory identifier and option registration

Added an emulator E2E test that creates a topic and subscription, runs `FakeSource` to `GooglePubSub`, pulls the published message, verifies its payload, and acknowledges it.

Verified with:

```shell
JAVA_HOME=<jdk8-home> ./mvnw -B -T 1 -pl :connector-google-pubsub test -Dskip.ui=true --no-snapshot-updates

JAVA_HOME=<jdk11-home> ./mvnw -B -T 1 -pl :connector-google-pubsub verify -Dskip.ui=true --no-snapshot-updates

JAVA_HOME=<jdk11-home> ./mvnw -B -T 1 verify -DskipUT=true -DskipIT=false -Dlicense.skipAddThirdParty=true -Dskip.ui=true --no-snapshot-updates -pl :connector-google-pubsub-e2e -am -Pci
```

The emulator E2E test passed on Flink 1.13, Flink 1.15, Flink 1.18, Flink 1.20, SeaTunnel Zeta, Spark 2, and Spark 3.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
  No Jar binary package is added to the repository.
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
  No incompatible change is introduced.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)