### PR TITLE
[Fix][Connector-V2][Jdbc] Preserve MySQL and PostgreSQL TIME fractional precision

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlJdbcRowConverter.java
@@ -19,8 +19,10 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql;
 
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.AbstractJdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.utils.JdbcFieldTypeUtils;
 
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -30,6 +32,11 @@ public class MysqlJdbcRowConverter extends AbstractJdbcRowConverter {
     @Override
     public String converterName() {
         return DatabaseIdentifier.MYSQL;
+    }
+
+    @Override
+    protected LocalTime readTime(ResultSet rs, int resultSetIndex) throws SQLException {
+        return JdbcFieldTypeUtils.getLocalTime(rs, resultSetIndex);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverter.java
@@ -46,7 +46,6 @@ import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -71,6 +70,12 @@ public class PostgresJdbcRowConverter extends AbstractJdbcRowConverter {
     @Override
     public String converterName() {
         return DatabaseIdentifier.POSTGRESQL;
+    }
+
+    @Override
+    protected void writeTime(PreparedStatement statement, int index, LocalTime time)
+            throws SQLException {
+        statement.setObject(index, time);
     }
 
     @Override
@@ -145,9 +150,7 @@ public class PostgresJdbcRowConverter extends AbstractJdbcRowConverter {
                             Optional.ofNullable(sqlDate).map(e -> e.toLocalDate()).orElse(null);
                     break;
                 case TIME:
-                    Time sqlTime = JdbcFieldTypeUtils.getTime(rs, resultSetIndex);
-                    fields[fieldIndex] =
-                            Optional.ofNullable(sqlTime).map(e -> e.toLocalTime()).orElse(null);
+                    fields[fieldIndex] = JdbcFieldTypeUtils.getLocalTime(rs, resultSetIndex);
                     break;
                 case TIMESTAMP:
                     // Use getLocalDateTime() which avoids JVM-default-timezone influence.

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/executor/CopyManagerBatchStatementExecutor.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/executor/CopyManagerBatchStatementExecutor.java
@@ -140,7 +140,7 @@ public class CopyManagerBatchStatementExecutor implements JdbcBatchStatementExec
                     break;
                 case TIME:
                     LocalTime localTime = (LocalTime) record.getField(fieldIndex);
-                    csvRecord.add((java.sql.Time) java.sql.Time.valueOf(localTime));
+                    csvRecord.add(localTime.toString());
                     break;
                 case TIMESTAMP:
                     LocalDateTime localDateTime = (LocalDateTime) record.getField(fieldIndex);

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcFieldTypeUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcFieldTypeUtils.java
@@ -22,9 +22,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
@@ -93,6 +96,41 @@ public final class JdbcFieldTypeUtils {
 
     public static Time getTime(ResultSet resultSet, int columnIndex) throws SQLException {
         return resultSet.getTime(columnIndex);
+    }
+
+    /**
+     * Reads a JDBC TIME as LocalTime, falling back from JDBC 4.2 to plain and offset time text.
+     *
+     * <p>MySQL TIME values outside the 24-hour clock range are not representable as LocalTime; a
+     * fallback parse failure is reported as SQLException instead of silently changing the value.
+     */
+    public static LocalTime getLocalTime(ResultSet resultSet, int columnIndex) throws SQLException {
+        try {
+            return resultSet.getObject(columnIndex, LocalTime.class);
+        } catch (SQLException | AbstractMethodError e) {
+            String value = resultSet.getString(columnIndex);
+            if (value == null) {
+                return null;
+            }
+            try {
+                return LocalTime.parse(value.trim());
+            } catch (DateTimeException ignored) {
+                try {
+                    return OffsetTime.parse(value.trim().replaceFirst("([+-]\\d{2})$", "$1:00"))
+                            .toLocalTime();
+                } catch (DateTimeException parseException) {
+                    SQLException exception =
+                            new SQLException(
+                                    "Unable to parse JDBC TIME value at column "
+                                            + columnIndex
+                                            + ": "
+                                            + value,
+                                    e);
+                    exception.addSuppressed(parseException);
+                    throw exception;
+                }
+            }
+        }
     }
 
     public static Timestamp getTimestamp(ResultSet resultSet, int columnIndex) throws SQLException {

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlJdbcRowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/mysql/MysqlJdbcRowConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.mysql;
+
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MysqlJdbcRowConverterTest {
+
+    @Test
+    public void testTimeReadAndWritePreserveMicroseconds() throws Exception {
+        LocalTime expected = LocalTime.parse("12:34:56.123456");
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.builder()
+                                        .name("time_col")
+                                        .dataType(LocalTimeType.LOCAL_TIME_TYPE)
+                                        .build())
+                        .build();
+        MysqlJdbcRowConverter converter = new MysqlJdbcRowConverter();
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getObject(1, LocalTime.class)).thenReturn(expected);
+
+        SeaTunnelRow result = converter.toInternal(resultSet, tableSchema);
+        assertEquals(expected, result.getField(0));
+
+        PreparedStatement statement = mock(PreparedStatement.class);
+        converter.toExternal(tableSchema, new SeaTunnelRow(new Object[] {expected}), statement);
+        ArgumentCaptor<Timestamp> timestamp = ArgumentCaptor.forClass(Timestamp.class);
+        verify(statement).setTimestamp(org.mockito.ArgumentMatchers.eq(1), timestamp.capture());
+        assertEquals(expected.getNano(), timestamp.getValue().getNanos());
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverterTest.java
@@ -35,6 +35,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -158,6 +159,24 @@ public class PostgresJdbcRowConverterTest {
         Assertions.assertNotNull(row);
         Assertions.assertEquals(1, row.getField(0));
         Assertions.assertNull(row.getField(1), "timestamp_tz_col should be null");
+    }
+
+    @Test
+    public void testTimeReadAndWritePreserveMicroseconds() throws SQLException {
+        LocalTime expected = LocalTime.parse("12:34:56.123456");
+        ResultSet rs = mock(ResultSet.class);
+        TableSchema tableSchema =
+                createTableSchema("time_col", LocalTimeType.LOCAL_TIME_TYPE, "time(6)");
+        setupMockResultSet(rs, "INT4", "TIME", 1, expected);
+        when(rs.getObject(2, LocalTime.class)).thenReturn(expected);
+
+        SeaTunnelRow result = converter.toInternal(rs, tableSchema);
+        Assertions.assertEquals(expected, result.getField(1));
+
+        PreparedStatement statement = mock(PreparedStatement.class);
+        converter.toExternal(
+                tableSchema, null, new SeaTunnelRow(new Object[] {1, expected}), statement);
+        verify(statement).setObject(2, expected);
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/executor/CopyManagerBatchStatementExecutorTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/executor/CopyManagerBatchStatementExecutorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.executor;
+
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.apache.commons.csv.CSVPrinter;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CopyManagerBatchStatementExecutorTest {
+
+    @Test
+    public void testTimeValuePreservesMicroseconds() throws Exception {
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.builder()
+                                        .name("time_col")
+                                        .dataType(LocalTimeType.LOCAL_TIME_TYPE)
+                                        .build())
+                        .build();
+        CopyManagerBatchStatementExecutor executor =
+                new CopyManagerBatchStatementExecutor("COPY test", tableSchema);
+        executor.csvPrinter = new CSVPrinter(new StringBuilder(), executor.csvFormat);
+
+        executor.addToBatch(new SeaTunnelRow(new Object[] {LocalTime.parse("12:34:56.123456")}));
+        executor.csvPrinter.flush();
+
+        assertTrue(executor.csvPrinter.getOut().toString().contains("12:34:56.123456"));
+    }
+}

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcFieldTypeUtilsTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/JdbcFieldTypeUtilsTest.java
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -32,6 +34,55 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class JdbcFieldTypeUtilsTest {
+
+    @Test
+    public void testGetLocalTimePreservesMicroseconds() throws SQLException {
+        LocalTime expected = LocalTime.parse("12:34:56.123456");
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject(1, LocalTime.class)).thenReturn(expected);
+
+        assertEquals(expected, JdbcFieldTypeUtils.getLocalTime(rs, 1));
+    }
+
+    @Test
+    public void testGetLocalTimeFallsBackToFractionalText() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject(1, LocalTime.class)).thenThrow(new SQLFeatureNotSupportedException());
+        when(rs.getString(1)).thenReturn("12:34:56.123456");
+
+        assertEquals(LocalTime.parse("12:34:56.123456"), JdbcFieldTypeUtils.getLocalTime(rs, 1));
+    }
+
+    @Test
+    public void testGetLocalTimeFallsBackToOffsetTimeText() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject(1, LocalTime.class)).thenThrow(new SQLException("unsupported time type"));
+        when(rs.getString(1)).thenReturn("12:34:56.123456+08:00");
+
+        assertEquals(LocalTime.parse("12:34:56.123456"), JdbcFieldTypeUtils.getLocalTime(rs, 1));
+    }
+
+    @Test
+    public void testGetLocalTimeFallsBackToShortOffsetTimeText() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject(1, LocalTime.class)).thenThrow(new SQLException("unsupported time type"));
+        when(rs.getString(1)).thenReturn("12:34:56.123456+08");
+
+        assertEquals(LocalTime.parse("12:34:56.123456"), JdbcFieldTypeUtils.getLocalTime(rs, 1));
+    }
+
+    @Test
+    public void testGetLocalTimeReportsUnparseableFallbackTextAsSqlException() throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        SQLException original = new SQLException("unsupported time type");
+        when(rs.getObject(1, LocalTime.class)).thenThrow(original);
+        when(rs.getString(1)).thenReturn("24:00:00");
+
+        SQLException exception =
+                org.junit.jupiter.api.Assertions.assertThrows(
+                        SQLException.class, () -> JdbcFieldTypeUtils.getLocalTime(rs, 1));
+        assertEquals(original, exception.getCause());
+    }
 
     @Test
     public void testGetOffsetDateTimeFromTimestampUsesInstant() throws SQLException {


### PR DESCRIPTION
### Purpose of this pull request

MySQL and PostgreSQL JDBC `TIME` values can lose fractional seconds when they pass through `java.sql.Time`, which stores only whole seconds. This patch uses `LocalTime` for JDBC 4.2 reads and PostgreSQL writes, preserves the textual `LocalTime` value for COPY, and provides text fallbacks for drivers that do not support `getObject(index, LocalTime.class)`.

PostgreSQL 9.6 can expose `timetz` text with a short offset such as `+08`; the fallback normalizes that suffix before parsing while retaining the wall-clock time and fractional seconds.

### Does this PR introduce _any_ user-facing change?

Yes, as a bug fix for MySQL and PostgreSQL JDBC TIME values with fractional seconds, which are now preserved instead of being truncated to whole seconds.

### How was this patch tested?

Added unit coverage for MySQL and PostgreSQL TIME conversion, PostgreSQL TIMETZ fallback handling, PostgreSQL COPY text serialization, and invalid fallback values.

Validated locally with JDK 8 against real databases:

* MySQL 8.0.11: a `TIME(6)` value written and read through `MysqlJdbcRowConverter` remained `12:34:56.123456`.
* PostgreSQL 9.6.8: `time(6)`, `timetz(6)` returned as `12:34:56.123456+08`, and COPY input all preserved `12:34:56.123456` through the connector code.

Focused regression tests after the PostgreSQL short-offset fix: 11 tests run, 0 failures, 0 errors. Spotless check also passed.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation and incompatible-change updates are not required for this bug fix.
* [x] No new connector, plugin mapping, distribution dependency, or connector configuration is required.
