### PR TITLE
[Feature][Zeta] Add job lineage REST API design

### DIFF
--- a/docs/en/engines/zeta/job-lineage-rest-api.md
+++ b/docs/en/engines/zeta/job-lineage-rest-api.md
@@ -151,7 +151,8 @@ Example response:
 - `graphKind` is `EXECUTION` in this proposal.
 - `idScope` is `JOB`; clients must combine `jobId` and node `id` when storing a node.
 - `kind` is one of `SOURCE`, `TRANSFORM`, or `SINK`.
-- `name` is the action name already present in `VertexInfo`. It is display metadata, not an ID.
+- `name` is the connector type already present in `VertexInfo.connectorType`. It is display
+  metadata, not an ID.
 - `datasets` contains sorted, distinct table-path strings known for Source and Sink nodes.
 - `datasetMetadata` is one of:
   - `REPORTED`: the response contains the non-default table paths present in `JobDAGInfo`; this does
@@ -226,6 +227,11 @@ They must not include a Java stack trace, raw request value, connector configura
 class name. Clients must branch on `code`; `message` is descriptive text and may be refined without
 changing `schemaVersion`.
 
+The lineage servlet owns exception translation at its request boundary. It must catch unexpected
+failures and return the same `{code, message}` contract rather than allowing them to reach the
+shared `ExceptionHandlingFilter`, whose existing fallback response includes a stack trace and uses
+a different response shape. This proposal does not change that shared filter for other endpoints.
+
 ## Performance and Payload Bounds
 
 Mapping is `O(nodes + edges + datasets)` and uses the existing cached `JobDAGInfo`. The endpoint
@@ -270,7 +276,8 @@ paths are not URL-versioned, so the response version must remain explicit.
 1. Add an immutable REST response model and a pure mapper from `JobDAGInfo` with deterministic
    ordering, validation, dataset-status handling, and size accounting.
 2. Add `JobLineageService` and a dedicated servlet registered at `/job-lineage`, reusing the current
-   running/finished DAG lookup path without adding storage.
+   running/finished DAG lookup path without adding storage. The servlet handles all failures at its
+   boundary and emits only the error contract defined above.
 3. Add REST API documentation and security/retention notes after the contract is approved.
 4. Consider a separate Web UI or external-catalog integration only after operational use of the
    endpoint.

