### PR TITLE
[Fix][Zeta] Fix undefined job event timeout constant

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/event/JobStateEventTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/event/JobStateEventTest.java
@@ -162,7 +162,7 @@ class JobStateEventTest extends AbstractSeaTunnelServerTest {
 
         long jobIdFailed = System.currentTimeMillis();
         startJob(jobIdFailed, STREAM_CONF_WITH_ERROR_PATH, false);
-        await().atMost(FAILED_JOB_EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        await().atMost(RESTORE_TO_FAILED_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .untilAsserted(
                         () ->
                                 Assertions.assertEquals(


### PR DESCRIPTION
## Purpose of this pull request

Fix the scheduled benchmark build failure in [GitHub Actions run 32676735991](https://github.com/apache/seatunnel/actions/runs/32676735991).

## What is changed

- Replace the remaining reference to the deleted `FAILED_JOB_EVENT_TIMEOUT_SECONDS` constant.
- Reuse the shared `RESTORE_TO_FAILED_TIMEOUT_SECONDS` constant already imported by `JobStateEventTest`.

The earlier refactor replaced only the first reference, leaving the second reference undefined and causing `seatunnel-engine-server` test compilation to fail on both Java 8 and Java 11.

## Validation

- `./mvnw spotless:apply`
- `git diff --check`