### PR TITLE
[Docs] Fix ASF code of conduct link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Companies and organizations worldwide use SeaTunnel for research, production, an
 Explore real-world use cases of SeaTunnel, such as JP morgan, S7, JDT, Bytedance, Tencent Cloud. More use cases can be found on the [SeaTunnel Users](https://seatunnel.apache.org/user).
 
 ## Code of Conduct
-Participate in this project in accordance with the Contributor Covenant [Code of Conduct](https://www.apache.org/foundation/policies/conduct).
+Participate in this project in accordance with the Contributor Covenant [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
 
 ## Contributors
 We appreciate all developers for their contributions. See the [List Of Contributors](https://github.com/apache/seatunnel/graphs/contributors).


### PR DESCRIPTION
## Why
The current `Dead links` workflow flags the ASF Code of Conduct URL in `README.md` as dead on `dev`.

This is a standalone README fix split out from #11856 because the failure comes from the current `dev` baseline documentation, not from the engine changes in that PR.

## What
- update the ASF Code of Conduct link in `README.md` to the official `.html` URL

## Verification
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true spotless:apply`
- `git diff --check`