### PR TITLE
[Feature][E2E] Add Helm chart deployment test

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -93,19 +93,41 @@ jobs:
           fi
 
   helm-chart-check:
-    name: Check Helm Chart Syntax
-    needs: [ license-header, code-style]
+    name: Check Helm Chart
+    needs: [ license-header, code-style, changes ]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup Helm
         run: |
-          if ! command -v helm >/dev/null 2>&1; then
-            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          fi
+          HELM_VERSION=v3.18.4
+          HELM_ARCHIVE="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          curl --fail --silent --show-error --location \
+            --output "${HELM_ARCHIVE}" \
+            "https://get.helm.sh/${HELM_ARCHIVE}"
+          echo "f8180838c23d7c7d797b208861fecb591d9ce1690d8704ed1e4cb8e2add966c1  ${HELM_ARCHIVE}" \
+            | sha256sum --check
+          tar --extract --gzip --file "${HELM_ARCHIVE}"
+          sudo install linux-amd64/helm /usr/local/bin/helm
           helm version
-      - name: Lint Chart
-        run: helm lint deploy/kubernetes/seatunnel
+      - name: Validate Chart
+        run: deploy/kubernetes/helm-tests/test-chart.sh render
+      - name: Free disk space
+        if: needs.changes.outputs.helm == 'true'
+        run: tools/github/free_disk_space.sh
+      - name: Install k8s
+        if: needs.changes.outputs.helm == 'true'
+        run: |
+          curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=644 sh -s - --docker
+          mkdir -p ~/.kube
+          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+          kubectl wait --for=condition=Ready nodes --all --timeout=2m
+      - name: Test Chart Installation
+        if: needs.changes.outputs.helm == 'true'
+        run: deploy/kubernetes/helm-tests/test-chart.sh install
 
   dead-link:
     name: Dead links
@@ -143,6 +165,7 @@ jobs:
       edge-agent-e2e: ${{ steps.filter.outputs.edge-agent-e2e }}
       benchmarks: ${{ steps.filter.outputs.benchmarks }}
       docs: ${{ steps.filter.outputs.docs }}
+      helm: ${{ steps.filter.outputs.helm }}
       ut-modules: ${{ steps.ut-modules.outputs.modules }}
       it-modules: ${{ steps.it-modules.outputs.modules }}
     steps:
@@ -196,6 +219,12 @@ jobs:
           file_list=${doc_files#*$'\n'}
           echo "docs=$true_or_false" >> $GITHUB_OUTPUT
           echo "docs_files=$file_list" >> $GITHUB_OUTPUT
+
+          helm_files=`python tools/update_modules_check/check_file_updates.py ua $workspace apache/dev origin/$current_branch "deploy/kubernetes/**"`
+          true_or_false=${helm_files%%$'\n'*}
+          file_list=${helm_files#*$'\n'}
+          echo "helm=$true_or_false" >> $GITHUB_OUTPUT
+          echo "helm_files=$file_list" >> $GITHUB_OUTPUT
 
           benchmark_files=`python tools/update_modules_check/check_file_updates.py ua $workspace apache/dev origin/$current_branch "seatunnel-benchmarks/**" "tools/benchmarks/**" ".github/workflows/benchmarks.yml"`
           true_or_false=${benchmark_files%%$'\n'*}

--- a/deploy/kubernetes/helm-tests/test-chart.sh
+++ b/deploy/kubernetes/helm-tests/test-chart.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CHART_DIR="${SCRIPT_DIR}/../seatunnel"
+readonly RELEASE_NAME="seatunnel-e2e"
+readonly RELEASE_NAMESPACE="seatunnel-e2e"
+readonly REST_RESPONSE="${TMPDIR:-/tmp}/seatunnel-helm-rest-response.json"
+PORT_FORWARD_PID=""
+
+render_chart() {
+    helm lint --strict "${CHART_DIR}"
+    helm template "${RELEASE_NAME}" "${CHART_DIR}" \
+        --namespace "${RELEASE_NAMESPACE}" \
+        --set master.replicas=1 \
+        --set worker.replicas=1 \
+        > /dev/null
+    helm template "${RELEASE_NAME}" "${CHART_DIR}" \
+        --namespace "${RELEASE_NAMESPACE}" \
+        --set ingress.enabled=true \
+        --set ingress.tls.enabled=true \
+        --set master.replicas=1 \
+        --set worker.replicas=1 \
+        > /dev/null
+}
+
+print_diagnostics() {
+    kubectl --namespace "${RELEASE_NAMESPACE}" get all --output wide || true
+    kubectl --namespace "${RELEASE_NAMESPACE}" describe pods || true
+    kubectl --namespace "${RELEASE_NAMESPACE}" logs \
+        --selector "app.kubernetes.io/instance=${RELEASE_NAME}" \
+        --all-containers \
+        --prefix \
+        --tail=200 || true
+}
+
+cleanup() {
+    local exit_code=$?
+    trap - EXIT
+
+    if [[ -n "${PORT_FORWARD_PID}" ]]; then
+        kill "${PORT_FORWARD_PID}" 2>/dev/null || true
+        wait "${PORT_FORWARD_PID}" 2>/dev/null || true
+    fi
+    if [[ ${exit_code} -ne 0 ]]; then
+        print_diagnostics
+    fi
+    helm uninstall "${RELEASE_NAME}" --namespace "${RELEASE_NAMESPACE}" >/dev/null 2>&1 || true
+    kubectl delete namespace "${RELEASE_NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+    exit "${exit_code}"
+}
+
+verify_rest_api() {
+    rm -f "${REST_RESPONSE}"
+    kubectl --namespace "${RELEASE_NAMESPACE}" port-forward \
+        "service/${RELEASE_NAME}-master" 18080:8080 \
+        > "${TMPDIR:-/tmp}/seatunnel-helm-port-forward.log" 2>&1 &
+    PORT_FORWARD_PID=$!
+
+    for _ in $(seq 1 60); do
+        if curl --fail --silent --show-error \
+            --output "${REST_RESPONSE}" \
+            http://127.0.0.1:18080/system-monitoring-information \
+            && response_has_expected_members; then
+            return
+        fi
+        sleep 2
+    done
+
+    echo "SeaTunnel REST API did not report both cluster members" >&2
+    return 1
+}
+
+response_has_expected_members() {
+    python3 - "${REST_RESPONSE}" <<'PY'
+import json
+import pathlib
+import sys
+
+response_path = pathlib.Path(sys.argv[1])
+if not response_path.exists():
+    raise SystemExit(1)
+
+try:
+    members = json.loads(response_path.read_text(encoding="utf-8"))
+except (json.JSONDecodeError, OSError):
+    raise SystemExit(1)
+
+raise SystemExit(0 if isinstance(members, list) and len(members) >= 2 else 1)
+PY
+}
+
+install_chart() {
+    trap cleanup EXIT
+
+    helm upgrade --install "${RELEASE_NAME}" "${CHART_DIR}" \
+        --namespace "${RELEASE_NAMESPACE}" \
+        --create-namespace \
+        --wait \
+        --timeout 15m \
+        --set master.replicas=1 \
+        --set worker.replicas=1
+
+    kubectl --namespace "${RELEASE_NAMESPACE}" rollout status \
+        "deployment/${RELEASE_NAME}-master" --timeout=2m
+    kubectl --namespace "${RELEASE_NAMESPACE}" rollout status \
+        "deployment/${RELEASE_NAME}-worker" --timeout=2m
+    verify_rest_api
+}
+
+case "${1:-}" in
+    render)
+        render_chart
+        ;;
+    install)
+        install_chart
+        ;;
+    *)
+        echo "Usage: $0 <render|install>" >&2
+        exit 2
+        ;;
+esac

