### PR TITLE
[Improve][E2E] Use DependencyJar for MySQL error tests

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SinkErrorToMysqlIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SinkErrorToMysqlIT.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
+import org.apache.seatunnel.e2e.common.util.DependencyJar;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -36,6 +37,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 
+import com.mysql.cj.jdbc.Driver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
@@ -57,24 +59,12 @@ public class SinkErrorToMysqlIT extends TestSuiteBase implements TestResource {
     private static final String MYSQL_USERNAME = "root";
     private static final String MYSQL_PASSWORD = "Abc!@#135_seatunnel";
     private static final int MYSQL_PORT = 3306;
-    private static final String DRIVER_JAR =
-            "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib"
-                                        + " && cd /tmp/seatunnel/plugins/Jdbc/lib"
-                                        + " && (test -s mysql-connector-j-8.0.32.jar"
-                                        + " || curl -fsSLO --retry 5 --retry-delay 2 "
-                                        + DRIVER_JAR
-                                        + ")");
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
+            container ->
+                    DependencyJar.of(Driver.class)
+                            .copyTo(container, "/tmp/seatunnel/plugins/Jdbc/lib");
 
     private MySQLContainer<?> mysqlContainer;
 

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/TransformErrorToMysqlIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/TransformErrorToMysqlIT.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
+import org.apache.seatunnel.e2e.common.util.DependencyJar;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -36,6 +37,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 
+import com.mysql.cj.jdbc.Driver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
@@ -57,24 +59,12 @@ public class TransformErrorToMysqlIT extends TestSuiteBase implements TestResour
     private static final String MYSQL_USERNAME = "root";
     private static final String MYSQL_PASSWORD = "Abc!@#135_seatunnel";
     private static final int MYSQL_PORT = 3306;
-    private static final String DRIVER_JAR =
-            "https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.32/mysql-connector-j-8.0.32.jar";
 
     @TestContainerExtension
     private final ContainerExtendedFactory extendedFactory =
-            container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/Jdbc/lib"
-                                        + " && cd /tmp/seatunnel/plugins/Jdbc/lib"
-                                        + " && (test -s mysql-connector-j-8.0.32.jar"
-                                        + " || curl -fsSLO --retry 5 --retry-delay 2 "
-                                        + DRIVER_JAR
-                                        + ")");
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
-            };
+            container ->
+                    DependencyJar.of(Driver.class)
+                            .copyTo(container, "/tmp/seatunnel/plugins/Jdbc/lib");
 
     private MySQLContainer<?> mysqlContainer;
 


### PR DESCRIPTION
### Purpose of this pull request

Closes #11899.

`TransformErrorToMysqlIT` and `SinkErrorToMysqlIT` currently download MySQL Connector/J from Maven Central with `curl` inside the SeaTunnel test container. This change uses the existing E2E `DependencyJar` helper to copy the already-declared MySQL driver from the test classpath into `/tmp/seatunnel/plugins/Jdbc/lib`.

This removes the container-side network and `curl` dependency while keeping the existing MySQL Connector/J dependency and version unchanged.

AI assistance disclosure: OpenAI Codex (GPT-5) assisted with implementation and verification of this change.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./mvnw spotless:apply`
- `./mvnw -T 1 -B verify -Dapi.version=1.40 -DskipUT=true -DskipIT=false -Dit.test=TransformErrorToMysqlIT,SinkErrorToMysqlIT -Dit.failIfNoSpecifiedTests=false -DfailIfNoTests=false -Dlicense.skipAddThirdParty=true -Dskip.ui=true --no-snapshot-updates -pl :connector-seatunnel-e2e-base -am -Pci`
  - Result: 31 tests run, 0 failures, 0 errors, 2 skipped.
  - The submitted jobs loaded `file:/tmp/seatunnel/plugins/Jdbc/lib/mysql-connector-j-8.0.32.jar`.
- `./mvnw -q -DskipTests verify`
- `git diff --check`

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not necessary because there is no user-facing change.
* [x] No incompatible change is introduced.
* [x] The connector checklist is not applicable because this only changes E2E dependency setup.