### PR TITLE
[Bug][Zeta] Fix stale taskDone removing execution context of a newer restore generation (#11755)

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -1459,6 +1459,7 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                                     "Skip stale taskDone cleanup for %s because the active context "
                                             + "is no longer owned by this tracker.",
                                     taskGroupLocation));
+                    recycleClassLoader(taskGroupLocation, ownedContext);
                     return;
                 }
                 recycleClassLoader(taskGroupLocation, ownedContext);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -551,8 +551,6 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                             taskGroup.getTaskGroupLocation()));
             Collection<Task> tasks = taskGroup.getTasks();
             CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
-            TaskGroupExecutionTracker executionTracker =
-                    new TaskGroupExecutionTracker(cancellationFuture, taskGroup, resultFuture);
             ConcurrentMap<Long, TaskExecutionContext> taskExecutionContextMap =
                     new ConcurrentHashMap<>();
             final Map<Boolean, List<Task>> byCooperation =
@@ -585,8 +583,10 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                                                 return true;
                                             }));
             TaskGroupContext context = new TaskGroupContext(taskGroup, classLoaders, jars);
+            TaskGroupExecutionTracker executionTracker =
+                    new TaskGroupExecutionTracker(
+                            cancellationFuture, taskGroup, context, resultFuture);
             executionContexts.put(taskGroup.getTaskGroupLocation(), context);
-            executionTracker.ownedContext = context;
             cancellationFutures.put(taskGroup.getTaskGroupLocation(), cancellationFuture);
             submitThreadShareTask(executionTracker, byCooperation.get(true));
             submitBlockingTask(executionTracker, byCooperation.get(false));
