### PR TITLE
[Fix][Zeta] Make job status parsing locale independent

### DIFF
--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobStatus.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/job/JobStatus.java
@@ -18,6 +18,8 @@
 
 package org.apache.seatunnel.engine.common.job;
 
+import java.util.Locale;
+
 /** Possible states of a job once it has been accepted by the dispatcher. */
 public enum JobStatus {
     /**
@@ -84,6 +86,6 @@ public enum JobStatus {
     }
 
     public static JobStatus fromString(String status) {
-        return JobStatus.valueOf(status.toUpperCase());
+        return JobStatus.valueOf(status.toUpperCase(Locale.ROOT));
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.common.job;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JobStatusTest {
+
+    @Test
+    @ResourceLock("default-locale")
+    void testFromStringUsesLocaleIndependentCaseConversion() {
+        Locale originalLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            assertEquals(JobStatus.FINISHED, JobStatus.fromString("finished"));
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

`JobStatus.fromString` currently uppercases status values with the JVM default locale. Under a Turkish default locale, `finished` becomes `FİNİSHED`, so `JobStatus.valueOf` throws an `IllegalArgumentException`.

This patch uses `Locale.ROOT` for locale-independent enum parsing and adds a regression test that exercises the Turkish-locale case.

### Does this PR introduce _any_ user-facing change?

Yes. Lowercase job status values are now parsed consistently regardless of the JVM default locale. Behavior in locales unaffected by special case mappings remains unchanged.

### How was this patch tested?

A regression test was added in `JobStatusTest` and was verified to fail before the fix with `No enum constant ... JobStatus.FİNİSHED`.

The following checks pass:

```shell
./mvnw -q -pl seatunnel-engine/seatunnel-engine-common -am -Dtest=JobStatusTest -Dsurefire.failIfNoSpecifiedTests=false -Dskip.spotless=true test
./mvnw -q spotless:apply
CYPRESS_INSTALL_BINARY=0 ./mvnw -q -DskipTests verify
```

`CYPRESS_INSTALL_BINARY=0` only skips downloading the Cypress browser binary, which is not used by the `-DskipTests` verification.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation changes are not necessary for this internal parsing correction.
* [x] This change is backward compatible and does not require an `incompatible-changes.md` entry.
* [x] This is not connector code.
