### PR TITLE
[Fix][Transform-V2][DataValidator] Normalize numeric bounds in RANGE rule to fix ClassCastException

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/rule/RangeValidationRule.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/validator/rule/RangeValidationRule.java
@@ -88,10 +88,43 @@ public class RangeValidationRule implements ValidationRule {
     }
 
     private int compare(Comparable value, Comparable bound) {
-        if (value instanceof BigDecimal && bound instanceof Number) {
-            return ((BigDecimal) value).compareTo(new BigDecimal(bound.toString()));
+        if (value instanceof Number && bound instanceof Number) {
+            return compareNumbers((Number) value, (Number) bound);
         }
-        return value.compareTo(bound);
+        return compareAsNumberOrString(value, bound);
+    }
+
+    /**
+     * Compares two numeric values. The field value type (e.g. BIGINT/DOUBLE) may differ from the
+     * parsed bound type (Integer/Long/Double), so finite values are compared as {@link BigDecimal}
+     * to avoid {@link ClassCastException}. Non-finite values (NaN, Infinity) cannot be represented
+     * as {@link BigDecimal}, so they are compared as double - {@link Double#compare} sorts them
+     * beyond all finite values, so they are treated as out of range instead of crashing.
+     */
+    private int compareNumbers(Number value, Number bound) {
+        double valueAsDouble = value.doubleValue();
+        double boundAsDouble = bound.doubleValue();
+        if (Double.isNaN(valueAsDouble)
+                || Double.isInfinite(valueAsDouble)
+                || Double.isNaN(boundAsDouble)
+                || Double.isInfinite(boundAsDouble)) {
+            return Double.compare(valueAsDouble, boundAsDouble);
+        }
+        return new BigDecimal(value.toString()).compareTo(new BigDecimal(bound.toString()));
+    }
+
+    /**
+     * Compares a value and a bound of different types (e.g. a STRING field against a numeric bound,
+     * or a numeric field against a string bound) without throwing {@link ClassCastException}.
+     * Values are compared numerically when both can be parsed as {@link BigDecimal}, otherwise by
+     * their string representation.
+     */
+    private int compareAsNumberOrString(Comparable value, Comparable bound) {
+        try {
+            return new BigDecimal(value.toString()).compareTo(new BigDecimal(bound.toString()));
+        } catch (NumberFormatException e) {
+            return value.toString().compareTo(bound.toString());
+        }
     }
 
     @Override

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/validator/DataValidatorTransformTest.java
@@ -172,4 +172,129 @@ public class DataValidatorTransformTest {
 
         assertEquals(row, transform.map(row));
     }
+
+    @Test
+    void rangeRuleShouldValidateBigintFieldAgainstIntegerBounds() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"quantity"}, new SeaTunnelDataType[] {BasicType.LONG_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        ImmutableMap.of(
+                                "field_rules",
+                                Arrays.asList(
+                                        ImmutableMap.of(
+                                                "field_name",
+                                                "quantity",
+                                                "rules",
+                                                Arrays.asList(
+                                                        ImmutableMap.of(
+                                                                "rule_type",
+                                                                "RANGE",
+                                                                "min_value",
+                                                                0,
+                                                                "max_value",
+                                                                1000))))));
+        DataValidatorTransform transform = new DataValidatorTransform(config, inputCatalogTable);
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {500L});
+
+        assertEquals(row, transform.map(row));
+    }
+
+    @Test
+    void rangeRuleShouldValidateDoubleFieldAgainstIntegerBounds() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"score"}, new SeaTunnelDataType[] {BasicType.DOUBLE_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        ImmutableMap.of(
+                                "field_rules",
+                                Arrays.asList(
+                                        ImmutableMap.of(
+                                                "field_name",
+                                                "score",
+                                                "rules",
+                                                Arrays.asList(
+                                                        ImmutableMap.of(
+                                                                "rule_type",
+                                                                "RANGE",
+                                                                "min_value",
+                                                                0,
+                                                                "max_value",
+                                                                100))))));
+        DataValidatorTransform transform = new DataValidatorTransform(config, inputCatalogTable);
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {85.5d});
+
+        assertEquals(row, transform.map(row));
+    }
+
+    @Test
+    void rangeRuleShouldRouteNonFiniteDoubleToErrorTableWithIntegerBounds() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"score"}, new SeaTunnelDataType[] {BasicType.DOUBLE_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        ImmutableMap.of(
+                                "row_error_handle_way",
+                                "ROUTE_TO_TABLE",
+                                "row_error_handle_way.error_table",
+                                "ffp",
+                                "field_rules",
+                                Arrays.asList(
+                                        ImmutableMap.of(
+                                                "field_name",
+                                                "score",
+                                                "rules",
+                                                Arrays.asList(
+                                                        ImmutableMap.of(
+                                                                "rule_type",
+                                                                "RANGE",
+                                                                "min_value",
+                                                                0,
+                                                                "max_value",
+                                                                100))))));
+        DataValidatorTransform transform = new DataValidatorTransform(config, inputCatalogTable);
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {Double.NaN});
+
+        SeaTunnelRow routedRow = transform.map(row);
+        assertEquals("db1.ffp", routedRow.getTableId());
+    }
+
+    @Test
+    void rangeRuleShouldValidateNumericStringFieldAgainstIntegerBounds() {
+        SeaTunnelRowType inputRowType =
+                new SeaTunnelRowType(
+                        new String[] {"quantity"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+        CatalogTable inputCatalogTable =
+                CatalogTableUtil.getCatalogTable("catalog", "db1", null, "source", inputRowType);
+        ReadonlyConfig config =
+                ReadonlyConfig.fromMap(
+                        ImmutableMap.of(
+                                "field_rules",
+                                Arrays.asList(
+                                        ImmutableMap.of(
+                                                "field_name",
+                                                "quantity",
+                                                "rules",
+                                                Arrays.asList(
+                                                        ImmutableMap.of(
+                                                                "rule_type",
+                                                                "RANGE",
+                                                                "min_value",
+                                                                0,
+                                                                "max_value",
+                                                                1000))))));
+        DataValidatorTransform transform = new DataValidatorTransform(config, inputCatalogTable);
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {"500"});
+
+        assertEquals(row, transform.map(row));
+    }
 }


### PR DESCRIPTION
### Purpose of this pull request
Closes #11919. Follow-up of #11855, which only covered DECIMAL fields.
This PR normalizes any pair of numeric values to BigDecimal and falls back
to numeric/string comparison for mixed types, so the RANGE rule no longer
throws ClassCastException for:
- BIGINT/DOUBLE/FLOAT fields with integer bounds (#11855 left these unfixed)
- non-finite values (NaN/+/-Infinity) with integer bounds
- STRING fields with numeric content vs numeric bounds

### Does this PR introduce a user-facing change?
No.