--- a/docs/en/engines/zeta/job-lineage-rest-api.md
+++ b/docs/en/engines/zeta/job-lineage-rest-api.md
@@ -1,0 +1,331 @@
+# Job Lineage REST API Design
+
+## Status
+
+This document is a design proposal. It does not describe an API that is available in a released
+SeaTunnel version. It must remain outside the published documentation navigation until the STIP
+scope and public contract are accepted.
+
+## Motivation
+
+The Zeta REST API already returns a DAG inside `/job-info/{jobId}` for the built-in Web UI. That
+representation is UI-oriented and is not documented as a stable lineage contract. External catalog,
+governance, and operations tools therefore have no supported way to retrieve a job-level
+source-to-transform-to-sink graph.
+
+The first version should expose job-level execution lineage for both batch and streaming jobs. It
+must not imply column-level precision or depend on sampled row traces.
+
+## Scope
+
+### Goals
+
+- expose the Source, Transform, and Sink graph for one Zeta job;
+- return the same model while the job is pending, running, or retained as finished history;
+- use stable node identifiers within one job;
+- expose known source and sink table paths without inferring table-to-table mappings;
+- survive an active-master change through the state already used by job details;
+- keep the current `/job-info/{jobId}` response unchanged;
+- define deterministic ordering, errors, limits, and compatibility rules before implementation.
+
+### Non-goals
+
+The first version will not provide:
+
+- column-level lineage;
+- field-expression or transform-semantic analysis;
+- record-level provenance;
+- lineage across several jobs;
+- a global dataset graph or external metadata-catalog integration;
+- lineage for jobs running on Flink or Spark;
+- historical versions of a graph after the finished-job retention period;
+- live updates when a dynamic source discovers another table;
+- a Web UI lineage screen.
+
+## Terminology
+
+- **Job lineage** is the job-scoped execution graph of Source, Transform, and Sink nodes.
+- **Dataset metadata** is the set of table paths already known to a Source or Sink node when the
+  job DAG information is built.
+- **StainTrace** is sampled record tracing. It is useful for latency and record-flow analysis but is
+  not an authoritative topology source.
+- **Node ID** is stable only within one job lineage snapshot. It is not a connector, dataset, or
+  cross-job identity.
+
+## Existing Architecture
+
+`JobMaster` lazily builds `JobDAGInfo` through `DAGUtils.getJobDAGInfo()`. The object contains:
+
+- the job ID;
+- pipeline-grouped edges;
+- a vertex map with vertex ID, plugin type, connector name, and known table paths;
+- execution-location metadata used by the current job-detail path.
+
+For a running job, the coordinator returns this object from the active `JobMaster`. If the request
+reaches a follower, the existing master operation path obtains it from the active master. When a job
+finishes, `JobHistoryService` stores the same `JobDAGInfo` with the configured
+`history-job-expire-minutes` retention.
+
+The lineage endpoint should be a deterministic projection of this existing object. It should not
+deserialize connector configuration, scan trace files, or add another Hazelcast map.
+
+## Source of Truth
+
+The first version uses `JobDAGInfo` as the only source of truth because it represents the execution
+graph already exposed for running and finished Zeta jobs.
+
+Consequences of this choice:
+
+- lineage describes the graph executed by Zeta, not the original HOCON block layout;
+- optimizer-created or chained Transform nodes are represented as the nodes present in
+  `JobDAGInfo`; the endpoint does not reconstruct hidden components;
+- node IDs are reused from `VertexInfo.vertexId` and are stable for the lifetime of that job;
+- pipeline IDs are reused from `JobDAGInfo.pipelineEdges`;
+- table paths are advisory metadata and do not create table-level lineage edges;
+- dynamic tables discovered after `JobDAGInfo` is built are not added in the first version.
+
+StainTrace must not be used to fill graph gaps. It is optional, sampled, stored separately, and may
+contain only a subset of records and stages.
+
+## REST Contract
+
+Proposed endpoint:
+
+```text
+GET /job-lineage/{jobId}
+```
+
+A dedicated route avoids changing the current path parsing or response behavior of
+`/job-info/{jobId}`.
+
+Example response:
+
+```json
+{
+  "schemaVersion": 1,
+  "jobId": "733584788375093248",
+  "graphKind": "EXECUTION",
+  "idScope": "JOB",
+  "nodes": [
+    {
+      "id": "1",
+      "kind": "SOURCE",
+      "name": "Jdbc",
+      "datasets": ["catalog.sales.orders"],
+      "datasetMetadata": "REPORTED"
+    },
+    {
+      "id": "2",
+      "kind": "TRANSFORM",
+      "name": "Sql",
+      "datasets": [],
+      "datasetMetadata": "NOT_APPLICABLE"
+    },
+    {
+      "id": "3",
+      "kind": "SINK",
+      "name": "Kafka",
+      "datasets": ["default.default.orders"],
+      "datasetMetadata": "REPORTED"
+    }
+  ],
+  "edges": [
+    {
+      "pipelineId": 1,
+      "sourceNodeId": "1",
+      "targetNodeId": "2"
+    },
+    {
+      "pipelineId": 1,
+      "sourceNodeId": "2",
+      "targetNodeId": "3"
+    }
+  ],
+  "warnings": []
+}
+```
+
+### Field Semantics
+
+- `schemaVersion` is the version of this response contract. The first version is `1`.
+- `graphKind` is `EXECUTION` in this proposal.
+- `idScope` is `JOB`; clients must combine `jobId` and node `id` when storing a node.
+- `kind` is one of `SOURCE`, `TRANSFORM`, or `SINK`.
+- `name` is the action name already present in `VertexInfo`. It is display metadata, not an ID.
+- `datasets` contains sorted, distinct table-path strings known for Source and Sink nodes.
+- `datasetMetadata` is one of:
+  - `REPORTED`: the response contains the non-default table paths present in `JobDAGInfo`; this does
+    not assert that a dynamic connector has discovered every table;
+  - `UNAVAILABLE`: no reliable dataset metadata was available;
+  - `NOT_APPLICABLE`: used for Transform nodes in the first version.
+- `warnings` contains objects with a stable `code` and, when the warning applies to one node, its
+  `nodeId`. V1 defines `DATASET_METADATA_UNAVAILABLE` for a Source or Sink whose dataset metadata
+  cannot be represented reliably. Clients must use `code`, not array position, as the warning
+  identity.
+
+Nodes are ordered by numeric vertex ID. Edges are ordered by pipeline ID, source node ID, and target
+node ID. Dataset names are sorted. Warnings are ordered by `code` and then `nodeId`. The response is
+therefore deterministic even though the internal maps do not guarantee iteration order.
+
+## Dataset and Transform Semantics
+
+Multi-table Sources and Sinks keep one graph node with several `datasets` values. The first version
+does not claim which source table produced which sink table because that mapping is not represented
+by `JobDAGInfo`.
+
+A Transform or transform chain remains one execution node. The endpoint does not parse SQL,
+expressions, schemas, or transform implementation classes. A transform that filters, splits, joins,
+or renames data therefore changes graph connectivity only when that connectivity is already present
+in `JobDAGInfo`.
+
+For dynamic table discovery, the response is a snapshot of the metadata available when
+`JobDAGInfo` was built. If a connector cannot enumerate tables at that time, the node uses
+`UNAVAILABLE`; it must not expose `TablePath.DEFAULT` as if it were a real dataset.
+
+## Batch, Streaming, Restore, and Failover
+
+Batch and streaming jobs use the same response model because both are represented by a Zeta job
+DAG.
+
+A pipeline retry keeps the same job ID and graph. The legacy savepoint resume path can also reuse
+the same job ID, so it keeps the same job-scoped lineage identity. A restore submitted as a new job,
+including a submission that references a source job, receives a new job ID and therefore a separate
+lineage snapshot. The first version does not create a cross-job restore edge. Clients must not
+compare node IDs across different jobs.
+
+An active-master change does not require a new lineage store. The active master can return or
+reconstruct `JobDAGInfo` through the existing coordinator and `JobImmutableInformation` paths.
+Finished lineage remains available only while the corresponding `JobDAGInfo` entry is retained by
+`JobHistoryService`.
+
+## Availability and Error Semantics
+
+The endpoint returns:
+
+- `200` with a complete graph for a known job with usable DAG information;
+- `400` with code `INVALID_JOB_ID` for a missing, malformed, or non-positive job ID;
+- `404` with code `JOB_NOT_FOUND` when the job is unknown or its finished history has expired;
+- `409` with code `LINEAGE_UNAVAILABLE` when the job is known but no consistent DAG snapshot can be
+  obtained;
+- `413` with code `LINEAGE_GRAPH_TOO_LARGE` when the serialized response would exceed 8 MiB.
+
+The implementation must validate every edge reference before returning `200`. A dangling edge,
+duplicate node ID, or missing required node field makes the snapshot unavailable; the endpoint must
+not return a partial graph.
+
+Error responses use one JSON object with string fields `code` and `message`, for example:
+
+```json
+{
+  "code": "JOB_NOT_FOUND",
+  "message": "Job lineage is not available for the requested job"
+}
+```
+
+They must not include a Java stack trace, raw request value, connector configuration, or internal
+class name. Clients must branch on `code`; `message` is descriptive text and may be refined without
+changing `schemaVersion`.
+
+## Performance and Payload Bounds
+
+Mapping is `O(nodes + edges + datasets)` and uses the existing cached `JobDAGInfo`. The endpoint
+must not rebuild the execution plan for every request and must not scan StainTrace files.
+
+The first implementation proposes an 8 MiB serialized-response limit. The graph is atomic, so it
+is rejected rather than truncated or paginated. Truncation could leave edges without nodes and
+would make the result unsafe for governance tools. The error may include node and edge counts, but
+not dataset names.
+
+The implementation should serialize once into a bounded buffer, check the byte count, and then
+write the response. It must not create a second unbounded copy of the graph JSON.
+
+## Security
+
+The endpoint uses the same Jetty and `BasicAuthFilter` boundary as the other Zeta REST endpoints. It
+does not introduce endpoint-specific authorization.
+
+Connector names and table paths can disclose deployment topology and business dataset names.
+Operators should not expose the REST service without authentication and network controls. The
+response must not contain environment options, connector configuration, credentials, plugin JAR
+URLs, master/worker addresses, or StainTrace payloads.
+
+The first version inherits the existing cluster-wide authorization model: a caller admitted to the
+REST API can query any retained job. Per-job authorization is outside this proposal.
+
+## Compatibility and Versioning
+
+This proposal is additive:
+
+- `/job-info/{jobId}` remains unchanged;
+- no field is added to the Java-serialized `JobDAGInfo` or `JobImmutableInformation` classes;
+- no checkpoint, savepoint, or connector API changes are required;
+- no new Hazelcast map or retention setting is introduced.
+
+New optional response fields may be added while `schemaVersion` remains `1`. Removing a field,
+changing its meaning, or changing an enum value requires a new schema version. The existing REST
+paths are not URL-versioned, so the response version must remain explicit.
+
+## Implementation Slices
+
+1. Add an immutable REST response model and a pure mapper from `JobDAGInfo` with deterministic
+   ordering, validation, dataset-status handling, and size accounting.
+2. Add `JobLineageService` and a dedicated servlet registered at `/job-lineage`, reusing the current
+   running/finished DAG lookup path without adding storage.
+3. Add REST API documentation and security/retention notes after the contract is approved.
+4. Consider a separate Web UI or external-catalog integration only after operational use of the
+   endpoint.
+
+## Test Plan
+
+### Mapper tests
+
+- a Source-Transform-Sink graph produces stable node and edge ordering;
+- multiple pipelines preserve their pipeline IDs;
+- multi-table Sources and Sinks return sorted, distinct datasets;
+- Transform and transform-chain nodes do not claim dataset lineage;
+- unavailable dataset metadata produces an explicit state and warning;
+- a dangling edge or duplicate node ID fails closed;
+- the byte limit rejects the whole graph rather than truncating it.
+
+### Service and REST tests
+
+- pending, running, and finished jobs return the same response model;
+- representative batch and streaming jobs are supported;
+- follower requests resolve through the active-master path;
+- lineage remains available after active-master failover;
+- finished lineage expires with existing job DAG history;
+- malformed and unknown job IDs return controlled errors;
+- authentication protects the endpoint when Basic Auth is enabled;
+- `/job-info/{jobId}` output remains byte-for-byte unchanged for existing fixtures.
+
+### Compatibility tests
+
+- a legacy savepoint resume that reuses a job ID keeps the same job-scoped identity;
+- a restore submitted with a new job ID receives an independent job-scoped graph;
+- existing `JobDAGInfo` serialization is unchanged;
+- no StainTrace configuration is required;
+- no connector implementation change is required.
+
+## Acceptance Criteria
+
+1. A batch or streaming Zeta job exposes one deterministic Source-Transform-Sink graph.
+2. Running and retained finished jobs use the same response schema.
+3. Node IDs are stable within the job and explicitly not stable across jobs.
+4. Multi-table metadata does not imply unsupported table-to-table or column lineage.
+5. Dynamic or unavailable dataset metadata is marked rather than guessed.
+6. Pipeline retry and active-master failover do not change the graph.
+7. A separately submitted restore job receives its own graph and job-scoped IDs.
+8. Unknown, expired, inconsistent, and oversized graphs return controlled errors.
+9. The endpoint does not expose configuration, credentials, addresses, or trace payloads.
+10. `/job-info/{jobId}`, checkpoint/savepoint formats, and Java serialization remain unchanged.
+11. The endpoint adds no new HA state or retention configuration.
+12. Column lineage and a Web UI lineage view remain separate follow-up work.
+
+## Open Questions for Consensus
+
+1. Is `/job-lineage/{jobId}` preferred over `/job-info/{jobId}/lineage`?
+2. Is the existing execution-oriented `JobDAGInfo` the correct V1 source, or should the API expose a
+   separately retained logical-plan snapshot?
+3. Is 8 MiB an acceptable initial response limit?
+4. Should a future connector capability distinguish complete from partial dynamic discovery, while
+   V1 continues to describe existing table paths only as `REPORTED`?

