### PR TITLE
[Improve][Connector-V2][File] Migrate HDFS and S3 sink validation to declarative OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-hadoop/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hdfs/sink/HdfsFileSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-hadoop/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/hdfs/sink/HdfsFileSinkFactory.java
@@ -19,7 +19,6 @@ package org.apache.seatunnel.connectors.seatunnel.file.hdfs.sink;
 
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 
-import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
@@ -28,13 +27,9 @@ import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.common.config.CheckConfigUtil;
-import org.apache.seatunnel.common.config.CheckResult;
-import org.apache.seatunnel.common.constants.PluginType;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileFormat;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileSystemType;
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
-import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.file.factory.BaseMultipleTableFileSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.file.hdfs.config.HdfsFileSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.sink.commit.FileAggregatedCommitInfo;
@@ -144,16 +139,6 @@ public class HdfsFileSinkFactory extends BaseMultipleTableFileSinkFactory {
 
     public HadoopConf initHadoopConf(ReadonlyConfig readonlyConfig) {
         Config pluginConfig = readonlyConfig.toConfig();
-        CheckResult result =
-                CheckConfigUtil.checkAllExists(readonlyConfig.toConfig(), FS_DEFAULT_NAME_KEY);
-        if (!result.isSuccess()) {
-            throw new FileConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    String.format(
-                            "PluginName: %s, PluginType: %s, Message: %s",
-                            factoryIdentifier(), PluginType.SINK, result.getMsg()));
-        }
-
         HadoopConf hadoopConf = new HadoopConf(pluginConfig.getString(FS_DEFAULT_NAME_KEY));
 
         if (pluginConfig.hasPath(HdfsFileSinkOptions.HDFS_SITE_PATH.key())) {

--- a/seatunnel-connectors-v2/connector-file/connector-file-hadoop/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hdfs/HdfsFileFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-hadoop/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hdfs/HdfsFileFactoryTest.java
@@ -99,6 +99,32 @@ class HdfsFileFactoryTest {
         Assertions.assertDoesNotThrow(() -> validate(backupConfig, optionRule));
     }
 
+    @Test
+    void sinkOptionRuleRequiresDefaultFs() {
+        OptionRule optionRule = (new HdfsFileSinkFactory()).optionRule();
+        Map<String, Object> config = new HashMap<>();
+        config.put(FileBaseOptions.FILE_PATH.key(), "/sink");
+
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(config, optionRule));
+
+        config.put(FileBaseOptions.DEFAULT_FS.key(), "hdfs://localhost:9000");
+        Assertions.assertDoesNotThrow(() -> validate(config, optionRule));
+    }
+
+    @Test
+    void sinkOptionRuleRequiresFilePath() {
+        OptionRule optionRule = (new HdfsFileSinkFactory()).optionRule();
+        Map<String, Object> config = new HashMap<>();
+        config.put(FileBaseOptions.DEFAULT_FS.key(), "hdfs://localhost:9000");
+
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(config, optionRule));
+
+        config.put(FileBaseOptions.FILE_PATH.key(), "/sink");
+        Assertions.assertDoesNotThrow(() -> validate(config, optionRule));
+    }
+
     private static Map<String, Object> sourceConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put(FileBaseOptions.FILE_PATH.key(), "/source");

--- a/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/sink/S3FileSink.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-s3/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/s3/sink/S3FileSink.java
@@ -17,9 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.file.s3.sink;
 
-import org.apache.seatunnel.shade.com.typesafe.config.Config;
-
-import org.apache.seatunnel.api.common.SeaTunnelAPIErrorCode;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.DataSaveMode;
 import org.apache.seatunnel.api.sink.DefaultSaveModeHandler;
@@ -29,13 +26,8 @@ import org.apache.seatunnel.api.sink.SupportSaveMode;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.factory.CatalogFactory;
-import org.apache.seatunnel.common.config.CheckConfigUtil;
-import org.apache.seatunnel.common.config.CheckResult;
-import org.apache.seatunnel.common.constants.PluginType;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileSystemType;
-import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
-import org.apache.seatunnel.connectors.seatunnel.file.s3.config.S3FileSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.s3.config.S3HadoopConf;
 import org.apache.seatunnel.connectors.seatunnel.file.sink.BaseMultipleTableFileSink;
 
@@ -59,19 +51,6 @@ public class S3FileSink extends BaseMultipleTableFileSink implements SupportSave
         super(S3HadoopConf.buildWithReadOnlyConfig(readonlyConfig), readonlyConfig, catalogTable);
         this.catalogTable = catalogTable;
         this.readonlyConfig = readonlyConfig;
