### PR TITLE
[Feature][Connector-V2][Hive] Support AWS Glue Data Catalog metastore

### DIFF
--- a/docs/en/connectors/sink/Hive.md
+++ b/docs/en/connectors/sink/Hive.md
@@ -42,7 +42,7 @@ By default, we use 2PC commit to ensure `exactly-once`
 | name                                  | type    | required | default value  | description |
 |---------------------------------------|---------|----------|----------------|-------------|
 | table_name                            | string  | yes      | -              | Target Hive table name, e.g. `db1.table1`. For multi-table mode, you can use `${database_name}.${table_name}` and SeaTunnel will substitute the upstream values. |
-| metastore_uri                         | string  | yes      | -              | Hive metastore URI. Comma-separated values enable HA failover. |
+| metastore_uri                         | string  | no       | -              | Hive metastore URI. Required unless `hive.metastore.client.factory.class` is configured through `hive_site_path`, `hive.hadoop.conf-path`, or `hive.hadoop.conf`. Comma-separated values enable HA failover. |
 | compress_codec                        | string  | no       | none           | Output compression codec. `lzo` and `none` are supported. Parquet / ORC auto-detect compression. |
 | hdfs_site_path                        | string  | no       | -              | Local path of `hdfs-site.xml`. Deprecated for new jobs — prefer `hive.hadoop.conf` or `hive.hadoop.conf-path`. |
 | hive_site_path                        | string  | no       | -              | Local path of `hive-site.xml`. |
@@ -67,6 +67,31 @@ Target Hive table name eg: db1.table1, and if the source is multiple mode, you c
 ### metastore_uri [string]
 
 Hive metastore uri. Supports comma-separated multiple URIs for HA/failover (whitespace is ignored). SeaTunnel passes this value to Hive `hive.metastore.uris` and uses Hive `RetryingMetaStoreClient` (if available) to retry/failover between URIs. This is client-side endpoint failover; make sure your metastores share/replicate the same backend to keep metadata consistent.
+
+This option can be omitted when `hive.metastore.client.factory.class` selects an external metastore client through `hive_site_path`, `hive.hadoop.conf-path`, or `hive.hadoop.conf`. SeaTunnel does not fall back to an embedded metastore when neither a URI nor a client factory is configured.
+
+### AWS Glue Data Catalog
+
+AWS Glue Data Catalog can be used through the standard Hive metastore client factory:
+
+```hocon
+sink {
+  Hive {
+    table_name = "default.seatunnel_parquet"
+    hive.hadoop.conf = {
+      "hive.metastore.client.factory.class" = "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+      # Optional when accessing a catalog in another AWS account
+      # "hive.metastore.glue.catalogid" = "123456789012"
+    }
+  }
+}
+```
+
+The AWS Glue Data Catalog client and a compatible patched Hive runtime must be available on every SeaTunnel process that creates or uses the Hive sink. Amazon EMR distributions that support Glue include these components, but they must still be visible to the SeaTunnel runtime classpath. For other deployments, install a mutually compatible Hive runtime and AWS Glue Data Catalog client.
+
+Authentication is handled by the AWS SDK default credential provider chain. Use the IAM role, web identity, container credentials, instance profile, environment, or shared configuration supported by the runtime instead of placing access keys in the SeaTunnel job configuration.
+
+If the configured factory class or its compatible Hive classes are missing, sink initialization fails without falling back to a local metastore.
 
 ### hdfs_site_path [string]
 

--- a/docs/zh/connectors/sink/Hive.md
+++ b/docs/zh/connectors/sink/Hive.md
@@ -36,7 +36,7 @@ import ChangeLog from '../changelog/connector-hive.md';
 | 名称                                    | 类型      | 必需 | 默认值            |
 |---------------------------------------|---------|----|----------------|
 | table_name                            | string  | 是  | -              |
-| metastore_uri                         | string  | 是  | -              |
+| metastore_uri                         | string  | 否  | -              |
 | compress_codec                        | string  | 否  | none           |
 | hdfs_site_path                        | string  | 否  | -              |
 | hive_site_path                        | string  | 否  | -              |
@@ -61,6 +61,31 @@ import ChangeLog from '../changelog/connector-hive.md';
 ### metastore_uri [string]
 
 Hive 元存储 URI。支持通过逗号分隔配置多个 URI 用于高可用/故障切换（会自动去除空格）。SeaTunnel 会将该值写入 Hive 的 `hive.metastore.uris`，并在运行时优先使用 Hive 的 `RetryingMetaStoreClient` 实现重试/切换。注意：该能力仅做客户端连接端点切换，元数据一致性需要由 metastore 部署保证。