--- a/docs/zh/engines/zeta/job-lineage-rest-api.md
+++ b/docs/zh/engines/zeta/job-lineage-rest-api.md
@@ -141,7 +141,7 @@ GET /job-lineage/{jobId}
 - `graphKind` 在本提案中固定为 `EXECUTION`。
 - `idScope` 为 `JOB`；客户端保存节点时必须组合 `jobId` 和节点 `id`。
 - `kind` 为 `SOURCE`、`TRANSFORM` 或 `SINK`。
-- `name` 是 `VertexInfo` 已有的 Action 名称，只用于显示，不是标识符。
+- `name` 是 `VertexInfo.connectorType` 已有的连接器类型，只用于显示，不是标识符。
 - `datasets` 包含 Source 和 Sink 节点已知的、排序且去重后的表路径字符串。
 - `datasetMetadata` 为以下值之一：
   - `REPORTED`：响应包含 `JobDAGInfo` 中已有的非默认表路径，但不声明动态连接器已经发现全部表；
@@ -202,6 +202,10 @@ Active Master 切换不需要新的血缘存储。Active Master 可以通过现�
 响应不能包含 Java stack trace、原始请求值、连接器配置或内部类名。客户端必须根据 `code` 分支；
 `message` 是描述文本，可以在不修改 `schemaVersion` 的情况下调整。
 