-        Config pluginConfig = readonlyConfig.toConfig();
-        CheckResult result =
-                CheckConfigUtil.checkAllExists(
-                        pluginConfig,
-                        S3FileSinkOptions.FILE_PATH.key(),
-                        S3FileSinkOptions.S3_BUCKET.key());
-        if (!result.isSuccess()) {
-            throw new FileConnectorException(
-                    SeaTunnelAPIErrorCode.CONFIG_VALIDATION_FAILED,
-                    String.format(
-                            "PluginName: %s, PluginType: %s, Message: %s",
-                            getPluginName(), PluginType.SINK, result.getMsg()));
-        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-file/connector-file-s3/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/s3/S3FileFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-s3/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/s3/S3FileFactoryTest.java
@@ -18,9 +18,12 @@
 package org.apache.seatunnel.connectors.seatunnel.file.s3;
 
 import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.Condition;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.Expression;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.configuration.util.RequiredOption;
 import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.file.s3.config.S3FileBaseOptions;
@@ -29,6 +32,9 @@ import org.apache.seatunnel.connectors.seatunnel.file.s3.source.S3FileSourceFact
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 class S3FileFactoryTest {
 
@@ -92,6 +98,47 @@ class S3FileFactoryTest {
                         S3FileBaseOptions.S3A_AWS_CREDENTIALS_PROVIDER_CLASS,
                         S3FileBaseOptions.S3_SECRET_KEY),
                 "S3File sink optionRule should require secret_key when the credentials provider is SimpleAWSCredentialsProvider");
+    }
+
+    @Test
+    void sinkOptionRuleRequiresFilePath() {
+        OptionRule optionRule = new S3FileSinkFactory().optionRule();
+        Map<String, Object> config = sinkConfig();
+        config.remove(S3FileBaseOptions.FILE_PATH.key());
+
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(config, optionRule));
+
+        config.put(S3FileBaseOptions.FILE_PATH.key(), "/tmp/seatunnel");
+        Assertions.assertDoesNotThrow(() -> validate(config, optionRule));
+    }
+
+    @Test
+    void sinkOptionRuleRequiresBucket() {
+        OptionRule optionRule = new S3FileSinkFactory().optionRule();
+        Map<String, Object> config = sinkConfig();
+        config.remove(S3FileBaseOptions.S3_BUCKET.key());
+
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(config, optionRule));
+
+        config.put(S3FileBaseOptions.S3_BUCKET.key(), "s3a://seatunnel-test");
+        Assertions.assertDoesNotThrow(() -> validate(config, optionRule));
+    }
+
+    private static Map<String, Object> sinkConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(S3FileBaseOptions.FILE_PATH.key(), "/tmp/seatunnel");
+        config.put(S3FileBaseOptions.S3_BUCKET.key(), "s3a://seatunnel-test");
+        config.put(S3FileBaseOptions.FS_S3A_ENDPOINT.key(), "s3.example.com");
+        config.put(
+                S3FileBaseOptions.S3A_AWS_CREDENTIALS_PROVIDER_CLASS.key(),
+                S3FileBaseOptions.INSTANCE_PROFILE_CREDENTIALS_PROVIDER);
+        return config;
+    }
+
+    private static void validate(Map<String, Object> config, OptionRule optionRule) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(optionRule);
     }
 
     private static boolean optionRuleContains(OptionRule rule, Option<?> option) {


### PR DESCRIPTION
### Purpose of this pull request

Part of #11007. I claimed `connector-file` on the umbrella.

Two file-connector sinks re-checked, at runtime, options their own factory already declares required in `optionRule()`:

- `HdfsFileSinkFactory.initHadoopConf()` ran `CheckConfigUtil.checkAllExists(FS_DEFAULT_NAME_KEY)`, but the same factory's `optionRule()` already declares `required(DEFAULT_FS)`, and `FileBaseOptions.DEFAULT_FS` is keyed on `FS_DEFAULT_NAME_KEY`.
- `S3FileSink`'s constructor ran `checkAllExists(FILE_PATH, S3_BUCKET)`, and `S3FileSinkFactory.optionRule()` already declares both as `required`.

In both cases the imperative check could only fire after declarative validation had already passed, so it was unreachable duplication that reported the same failure later and in a different format. This removes both and lets `optionRule()` own the validation, so the failure surfaces at `--check` time.

Net effect is 36 deleted lines of production code and no new production code.

### One case deliberately left alone

`HdfsFileHadoopConfig.buildWithConfig()` also calls `checkAllExists`, on `FILE_PATH`, `FILE_FORMAT_TYPE` and `DEFAULT_FS`. I did **not** touch it, because unlike the two above it is not redundant:

- `HdfsFileSourceFactory.optionRule()` declares `DEFAULT_FS` and `FILE_FORMAT_TYPE` as `.optional(...)`, not `.required(...)`.
- It pairs `FILE_PATH` with `TABLE_CONFIGS` via `.exclusive(...)`, whereas the imperative check requires `FILE_PATH` unconditionally.
- `HdfsFileCatalogFactory.optionRule()` returns `OptionRule.builder().build()`, i.e. empty, and it reaches `buildWithConfig` too.

So removing that one would drop validation rather than move it, and reconciling it means deciding whether those options are genuinely required for the HDFS source and catalog. That is a semantic change, and the guide warns against silently converting optional into required, so I left it for a maintainer to weigh in on. Happy to do it in a follow-up if you tell me the intended semantics.

### Does this PR introduce _any_ user-facing change?

No behavioral change for valid configurations. For the two invalid cases the error now comes from declarative validation at `--check` time instead of an equivalent `FileConnectorException` raised slightly later during sink construction. Both paths already failed the job.

### How was this patch tested?

Regression tests added to the existing factory tests, asserting the declarative rules reject exactly the configurations the removed checks used to reject:

- `HdfsFileFactoryTest.sinkOptionRuleRequiresDefaultFs`
- `HdfsFileFactoryTest.sinkOptionRuleRequiresFilePath`
- `S3FileFactoryTest.sinkOptionRuleRequiresFilePath`
- `S3FileFactoryTest.sinkOptionRuleRequiresBucket`

Each asserts `OptionValidationException` when the option is absent and no throw once it is supplied.

I confirmed the tests are load-bearing rather than decorative by temporarily weakening `.required(S3FileSinkOptions.S3_BUCKET)` to `.optional(...)`, which fails `sinkOptionRuleRequiresBucket` with "Expected OptionValidationException to be thrown, but nothing was thrown", then reverting. I also checked no existing test depended on the removed `FileConnectorException`.

Full module suites pass locally on JDK 11: `connector-file-s3` 21 tests, `connector-file-hadoop` 13 tests (2 pre-existing Windows-only skips), and `spotless:check` is clean on both.

---

Disclosure: this change was AI-assisted (Claude). I reviewed it and can speak to the reasoning.