--- a/deploy/kubernetes/helm-tests/test-chart.sh
+++ b/deploy/kubernetes/helm-tests/test-chart.sh
@@ -23,7 +23,6 @@ readonly CHART_DIR="${SCRIPT_DIR}/../seatunnel"
 readonly RELEASE_NAME="seatunnel-e2e"
 readonly RELEASE_NAMESPACE="seatunnel-e2e"
 readonly REST_RESPONSE="${TMPDIR:-/tmp}/seatunnel-helm-rest-response.json"
-PORT_FORWARD_PID=""
 
 render_chart() {
     helm lint --strict "${CHART_DIR}"
@@ -55,10 +54,6 @@ cleanup() {
     local exit_code=$?
     trap - EXIT
 
-    if [[ -n "${PORT_FORWARD_PID}" ]]; then
-        kill "${PORT_FORWARD_PID}" 2>/dev/null || true
-        wait "${PORT_FORWARD_PID}" 2>/dev/null || true
-    fi
     if [[ ${exit_code} -ne 0 ]]; then
         print_diagnostics
     fi
@@ -69,15 +64,13 @@ cleanup() {
 
 verify_rest_api() {
     rm -f "${REST_RESPONSE}"
-    kubectl --namespace "${RELEASE_NAMESPACE}" port-forward \
-        "service/${RELEASE_NAME}-master" 18080:8080 \
-        > "${TMPDIR:-/tmp}/seatunnel-helm-port-forward.log" 2>&1 &
-    PORT_FORWARD_PID=$!
 
     for _ in $(seq 1 60); do
-        if curl --fail --silent --show-error \
-            --output "${REST_RESPONSE}" \
-            http://127.0.0.1:18080/system-monitoring-information \
+        if kubectl --namespace "${RELEASE_NAMESPACE}" exec \
+            "deployment/${RELEASE_NAME}-master" -- \
+            curl --fail --silent --show-error --max-time 5 \
+            http://127.0.0.1:8080/system-monitoring-information \
+            > "${REST_RESPONSE}" \
             && response_has_expected_members; then
             return
         fi


### PR DESCRIPTION
### Purpose of this pull request

Closes #8982.

PR #9006 added Helm linting and template validation. This change covers the remaining deployment path by installing the chart on a temporary K3s cluster and checking that one master and one worker become ready.

The workflow:

- keeps strict lint and render checks for every backend change;
- runs the K3s installation only when `deploy/kubernetes/**` changes;
- waits for both deployments and verifies that `/system-monitoring-information` reports both cluster members;
- prints pod and log diagnostics when installation fails;
- pins the Helm binary and verifies its published checksum.

### Does this PR introduce _any_ user-facing change?

No. This changes repository CI only.

### How was this patch tested?

Verified locally with:

```shell
bash -n deploy/kubernetes/helm-tests/test-chart.sh
deploy/kubernetes/helm-tests/test-chart.sh render
```

The REST readiness polling was also checked with delayed, permanently incomplete, and malformed responses. The real K3s installation is the PR CI gate because it requires a Docker-backed runner.

### Check list

* [x] No new Jar binary package is added.
* [x] No user documentation update is required.
* [x] No incompatible change is introduced.
* [x] This is not connector code.