+
+通过 `hive_site_path`、`hive.hadoop.conf-path` 或 `hive.hadoop.conf` 配置 `hive.metastore.client.factory.class` 时，可以省略此选项。如果 URI 和客户端工厂均未配置，SeaTunnel 不会回退到内嵌 metastore。
+
+### AWS Glue Data Catalog
+
+可以通过 Hive 标准的 metastore 客户端工厂使用 AWS Glue Data Catalog：
+
+```hocon
+sink {
+  Hive {
+    table_name = "default.seatunnel_parquet"
+    hive.hadoop.conf = {
+      "hive.metastore.client.factory.class" = "com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory"
+      # 跨 AWS 账号访问 Data Catalog 时可配置
+      # "hive.metastore.glue.catalogid" = "123456789012"
+    }
+  }
+}
+```
+
+所有创建或使用 Hive Sink 的 SeaTunnel 进程都必须能够从运行时 classpath 加载 AWS Glue Data Catalog 客户端和兼容的已修补 Hive 运行时。支持 Glue 的 Amazon EMR 发行版包含这些组件，但仍需确保 SeaTunnel 进程能够加载它们。其他部署需要安装相互兼容的 Hive 运行时和 AWS Glue Data Catalog 客户端。
+
+认证使用 AWS SDK 默认凭据提供链。请使用运行环境支持的 IAM Role、Web Identity、容器凭据、实例配置文件、环境变量或共享配置，不要在 SeaTunnel 作业配置中填写访问密钥。
+
+如果无法加载配置的工厂类或其兼容 Hive 类，Sink 初始化会直接失败，不会回退到本地 metastore。
 
 ### hdfs_site_path [string]
 

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/sink/HiveSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/sink/HiveSinkFactory.java
@@ -44,7 +44,8 @@ public class HiveSinkFactory
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .required(HiveSinkOptions.TABLE_NAME)
-                .required(HiveSinkOptions.METASTORE_URI)
+                .optional(HiveSinkOptions.METASTORE_URI)
+                .optional(HiveSinkOptions.HIVE_SITE_PATH)
                 .optional(HiveSinkOptions.ABORT_DROP_PARTITION_METADATA)
                 .optional(HiveSinkOptions.KERBEROS_PRINCIPAL)
                 .optional(HiveSinkOptions.KERBEROS_KEYTAB_PATH)

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreCatalog.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreCatalog.java
@@ -35,6 +35,7 @@ import org.apache.seatunnel.connectors.seatunnel.hive.exception.HiveConnectorExc
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
@@ -50,6 +51,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -60,8 +62,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * HiveMetaStoreCatalog implements the SeaTunnel Catalog interface. Provides Hive Metastore database
@@ -72,12 +77,14 @@ public class HiveMetaStoreCatalog implements Catalog, Closeable, Serializable {
     private static final List<String> HADOOP_CONF_FILES = ImmutableList.of("hive-site.xml");
     private static final String RETRYING_METASTORE_CLIENT_CLASS_NAME =
             "org.apache.hadoop.hive.metastore.RetryingMetaStoreClient";
+    static final String METASTORE_CLIENT_FACTORY_CLASS = "hive.metastore.client.factory.class";
     private static final String RETRYING_METASTORE_CLIENT_NO_COMPATIBLE_GET_PROXY_MESSAGE =
             "RetryingMetaStoreClient found but no compatible getProxy method, falling back to HiveMetaStoreClient";
 
     private final String metastoreUri;
     private final String hadoopConfDir;
     private final String hiveSitePath;
+    private final Map<String, String> hadoopProperties;
     private final boolean kerberosEnabled;
     private final boolean remoteUserEnabled;
 
@@ -94,6 +101,9 @@ public class HiveMetaStoreCatalog implements Catalog, Closeable, Serializable {
         this.metastoreUri = config.get(HiveBaseOptions.METASTORE_URI);
         this.hadoopConfDir = config.get(HiveBaseOptions.HADOOP_CONF_PATH);
         this.hiveSitePath = config.get(HiveBaseOptions.HIVE_SITE_PATH);
+        Map<String, String> configuredProperties = config.get(HiveBaseOptions.HADOOP_CONF);
+        this.hadoopProperties =
+                configuredProperties == null ? Collections.emptyMap() : configuredProperties;
         this.kerberosEnabled = HiveMetaStoreProxyUtils.enableKerberos(config);
         this.remoteUserEnabled = HiveMetaStoreProxyUtils.enableRemoteUser(config);
         this.krb5Path = config.get(HiveBaseOptions.KRB5_PATH);
@@ -141,11 +151,74 @@ public class HiveMetaStoreCatalog implements Catalog, Closeable, Serializable {
     }
 
     private IMetaStoreClient createClient(HiveConf hiveConf) throws Exception {
+        String clientFactoryClassName = hiveConf.getTrimmed(METASTORE_CLIENT_FACTORY_CLASS);
+        if (StringUtils.isNotBlank(clientFactoryClassName)) {
+            return createClientFromFactory(hiveConf, clientFactoryClassName);
+        }
+        if (StringUtils.isBlank(hiveConf.getTrimmed("hive.metastore.uris"))) {
+            throw new IllegalArgumentException(
+                    "Either metastore_uri or hive.metastore.client.factory.class must be configured");
+        }
         IMetaStoreClient retryingClient = tryCreateRetryingClient(hiveConf);
         if (retryingClient != null) {
             return retryingClient;
         }
         return new HiveMetaStoreClient(hiveConf);
+    }
+
+    private IMetaStoreClient createClientFromFactory(
+            HiveConf hiveConf, String clientFactoryClassName) {
+        try {
+            Class<?> factoryClass = loadClass(clientFactoryClassName, hiveConf);
+            Object factory = factoryClass.getDeclaredConstructor().newInstance();
+            Method createClientMethod =
+                    factoryClass.getMethod(
+                            "createMetaStoreClient",
+                            HiveConf.class,
+                            HiveMetaHookLoader.class,
+                            boolean.class,
+                            ConcurrentHashMap.class);
+            HiveMetaHookLoader hookLoader = tableName -> null;
+            Object client =
+                    createClientMethod.invoke(
+                            factory,
+                            hiveConf,
+                            hookLoader,
+                            false,
+                            new ConcurrentHashMap<String, Long>());
+            if (!(client instanceof IMetaStoreClient)) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Hive metastore client factory %s returned an incompatible client",
+                                clientFactoryClassName));
+            }
+            log.info("Using Hive metastore client factory {}", clientFactoryClassName);
+            return (IMetaStoreClient) client;
+        } catch (InvocationTargetException e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Hive metastore client factory %s failed to create a client",
+                            clientFactoryClassName),
+                    e.getCause());
+        } catch (ReflectiveOperationException | LinkageError e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unable to load Hive metastore client factory %s. Make sure the factory and compatible Hive classes are available on the runtime classpath",
+                            clientFactoryClassName),
+                    e);
+        }
+    }
+
+    private static Class<?> loadClass(String className, HiveConf hiveConf)
+            throws ClassNotFoundException {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        if (contextClassLoader != null) {
+            try {
+                return Class.forName(className, true, contextClassLoader);
+            } catch (ClassNotFoundException ignored) {
+            }
+        }
+        return hiveConf.getClassByName(className);
     }
 
     private IMetaStoreClient tryCreateRetryingClient(HiveConf hiveConf) {
@@ -311,6 +384,7 @@ public class HiveMetaStoreCatalog implements Catalog, Closeable, Serializable {
                 log.warn("Invalid hiveSitePath {}", hiveSitePath, e);
             }
         }
