### PR TITLE
[Feature][Zeta] Add selectable live metrics chart for running jobs

### DIFF
--- a/seatunnel-engine/seatunnel-engine-ui/package-lock.json
+++ b/seatunnel-engine/seatunnel-engine-ui/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.7.7",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.1.3",
+        "echarts": "^6.1.0",
         "naive-ui": "^2.39.0",
         "nprogress": "^0.2.0",
         "pinia": "^2.1.7",
@@ -4071,6 +4072,22 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/editorconfig": {
       "version": "1.0.4",
@@ -10308,6 +10325,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmmirror.com/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/seatunnel-engine/seatunnel-engine-ui/package.json
+++ b/seatunnel-engine/seatunnel-engine-ui/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.7.7",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "echarts": "^6.1.0",
     "naive-ui": "^2.39.0",
     "nprogress": "^0.2.0",
     "pinia": "^2.1.7",

--- a/seatunnel-engine/seatunnel-engine-ui/src/components/live-metrics-chart/index.tsx
+++ b/seatunnel-engine/seatunnel-engine-ui/src/components/live-metrics-chart/index.tsx
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineComponent, ref, watch, onMounted, onUnmounted, type PropType } from 'vue'
+import * as echarts from 'echarts/core'
+import { LineChart } from 'echarts/charts'
+import { TitleComponent, TooltipComponent, LegendComponent, GridComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
+
+echarts.use([TitleComponent, TooltipComponent, LegendComponent, GridComponent, LineChart, CanvasRenderer])
+
+export interface ChartSeries {
+  name: string
+  data: [number, number][]
+}
+
+export default defineComponent({
+  name: 'LiveMetricsChart',
+  props: {
+    series: {
+      type: Array as PropType<ChartSeries[]>,
+      default: () => []
+    },
+    height: {
+      type: String,
+      default: '300px'
+    },
+    emptyText: {
+      type: String,
+      default: 'No data'
+    }
+  },
+  setup(props) {
+    const chartRef = ref<HTMLDivElement>()
+    let chartInstance: echarts.ECharts | null = null
+    let resizeObserver: ResizeObserver | null = null
+
+    const getChartOption = () => {
+      const seriesData = props.series || []
+      if (seriesData.length === 0) {
+        return {
+          title: {
+            text: props.emptyText,
+            left: 'center',
+            top: 'center',
+            textStyle: { color: '#999', fontSize: 14 }
+          }
+        }
+      }
+
+      return {
+        tooltip: {
+          trigger: 'axis',
+          formatter: (params: any) => {
+            if (!Array.isArray(params)) params = [params]
+            const time = new Date(params[0]?.data?.[0]).toLocaleTimeString()
+            let html = `<div style="font-weight:bold;margin-bottom:4px">${time}</div>`
+            params.forEach((p: any) => {
+              const value = p.data?.[1]
+              const formatted = typeof value === 'number' ? value.toFixed(4) : value
+              html += `<div style="display:flex;align-items:center;gap:4px">
+                <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${p.color}"></span>
+                ${p.seriesName}: ${formatted}
+              </div>`
+            })
+            return html
+          }
+        },
+        legend: {
+          data: seriesData.map((s) => s.name),
+          bottom: 0
+        },
+        grid: {
+          left: '3%',
+          right: '4%',
+          bottom: '12%',
+          top: '8%',
+          containLabel: true
+        },
+        xAxis: {
+          type: 'time',
+          axisLabel: {
+            formatter: (value: number) => {
+              const d = new Date(value)
+              return d.toLocaleTimeString()
+            }
+          }
+        },
+        yAxis: {
+          type: 'value',
+          axisLabel: {
+            formatter: (value: number) => {
+              if (Math.abs(value) >= 1_000_000) return (value / 1_000_000).toFixed(1) + 'M'
+              if (Math.abs(value) >= 1_000) return (value / 1_000).toFixed(1) + 'K'
+              return value.toFixed(2)
+            }
+          }
+        },
+        series: seriesData.map((s) => ({
+          name: s.name,
+          type: 'line',
+          data: s.data,
+          showSymbol: false,
+          smooth: true,
+          animation: false,
+          sampling: 'lttb'
+        }))
+      }
+    }
+
+    const initChart = () => {
+      if (!chartRef.value) return
+      if (chartInstance) {
+        chartInstance.dispose()
+      }
+      chartInstance = echarts.init(chartRef.value)
+      chartInstance.setOption(getChartOption(), true)
+    }
+
+    const updateChart = () => {
+      if (!chartInstance) return
+      chartInstance.setOption(getChartOption(), true)
+    }
+
+    watch(
+      () => props.series,
+      () => updateChart(),
+      { deep: true }
+    )
+
+    onMounted(() => {
+      initChart()
+      if (chartRef.value) {
+        resizeObserver = new ResizeObserver(() => {
+          chartInstance?.resize()
+        })
+        resizeObserver.observe(chartRef.value)
+      }
+    })
+
+    onUnmounted(() => {
+      resizeObserver?.disconnect()
+      chartInstance?.dispose()
+      chartInstance = null
+    })
+
+    return () => (
+      <div ref={chartRef} style={{ width: '100%', height: props.height }} />
+    )
+  }
+})

--- a/seatunnel-engine/seatunnel-engine-ui/src/locales/en_US/detail.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/locales/en_US/detail.ts
@@ -53,4 +53,11 @@ export default {
     bpRatio: 'Downstream Wait Ratio',
     queueFillRatio: 'Queue Fill Ratio',
   },
+  pinnedMetrics: {
+    title: 'Pinned Metrics',
+    clearAll: 'Clear All',
+    pinButton: 'Pin',
+    limitReached: 'Max 6 pins reached',
+    noData: 'Pin a metric to see live chart',
+  },
 }