+血缘 Servlet 在请求边界负责异常转换。它必须捕获未预期的失败并返回相同的 `{code, message}`
+契约，不能让异常进入共享的 `ExceptionHandlingFilter`。该过滤器现有的兜底响应会包含 stack trace，
+并且使用不同的响应结构。本提案不修改其他端点使用的共享过滤器。
+
 ## 性能和负载限制
 
 映射复杂度为 `O(nodes + edges + datasets)`，并复用已有缓存的 `JobDAGInfo`。端点不能在每次请求
@@ -240,7 +244,7 @@ StainTrace payload。
 1. 增加不可变 REST 响应模型和从 `JobDAGInfo` 转换的纯 Mapper，包含确定性排序、校验、数据集状态
    处理和大小统计。
 2. 增加 `JobLineageService` 和注册在 `/job-lineage` 的独立 Servlet，复用当前运行中/已完成 DAG
-   查询路径，不增加存储。
+   查询路径，不增加存储。Servlet 在自身边界处理所有失败，并只返回上文定义的错误契约。
 3. 契约获批后补充 REST API 文档以及安全和保留说明。
 4. 在获得实际使用反馈后，再单独考虑 Web UI 或外部元数据目录集成。
 

--- a/docs/zh/engines/zeta/job-lineage-rest-api.md
+++ b/docs/zh/engines/zeta/job-lineage-rest-api.md
@@ -1,0 +1,299 @@
+# 作业血缘 REST API 设计
+
+## 状态
+
+本文档是设计提案，并不表示该 API 已在已发布的 SeaTunnel 版本中可用。在 STIP 范围和公开契约
+获得认可之前，它必须保持在已发布文档导航之外。
+
+## 背景
+
+Zeta REST API 已经在 `/job-info/{jobId}` 中返回供内置 Web UI 使用的 DAG，但该结构主要服务于
+UI，并未被定义为稳定的血缘契约。因此，外部元数据目录、治理平台和运维工具目前没有受支持的
+方式获取作业级的 Source、Transform、Sink 流向。
+
+第一版应同时支持批处理和流处理作业的作业级执行血缘，但不能暗示列级精度，也不能依赖抽样的
+行记录链路。
+
+## 范围
+
+### 目标
+
+- 暴露一个 Zeta 作业的 Source、Transform、Sink 图；
+- 作业处于等待、运行以及保留在完成历史中时返回同一种模型；
+- 节点 ID 在单个作业内保持稳定；
+- 暴露已知的 Source 和 Sink 表路径，但不推断表到表的映射；
+- 复用作业详情已有状态，在 Active Master 切换后仍可查询；
+- 保持现有 `/job-info/{jobId}` 响应不变；
+- 在实现前明确排序、错误、限制和兼容性规则。
+
+### 非目标
+
+第一版不提供：
+
+- 列级血缘；
+- 字段表达式或 Transform 语义分析；
+- 记录级来源追踪；
+- 跨多个作业的血缘；
+- 全局数据集图或外部元数据目录集成；
+- Flink 或 Spark 引擎作业的血缘；
+- 已完成作业超过保留时间后的历史图版本；
+- 动态 Source 发现新表后的实时更新；
+- Web UI 血缘页面。
+
+## 术语
+
+- **作业血缘**：作业范围内的 Source、Transform、Sink 执行图。
+- **数据集元数据**：构建作业 DAG 信息时，Source 或 Sink 节点已经知道的表路径集合。
+- **StainTrace**：抽样的记录链路，用于延迟和记录流分析，不是权威拓扑来源。
+- **节点 ID**：只在一个作业血缘快照内稳定，不是连接器、数据集或跨作业标识。
+
+## 现有架构
+
+`JobMaster` 通过 `DAGUtils.getJobDAGInfo()` 延迟构建 `JobDAGInfo`。该对象包含：
+
+- 作业 ID；
+- 按 pipeline 分组的边；
+- 包含节点 ID、插件类型、连接器名称和已知表路径的节点映射；
+- 当前作业详情使用的执行位置信息。
+
+运行中作业由 Coordinator 从 Active `JobMaster` 返回该对象。请求到达 Follower 时，现有 Master
+Operation 路径会从 Active Master 获取。作业完成后，`JobHistoryService` 使用配置的
+`history-job-expire-minutes` 保留同一个 `JobDAGInfo`。
+
+血缘端点应是该现有对象的确定性投影，不应反序列化连接器配置、扫描 trace 文件或增加新的
+Hazelcast Map。
+
+## 权威数据源
+
+第一版只使用 `JobDAGInfo` 作为权威数据源，因为它表示 Zeta 对运行中和已完成作业已暴露的执行图。
+
+该选择带来以下约束：
+
+- 血缘描述 Zeta 执行的图，而不是原始 HOCON block 布局；
+- 优化器生成或合并的 Transform 按 `JobDAGInfo` 中已有节点展示，不重新构造内部组件；
+- 节点 ID 复用 `VertexInfo.vertexId`，在该作业生命周期内稳定；
+- pipeline ID 复用 `JobDAGInfo.pipelineEdges`；
+- 表路径只是辅助元数据，不产生表级血缘边；
+- 第一版不追加 `JobDAGInfo` 创建后动态发现的新表。
+
+不得使用 StainTrace 补全图。StainTrace 是可选、抽样且独立存储的，只可能包含部分记录和阶段。
+
+## REST 契约
+
+建议端点：
+
+```text
+GET /job-lineage/{jobId}
+```
+
+独立路由可以避免修改 `/job-info/{jobId}` 当前的路径解析和响应行为。
+
+响应示例：
+
+```json
+{
+  "schemaVersion": 1,
+  "jobId": "733584788375093248",
+  "graphKind": "EXECUTION",
+  "idScope": "JOB",
+  "nodes": [
+    {
+      "id": "1",
+      "kind": "SOURCE",
+      "name": "Jdbc",
+      "datasets": ["catalog.sales.orders"],
+      "datasetMetadata": "REPORTED"
+    },
+    {
+      "id": "2",
+      "kind": "TRANSFORM",
+      "name": "Sql",
+      "datasets": [],
+      "datasetMetadata": "NOT_APPLICABLE"
+    },
+    {
+      "id": "3",
+      "kind": "SINK",
+      "name": "Kafka",
+      "datasets": ["default.default.orders"],
+      "datasetMetadata": "REPORTED"
+    }
+  ],
+  "edges": [
+    {
+      "pipelineId": 1,
+      "sourceNodeId": "1",
+      "targetNodeId": "2"
+    },
+    {
+      "pipelineId": 1,
+      "sourceNodeId": "2",
+      "targetNodeId": "3"
+    }
+  ],
+  "warnings": []
+}
+```
+
+### 字段语义
+
+- `schemaVersion` 是响应契约版本，第一版为 `1`。
+- `graphKind` 在本提案中固定为 `EXECUTION`。
+- `idScope` 为 `JOB`；客户端保存节点时必须组合 `jobId` 和节点 `id`。
+- `kind` 为 `SOURCE`、`TRANSFORM` 或 `SINK`。
+- `name` 是 `VertexInfo` 已有的 Action 名称，只用于显示，不是标识符。
+- `datasets` 包含 Source 和 Sink 节点已知的、排序且去重后的表路径字符串。
+- `datasetMetadata` 为以下值之一：
+  - `REPORTED`：响应包含 `JobDAGInfo` 中已有的非默认表路径，但不声明动态连接器已经发现全部表；
+  - `UNAVAILABLE`：没有可靠的数据集元数据；
+  - `NOT_APPLICABLE`：第一版中用于 Transform 节点。
+- `warnings` 包含具有稳定 `code` 的对象；当 warning 只针对一个节点时，还包含
+  `nodeId`。第一版定义 `DATASET_METADATA_UNAVAILABLE`，用于无法可靠表示数据集元数据的
+  Source 或 Sink。客户端必须使用 `code` 而不是数组位置识别 warning。
+
+节点按数字节点 ID 排序。边按 pipeline ID、源节点 ID 和目标节点 ID 排序。数据集名称排序，warning
+按 `code` 和 `nodeId` 排序。因此，即使内部 Map 没有顺序保证，响应仍然确定。
+
+## 数据集和 Transform 语义
+
+多表 Source 和 Sink 仍为一个图节点，并带有多个 `datasets`。第一版不声明某个源表对应某个目标
+表，因为 `JobDAGInfo` 中没有这种映射。
+
+Transform 或 Transform chain 保留为一个执行节点。端点不解析 SQL、表达式、schema 或 Transform
+实现类。过滤、拆分、Join 或重命名只有在 `JobDAGInfo` 已经包含对应连边时才会反映在图连接关系中。
+
+对于动态表发现，响应是创建 `JobDAGInfo` 时可用元数据的快照。如果连接器当时无法枚举表，节点
+使用 `UNAVAILABLE`，不得把 `TablePath.DEFAULT` 当作真实数据集暴露。
+
+## 批处理、流处理、恢复和故障转移
+
+批处理和流处理使用相同响应模型，因为二者都有 Zeta 作业 DAG。
+
+Pipeline 重试保留同一个作业 ID 和图。旧的 savepoint resume 路径也可能复用同一个作业 ID，
+因此保留同一个作业范围血缘标识。恢复提交为新作业时，包括引用源作业的提交，会获得
+新的作业 ID 和独立血缘快照。第一版不创建跨作业恢复边，客户端不能跨不同作业比较节点 ID。
+
+Active Master 切换不需要新的血缘存储。Active Master 可以通过现有 Coordinator 和
+`JobImmutableInformation` 路径返回或重建 `JobDAGInfo`。已完成作业的血缘只在
+`JobHistoryService` 保留对应 `JobDAGInfo` 期间可用。
+
+## 可用性和错误语义
+
+端点返回：
+
+- 已知作业且 DAG 信息可用时返回 `200` 和完整图；
+- 作业 ID 缺失、格式错误或非正数时返回 `400`，code 为 `INVALID_JOB_ID`；
+- 作业未知或已完成历史过期时返回 `404`，code 为 `JOB_NOT_FOUND`；
+- 作业已知但无法获取一致 DAG 快照时返回 `409`，code 为 `LINEAGE_UNAVAILABLE`；
+- 序列化响应超过 8 MiB 时返回 `413`，code 为 `LINEAGE_GRAPH_TOO_LARGE`。
+
+返回 `200` 前必须校验所有边引用。悬空边、重复节点 ID 或缺失必填节点字段会使快照不可用，端点
+不得返回部分图。
+
+错误响应使用一个 JSON 对象，并包含字符串字段 `code` 和 `message`，例如：
+
+```json
+{
+  "code": "JOB_NOT_FOUND",
+  "message": "Job lineage is not available for the requested job"
+}
+```
+
+响应不能包含 Java stack trace、原始请求值、连接器配置或内部类名。客户端必须根据 `code` 分支；
+`message` 是描述文本，可以在不修改 `schemaVersion` 的情况下调整。
+
+## 性能和负载限制
+
+映射复杂度为 `O(nodes + edges + datasets)`，并复用已有缓存的 `JobDAGInfo`。端点不能在每次请求
+时重建执行计划，也不能扫描 StainTrace 文件。
+
+第一版提议使用 8 MiB 序列化响应限制。图是一个原子整体，超限时拒绝返回，而不是截断或分页。截断可能
+产生没有节点的边，对治理工具不安全。错误中可以包含节点数和边数，但不能包含数据集名称。
+
+实现应只序列化一次到有界缓冲区，检查字节数后写入响应，不能再创建第二份无界 JSON 副本。
+
+## 安全
+
+端点使用其他 Zeta REST 端点相同的 Jetty 和 `BasicAuthFilter` 边界，不增加端点级授权。
+
+连接器名称和表路径可能泄露部署拓扑和业务数据集名称。运维人员不应在没有认证和网络控制的情况下
+暴露 REST 服务。响应不能包含环境选项、连接器配置、凭证、插件 JAR URL、Master/Worker 地址或
+StainTrace payload。
+
+第一版继承现有集群级授权模型：通过 REST API 认证的调用方可以查询所有仍被保留的作业。按作业
+授权不在本提案范围内。
+
+## 兼容性和版本管理
+
+本提案是增量能力：
+
+- `/job-info/{jobId}` 保持不变；
+- 不向 Java 序列化的 `JobDAGInfo` 或 `JobImmutableInformation` 增加字段；
+- 不修改 checkpoint、savepoint 或连接器 API；
+- 不增加 Hazelcast Map 或新的保留配置。
+
+`schemaVersion` 保持 `1` 时可以增加新的可选响应字段。删除字段、改变字段语义或修改枚举值需要新
+的 schema 版本。现有 REST 路径没有 URL 版本，因此响应中的版本必须明确保留。
+
+## 实现切片
+
+1. 增加不可变 REST 响应模型和从 `JobDAGInfo` 转换的纯 Mapper，包含确定性排序、校验、数据集状态
+   处理和大小统计。
+2. 增加 `JobLineageService` 和注册在 `/job-lineage` 的独立 Servlet，复用当前运行中/已完成 DAG
+   查询路径，不增加存储。
+3. 契约获批后补充 REST API 文档以及安全和保留说明。
+4. 在获得实际使用反馈后，再单独考虑 Web UI 或外部元数据目录集成。
+
+## 测试计划
+
+### Mapper 测试
+
+- Source-Transform-Sink 图产生稳定的节点和边排序；
+- 多个 pipeline 保留各自 pipeline ID；
+- 多表 Source 和 Sink 返回排序、去重的数据集；
+- Transform 和 transform chain 不声明数据集血缘；
+- 不可用的数据集元数据产生明确状态和 warning；
+- 悬空边或重复节点 ID 按失败关闭；
+- 字节限制拒绝整个图而不是截断。
+
+### Service 和 REST 测试
+
+- 等待、运行和已完成作业返回相同模型；
+- 支持有代表性的批处理和流处理作业；
+- Follower 请求通过 Active Master 路径解析；
+- Active Master 切换后血缘仍可用；
+- 已完成作业血缘随现有作业 DAG 历史过期；
+- 格式错误和未知作业 ID 返回受控错误；
+- 启用 Basic Auth 时端点受到保护；
+- 现有 fixture 的 `/job-info/{jobId}` 输出逐字节保持不变。
+
+### 兼容性测试
+
+- 复用作业 ID 的旧 savepoint resume 保留同一个作业范围标识；
+- 使用新作业 ID 提交的恢复获得独立作业范围图；
+- 现有 `JobDAGInfo` 序列化保持不变；
+- 不要求配置 StainTrace；
+- 不要求修改连接器实现。
+
+## 验收标准
+
+1. 批处理或流处理 Zeta 作业暴露一个确定的 Source-Transform-Sink 图。
+2. 运行中和保留的已完成作业使用同一响应 schema。
+3. 节点 ID 在作业内稳定，并明确不能跨作业使用。
+4. 多表元数据不暗示不受支持的表到表或列级血缘。
+5. 动态或不可用数据集元数据会被标记，而不是猜测。
+6. Pipeline 重试和 Active Master 切换不改变图。
+7. 单独提交的恢复作业拥有自己的图和作业范围 ID。
+8. 未知、过期、不一致和超大图返回受控错误。
+9. 端点不暴露配置、凭证、地址或 trace payload。
+10. `/job-info/{jobId}`、checkpoint/savepoint 格式和 Java 序列化保持不变。
+11. 端点不增加新的 HA 状态或保留配置。
+12. 列级血缘和 Web UI 血缘视图作为独立后续工作。
+
+## 需要社区确认的问题
+
+1. `/job-lineage/{jobId}` 是否优于 `/job-info/{jobId}/lineage`？
+2. 现有偏执行视角的 `JobDAGInfo` 是否适合作为第一版数据源，还是应该单独保留逻辑计划快照？
+3. 8 MiB 是否适合作为第一版响应上限？
+4. 后续是否应增加连接器能力来区分完整和部分动态发现，而第一版只把已有表路径描述为
+   `REPORTED`？


