### PR TITLE
[Fix][Connector-V2] Fix MongoDB reader cursor cleanup

### DIFF
--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReader.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReader.java
@@ -17,8 +17,6 @@
 
 package org.apache.seatunnel.connectors.seatunnel.mongodb.source.reader;
 
-import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
-
 import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
@@ -150,7 +148,10 @@ public class MongodbReader implements SourceReader<SeaTunnelRow, MongoSplit> {
     public void notifyCheckpointComplete(long checkpointId) {}
 
     private void closeCurrentSplit() {
-        Preconditions.checkNotNull(cursor);
+        if (cursor == null) {
+            // Preserve the original cursor-creation failure from pollNext().
+            return;
+        }
         cursor.close();
         cursor = null;
     }

--- a/seatunnel-connectors-v2/connector-mongodb/src/test/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReaderTest.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/test/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/reader/MongodbReaderTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.mongodb.source.reader;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.internal.MongodbClientProvider;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.serde.DocumentDeserializer;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.source.config.MongodbReadOptions;
+import org.apache.seatunnel.connectors.seatunnel.mongodb.source.split.MongoSplit;
+
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.ServerAddress;
+import com.mongodb.ServerCursor;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MongodbReaderTest {
+
+    @Test
+    void pollNextPreservesOriginalCursorCreationException() {
+        RuntimeException cursorCreationFailure = new RuntimeException("cursor creation failed");
+        MongodbClientProvider clientProvider = mock(MongodbClientProvider.class);
+        when(clientProvider.getDefaultCollection()).thenThrow(cursorCreationFailure);
+
+        SourceReader.Context context = mock(SourceReader.Context.class);
+        DocumentDeserializer<SeaTunnelRow> deserializer = mock(DocumentDeserializer.class);
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        when(collector.getCheckpointLock()).thenReturn(new Object());
+
+        MongodbReader reader =
+                new MongodbReader(
+                        context,
+                        clientProvider,
+                        deserializer,
+                        MongodbReadOptions.builder().build());
+        reader.addSplits(
+                Collections.singletonList(
+                        new MongoSplit("split-1", new BsonDocument(), new BsonDocument(), 0L)));
+
+        RuntimeException actual =
+                assertThrows(RuntimeException.class, () -> reader.pollNext(collector));
+
+        assertSame(cursorCreationFailure, actual);
+    }
+
+    @Test
+    void pollNextClosesCursorWhenDeserializationFails() {
+        RuntimeException deserializationFailure = new RuntimeException("deserialization failed");
+        MongodbClientProvider clientProvider = mock(MongodbClientProvider.class);
+        MongoCollection<BsonDocument> collection = mock(MongoCollection.class);
+        FindIterable<BsonDocument> iterable = mock(FindIterable.class);
+        AtomicBoolean cursorClosed = new AtomicBoolean();
+        MongoCursor<BsonDocument> cursor =
+                new MongoCursor<BsonDocument>() {
+                    private boolean consumed;
+
+                    @Override
+                    public void close() {
+                        cursorClosed.set(true);
+                    }
+
+                    @Override
+                    public boolean hasNext() {
+                        return !consumed;
+                    }
+
+                    @Override
+                    public BsonDocument next() {
+                        consumed = true;
+                        return new BsonDocument();
+                    }
+
+                    @Override
+                    public int available() {
+                        return hasNext() ? 1 : 0;
+                    }
+
+                    @Override
+                    public BsonDocument tryNext() {
+                        return hasNext() ? next() : null;
+                    }
+
+                    @Override
+                    public ServerCursor getServerCursor() {
+                        return null;
+                    }
+
+                    @Override
+                    public ServerAddress getServerAddress() {
+                        return null;
+                    }
+                };
+
+        when(clientProvider.getDefaultCollection()).thenReturn(collection);
+        when(collection.find(any(BsonDocument.class))).thenReturn(iterable);
+        when(iterable.projection(any(BsonDocument.class))).thenReturn(iterable);
+        when(iterable.batchSize(anyInt())).thenReturn(iterable);
+        when(iterable.noCursorTimeout(anyBoolean())).thenReturn(iterable);
+        when(iterable.maxTime(anyLong(), any(TimeUnit.class))).thenReturn(iterable);
+        when(iterable.iterator()).thenReturn(cursor);
+
+        SourceReader.Context context = mock(SourceReader.Context.class);
+        DocumentDeserializer<SeaTunnelRow> deserializer = mock(DocumentDeserializer.class);
+        Collector<SeaTunnelRow> collector = mock(Collector.class);
+        when(collector.getCheckpointLock()).thenReturn(new Object());
+        when(deserializer.deserialize(any(BsonDocument.class))).thenThrow(deserializationFailure);
+
+        MongodbReader reader =
+                new MongodbReader(
+                        context,
+                        clientProvider,
+                        deserializer,
+                        MongodbReadOptions.builder().build());
+        reader.addSplits(
+                Collections.singletonList(
+                        new MongoSplit("split-1", new BsonDocument(), new BsonDocument(), 0L)));
+
+        RuntimeException actual =
+                assertThrows(RuntimeException.class, () -> reader.pollNext(collector));
+
+        assertSame(deserializationFailure, actual);
+        assertTrue(cursorClosed.get());
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Supersedes #11002 so this release-blocking MongoDB cleanup fix can receive a fresh CI run.

This PR preserves the original functional change and regression test from @preko-p. Its sole commit retains the original Git author metadata:

```
preko06 <istvan.orban@workl.com>
original commit: e7a4b61eb14f78d1e5418dab06ff4d2dbfff93ef
```

When cursor creation fails before `cursor` is assigned, `pollNext()` still executes `closeCurrentSplit()` in its `finally` block. The null guard prevents cleanup from masking the original MongoDB exception with a secondary `NullPointerException`.

### Validation

- Rechecked the patch against the current `apache:dev` baseline; the target cleanup path is unchanged and the test file does not yet exist.
- This branch contains only the original reader cleanup and its two regression tests.
- GitHub CI is required for compile/test/runtime proof.