### PR TITLE
[Fix][Connector-V2][Jdbc] Bind PostgreSQL JSON and UUID with native types

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/highgo/HighGoDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/highgo/HighGoDialect.java
@@ -15,25 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dsql;
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.highgo;
 
-import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
-import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresJdbcRowConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresDialect;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+public class HighGoDialect extends PostgresDialect {
 
-public class DsqlJdbcRowConverter extends PostgresJdbcRowConverter {
-
-    @Override
-    public String converterName() {
-        return DatabaseIdentifier.DSQL;
+    public HighGoDialect(String fieldIde) {
+        super(fieldIde);
     }
 
     @Override
-    protected void setJsonOrUuid(
-            PreparedStatement statement, int index, String sourceType, String value)
-            throws SQLException {
-        statement.setString(index, value);
+    public JdbcRowConverter getRowConverter() {
+        return new HighGoJdbcRowConverter();
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/highgo/HighGoDialectFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/highgo/HighGoDialectFactory.java
@@ -17,10 +17,13 @@
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.highgo;
 
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialect;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.JdbcDialectFactory;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresDialectFactory;
 
 import com.google.auto.service.AutoService;
+
+import javax.annotation.Nonnull;
 
 @AutoService(JdbcDialectFactory.class)
 public class HighGoDialectFactory extends PostgresDialectFactory {
@@ -32,5 +35,10 @@ public class HighGoDialectFactory extends PostgresDialectFactory {
     @Override
     public boolean acceptsURL(String url) {
         return url.startsWith("jdbc:highgo:");
+    }
+
+    @Override
+    public JdbcDialect create(@Nonnull String compatibleMode, String fieldIde) {
+        return new HighGoDialect(fieldIde);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/highgo/HighGoJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/highgo/HighGoJdbcRowConverter.java
@@ -15,20 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dsql;
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.highgo;
 
-import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresJdbcRowConverter;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-public class DsqlJdbcRowConverter extends PostgresJdbcRowConverter {
-
-    @Override
-    public String converterName() {
-        return DatabaseIdentifier.DSQL;
-    }
+public class HighGoJdbcRowConverter extends PostgresJdbcRowConverter {
 
     @Override
     protected void setJsonOrUuid(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/opengauss/OpenGaussDialect.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/opengauss/OpenGaussDialect.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.opengauss;
 
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresDialect;
 
 import java.util.Arrays;
@@ -24,6 +25,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class OpenGaussDialect extends PostgresDialect {
+
+    @Override
+    public JdbcRowConverter getRowConverter() {
+        return new OpenGaussJdbcRowConverter();
+    }
 
     @Override
     public Optional<String> getUpsertStatement(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/opengauss/OpenGaussJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/opengauss/OpenGaussJdbcRowConverter.java
@@ -15,20 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dsql;
+package org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.opengauss;
 
-import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.DatabaseIdentifier;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresJdbcRowConverter;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-public class DsqlJdbcRowConverter extends PostgresJdbcRowConverter {
-
-    @Override
-    public String converterName() {
-        return DatabaseIdentifier.DSQL;
-    }
+public class OpenGaussJdbcRowConverter extends PostgresJdbcRowConverter {
 
     @Override
     protected void setJsonOrUuid(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverter.java
@@ -62,8 +62,11 @@ import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.ps
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_GEOMETRY;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_INET;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_INTERVAL;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_JSON;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_JSONB;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_MAC_ADDR;
 import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_MAC_ADDR8;
+import static org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.psql.PostgresTypeConverter.PG_UUID;
 
 @Slf4j
 public class PostgresJdbcRowConverter extends AbstractJdbcRowConverter {
@@ -238,6 +241,14 @@ public class PostgresJdbcRowConverter extends AbstractJdbcRowConverter {
                             networkTypeObject.setType(sourceType);
                             networkTypeObject.setValue(String.valueOf(row.getField(fieldIndex)));
                             statement.setObject(statementIndex, networkTypeObject);
+                        } else if (PG_JSON.equalsIgnoreCase(sourceType)
+                                || PG_JSONB.equalsIgnoreCase(sourceType)
+                                || PG_UUID.equalsIgnoreCase(sourceType)) {
+                            setJsonOrUuid(
+                                    statement,
+                                    statementIndex,
+                                    sourceType,
+                                    String.valueOf(row.getField(fieldIndex)));
                         } else if (PG_INTERVAL.equalsIgnoreCase(sourceType)) {
                             PGobject intervalObject = new PGobject();
                             intervalObject.setType(PG_INTERVAL);
@@ -454,6 +465,15 @@ public class PostgresJdbcRowConverter extends AbstractJdbcRowConverter {
             return null;
         }
         return parsePostgresTimestampTz(str);
+    }
+
+    protected void setJsonOrUuid(
+            PreparedStatement statement, int index, String sourceType, String value)
+            throws SQLException {
+        PGobject typedObject = new PGobject();
+        typedObject.setType(sourceType.toLowerCase(Locale.ROOT));
+        typedObject.setValue(value);
+        statement.setObject(index, typedObject);
     }
 
     private String normalizeIsoTimestamp(String value) {

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/psql/PostgresJdbcRowConverterTest.java
@@ -24,6 +24,9 @@ import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dsql.DsqlJdbcRowConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.highgo.HighGoJdbcRowConverter;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.opengauss.OpenGaussJdbcRowConverter;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,6 +104,56 @@ public class PostgresJdbcRowConverterTest {
         Assertions.assertEquals(hour, offsetDateTime.getHour());
         Assertions.assertEquals(minute, offsetDateTime.getMinute());
         Assertions.assertEquals(offset, offsetDateTime.getOffset());
+    }
+
+    private void assertPostgresTypedObject(String sourceType, String value) throws SQLException {
+        TableSchema tableSchema = createTableSchema("value", BasicType.STRING_TYPE, null);
+        TableSchema databaseTableSchema =
+                createTableSchema("value", BasicType.STRING_TYPE, sourceType);
+        PreparedStatement statement = mock(PreparedStatement.class);
+
+        converter.toExternal(
+                tableSchema,
+                databaseTableSchema,
+                new SeaTunnelRow(new Object[] {1, value}),
+                statement);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(statement).setObject(eq(2), captor.capture());
+        Object valueObject = captor.getValue();
+        Assertions.assertTrue(valueObject instanceof PGobject);
+        PGobject object = (PGobject) valueObject;
+        Assertions.assertEquals(sourceType, object.getType());
+        Assertions.assertEquals(value, object.getValue());
+    }
+
+    private void assertStringBinding(PostgresJdbcRowConverter rowConverter) throws SQLException {
+        TableSchema tableSchema = createTableSchema("value", BasicType.STRING_TYPE, null);
+        TableSchema databaseTableSchema = createTableSchema("value", BasicType.STRING_TYPE, "json");
+        PreparedStatement statement = mock(PreparedStatement.class);
+
+        rowConverter.toExternal(
+                tableSchema,
+                databaseTableSchema,
+                new SeaTunnelRow(new Object[] {1, "{\"key\":\"value\"}"}),
+                statement);
+
+        verify(statement).setString(2, "{\"key\":\"value\"}");
+    }
+
+    @Test
+    public void testOpenGaussJsonUsesStringBinding() throws SQLException {
+        assertStringBinding(new OpenGaussJdbcRowConverter());
+    }
+
+    @Test
+    public void testDsqlJsonUsesStringBinding() throws SQLException {
+        assertStringBinding(new DsqlJdbcRowConverter());
+    }
+
+    @Test
+    public void testHighGoJsonUsesStringBinding() throws SQLException {
+        assertStringBinding(new HighGoJdbcRowConverter());
     }
 
     @Test
@@ -279,5 +332,20 @@ public class PostgresJdbcRowConverterTest {
         PGobject pg = (PGobject) arg;
         Assertions.assertEquals("geography", pg.getType());
         Assertions.assertEquals("0102FF", pg.getValue());
+    }
+
+    @Test
+    public void testToExternalWithPostgresJsonTargetType() throws SQLException {
+        assertPostgresTypedObject("json", "{\"id\":1}");
+    }
+
+    @Test
+    public void testToExternalWithPostgresJsonbTargetType() throws SQLException {
+        assertPostgresTypedObject("jsonb", "{\"id\":1}");
+    }
+
+    @Test
+    public void testToExternalWithPostgresUuidTargetType() throws SQLException {
+        assertPostgresTypedObject("uuid", "550e8400-e29b-41d4-a716-446655440000");
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

PostgreSQL `json`, `jsonb`, and `uuid` columns can be represented as SeaTunnel strings. Binding those values with `setString` makes the driver infer a varchar parameter, which can fail for prepared statements where PostgreSQL cannot infer the intended native type.

This patch binds these source types as typed `PGobject` values so the PostgreSQL JDBC driver receives the correct `json`, `jsonb`, or `uuid` parameter type. PostgreSQL-compatible dialects that use their own JDBC drivers (OpenGauss, DSQL, and HighGo) retain the previous string binding and do not require pgjdbc on the engine classpath.

### Does this PR introduce _any_ user-facing change?

Yes, as a bug fix. JDBC sink writes to PostgreSQL JSON, JSONB, and UUID columns now use native PostgreSQL parameter types rather than varchar inference.

### How was this patch tested?

Added `PostgresJdbcRowConverterTest` coverage that verifies typed PostgreSQL binding for `json`, `jsonb`, and `uuid`, and verifies string binding remains in the OpenGauss, DSQL, and HighGo converter paths.

Validated locally with JDK 8 against PostgreSQL 9.6.8: the connector converter inserted JSON, JSONB, and UUID values into native columns; `pg_typeof` returned `json`, `jsonb`, and `uuid`, and the stored JSON fields and UUID matched the input.

Focused unit test result: 16 tests run, 0 failures, 0 errors. Spotless check also passed.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation and incompatible-change updates are not required for this bug fix.
* [x] No new connector, plugin mapping, distribution dependency, or connector configuration is required.