### PR TITLE
[Fix][CI] Use a uniform 300-minute timeout for updated-modules IT parts

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -566,7 +566,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 180
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -598,7 +598,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 180
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -662,7 +662,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 200
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -693,7 +693,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 180
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -724,7 +724,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 210
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -755,7 +755,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 210
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}
@@ -787,7 +787,7 @@ jobs:
       matrix:
         java: [ '8', '11' ]
         os: [ 'ubuntu-latest' ]
-    timeout-minutes: 210
+    timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}


### PR DESCRIPTION
## Purpose

Make the `updated-modules-integration-test` part timeouts robust so that PRs touching widely shared connector modules (for example `connector-common`) can pass CI at all.

## Problem

The updated-modules split assigns e2e modules to the 8 parts round-robin by list index (`update_modules_check.py sub_update_it_module <list> 8 <part>`). Bucket contents therefore rotate whenever any e2e module is added or removed from the reactor, and the individually tuned part timeouts (180/180/300/200/180/210/210/210) silently go stale.

Concrete evidence from https://github.com/apache/seatunnel/pull/11929 (a `connector-common` fix, which fans out to the full connector e2e matrix), run `32566585266`:

- part-5 (timeout 180) received `jdbc-e2e-part-2, clickhouse, file-s3, cdc-mongodb, hbase, easysearch, sls, aerospike, starter-e2e`.
- It hit the 180-minute cancellation on **both JDKs in both attempts** (4/4 executions) while still making healthy progress — no hang.
- Measured module wall times from the job logs: clickhouse 59.9m, cdc-mongodb 26.9m, file-s3 2.0m, and HbaseIT at 83m and still running when the job was cancelled (22 `@TestTemplate` methods against the full engine-container matrix). The bucket needs roughly 240 minutes.

Because two e2e modules were added on `dev` since that branch was cut (`connector-cdc-db2-e2e`, `connector-google-pubsub-e2e`), the same heavy cluster rotates into part-6 (timeout 210) for up-to-date branches — still over budget. Re-tuning a single part would break again on the next module addition.

## Change

Align all 8 `updated-modules-integration-test` parts to the 300-minute budget that part-3 already uses. 7 lines, no coverage change, no test change. Timeouts only bind on overruns; green runs finish exactly as fast as before.

## Verification

- Workflow-only change; the `changes` filter routes this PR through the light job set.
- The full-matrix effect is exercised by #11929, whose branch carries this same bump until it lands on `dev` (whichever merges first makes the other a no-op).