+        hadoopProperties.forEach(hiveConf::set);
         log.debug("Hive client configuration initialized");
         return hiveConf;
     }

--- a/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreCatalog.java
+++ b/seatunnel-connectors-v2/connector-hive/src/main/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreCatalog.java
@@ -166,6 +166,9 @@ public class HiveMetaStoreCatalog implements Catalog, Closeable, Serializable {
         return new HiveMetaStoreClient(hiveConf);
     }
 
+    /**
+     * Creates a metastore client through the Hive 3 factory contract used by AWS Glue Data Catalog.
+     */
     private IMetaStoreClient createClientFromFactory(
             HiveConf hiveConf, String clientFactoryClassName) {
         try {
@@ -209,6 +212,10 @@ public class HiveMetaStoreCatalog implements Catalog, Closeable, Serializable {
         }
     }
 
+    /**
+     * Resolves an optional metastore factory from the runtime context before falling back to Hive's
+     * configured class loader.
+     */
     private static Class<?> loadClass(String className, HiveConf hiveConf)
             throws ClassNotFoundException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/sink/HiveSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/sink/HiveSinkFactoryTest.java
@@ -248,6 +248,10 @@ public class HiveSinkFactoryTest {
                 factory.optionRule()
                         .getOptionalOptions()
                         .contains(HiveSinkOptions.SAVE_MODE_CREATE_TEMPLATE));
+        assertTrue(
+                factory.optionRule().getOptionalOptions().contains(HiveSinkOptions.METASTORE_URI));
+        assertTrue(
+                factory.optionRule().getOptionalOptions().contains(HiveSinkOptions.HIVE_SITE_PATH));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreCatalogClientFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-hive/src/test/java/org/apache/seatunnel/connectors/seatunnel/hive/utils/HiveMetaStoreCatalogClientFactoryTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.hive.utils;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.catalog.exception.CatalogException;
+import org.apache.seatunnel.connectors.seatunnel.hive.config.HiveBaseOptions;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HiveMetaStoreCatalogClientFactoryTest {
+
+    @TempDir private Path temporaryDirectory;
+
+    @AfterEach
+    void resetFactory() {
+        TestingMetaStoreClientFactory.reset();
+    }
+
+    @Test
+    void testCreateClientFromConfiguredFactory() throws Exception {
+        Map<String, String> hadoopProperties = new HashMap<>();
+        hadoopProperties.put(
+                HiveMetaStoreCatalog.METASTORE_CLIENT_FACTORY_CLASS,
+                TestingMetaStoreClientFactory.class.getName());
+        hadoopProperties.put("hive.metastore.glue.catalogid", "123456789012");
+        try (HiveMetaStoreCatalog catalog = createCatalog(null, hadoopProperties)) {
+            catalog.open();
+        }
+
+        assertNotNull(TestingMetaStoreClientFactory.hiveConf);
+        assertNotNull(TestingMetaStoreClientFactory.hookLoader);
+        assertFalse(TestingMetaStoreClientFactory.allowEmbedded);
+        assertNotNull(TestingMetaStoreClientFactory.metaCallTimeMap);
+        assertEquals(
+                "123456789012",
+                TestingMetaStoreClientFactory.hiveConf.get("hive.metastore.glue.catalogid"));
+    }
+
+    @Test
+    void testConfiguredFactoryTakesPriorityOverMetastoreUri() throws Exception {
+        Map<String, String> hadoopProperties = new HashMap<>();
+        hadoopProperties.put(
+                HiveMetaStoreCatalog.METASTORE_CLIENT_FACTORY_CLASS,
+                TestingMetaStoreClientFactory.class.getName());
+        try (HiveMetaStoreCatalog catalog =
+                createCatalog("thrift://hive-metastore:9083", hadoopProperties)) {
+            catalog.open();
+        }
+
+        assertTrue(TestingMetaStoreClientFactory.created);
+    }
+
+    @Test
+    void testCreateClientFromHiveSite() throws Exception {
+        Path hiveSite = temporaryDirectory.resolve("hive-site.xml");
+        Files.write(
+                hiveSite,
+                Arrays.asList(
+                        "<configuration>",
+                        "  <property>",
+                        "    <name>hive.metastore.client.factory.class</name>",
+                        "    <value>" + TestingMetaStoreClientFactory.class.getName() + "</value>",
+                        "  </property>",
+                        "</configuration>"));
+        Map<String, Object> options = new HashMap<>();
+        options.put(HiveBaseOptions.HIVE_SITE_PATH.key(), hiveSite.toString());
+        try (HiveMetaStoreCatalog catalog =
+                new HiveMetaStoreCatalog(ReadonlyConfig.fromMap(options))) {
+            catalog.open();
+        }
+
+        assertEquals(
+                TestingMetaStoreClientFactory.class.getName(),
+                TestingMetaStoreClientFactory.hiveConf.get(
+                        HiveMetaStoreCatalog.METASTORE_CLIENT_FACTORY_CLASS));
+    }
+
+    @Test
+    void testMissingFactoryDoesNotFallBackToEmbeddedMetastore() throws Exception {
+        Map<String, String> hadoopProperties = new HashMap<>();
+        hadoopProperties.put(
+                HiveMetaStoreCatalog.METASTORE_CLIENT_FACTORY_CLASS,
+                "org.apache.seatunnel.hive.MissingMetaStoreClientFactory");
+        HiveMetaStoreCatalog catalog = createCatalog(null, hadoopProperties);
+
+        CatalogException exception = assertThrows(CatalogException.class, catalog::open);
+
+        assertTrue(rootCause(exception) instanceof ClassNotFoundException);
+        assertTrue(hasCauseMessage(exception, "MissingMetaStoreClientFactory"));
+    }
+
+    @Test
+    void testMissingMetastoreConfigurationDoesNotUseEmbeddedMetastore() throws Exception {
+        HiveMetaStoreCatalog catalog = createCatalog(null, new HashMap<>());
+
+        CatalogException exception = assertThrows(CatalogException.class, catalog::open);
+
+        assertTrue(rootCause(exception) instanceof IllegalArgumentException);
+        assertTrue(
+                hasCauseMessage(exception, "metastore_uri or hive.metastore.client.factory.class"));
+    }
+
+    private static HiveMetaStoreCatalog createCatalog(
+            String metastoreUri, Map<String, String> hadoopProperties) {
+        Map<String, Object> options = new HashMap<>();
+        if (metastoreUri != null) {
+            options.put(HiveBaseOptions.METASTORE_URI.key(), metastoreUri);
+        }
+        options.put(HiveBaseOptions.HADOOP_CONF.key(), hadoopProperties);
+        return new HiveMetaStoreCatalog(ReadonlyConfig.fromMap(options));
+    }
+
+    private static Throwable rootCause(Throwable throwable) {
+        Throwable cause = throwable;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+
+    private static boolean hasCauseMessage(Throwable throwable, String message) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (cause.getMessage() != null && cause.getMessage().contains(message)) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    public static class TestingMetaStoreClientFactory {
+        private static final IMetaStoreClient CLIENT =
+                (IMetaStoreClient)
+                        Proxy.newProxyInstance(
+                                IMetaStoreClient.class.getClassLoader(),
+                                new Class<?>[] {IMetaStoreClient.class},
+                                (proxy, method, arguments) -> null);
+
+        private static HiveConf hiveConf;
+        private static HiveMetaHookLoader hookLoader;
+        private static boolean allowEmbedded;
+        private static ConcurrentHashMap<String, Long> metaCallTimeMap;
+        private static boolean created;
+
+        public IMetaStoreClient createMetaStoreClient(
+                HiveConf hiveConf,
+                HiveMetaHookLoader hookLoader,
+                boolean allowEmbedded,
+                ConcurrentHashMap<String, Long> metaCallTimeMap) {
+            TestingMetaStoreClientFactory.hiveConf = hiveConf;
+            TestingMetaStoreClientFactory.hookLoader = hookLoader;
+            TestingMetaStoreClientFactory.allowEmbedded = allowEmbedded;
+            TestingMetaStoreClientFactory.metaCallTimeMap = metaCallTimeMap;
+            TestingMetaStoreClientFactory.created = true;
+            return CLIENT;
+        }
+
+        private static void reset() {
+            hiveConf = null;
+            hookLoader = null;
+            allowEmbedded = false;
+            metaCallTimeMap = null;
+            created = false;
+        }
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Closes #9856.

- Allow Hive sink configuration without `metastore_uri` when `hive.metastore.client.factory.class` is configured.
- Create the metastore client through the standard Hive client factory contract.
- Load factory and catalog properties from `hive_site_path`, `hive.hadoop.conf-path`, or `hive.hadoop.conf`.
- Keep the existing Thrift metastore path unchanged.
- Fail during catalog initialization when neither route is configured or the factory classes are unavailable.
- Document AWS Glue Data Catalog setup in English and Chinese.

### Does this PR introduce _any_ user-facing change?

Yes.

Hive sink can now use AWS Glue Data Catalog, or another compatible Hive metastore client factory, without a Thrift `metastore_uri`.

The configured client factory and its compatible Hive runtime classes must be available on the SeaTunnel runtime classpath. Authentication remains with the client implementation. The AWS Glue client uses the AWS SDK default credential provider chain.

Existing `metastore_uri` configurations continue to use the current Thrift client path.

### How was this patch tested?

Added coverage for inline factory configuration, `hive-site.xml` configuration, factory precedence over a Thrift URI, missing factory classes, missing metastore configuration, and Hive sink option exposure.

Focused tests:

```shell
./mvnw -pl seatunnel-connectors-v2/connector-hive -Dtest=HiveMetaStoreCatalogClientFactoryTest,HiveSinkFactoryTest test
```

The full Hive connector package was also verified on Java 11. All 98 tests passed.

### Check list

* [x] No new Jar binary package is added.
* [x] English and Chinese Hive sink documentation is updated.
* [x] No incompatible change is introduced.
* [x] This extends the existing Hive connector, so connector registration and distribution files do not need changes.