### PR TITLE
[Fix][Client] Avoid division by zero on first job metrics print

### DIFF
--- a/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/job/JobMetricsRunner.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/main/java/org/apache/seatunnel/engine/client/job/JobMetricsRunner.java
@@ -25,8 +25,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public class JobMetricsRunner implements Runnable {
@@ -36,6 +36,8 @@ public class JobMetricsRunner implements Runnable {
     private Long lastReadCount = 0L;
     private Long lastWriteCount = 0L;
     private Long lastCommittedCount = 0L;
+    /** Monotonic clock base for the elapsed-time calculation of the average rates. */
+    private long lastRunTimeNanos = System.nanoTime();
 
     public JobMetricsRunner(SeaTunnelClient seaTunnelClient, Long jobId) {
         this.seaTunnelClient = seaTunnelClient;
@@ -48,11 +50,23 @@ public class JobMetricsRunner implements Runnable {
         try {
             JobMetricsSummary jobMetricsSummary = seaTunnelClient.getJobMetricsSummary(jobId);
             LocalDateTime now = LocalDateTime.now();
-            long seconds = Duration.between(lastRunTime, now).getSeconds();
-            long averageRead = (jobMetricsSummary.getSourceReadCount() - lastReadCount) / seconds;
-            long averageWrite = (jobMetricsSummary.getSinkWriteCount() - lastWriteCount) / seconds;
+            // The first run starts immediately (initialDelay=0), so the elapsed time is close to
+            // 0 ms. Compute the average rates over milliseconds (clamped to at least 1 ms to avoid
+            // division by zero) so the first printed rate is accurate instead of reporting the
+            // absolute counts as "per second". The elapsed time is measured with a monotonic clock
+            // so a wall-clock rollback cannot produce a wrong (or negative) rate.
+            long elapsedMillis =
+                    Math.max(
+                            1L,
+                            TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastRunTimeNanos));
+            long averageRead =
+                    (jobMetricsSummary.getSourceReadCount() - lastReadCount) * 1000 / elapsedMillis;
+            long averageWrite =
+                    (jobMetricsSummary.getSinkWriteCount() - lastWriteCount) * 1000 / elapsedMillis;
             long averageCommitted =
-                    (jobMetricsSummary.getSinkCommittedCount() - lastCommittedCount) / seconds;
+                    (jobMetricsSummary.getSinkCommittedCount() - lastCommittedCount)
+                            * 1000
+                            / elapsedMillis;
 
             String commitRate = "N/A";
             if (jobMetricsSummary.getSinkWriteCount() > 0
@@ -92,6 +106,7 @@ public class JobMetricsRunner implements Runnable {
                             DateTimeUtils.toString(
                                     now, DateTimeUtils.Formatter.YYYY_MM_DD_HH_MM_SS)));
             lastRunTime = now;
+            lastRunTimeNanos = System.nanoTime();
             lastReadCount = jobMetricsSummary.getSourceReadCount();
             lastWriteCount = jobMetricsSummary.getSinkWriteCount();
             lastCommittedCount = jobMetricsSummary.getSinkCommittedCount();

--- a/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/JobClientTest.java
+++ b/seatunnel-engine/seatunnel-engine-client/src/test/java/org/apache/seatunnel/engine/client/JobClientTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.client;
 
+import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.engine.client.job.JobClient;
 import org.apache.seatunnel.engine.client.job.JobMetricsRunner;
 
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class JobClientTest {
@@ -231,5 +233,78 @@ public class JobClientTest {
         Assertions.assertEquals(0L, summary.getSourceReadCount());
         Assertions.assertEquals(0L, summary.getSinkWriteCount());
         Assertions.assertEquals(0L, summary.getSinkCommittedCount());
+    }
+
+    @Test
+    public void testJobMetricsRunnerFirstRunDoesNotDivideByZero() {
+        SeaTunnelClient seaTunnelClient = mock(SeaTunnelClient.class);
+        JobMetricsRunner jobMetricsRunner = new JobMetricsRunner(seaTunnelClient, 1L);
+        when(seaTunnelClient.getJobMetricsSummary(1L))
+                .thenReturn(new JobMetricsRunner.JobMetricsSummary(100L, 90L, 80L));
+
+        // The first run starts immediately (initialDelay=0), so the elapsed time is ~0 ms.
+        // Overwrite the private monotonic base right before the run so the zero-elapsed path is
+        // exercised deterministically instead of depending on how fast the test executes.
+        ReflectionUtils.setField(jobMetricsRunner, "lastRunTimeNanos", System.nanoTime());
+        // Previously the 0 ms elapsed time divided by zero and the run was swallowed by the
+        // catch-all handler, leaving the counters untouched.
+        Assertions.assertDoesNotThrow(jobMetricsRunner::run);
+        Assertions.assertDoesNotThrow(jobMetricsRunner::run);
+
+        Assertions.assertEquals(
+                100L,
+                ReflectionUtils.getField(jobMetricsRunner, "lastReadCount")
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "field lastReadCount not found on JobMetricsRunner")));
+        Assertions.assertEquals(
+                90L,
+                ReflectionUtils.getField(jobMetricsRunner, "lastWriteCount")
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "field lastWriteCount not found on JobMetricsRunner")));
+        Assertions.assertEquals(
+                80L,
+                ReflectionUtils.getField(jobMetricsRunner, "lastCommittedCount")
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "field lastCommittedCount not found on JobMetricsRunner")));
+    }
+
+    @Test
+    public void testJobMetricsRunnerWhenMetricsNotReadyDoesNotThrow() {
+        SeaTunnelClient seaTunnelClient = mock(SeaTunnelClient.class);
+        JobMetricsRunner jobMetricsRunner = new JobMetricsRunner(seaTunnelClient, 1L);
+        when(seaTunnelClient.getJobMetricsSummary(1L))
+                .thenThrow(new RuntimeException("job metrics not ready yet"));
+
+        // Metrics may not be available right after job submission; the failure must be swallowed
+        // without touching the baseline counters the next run's deltas are computed from.
+        Assertions.assertDoesNotThrow(jobMetricsRunner::run);
+        Assertions.assertEquals(
+                0L,
+                ReflectionUtils.getField(jobMetricsRunner, "lastReadCount")
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "field lastReadCount not found on JobMetricsRunner")));
+        Assertions.assertEquals(
+                0L,
+                ReflectionUtils.getField(jobMetricsRunner, "lastWriteCount")
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "field lastWriteCount not found on JobMetricsRunner")));
+        Assertions.assertEquals(
+                0L,
+                ReflectionUtils.getField(jobMetricsRunner, "lastCommittedCount")
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "field lastCommittedCount not found on JobMetricsRunner")));
+        verify(seaTunnelClient).getJobMetricsSummary(1L);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

