### PR TITLE
[Fix][Connector-V2][Jdbc] Handle empty sink primary keys

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSink.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSink.java
@@ -34,6 +34,7 @@ import org.apache.seatunnel.api.sink.SupportSaveMode;
 import org.apache.seatunnel.api.sink.SupportSchemaEvolutionSink;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.catalog.exception.TableNotExistException;
@@ -141,14 +142,7 @@ public class JdbcSink
                             new ArrayList<>());
 
         } else {
-            Integer primaryKeyIndex = null;
-            if (catalogTable.getTableSchema().getPrimaryKey() != null) {
-                String keyName = tableSchema.getPrimaryKey().getColumnNames().get(0);
-                int index = tableSchema.toPhysicalRowDataType().indexOf(keyName);
-                if (index > -1) {
-                    primaryKeyIndex = index;
-                }
-            }
+            Integer primaryKeyIndex = getPrimaryKeyIndex(tableSchema).orElse(null);
             sinkWriter =
                     new JdbcSinkWriter(
                             sinkTablePath,
@@ -160,6 +154,17 @@ public class JdbcSink
                             primaryKeyIndex);
         }
         return sinkWriter;
+    }
+
+    static Optional<Integer> getPrimaryKeyIndex(TableSchema tableSchema) {
+        PrimaryKey primaryKey = tableSchema.getPrimaryKey();
+        if (primaryKey == null
+                || primaryKey.getColumnNames() == null
+                || primaryKey.getColumnNames().isEmpty()) {
+            return Optional.empty();
+        }
+        int index = tableSchema.toPhysicalRowDataType().indexOf(primaryKey.getColumnNames().get(0));
+        return index > -1 ? Optional.of(index) : Optional.empty();
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.jdbc.sink;
+
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+class JdbcSinkTest {
+
+    @Test
+    void getPrimaryKeyIndexReturnsEmptyForPrimaryKeyWithoutColumns() {
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.builder()
+                                        .name("id")
+                                        .dataType(BasicType.INT_TYPE)
+                                        .build())
+                        .primaryKey(PrimaryKey.of("empty_pk", Collections.emptyList()))
+                        .build();
+
+        Assertions.assertFalse(JdbcSink.getPrimaryKeyIndex(tableSchema).isPresent());
+    }
+
+    @Test
+    void getPrimaryKeyIndexReturnsEmptyForPrimaryKeyWithNullColumns() {
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.builder()
+                                        .name("id")
+                                        .dataType(BasicType.INT_TYPE)
+                                        .build())
+                        .primaryKey(PrimaryKey.of("null_pk", null))
+                        .build();
+
+        Assertions.assertFalse(JdbcSink.getPrimaryKeyIndex(tableSchema).isPresent());
+    }
+
+    @Test
+    void getPrimaryKeyIndexReturnsFirstPrimaryKeyColumnIndex() {
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.builder()
+                                        .name("name")
+                                        .dataType(BasicType.STRING_TYPE)
+                                        .build())
+                        .column(
+                                PhysicalColumn.builder()
+                                        .name("id")
+                                        .dataType(BasicType.INT_TYPE)
+                                        .build())
+                        .primaryKey(PrimaryKey.of("id_pk", Collections.singletonList("id")))
+                        .build();
+
+        Assertions.assertEquals(1, JdbcSink.getPrimaryKeyIndex(tableSchema).get());
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

`JdbcSink.createWriter()` assumes that every non-null primary-key object has at least one column name. Schema metadata can instead contain an empty or null primary-key column list, causing sink writer creation to fail before any JDBC statement is executed.

This patch centralizes primary-key index lookup and treats absent, empty, null, or unknown primary-key columns as no primary-key index.

### Does this PR introduce _any_ user-facing change?

Yes, as a bug fix. JDBC sink writer creation no longer fails when upstream schema metadata reports a primary key without usable column names.

### How was this patch tested?

Added `JdbcSinkTest` coverage for empty and null primary-key column lists, plus the normal first-primary-key-column lookup.

Ran focused connector-JDBC unit tests locally with JDK 8:

```shell
./mvnw -pl seatunnel-connectors-v2/connector-jdbc -am \
  -Dtest=JdbcSinkTest \
  -DfailIfNoTests=false test
```

Result: 3 tests run, 0 failures, 0 errors.

A database E2E is not required because the failure occurs while deriving the writer schema before JDBC statements are created.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation and incompatible-change updates are not required for this bug fix.
* [x] No new connector, plugin mapping, distribution dependency, or connector configuration is required.
