### PR TITLE
[Fix][Transform-V2] Correct EXTRACT epoch and subsecond units

### DIFF
--- a/docs/en/introduction/concepts/incompatible-changes.md
+++ b/docs/en/introduction/concepts/incompatible-changes.md
@@ -144,6 +144,12 @@ You need to check this document before you upgrade to related version.
 
 ### Transform Changes
 
+- **Breaking Change: SQL `EXTRACT(EPOCH|MILLISECOND(S)|MICROSECOND(S))` now follows documented semantics**
+  - **Affected component**: `seatunnel-transforms-v2` SQL Transform (`EXTRACT` in Zeta SQL)
+  - **Description**: `EXTRACT(EPOCH FROM ...)` now returns a `BIGINT`-compatible value instead of truncating the epoch seconds to `INT`. `EXTRACT(MILLISECOND(S) FROM ...)` and `EXTRACT(MICROSECOND(S) FROM ...)` now include the whole-seconds field, matching the SQL-standard behavior already documented in `sql-functions.md`, instead of returning only the fractional remainder.
+  - **Impact**: Downstream typed sinks or schema assertions that previously expected `INT` for `EPOCH` may now see `BIGINT`. Pipelines that relied on the old fractional-only millisecond or microsecond value will now receive `seconds * 10^n + fractional_part`.
+  - **Migration Guide**: If your downstream schema still expects an integer-sized epoch value, cast it explicitly after confirming the values fit your range. If you need the old fractional-only millisecond or microsecond behavior, use `MOD(EXTRACT(MILLISECONDS FROM ts), 1000)` or `MOD(EXTRACT(MICROSECONDS FROM ts), 1000000)`.
+
 - **[BREAKING]** SQL Transform `PARSEDATETIME`, `TO_DATE`, and `IS_DATE` functions now only accept whitelisted datetime format patterns. Custom format patterns that were previously accepted will now fail at runtime. The supported patterns are:
   - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`, `yyyy/MM/dd HH:mm:ss`, `yyyy/MM/dd HH:mm:ss.SSS`, `yyyyMMddHHmmss`
   - Date: `yyyy-MM-dd`, `yyyy/MM/dd`, `yyyyMMdd`

--- a/docs/zh/introduction/concepts/incompatible-changes.md
+++ b/docs/zh/introduction/concepts/incompatible-changes.md
@@ -139,6 +139,12 @@
 
 ### 转换变更
 
+- **破坏性变更：SQL `EXTRACT(EPOCH|MILLISECOND(S)|MICROSECOND(S))` 现在与文档语义保持一致**
+  - **影响范围**：`seatunnel-transforms-v2` SQL Transform（Zeta SQL 中的 `EXTRACT`）
+  - **变更说明**：`EXTRACT(EPOCH FROM ...)` 现在返回兼容 `BIGINT` 的值，不再把 epoch 秒数截断成 `INT`。`EXTRACT(MILLISECOND(S) FROM ...)` 和 `EXTRACT(MICROSECOND(S) FROM ...)` 现在会把整秒部分一起折算进结果，和 `sql-functions.md` 中已公开的 SQL 标准语义保持一致，而不是只返回小数秒余数。
+  - **影响**：如果下游 typed sink 或 schema 断言以前假定 `EPOCH` 输出是 `INT`，升级后可能看到 `BIGINT`。如果已有任务依赖旧的“仅小数部分”毫秒/微秒值，升级后将收到 `秒数 * 10^n + 小数部分` 的新结果。
+  - **迁移指南**：如果下游 schema 仍要求整数大小的 epoch 值，请在确认数值范围后显式做类型转换。如果您需要旧的“仅小数部分”毫秒/微秒行为，可以使用 `MOD(EXTRACT(MILLISECONDS FROM ts), 1000)` 或 `MOD(EXTRACT(MICROSECONDS FROM ts), 1000000)`。
+
 - **[BREAKING]** SQL Transform 的 `PARSEDATETIME`、`TO_DATE` 和 `IS_DATE` 函数现在只接受白名单中的日期时间格式模式。以前接受的自定义格式模式现在将在运行时失败。支持的模式有：
   - DateTime: `yyyy-MM-dd HH:mm:ss`, `yyyy-MM-dd HH:mm:ss.SSS`, `yyyy-MM-dd'T'HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`, `yyyy/MM/dd HH:mm:ss`, `yyyy/MM/dd HH:mm:ss.SSS`, `yyyyMMddHHmmss`
   - Date: `yyyy-MM-dd`, `yyyy/MM/dd`, `yyyyMMdd`

--- a/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/resources/sql_transform/func_datetime.conf
+++ b/seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2/src/test/resources/sql_transform/func_datetime.conf
@@ -282,7 +282,7 @@ sink {
           field_name = "c3_16"
           field_type = "int"
           field_value = [
-            {equals_to = 235}
+            {equals_to = 45235}
           ]
         },
         {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
@@ -319,6 +319,12 @@ public class ZetaSQLType {
         return getMaxType(types);
     }
 
+    /**
+     * Returns the runtime type of an EXTRACT expression.
+     *
+     * <p>EPOCH values can exceed 32-bit integer range, so they must stay BIGINT-compatible even
+     * though the other EXTRACT fields still fit in INT.
+     */
     private SeaTunnelDataType<?> getExtractType(ExtractExpression expression) {
         if ("EPOCH".equalsIgnoreCase(expression.getName())) {
             return BasicType.LONG_TYPE;

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/ZetaSQLType.java
@@ -164,7 +164,7 @@ public class ZetaSQLType {
             return getTimeKeyExprType((TimeKeyExpression) expression);
         }
         if (expression instanceof ExtractExpression) {
-            return BasicType.INT_TYPE;
+            return getExtractType((ExtractExpression) expression);
         }
         if (expression instanceof Parenthesis) {
             Parenthesis parenthesis = (Parenthesis) expression;
@@ -317,6 +317,13 @@ public class ZetaSQLType {
             types.add(getExpressionType(caseExpression.getElseExpression()));
         }
         return getMaxType(types);
+    }
+
+    private SeaTunnelDataType<?> getExtractType(ExtractExpression expression) {
+        if ("EPOCH".equalsIgnoreCase(expression.getName())) {
+            return BasicType.LONG_TYPE;
+        }
+        return BasicType.INT_TYPE;
     }
 
     private SeaTunnelDataType<?> getFunctionType(Function function) {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -375,7 +375,7 @@ public class DateTimeFunction {
         return localDate.getDayOfYear();
     }
 
-    public static Integer extract(List<Object> args) {
+    public static Number extract(List<Object> args) {
         Temporal datetime = (Temporal) args.get(0);
         if (datetime == null) {
             return null;
@@ -449,39 +449,47 @@ public class DateTimeFunction {
                 }
                 break;
             case "MILLISECOND":
+            case "MILLISECONDS":
                 if (datetime instanceof LocalTime) {
-                    return ((LocalTime) datetime).getNano() / 1000_000;
+                    LocalTime time = (LocalTime) datetime;
+                    return extractMilliseconds(time.getSecond(), time.getNano());
                 }
                 if (datetime instanceof LocalDateTime) {
-                    return ((LocalDateTime) datetime).getNano() / 1000_000;
+                    LocalDateTime dateTime = (LocalDateTime) datetime;
+                    return extractMilliseconds(dateTime.getSecond(), dateTime.getNano());
                 }
                 if (datetime instanceof OffsetDateTime) {
-                    return ((OffsetDateTime) datetime).getNano() / 1000_000;
+                    OffsetDateTime dateTime = (OffsetDateTime) datetime;
+                    return extractMilliseconds(dateTime.getSecond(), dateTime.getNano());
                 }
                 break;
+            case "MICROSECOND":
             case "MICROSECONDS":
                 if (datetime instanceof LocalTime) {
-                    return ((LocalTime) datetime).getNano() / 1000;
+                    LocalTime time = (LocalTime) datetime;
+                    return extractMicroseconds(time.getSecond(), time.getNano());
                 }
                 if (datetime instanceof LocalDateTime) {
-                    return ((LocalDateTime) datetime).getNano() / 1000;
+                    LocalDateTime dateTime = (LocalDateTime) datetime;
+                    return extractMicroseconds(dateTime.getSecond(), dateTime.getNano());
                 }
                 if (datetime instanceof OffsetDateTime) {
-                    return ((OffsetDateTime) datetime).getNano() / 1000;
+                    OffsetDateTime dateTime = (OffsetDateTime) datetime;
+                    return extractMicroseconds(dateTime.getSecond(), dateTime.getNano());
                 }
                 break;
             case "EPOCH":
                 if (datetime instanceof LocalDateTime) {
                     ZoneOffset offset = ZoneOffset.UTC;
-                    return (int) ((LocalDateTime) datetime).toEpochSecond(offset);
+                    return ((LocalDateTime) datetime).toEpochSecond(offset);
                 }
                 if (datetime instanceof LocalDate) {
                     LocalDateTime ldt = LocalDateTime.of((LocalDate) datetime, LocalTime.MIDNIGHT);
                     ZoneOffset offset = ZoneOffset.UTC;
-                    return (int) ldt.toEpochSecond(offset);
+                    return ldt.toEpochSecond(offset);
                 }
                 if (datetime instanceof OffsetDateTime) {
-                    return (int) ((OffsetDateTime) datetime).toEpochSecond();
+                    return ((OffsetDateTime) datetime).toEpochSecond();
                 }
                 break;
             case "QUARTER":
@@ -605,6 +613,14 @@ public class DateTimeFunction {
                                 datetimeField, ZetaSQLFunction.EXTRACT));
         }
         return null;
+    }
+
+    private static int extractMilliseconds(int second, int nano) {
+        return second * 1000 + nano / 1000_000;
+    }
+
+    private static int extractMicroseconds(int second, int nano) {
+        return second * 1000_000 + nano / 1000;
     }
 
     public static String formatdatetime(List<Object> args) {

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/DateTimeFunction.java
@@ -615,10 +615,22 @@ public class DateTimeFunction {
         return null;
     }
 
+    /**
+     * Converts the EXTRACT milliseconds field to the SQL-standard whole-seconds-based value.
+     *
+     * <p>This keeps the seconds component in the result instead of returning only the fractional
+     * remainder.
+     */
     private static int extractMilliseconds(int second, int nano) {
         return second * 1000 + nano / 1000_000;
     }
 
+    /**
+     * Converts the EXTRACT microseconds field to the SQL-standard whole-seconds-based value.
+     *
+     * <p>This keeps the seconds component in the result instead of returning only the fractional
+     * remainder.
+     */
     private static int extractMicroseconds(int second, int nano) {
         return second * 1000_000 + nano / 1000;
     }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ExtractFunctionTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ExtractFunctionTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.table.type.LocalTimeType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
 import org.apache.seatunnel.transform.sql.SQLEngine;
 import org.apache.seatunnel.transform.sql.SQLEngineFactory;
 
@@ -76,11 +77,10 @@ public class ExtractFunctionTest {
         Assertions.assertEquals(14, outRow.getField(3));
         Assertions.assertEquals(30, outRow.getField(4));
         Assertions.assertEquals(45, outRow.getField(5));
-        Assertions.assertEquals(123, outRow.getField(6));
-        Assertions.assertEquals(123456, outRow.getField(7));
+        Assertions.assertEquals(45123, outRow.getField(6));
+        Assertions.assertEquals(45123456, outRow.getField(7));
 
-        Assertions.assertEquals(
-                (int) testDateTime.toEpochSecond(ZoneOffset.UTC), outRow.getField(8));
+        Assertions.assertEquals(testDateTime.toEpochSecond(ZoneOffset.UTC), outRow.getField(8));
         Assertions.assertEquals(2, outRow.getField(9));
         Assertions.assertEquals(21, outRow.getField(10));
         Assertions.assertEquals(202, outRow.getField(11));
@@ -88,6 +88,59 @@ public class ExtractFunctionTest {
         Assertions.assertEquals(2, outRow.getField(13));
         Assertions.assertEquals(140, outRow.getField(14));
         Assertions.assertEquals(3, outRow.getField(15));
+    }
+
+    @Test
+    public void testExtractFractionalSecondUnits() {
+        SQLEngine sqlEngine = SQLEngineFactory.getSQLEngine(SQLEngineFactory.EngineType.ZETA);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"event_time"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        LocalDateTime testDateTime = LocalDateTime.of(2025, 5, 20, 14, 30, 45, 123456789);
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {testDateTime});
+
+        sqlEngine.init(
+                "test",
+                null,
+                rowType,
+                "SELECT "
+                        + "EXTRACT(MILLISECOND FROM event_time) as millisecond, "
+                        + "EXTRACT(MILLISECONDS FROM event_time) as milliseconds, "
+                        + "EXTRACT(MICROSECOND FROM event_time) as microsecond, "
+                        + "EXTRACT(MICROSECONDS FROM event_time) as microseconds "
+                        + "FROM dual");
+
+        SeaTunnelRow outRow = sqlEngine.transformBySQL(inputRow, rowType).get(0);
+
+        Assertions.assertEquals(45123, outRow.getField(0));
+        Assertions.assertEquals(45123, outRow.getField(1));
+        Assertions.assertEquals(45123456, outRow.getField(2));
+        Assertions.assertEquals(45123456, outRow.getField(3));
+    }
+
+    @Test
+    public void testExtractEpochAfter2038() {
+        SQLEngine sqlEngine = SQLEngineFactory.getSQLEngine(SQLEngineFactory.EngineType.ZETA);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"event_time"},
+                        new SeaTunnelDataType[] {LocalTimeType.LOCAL_DATE_TIME_TYPE});
+
+        LocalDateTime testDateTime = LocalDateTime.of(2040, 1, 1, 0, 0, 0);
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {testDateTime});
+
+        sqlEngine.init(
+                "test", null, rowType, "SELECT EXTRACT(EPOCH FROM event_time) as epoch FROM dual");
+
+        SeaTunnelRowType outRowType = sqlEngine.typeMapping(null);
+        SeaTunnelRow outRow = sqlEngine.transformBySQL(inputRow, rowType).get(0);
+
+        Assertions.assertEquals(SqlType.BIGINT, outRowType.getFieldType(0).getSqlType());
+        Assertions.assertEquals(testDateTime.toEpochSecond(ZoneOffset.UTC), outRow.getField(0));
     }
 
     @Test

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ExtractFunctionTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/ExtractFunctionTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 public class ExtractFunctionTest {
@@ -141,6 +143,77 @@ public class ExtractFunctionTest {
 
         Assertions.assertEquals(SqlType.BIGINT, outRowType.getFieldType(0).getSqlType());
         Assertions.assertEquals(testDateTime.toEpochSecond(ZoneOffset.UTC), outRow.getField(0));
+    }
+
+    @Test
+    public void testExtractFractionalSecondUnitsForLocalTimeAndOffsetDateTime() {
+        SQLEngine sqlEngine = SQLEngineFactory.getSQLEngine(SQLEngineFactory.EngineType.ZETA);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"event_time", "event_time_tz"},
+                        new SeaTunnelDataType[] {
+                            LocalTimeType.LOCAL_TIME_TYPE, LocalTimeType.OFFSET_DATE_TIME_TYPE
+                        });
+
+        LocalTime localTime = LocalTime.of(14, 30, 45, 123456789);
+        OffsetDateTime offsetDateTime =
+                OffsetDateTime.of(2025, 5, 20, 14, 30, 45, 123456789, ZoneOffset.ofHours(8));
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {localTime, offsetDateTime});
+
+        sqlEngine.init(
+                "test",
+                null,
+                rowType,
+                "SELECT "
+                        + "EXTRACT(MILLISECONDS FROM event_time) as time_milliseconds, "
+                        + "EXTRACT(MICROSECONDS FROM event_time) as time_microseconds, "
+                        + "EXTRACT(MILLISECONDS FROM event_time_tz) as time_tz_milliseconds, "
+                        + "EXTRACT(MICROSECONDS FROM event_time_tz) as time_tz_microseconds "
+                        + "FROM dual");
+
+        SeaTunnelRow outRow = sqlEngine.transformBySQL(inputRow, rowType).get(0);
+
+        Assertions.assertEquals(45123, outRow.getField(0));
+        Assertions.assertEquals(45123456, outRow.getField(1));
+        Assertions.assertEquals(45123, outRow.getField(2));
+        Assertions.assertEquals(45123456, outRow.getField(3));
+    }
+
+    @Test
+    public void testExtractEpochForLocalDateAndOffsetDateTime() {
+        SQLEngine sqlEngine = SQLEngineFactory.getSQLEngine(SQLEngineFactory.EngineType.ZETA);
+
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"event_date", "event_time_tz"},
+                        new SeaTunnelDataType[] {
+                            LocalTimeType.LOCAL_DATE_TYPE, LocalTimeType.OFFSET_DATE_TIME_TYPE
+                        });
+
+        LocalDate localDate = LocalDate.of(2040, 1, 1);
+        OffsetDateTime offsetDateTime =
+                OffsetDateTime.of(2040, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(8));
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {localDate, offsetDateTime});
+
+        sqlEngine.init(
+                "test",
+                null,
+                rowType,
+                "SELECT "
+                        + "EXTRACT(EPOCH FROM event_date) as date_epoch, "
+                        + "EXTRACT(EPOCH FROM event_time_tz) as time_tz_epoch "
+                        + "FROM dual");
+
+        SeaTunnelRowType outRowType = sqlEngine.typeMapping(null);
+        SeaTunnelRow outRow = sqlEngine.transformBySQL(inputRow, rowType).get(0);
+
+        Assertions.assertEquals(SqlType.BIGINT, outRowType.getFieldType(0).getSqlType());
+        Assertions.assertEquals(SqlType.BIGINT, outRowType.getFieldType(1).getSqlType());
+        Assertions.assertEquals(
+                LocalDateTime.of(localDate, LocalTime.MIDNIGHT).toEpochSecond(ZoneOffset.UTC),
+                outRow.getField(0));
+        Assertions.assertEquals(offsetDateTime.toEpochSecond(), outRow.getField(1));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- republish the #11142 EXTRACT fix onto a writable davidzollo branch based on the latest dev
- carry the review follow-ups that were still missing on the original fork PR: incompatible-changes entries in docs/en and docs/zh, broader EXTRACT regression coverage, and the transform-v2 E2E expectation update
- supersede the conflicted DanielLeens replacement path in #11905 with a clean current-head delivery branch

## Validation
- ./mvnw spotless:apply -pl seatunnel-transforms-v2,seatunnel-e2e/seatunnel-transforms-v2-e2e/seatunnel-transforms-v2-e2e-part-2 -am -nsu
- git diff --check

Original fix author: @fallintoplace