--- a/seatunnel-engine/seatunnel-engine-ui/src/locales/zh_CN/detail.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/locales/zh_CN/detail.ts
@@ -53,4 +53,11 @@ export default {
     bpRatio: '下游等待占比',
     queueFillRatio: '队列填充率',
   },
+  pinnedMetrics: {
+    title: '已固定指标',
+    clearAll: '清除全部',
+    pinButton: '固定',
+    limitReached: '已达到最多 6 个固定指标',
+    noData: '固定指标以查看实时图表',
+  },
 }

--- a/seatunnel-engine/seatunnel-engine-ui/src/views/jobs/detail.scss
+++ b/seatunnel-engine/seatunnel-engine-ui/src/views/jobs/detail.scss
@@ -23,3 +23,11 @@
     }
   }
  }
+
+.pinned-metrics-panel {
+  .pinned-chips {
+    .n-tag {
+      cursor: default;
+    }
+  }
+}

--- a/seatunnel-engine/seatunnel-engine-ui/src/views/jobs/detail.tsx
+++ b/seatunnel-engine/seatunnel-engine-ui/src/views/jobs/detail.tsx
@@ -23,9 +23,11 @@ import {
   NDataTable,
   type DataTableColumns,
   NDrawer,
-  NDrawerContent
+  NDrawerContent,
+  NButton,
+  NSpace
 } from 'naive-ui'
-import {computed, defineComponent, onUnmounted, reactive, ref, watch} from 'vue'
+import { computed, defineComponent, onUnmounted, reactive, ref, watch } from 'vue'
 import { getJobInfo } from '@/service/job'
 import { useRoute } from 'vue-router'
 import type { Job, Vertex } from '@/service/job/types'
@@ -37,6 +39,7 @@ import { getColorFromStatus } from '@/utils/getTypeFromStatus'
 import './detail.scss'
 import Configuration from '@/components/configuration'
 import JobLog from '@/components/job-log'