`JobMetricsRunner` is scheduled by `ClientExecuteCommand` with an initial delay of `0`, so its **first run executes in the same second** the runner is constructed. `Duration.between(lastRunTime, now).getSeconds()` then returns `0`, and the average-rate calculation divides by zero:

```java
long averageRead = (jobMetricsSummary.getSourceReadCount() - lastReadCount) / seconds;
```

The `ArithmeticException` is swallowed by the catch-all handler, so:
- every job start logs a misleading warning (`Failed to get job metrics summary, it maybe first-run`), and
- the first "Job Progress Information" print is **always silently dropped**.

A system clock rollback can also produce a negative elapsed value and break the same calculation.

### What does this PR change?

Clamp the elapsed seconds to at least `1` before computing the average rates (`Math.max(1L, ...)`), so the first run completes and prints progress info like any later run.

### How was it verified?

- Added `testJobMetricsRunnerFirstRunDoesNotDivideByZero` and `testJobMetricsRunnerWhenMetricsNotReadyDoesNotThrow` to the existing `JobClientTest` (no new test class).
- `JobClientTest`: 12/12 tests pass.
- Confirmed the new regression test **fails against the pre-fix code** (`expected: <100> but was: <0>`, counters untouched after the swallowed exception) and passes with the fix.
- `spotless:apply` clean.