@@ -1310,18 +1310,20 @@ public class TaskExecutionService implements DynamicMetricsProvider {
 
         /**
          * The TaskGroupContext that this tracker owns. Used to guard against stale taskDone calls
-         * from a previous restore generation removing the execution context installed by a newer
-         * generation for the same TaskGroupLocation.
+         * from a previous restore generation removing resources installed by a newer generation for
+         * the same TaskGroupLocation.
          */
-        private volatile TaskGroupContext ownedContext;
+        private final TaskGroupContext ownedContext;
 
         TaskGroupExecutionTracker(
                 @NonNull CompletableFuture<Void> cancellationFuture,
                 @NonNull TaskGroup taskGroup,
+                @NonNull TaskGroupContext ownedContext,
                 @NonNull CompletableFuture<TaskExecutionState> future) {
             this.future = future;
             this.completionLatch = new AtomicInteger(taskGroup.getTasks().size());
             this.taskGroup = taskGroup;
+            this.ownedContext = ownedContext;
             cancellationFuture.whenComplete(
                     withTryCatch(
                             logger,
@@ -1396,22 +1398,7 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                             task.getTaskID(), taskGroupLocation));
             Throwable ex = executionException.get();
             if (completionLatch.decrementAndGet() == 0) {
-                recycleClassLoader(taskGroupLocation);
-                // Only remove the execution context if it is still the one this tracker
-                // installed. A stale taskDone belonging to an earlier restore generation must
-                // not evict the context installed by a newer generation for the same location.
-                finishExecutionContext(taskGroupLocation);
-                cancellationFutures.remove(taskGroupLocation);
-                try {
-                    cancelAsyncFunction(taskGroupLocation);
-                } catch (Throwable t) {
-                    logger.severe("cancel async function failed", t);
-                }
-                try {
-                    cancelTimerFlushForTaskGroup(taskGroupLocation);
-                } catch (Throwable t) {
-                    logger.severe("cancel timer-flush tasks failed", t);
-                }
+                finishOwnedResources(taskGroupLocation);
                 try {
                     updateMetricsContextInImap();
                 } catch (Throwable t) {
@@ -1447,26 +1434,62 @@ public class TaskExecutionService implements DynamicMetricsProvider {
             }
         }
 
-        private void recycleClassLoader(TaskGroupLocation taskGroupLocation) {
-            TaskGroupContext context = executionContexts.get(taskGroupLocation);
-            executionContexts.get(taskGroupLocation).setClassLoaders(null);
+        private void recycleClassLoader(
+                TaskGroupLocation taskGroupLocation, TaskGroupContext context) {
+            context.setClassLoaders(null);
             for (Collection<URL> jars : context.getJars().values()) {
                 classLoaderService.releaseClassLoader(taskGroupLocation.getJobId(), jars);
             }
         }
 
         /**
-         * Moves the execution context from the active map to the finished map, but only if the
-         * entry is still the context this tracker installed. TaskGroupLocation is reused across
-         * pipeline restore generations, so a stale {@link #taskDone(Task)} from an earlier
-         * generation must not evict the context installed by a newer generation for the same
-         * location. {@link java.util.concurrent.ConcurrentMap#remove(Object, Object)} performs the
-         * check atomically.
+         * Finishes all resources owned by this tracker under the same monitor used by deployment.
+         *
+         * <p>TaskGroupLocation is reused across restore generations. The ownership check and
+         * teardown must therefore be one critical section: otherwise an older generation can remove
+         * its context, let a newer deployment install resources for the same location, and then
+         * accidentally tear down the newer generation's cancellation future, async functions, or
+         * timer flushes.
          */
-        private void finishExecutionContext(TaskGroupLocation taskGroupLocation) {
+        private void finishOwnedResources(TaskGroupLocation taskGroupLocation) {
+            synchronized (TaskExecutionService.this) {
+                if (!finishExecutionContext(taskGroupLocation)) {
+                    logger.warning(
+                            String.format(
+                                    "Skip stale taskDone cleanup for %s because the active context "
+                                            + "is no longer owned by this tracker.",
+                                    taskGroupLocation));
+                    return;
+                }
+                recycleClassLoader(taskGroupLocation, ownedContext);
+                cancellationFutures.remove(taskGroupLocation);
+                try {
+                    cancelAsyncFunction(taskGroupLocation);
+                } catch (Throwable t) {
+                    logger.severe("cancel async function failed", t);
+                }
+                try {
+                    cancelTimerFlushForTaskGroup(taskGroupLocation);
+                } catch (Throwable t) {
+                    logger.severe("cancel timer-flush tasks failed", t);
+                }
+            }
+        }
+
+        /**
+         * Moves the execution context from the active map to the finished map only when the active
+         * map still points to the exact context object installed by this tracker.
+         */
+        private boolean finishExecutionContext(TaskGroupLocation taskGroupLocation) {
+            TaskGroupContext activeContext = executionContexts.get(taskGroupLocation);
+            if (activeContext != ownedContext) {
+                return false;
+            }
             if (executionContexts.remove(taskGroupLocation, ownedContext)) {
                 finishedExecutionContexts.put(taskGroupLocation, ownedContext);
+                return true;
             }
+            return false;
         }
 
         boolean executionCompletedExceptionally() {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -585,9 +585,7 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                                                 return true;
                                             }));
             TaskGroupContext context = new TaskGroupContext(taskGroup, classLoaders, jars);
-            executionContexts.put(
-                    taskGroup.getTaskGroupLocation(),
-                    context);
+            executionContexts.put(taskGroup.getTaskGroupLocation(), context);
             executionTracker.ownedContext = context;
             cancellationFutures.put(taskGroup.getTaskGroupLocation(), cancellationFuture);
             submitThreadShareTask(executionTracker, byCooperation.get(true));
@@ -1311,9 +1309,9 @@ public class TaskExecutionService implements DynamicMetricsProvider {
         private final Map<Long, Future<?>> currRunningTaskFuture = new ConcurrentHashMap<>();
 
         /**
-         * The TaskGroupContext that this tracker owns. Used to guard against stale
-         * taskDone calls from a previous restore generation removing the execution
-         * context installed by a newer generation for the same TaskGroupLocation.
+         * The TaskGroupContext that this tracker owns. Used to guard against stale taskDone calls
+         * from a previous restore generation removing the execution context installed by a newer
+         * generation for the same TaskGroupLocation.
          */
         private volatile TaskGroupContext ownedContext;
 
@@ -1458,12 +1456,12 @@ public class TaskExecutionService implements DynamicMetricsProvider {
         }
 
         /**
-         * Moves the execution context from the active map to the finished map, but only if
-         * the entry is still the context this tracker installed. TaskGroupLocation is reused
-         * across pipeline restore generations, so a stale {@link #taskDone(Task)} from an
-         * earlier generation must not evict the context installed by a newer generation for
-         * the same location. {@link java.util.concurrent.ConcurrentMap#remove(Object, Object)}
-         * performs the check atomically.
+         * Moves the execution context from the active map to the finished map, but only if the
+         * entry is still the context this tracker installed. TaskGroupLocation is reused across
+         * pipeline restore generations, so a stale {@link #taskDone(Task)} from an earlier
+         * generation must not evict the context installed by a newer generation for the same
+         * location. {@link java.util.concurrent.ConcurrentMap#remove(Object, Object)} performs the
+         * check atomically.
          */
         private void finishExecutionContext(TaskGroupLocation taskGroupLocation) {
             if (executionContexts.remove(taskGroupLocation, ownedContext)) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -584,9 +584,11 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                                                 }
                                                 return true;
                                             }));
+            TaskGroupContext context = new TaskGroupContext(taskGroup, classLoaders, jars);
             executionContexts.put(
                     taskGroup.getTaskGroupLocation(),
-                    new TaskGroupContext(taskGroup, classLoaders, jars));
+                    context);
+            executionTracker.ownedContext = context;
             cancellationFutures.put(taskGroup.getTaskGroupLocation(), cancellationFuture);
             submitThreadShareTask(executionTracker, byCooperation.get(true));
             submitBlockingTask(executionTracker, byCooperation.get(false));
