### PR TITLE
[Improve][Connector-V2][MongoDB] Migrate fetch size validation to declarative OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/MongodbSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/MongodbSourceFactory.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.mongodb.source;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
@@ -56,8 +57,10 @@ public class MongodbSourceFactory implements TableSourceFactory {
                         MongodbSourceOptions.SPLIT_SIZE,
                         MongodbSourceOptions.SPLIT_KEY,
                         MongodbSourceOptions.CURSOR_NO_TIMEOUT,
-                        MongodbSourceOptions.FETCH_SIZE,
                         MongodbSourceOptions.MAX_TIME_MIN)
+                .optional(
+                        MongodbSourceOptions.FETCH_SIZE,
+                        Conditions.greaterThan(MongodbSourceOptions.FETCH_SIZE, 0))
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/config/MongodbReadOptions.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/config/MongodbReadOptions.java
@@ -24,8 +24,6 @@ import lombok.Getter;
 
 import java.io.Serializable;
 
-import static org.apache.seatunnel.shade.com.google.common.base.Preconditions.checkArgument;
-
 /** The configuration class for MongoDB source. */
 @EqualsAndHashCode
 @Getter
@@ -61,7 +59,6 @@ public class MongodbReadOptions implements Serializable {
         private MongoReadOptionsBuilder() {}
 
         public MongoReadOptionsBuilder setFetchSize(int fetchSize) {
-            checkArgument(fetchSize > 0, "The fetch size must be larger than 0.");
             this.fetchSize = fetchSize;
             return this;
         }

--- a/seatunnel-connectors-v2/connector-mongodb/src/test/java/org/apache/seatunnel/connectors/seatunnel/mongodb/MongodbFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/test/java/org/apache/seatunnel/connectors/seatunnel/mongodb/MongodbFactoryTest.java
@@ -17,17 +17,85 @@
 
 package org.apache.seatunnel.connectors.seatunnel.mongodb;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.config.MongodbSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.mongodb.sink.MongodbSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.mongodb.source.MongodbSourceFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 class MongodbFactoryTest {
+
+    private final MongodbSourceFactory sourceFactory = new MongodbSourceFactory();
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new MongodbSourceFactory()).optionRule());
-        Assertions.assertNotNull((new MongodbSinkFactory()).optionRule());
+        Assertions.assertNotNull(sourceFactory.optionRule());
+        Assertions.assertNotNull(new MongodbSinkFactory().optionRule());
+    }
+
+    @Test
+    void testDefaultFetchSizePassesOptionValidation() {
+        Assertions.assertDoesNotThrow(() -> validateSourceOptionRule(validSourceConfig()));
+    }
+
+    @Test
+    void testPositiveFetchSizePassesOptionValidation() {
+        Map<String, Object> config = validSourceConfig();
+        config.put(MongodbSourceOptions.FETCH_SIZE.key(), 1);
+
+        Assertions.assertDoesNotThrow(() -> validateSourceOptionRule(config));
+
+        config.put(MongodbSourceOptions.FETCH_SIZE.key(), 2048);
+        Assertions.assertDoesNotThrow(() -> validateSourceOptionRule(config));
+    }
+
+    @Test
+    void testZeroFetchSizeFailsOptionValidation() {
+        Map<String, Object> config = validSourceConfig();
+        config.put(MongodbSourceOptions.FETCH_SIZE.key(), 0);
+
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateSourceOptionRule(config));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains(MongodbSourceOptions.FETCH_SIZE.key()));
+    }
+
+    @Test
+    void testNegativeFetchSizeFailsOptionValidation() {
+        Map<String, Object> config = validSourceConfig();
+        config.put(MongodbSourceOptions.FETCH_SIZE.key(), -1);
+
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateSourceOptionRule(config));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains(MongodbSourceOptions.FETCH_SIZE.key()));
+    }
+
+    private void validateSourceOptionRule(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(sourceFactory.optionRule());
+    }
+
+    private Map<String, Object> validSourceConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(MongodbSourceOptions.URI.key(), "mongodb://localhost:27017");
+        config.put(MongodbSourceOptions.DATABASE.key(), "test_database");
+        config.put(MongodbSourceOptions.COLLECTION.key(), "test_collection");
+        config.put(
+                ConnectorCommonOptions.SCHEMA.key(),
+                Collections.singletonMap("fields", Collections.singletonMap("value", "string")));
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Related #11007

Migrate MongoDB Source `fetch.size` validation from the imperative runtime check in `MongodbReadOptions` to declarative `OptionRule` validation.

Changes:

- Add `Conditions.greaterThan(MongodbSourceOptions.FETCH_SIZE, 0)` to `MongodbSourceFactory.optionRule()`.
- Remove the now-redundant `checkArgument(fetchSize > 0, ...)` validation from `MongodbReadOptions`.
- Add factory-level validation tests covering the default, positive, zero, and negative `fetch.size` cases.

This preserves the existing `fetch.size > 0` contract. The default value remains unchanged, and no previously valid configuration becomes invalid.

### Does this PR introduce _any_ user-facing change?

Yes, only the validation timing and error reporting change.

Previously, a non-positive `fetch.size` could pass `OptionRule` validation and fail later when MongoDB read options were constructed by the runtime validation in `MongodbReadOptions`.

With this change, `fetch.size <= 0` is rejected earlier during standard configuration validation with `OptionValidationException`.

There is no backward-incompatible configuration change:

- The option name is unchanged.
- The default value is unchanged.
- Positive `fetch.size` values remain valid.
- `fetch.size = 0` and negative values were already invalid before this change.

### How was this patch tested?

Added focused cases to `MongodbFactoryTest` covering:

- omitted `fetch.size` — passes validation using the existing default
- `fetch.size = 1` — passes validation
- `fetch.size = 2048` — passes validation
- `fetch.size = 0` — rejected with `OptionValidationException`
- `fetch.size = -1` — rejected with `OptionValidationException`

Focused unit test:

```bash
./mvnw \
  -pl seatunnel-connectors-v2/connector-mongodb \
  -Dtest=MongodbFactoryTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test