+import LiveMetricsChart from '@/components/live-metrics-chart'
 import { formatPercentFromRatio } from '@/utils/format'
 import {
   getRealtimeJobEdges,
@@ -47,6 +50,7 @@ import {
   type RealtimeVertexPoint
 } from '@/service/realtime-metrics'
 import { readVertexMetricValue, collectVertexMetrics, extractVertexIdentifier } from './detail-metrics'
+import { usePinnedMetrics, type PinnedMetric } from './usePinnedMetrics'
 
 export default defineComponent({
   setup() {
@@ -89,10 +93,11 @@ export default defineComponent({
       clearInterval(timer)
       clearTimeout(fetchTimer)
       clearInterval(realtimeTimer)
+      pinnedMetrics.clearPins()
     })
 
     const isTerminalState = (status: string) => {
-      return ['FINISHED', 'FAILED', 'CANCELED','SAVEPOINT_DONE'].includes(status)
+      return ['FINISHED', 'FAILED', 'CANCELED', 'SAVEPOINT_DONE'].includes(status)
     }
 
     const isRunningState = (status: string) => {
@@ -557,21 +562,175 @@ export default defineComponent({
       // Fallback: show a minimal common view.
       return base
     })
+
+    // --- Pinned Metrics ---
+    const pinnedMetrics = usePinnedMetrics()
+
+    const vertexNameMap = computed(() => {
+      const map = new Map<number, string>()
+      job.jobDag?.vertexInfoMap?.forEach((v) => {
+        map.set(v.vertexId, v.vertexName || `Vertex-${v.vertexId}`)
+      })
+      return map
+    })
+
+    const pinnedSeriesData = computed(() =>
+      pinnedMetrics.getPinnedSeriesData(
+        realtimeVertices.value,
+        realtimeEdges.value,
+        vertexNameMap.value
+      )
+    )
+
+    const pinMetricLabel = (metricKey: string): string => {
+      const labels: Record<string, string> = {
+        // Vertex - Source
+        sourceReadRatio: t('detail.observability.sourceReadRatio'),
+        sourceIdleRatio: t('detail.observability.sourceIdleRatio'),
+        // Vertex - Transform
+        transformBusyRatio: t('detail.observability.transformBusyRatio'),
+        transformProcessNsPerRecord: t('detail.observability.processMsPerRecord'),
+        transformRecordsIn: t('detail.observability.recordsIn'),
+        transformRecordsOut: t('detail.observability.recordsOut'),
+        // Vertex - Sink
+        sinkBusyRatio: t('detail.observability.sinkBusyRatio'),
+        sinkWriteNsPerRecord: t('detail.observability.writeMsPerRecord'),
+        sinkRecordsIn: t('detail.observability.recordsIn'),
+        // Edge
+        bpRatio: t('detail.observability.bpRatio'),
+        queueFillRatio: t('detail.observability.queueFillRatio')
+      }
+      return labels[metricKey] || metricKey
+    }
+
+    const pinVertexMetric = (metricKey: string) => {
+      const vertex = focusedVertex.value
+      if (!vertex) return
+      const id = `vertex-${vertex.vertexId}-${metricKey}`
+      pinnedMetrics.addPin({
+        id,
+        label: `${vertex.vertexName || `Vertex-${vertex.vertexId}`} - ${pinMetricLabel(metricKey)}`,
+        sourceType: 'vertex',
+        sourceId: vertex.vertexId,
+        metricKey,
+        metricLabel: pinMetricLabel(metricKey),
+        vertexType: vertex.type as 'source' | 'transform' | 'sink'
+      })
+    }
+
+    const pinEdgeMetric = (metricKey: string) => {
+      const edge = focusedEdge.value
+      if (!edge) return
+      const target = job.jobDag?.vertexInfoMap?.find((v) => v.vertexId === edge.targetVertexId)
+      const id = `edge-${edge.edgeId}-${metricKey}`
+      pinnedMetrics.addPin({
+        id,
+        label: `${target?.vertexName || `Edge-${edge.edgeId}`} - ${pinMetricLabel(metricKey)}`,
+        sourceType: 'edge',
+        sourceId: edge.targetVertexId,
+        metricKey,
+        metricLabel: pinMetricLabel(metricKey)
+      })
+    }
+
+    // --- Chart series for the drawer ---
+    const drawerChartSeries = computed(() => {
+      const series: { name: string; data: [number, number][] }[] = []
+
+      if (focusedEdge.value) {
+        const points = focusedEdgeSeries.value
+        if (points.length > 0) {
+          const bpData = points
+            .map((p) => [p.ts, p.bpRatio] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          const qfData = points
+            .map((p) => [p.ts, p.queueFillRatio] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          if (bpData.length > 0) {
+            series.push({ name: t('detail.observability.bpRatio'), data: bpData })
+          }
+          if (qfData.length > 0) {
+            series.push({ name: t('detail.observability.queueFillRatio'), data: qfData })
+          }
+        }
+      } else if (focusedId.value) {
+        const points = focusedVertexSeries.value
+        const v = focusedVertex.value as any
+        const type = v?.type
+        if (type === 'source' && points.length > 0) {
+          const readData = points
+            .map((p) => [p.ts, p.sourceReadRatio] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          const idleData = points
+            .map((p) => [p.ts, p.sourceIdleRatio] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          if (readData.length > 0) {
+            series.push({ name: t('detail.observability.sourceReadRatio'), data: readData })
+          }
+          if (idleData.length > 0) {
+            series.push({ name: t('detail.observability.sourceIdleRatio'), data: idleData })
+          }
+        } else if (type === 'sink' && points.length > 0) {
+          const busyData = points
+            .map((p) => [p.ts, p.sinkBusyRatio] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          const writeData = points
+            .map((p) => [p.ts, p.sinkWriteNsPerRecord / 1_000_000] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          const recordsData = points
+            .map((p) => [p.ts, p.sinkRecordsIn] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          if (busyData.length > 0) {
+            series.push({ name: t('detail.observability.sinkBusyRatio'), data: busyData })
+          }
+          if (writeData.length > 0) {
+            series.push({ name: t('detail.observability.writeMsPerRecord'), data: writeData })
+          }
+          if (recordsData.length > 0) {
+            series.push({ name: t('detail.observability.recordsIn'), data: recordsData })
+          }
+        } else if (type === 'transform' && points.length > 0) {
+          const busyData = points
+            .map((p) => [p.ts, p.transformBusyRatio] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          const procData = points
+            .map((p) => [p.ts, p.transformProcessNsPerRecord / 1_000_000] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          if (busyData.length > 0) {
+            series.push({ name: t('detail.observability.transformBusyRatio'), data: busyData })
+          }
+          if (procData.length > 0) {
+            series.push({ name: t('detail.observability.processMsPerRecord'), data: procData })
+          }
+        }
+      }
+      return series
+    })
+
     return () => (
       <div class="w-full bg-white px-12 pt-6 pb-12 border border-gray-100 rounded-xl">
-	        <div class="font-bold text-xl">
-	          {job.jobName}
-	          <NTag bordered={false} color={getColorFromStatus(job.jobStatus)} class="ml-3">
-	            {job.jobStatus}
-	          </NTag>
-	          {realtimeError.value ? (
-	            <span title={realtimeError.value}>
-	              <NTag bordered={false} type="warning" class="ml-3">
-	                Realtime metrics unavailable
-	              </NTag>
-	            </span>
-	          ) : null}
-	        </div>
+        <div class="font-bold text-xl">
+          {job.jobName}
+          <NTag bordered={false} color={getColorFromStatus(job.jobStatus)} class="ml-3">
+            {job.jobStatus}
+          </NTag>
+          {realtimeError.value ? (
+            <span title={realtimeError.value}>
+              <NTag bordered={false} type="warning" class="ml-3">
+                Realtime metrics unavailable
+              </NTag>
+            </span>
+          ) : null}
+        </div>
         <div class="mt-3 flex items-center gap-3">
           <span>{t('detail.id')}:</span>
           <span class="font-bold">{job.jobId}</span>
@@ -594,6 +753,36 @@ export default defineComponent({
                 realtimeVertexStats={realtimeVertexStats.value}
                 realtimeTick={realtimeTick.value}
               />
+              {/* Pinned Metrics Panel */}
+              {pinnedMetrics.hasPins.value && (
+                <div class="pinned-metrics-panel mt-4 mb-4 p-4 border border-gray-200 rounded-lg">
+                  <div class="flex items-center justify-between mb-2">
+                    <span class="font-bold text-sm">
+                      {t('detail.pinnedMetrics.title')} ({pinnedMetrics.pinCount.value}/{pinnedMetrics.MAX_PINS})
+                    </span>
+                    <NButton size="tiny" type="error" quaternary onClick={pinnedMetrics.clearPins}>
+                      {t('detail.pinnedMetrics.clearAll')}
+                    </NButton>
+                  </div>
+                  <div class="pinned-chips flex flex-wrap gap-2 mb-3">
+                    {pinnedMetrics.pins.value.map((pin) => (
+                      <NTag
+                        key={pin.id}
+                        closable
+                        size="small"
+                        onClose={() => pinnedMetrics.removePin(pin.id)}
+                      >
+                        {pin.label}
+                      </NTag>
+                    ))}
+                  </div>
+                  <LiveMetricsChart
+                    series={pinnedSeriesData.value}
+                    height="280px"
+                    emptyText={t('detail.pinnedMetrics.noData')}
+                  />
+                </div>
+              )}
               <NDataTable
                 columns={columns}
                 data={tableData.value}
@@ -630,6 +819,39 @@ export default defineComponent({
               <NDrawerContent title={focusedEdgeInfo.value?.['edge.id']} closable>
                 <Configuration data={focusedEdgeInfo.value}></Configuration>
                 <NDivider />
+                <div class="mb-2">
+                  <NSpace>
+                    <NButton
+                      size="tiny"
+                      type="primary"
+                      ghost
+                      disabled={pinnedMetrics.pinLimitReached.value}
+                      onClick={() => pinEdgeMetric('bpRatio')}
+                    >
+                      {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.bpRatio')}
+                    </NButton>
+                    <NButton
+                      size="tiny"
+                      type="primary"
+                      ghost
+                      disabled={pinnedMetrics.pinLimitReached.value}
+                      onClick={() => pinEdgeMetric('queueFillRatio')}
+                    >
+                      {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.queueFillRatio')}
+                    </NButton>
+                  </NSpace>
+                  {pinnedMetrics.pinLimitReached.value && (
+                    <span class="text-xs text-gray-400 ml-2">
+                      {t('detail.pinnedMetrics.limitReached')}
+                    </span>
+                  )}
+                </div>
+                <LiveMetricsChart
+                  series={drawerChartSeries.value}
+                  height="260px"
+                  emptyText={t('detail.pinnedMetrics.noData')}
+                />
+                <NDivider />
                 <NDataTable
                   columns={edgePointColumns}
                   data={focusedEdgeSeries.value}
@@ -640,6 +862,87 @@ export default defineComponent({
             ) : (
               <NDrawerContent title={focusedVertex.value?.vertexName} closable>
                 <Configuration data={focusedVertex.value}></Configuration>
+                <NDivider />
+                <div class="mb-2">
+                  <NSpace>
+                    {focusedVertex.value?.type === 'source' && (
+                      <>
+                        <NButton
+                          size="tiny"
+                          type="primary"
+                          ghost
+                          disabled={pinnedMetrics.pinLimitReached.value}
+                          onClick={() => pinVertexMetric('sourceReadRatio')}
+                        >
+                          {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.sourceReadRatio')}
+                        </NButton>
+                        <NButton
+                          size="tiny"
+                          type="primary"
+                          ghost
+                          disabled={pinnedMetrics.pinLimitReached.value}
+                          onClick={() => pinVertexMetric('sourceIdleRatio')}
+                        >
+                          {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.sourceIdleRatio')}
+                        </NButton>
+                      </>
+                    )}
+                    {focusedVertex.value?.type === 'transform' && (
+                      <>
+                        <NButton
+                          size="tiny"
+                          type="primary"
+                          ghost
+                          disabled={pinnedMetrics.pinLimitReached.value}
+                          onClick={() => pinVertexMetric('transformBusyRatio')}
+                        >
+                          {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.transformBusyRatio')}
+                        </NButton>
+                        <NButton
+                          size="tiny"
+                          type="primary"
+                          ghost
+                          disabled={pinnedMetrics.pinLimitReached.value}
+                          onClick={() => pinVertexMetric('transformProcessNsPerRecord')}
+                        >
+                          {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.processMsPerRecord')}
+                        </NButton>
+                      </>
+                    )}
+                    {focusedVertex.value?.type === 'sink' && (
+                      <>
+                        <NButton
+                          size="tiny"
+                          type="primary"
+                          ghost
+                          disabled={pinnedMetrics.pinLimitReached.value}
+                          onClick={() => pinVertexMetric('sinkBusyRatio')}
+                        >
+                          {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.sinkBusyRatio')}
+                        </NButton>
+                        <NButton
+                          size="tiny"
+                          type="primary"
+                          ghost
+                          disabled={pinnedMetrics.pinLimitReached.value}
+                          onClick={() => pinVertexMetric('sinkWriteNsPerRecord')}
+                        >
+                          {t('detail.pinnedMetrics.pinButton')} {t('detail.observability.writeMsPerRecord')}
+                        </NButton>
+                      </>
+                    )}
+                  </NSpace>
+                  {pinnedMetrics.pinLimitReached.value && (
+                    <span class="text-xs text-gray-400 ml-2">
+                      {t('detail.pinnedMetrics.limitReached')}
+                    </span>
+                  )}
+                </div>
+                <LiveMetricsChart
+                  series={drawerChartSeries.value}
+                  height="260px"
+                  emptyText={t('detail.pinnedMetrics.noData')}
+                />
                 <NDivider />
                 <NDataTable
                   columns={vertexPointColumns.value}

--- a/seatunnel-engine/seatunnel-engine-ui/src/views/jobs/usePinnedMetrics.ts
+++ b/seatunnel-engine/seatunnel-engine-ui/src/views/jobs/usePinnedMetrics.ts
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ref, computed } from 'vue'
+import type {
+  RealtimeVertexPoint,
+  RealtimeEdgePoint,
+  RealtimeVerticesResponse,
+  RealtimeEdgesResponse
+} from '@/service/realtime-metrics'
+
+export interface PinnedMetric {
+  /** Unique identifier for this pin */
+  id: string
+  /** Label shown in the pin chip and chart legend */
+  label: string
+  /** 'vertex' or 'edge' */
+  sourceType: 'vertex' | 'edge'
+  /** Vertex or edge target vertex ID */
+  sourceId: number
+  /** The metric key on the point object (e.g., 'sourceReadRatio', 'bpRatio') */
+  metricKey: string
+  /** Human-readable metric name */
+  metricLabel: string
+  /** Vertex type for determining which metrics are available */
+  vertexType?: 'source' | 'transform' | 'sink'
+}
+
+const MAX_PINS = 6
+
+export function usePinnedMetrics() {
+  const pins = ref<PinnedMetric[]>([])
+
+  const pinLimitReached = computed(() => pins.value.length >= MAX_PINS)
+
+  const pinCount = computed(() => pins.value.length)
+
+  const addPin = (pin: PinnedMetric): boolean => {
+    if (pinLimitReached.value) return false
+    const exists = pins.value.some(
+      (p) => p.sourceType === pin.sourceType && p.sourceId === pin.sourceId && p.metricKey === pin.metricKey
+    )
+    if (exists) return false
+    pins.value.push(pin)
+    return true
+  }
+
+  const removePin = (id: string) => {
+    pins.value = pins.value.filter((p) => p.id !== id)
+  }
+
+  const clearPins = () => {
+    pins.value = []
+  }
+
+  const hasPins = computed(() => pins.value.length > 0)
+
+  /**
+   * Extract time-series data for all pinned metrics from the current realtime data snapshots.
+   * Returns series data suitable for ECharts.
+   */
+  const getPinnedSeriesData = (
+    vertices: RealtimeVerticesResponse | undefined,
+    edges: RealtimeEdgesResponse | undefined,
+    vertexNameMap: Map<number, string>
+  ) => {
+    if (!hasPins.value || (!vertices && !edges)) return []
+
+    const seriesMap = new Map<string, { name: string; data: [number, number][] }>()
+
+    pins.value.forEach((pin) => {
+      if (pin.sourceType === 'vertex' && vertices) {
+        const vertex = vertices.vertices?.find((v) => v.vertexId === pin.sourceId)
+        if (vertex?.points) {
+          const data = vertex.points
+            .map((p) => [p.ts, (p as any)[pin.metricKey] as number] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          if (data.length > 0) {
+            seriesMap.set(pin.id, { name: pin.label, data })
+          }
+        }
+      } else if (pin.sourceType === 'edge' && edges) {
+        const decodeTargetVertexId = (queueId: number) => {
+          if (queueId >= 0) return queueId
+          const abs = Math.abs(queueId)
+          if (!abs) return undefined
+          if (abs % 2 === 0) return abs / 2
+          return (abs - 1) / 2
+        }
+        const edge = edges.edges?.find(
+          (e) => (e.targetVertexId ?? decodeTargetVertexId(e.queueId)) === pin.sourceId
+        )
+        if (edge?.points) {
+          const data = edge.points
+            .map((p) => [p.ts, (p as any)[pin.metricKey] as number] as [number, number])
+            .filter(([, v]) => typeof v === 'number' && Number.isFinite(v))
+            .sort((a, b) => a[0] - b[0])
+          if (data.length > 0) {
+            seriesMap.set(pin.id, { name: pin.label, data })
+          }
+        }
+      }
+    })
+
+    return Array.from(seriesMap.values())
+  }
+
+  return {
+    pins,
+    pinLimitReached,
+    pinCount,
+    addPin,
+    removePin,
+    clearPins,
+    hasPins,
+    getPinnedSeriesData,
+    MAX_PINS
+  }
+}


### PR DESCRIPTION
## Purpose

Add a live-updating metrics chart to the Zeta engine job detail page, replacing the raw time-series table in the node/edge drawer with an interactive line chart and allowing users to pin metrics for side-by-side comparison.

Closes #11666

## Changes

- Add Apache ECharts (Apache-2.0 license) as a charting library in seatunnel-engine-ui
- Create LiveMetricsChart component with time-series line chart rendering (tooltip, legend, auto-resize)
- Add usePinnedMetrics composable for session-scoped pin management (max 6 pins, deduplication, clear on unmount)
- Add pin panel between DAG and summary table showing pinned series with a live chart
- Enhance drawer with a live chart above the existing series table, keeping the key-field summary above the divider
- Add Pin buttons in the drawer for each available metric
- Reuse existing 2s polling of /metrics/realtime endpoints - no extra requests per pin
- Update en_US and zh_CN locale files with pinned metrics translations

## Design Decisions

- Chart library: Apache ECharts (Apache-2.0, ASF-compatible)
- Pin lifecycle: Session-scoped only (current Job Detail visit). Cleared on component unmount
- Pin limit: 6 series max, with a clear message when the limit is reached
- Polling: No additional polling - pinned series consume the same response data from the existing Overview 2s poll
- Chart vs table: V1 adds the chart above the existing table in the drawer, keeping both views available