@@ -1308,6 +1310,13 @@ public class TaskExecutionService implements DynamicMetricsProvider {
 
         private final Map<Long, Future<?>> currRunningTaskFuture = new ConcurrentHashMap<>();
 
+        /**
+         * The TaskGroupContext that this tracker owns. Used to guard against stale
+         * taskDone calls from a previous restore generation removing the execution
+         * context installed by a newer generation for the same TaskGroupLocation.
+         */
+        private volatile TaskGroupContext ownedContext;
+
         TaskGroupExecutionTracker(
                 @NonNull CompletableFuture<Void> cancellationFuture,
                 @NonNull TaskGroup taskGroup,
@@ -1390,8 +1399,10 @@ public class TaskExecutionService implements DynamicMetricsProvider {
             Throwable ex = executionException.get();
             if (completionLatch.decrementAndGet() == 0) {
                 recycleClassLoader(taskGroupLocation);
-                finishedExecutionContexts.put(
-                        taskGroupLocation, executionContexts.remove(taskGroupLocation));
+                // Only remove the execution context if it is still the one this tracker
+                // installed. A stale taskDone belonging to an earlier restore generation must
+                // not evict the context installed by a newer generation for the same location.
+                finishExecutionContext(taskGroupLocation);
                 cancellationFutures.remove(taskGroupLocation);
                 try {
                     cancelAsyncFunction(taskGroupLocation);
@@ -1443,6 +1454,20 @@ public class TaskExecutionService implements DynamicMetricsProvider {
             executionContexts.get(taskGroupLocation).setClassLoaders(null);
             for (Collection<URL> jars : context.getJars().values()) {
                 classLoaderService.releaseClassLoader(taskGroupLocation.getJobId(), jars);
+            }
+        }
+
+        /**
+         * Moves the execution context from the active map to the finished map, but only if
+         * the entry is still the context this tracker installed. TaskGroupLocation is reused
+         * across pipeline restore generations, so a stale {@link #taskDone(Task)} from an
+         * earlier generation must not evict the context installed by a newer generation for
+         * the same location. {@link java.util.concurrent.ConcurrentMap#remove(Object, Object)}
+         * performs the check atomically.
+         */
+        private void finishExecutionContext(TaskGroupLocation taskGroupLocation) {
+            if (executionContexts.remove(taskGroupLocation, ownedContext)) {
+                finishedExecutionContexts.put(taskGroupLocation, ownedContext);
             }
         }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.engine.server;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
+import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.server.execution.BlockTask;
@@ -52,9 +53,12 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -458,6 +462,68 @@ public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
         taskExecutionService.cancelTaskGroup(location);
     }
 
+    /**
+     * Verifies that a stale tracker cannot tear down resources installed by a newer restore
+     * generation for the same TaskGroupLocation.
+     */
+    @Test
+    public void testStaleTaskDoneDoesNotCleanupNewerGenerationResources() throws Exception {
+        TaskExecutionService taskExecutionService = server.getTaskExecutionService();
+        TaskGroupLocation location =
+                new TaskGroupLocation(
+                        System.currentTimeMillis(), pipeLineId, FLAKE_ID_GENERATOR.newId());
+        Task oldTask = new TestTask(new AtomicBoolean(true), 0, true);
+        TaskGroup oldTaskGroup =
+                new TaskGroupDefaultImpl(location, "old-generation", Lists.newArrayList(oldTask));
+        TaskGroup newTaskGroup =
+                new TaskGroupDefaultImpl(
+                        location,
+                        "new-generation",
+                        Lists.newArrayList(new TestTask(new AtomicBoolean(true), 0, true)));
+        TaskGroupContext oldContext = newTaskGroupContext(oldTaskGroup);
+        TaskGroupContext newContext = newTaskGroupContext(newTaskGroup);
+        CompletableFuture<Void> oldCancellationFuture = new CompletableFuture<>();
+        CompletableFuture<TaskExecutionState> oldResultFuture = new CompletableFuture<>();
+        TaskExecutionService.TaskGroupExecutionTracker oldTracker =
+                taskExecutionService
+                .new TaskGroupExecutionTracker(
+                        oldCancellationFuture, oldTaskGroup, oldContext, oldResultFuture);
+
+        ConcurrentMap<TaskGroupLocation, TaskGroupContext> executionContexts =
+                getField(taskExecutionService, "executionContexts");
+        ConcurrentMap<TaskGroupLocation, CompletableFuture<Void>> cancellationFutures =
+                getField(taskExecutionService, "cancellationFutures");
+        ConcurrentMap<TaskGroupLocation, Map<String, CompletableFuture<?>>>
+                taskAsyncFunctionFuture = getField(taskExecutionService, "taskAsyncFunctionFuture");
+        ConcurrentMap<TaskGroupLocation, ConcurrentMap<TaskLocation, ScheduledFuture<?>>>
+                timerFlushFutures = getField(taskExecutionService, "timerFlushFutures");
+        CompletableFuture<Void> newCancellationFuture = new CompletableFuture<>();
+        CompletableFuture<?> asyncFuture = new CompletableFuture<>();
+        Map<String, CompletableFuture<?>> asyncFutures = new ConcurrentHashMap<>();
+        asyncFutures.put("new-generation-async", asyncFuture);
+        TaskLocation taskLocation = new TaskLocation(location, 1L, 1);
+        ScheduledFuture<?> timerFlushFuture =
+                taskExecutionService.registerTimerFlushTask(taskLocation, () -> {}, 60_000L);
+
+        executionContexts.put(location, newContext);
+        cancellationFutures.put(location, newCancellationFuture);
+        taskAsyncFunctionFuture.put(location, asyncFutures);
+
+        oldTracker.taskDone(oldTask);
+
+        Assertions.assertSame(newContext, executionContexts.get(location));
+        Assertions.assertNotNull(newContext.getClassLoaders());
+        Assertions.assertFalse(newCancellationFuture.isCancelled());
+        Assertions.assertSame(newCancellationFuture, cancellationFutures.get(location));
+        Assertions.assertSame(asyncFutures, taskAsyncFunctionFuture.get(location));
+        Assertions.assertFalse(asyncFuture.isCancelled());
+        Assertions.assertSame(timerFlushFuture, timerFlushFutures.get(location).get(taskLocation));
+        Assertions.assertFalse(timerFlushFuture.isCancelled());
+        assertEquals(FINISHED, oldResultFuture.get().getExecutionState());
+
+        taskExecutionService.closeTimerFlushTask(taskLocation);
+    }
+
     public List<Task> buildFixedTestTask(
             long callTime, long count, AtomicBoolean stopMart, CopyOnWriteArrayList<Long> lagList) {
         List<Task> taskQueue = new ArrayList<>();
@@ -466,6 +532,31 @@ public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
                     new FixedCallTestTimeTask(callTime, callTime + "t" + i, stopMart, lagList));
         }
         return taskQueue;
+    }
+
+    private static TaskGroupContext newTaskGroupContext(TaskGroup taskGroup) {
+        ConcurrentHashMap<Long, ClassLoader> classLoaders = new ConcurrentHashMap<>();
+        ConcurrentHashMap<Long, Collection<URL>> jars = new ConcurrentHashMap<>();
+        taskGroup
+                .getTasks()
+                .forEach(
+                        task -> {
+                            classLoaders.put(
+                                    task.getTaskID(),
+                                    Thread.currentThread().getContextClassLoader());
+                            jars.put(task.getTaskID(), Collections.emptyList());
+                        });
+        return new TaskGroupContext(taskGroup, classLoaders, jars);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getField(Object target, String fieldName) {
+        return (T)
+                ReflectionUtils.getField(target, fieldName)
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "Field " + fieldName + " not found on " + target));
     }
 
     public List<Task> buildStopTestTask(


### PR DESCRIPTION
This republishes the current fix stream from #11757 onto an Apache-owned branch so CI and review can continue without depending on the contributor fork.

Included in this branch:
- the current #11757 generation-safe cleanup fix and regression test
- one additional stale-branch cleanup fix for the reviewer-identified classloader leak on the rejected cleanup path

Follow-up context:
- original PR: #11757
- related issue: #11755

Please review this PR as the Apache-side continuation of #11757.