### PR DESCRIPTION
### Purpose of this pull request

Related to #11484.

This draft defines a first job-level lineage contract for the Zeta engine before runtime implementation starts. It deliberately limits V1 to the Source, Transform, and Sink graph already represented by `JobDAGInfo`; column-level lineage and cross-job dataset graphs remain out of scope.

The design covers:

- the REST response and deterministic node and edge ordering;
- running and retained finished jobs;
- savepoint resume and separately submitted restore behavior;
- partial dataset metadata warnings;
- bounded response size and stable error codes;
- compatibility with the existing `/job-info/{jobId}` response;
- implementation and test slices after STIP approval.

This PR should remain a draft until the STIP discussion reaches consensus.

### Does this PR introduce _any_ user-facing change?

Yes. It adds an English and Chinese design document for discussion. It does not add or change a runtime REST API.

### How was this patch tested?

The proposal was checked against the current `JobDAGInfo`, `JobMaster`, `JobHistoryService`, and client restore paths. English and Chinese documents contain the same contract. The Markdown diff and repository formatting checks pass.

No runtime tests are added because this is a design-only draft. Runtime tests are listed as acceptance criteria for the implementation slices.

### Check list

* [x] No new Jar binary package is added.
* [x] English and Chinese documentation are included.
* [x] No runtime or incompatible behavior is introduced.
* [x] This is not connector code.
```