### PR TITLE
[Docs][Core] Add Javadoc to SinkFlowLifeCycle

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -218,6 +218,14 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         this.flushSignalSinkQPS = metricsContext.meter(MetricNames.FLUSH_SIGNAL_SINK_QPS);
     }
 
+    /**
+     * Initializes the serializers and optional task-local committer supplied by the sink.
+     *
+     * <p>The writer is created later by {@link #restoreState(List)}, after the checkpoint
+     * coordinator has supplied this action's restored state.
+     *
+     * @throws Exception if the sink cannot create its committer
+     */
     @Override
     public void init() throws Exception {
         this.commitInfoSerializer = sinkAction.getSink().getCommitInfoSerializer();
@@ -226,6 +234,14 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         this.lastCommitInfo = Optional.empty();
     }
 
+    /**
+     * Registers this sink task with the aggregate committer, when the execution plan contains one.
+     *
+     * <p>Writer creation or restoration has already completed before this lifecycle method is
+     * called. Sinks without an aggregate committer require no remote registration.
+     *
+     * @throws Exception if the aggregate committer address cannot be resolved or registration fails
+     */
     @Override
     public void open() throws Exception {
         super.open();
@@ -243,6 +259,14 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
                         .get();
     }
 
+    /**
+     * Marks this flow complete and closes its writer.
+     *
+     * <p>After the writer closes successfully, any delayed row outcomes are emitted before the
+     * {@link WriterCloseEvent} is sent to the writer's event listener.
+     *
+     * @throws IOException if the lifecycle or writer cannot be closed
+     */
     @Override
     public void close() throws IOException {
         super.close();
@@ -263,7 +287,16 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         }
     }
 
-    /** Handles barriers for checkpointing and rows for sink writes plus trace event reporting. */
+    /**
+     * Dispatches an upstream record to checkpoint, schema-change, signal, or data processing.
+     *
+     * <p>Once a close barrier marks this flow as preparing to close, subsequent non-barrier records
+     * are ignored. Barriers continue to be processed so the task can finish its checkpoint and
+     * close protocol.
+     *
+     * @param record the upstream record to process
+     * @throws RuntimeException if dispatch or sink processing fails
+     */
     @Override
     public void received(Record<?> record) {
         try {
@@ -327,6 +360,16 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         }
     }
 
+    /**
+     * Creates the sink writer from the checkpoint state assigned to this action.
+     *
+     * <p>Serialized states are deserialized with the sink's writer-state serializer. An empty state
+     * list creates a new writer; otherwise the states are passed to the sink's restore path. The
+     * writer context and row-error handling are initialized before writer creation.
+     *
+     * @param actionStateList checkpoint state assigned to this sink action
+     * @throws Exception if state deserialization or writer creation fails
+     */
     @Override
     public void restoreState(List<ActionSubtaskState> actionStateList) throws Exception {
         List<StateT> states = new ArrayList<>();
@@ -740,6 +783,19 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         }
     }
 
+    /**
+     * Prepares and snapshots the writer before acknowledging a checkpoint barrier.
+     *
+     * <p>Snapshot barriers prepare commit information, flush delayed row outcomes, seal pending
+     * metrics, and add serialized writer state to the running task. Commit information is also sent
+     * to the aggregate committer when configured. A failure invokes {@link
+     * SinkWriter#abortPrepare()} before it is propagated. When an aggregate committer is
+     * configured, non-snapshot barriers are forwarded to it. The task acknowledges the barrier
+     * after processing succeeds.
+     *
+     * @param barrier the barrier to process
+     * @throws IOException if writer preparation or state snapshotting fails
+     */
     private void processCheckpointBarrier(Barrier barrier) throws IOException {
         boolean metricsEnabled = runningTask != null && runningTask.isObservabilityEnabled();
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
### Purpose of this pull request

Part of #10533.

This documents the remaining `SinkFlowLifeCycle` methods using their current behavior and lifecycle responsibilities.

The Javadocs cover initialization, writer creation during restore, record delivery, checkpoint barrier processing, and resource cleanup.

### Does this PR introduce _any_ user-facing change?

No.

This is a documentation-only change and does not modify runtime behavior or public APIs.

### How was this patch tested?

Verified formatting and dependency-aware compilation with:

`./mvnw -pl seatunnel-engine/seatunnel-engine-server -am -DskipTests package -DenableSourceJarCreation=false`

The 53-module reactor build passed.

### Check list

* [x] No new Jar binary package is added.
* [x] No user documentation update is required.
* [x] No incompatible behavior is introduced.
* [x] This does not change connector code or connector registration.