### PR TITLE
[Fix][Common] Mask credentials with quoted keys

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/DryRunConnectFailureMessageSanitizer.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/DryRunConnectFailureMessageSanitizer.java
@@ -31,9 +31,9 @@ public final class DryRunConnectFailureMessageSanitizer {
             Pattern.compile("\\bjdbc:[^\\s]+", Pattern.CASE_INSENSITIVE);
     private static final Pattern SENSITIVE_FREE_TEXT_KEY =
             Pattern.compile(
-                    "\\b("
+                    "([\"']?\\b(?:"
                             + SENSITIVE_KEYS
-                            + ")(\\s*[:=]\\s*)(\\\"[^\\\"]*\\\"|'[^']*'|[^\\s,;&]+)",
+                            + ")\\b[\"']?)(\\s*[:=]\\s*)(\\\"[^\\\"]*\\\"|'[^']*'|[^\\s,;&]+)",
                     Pattern.CASE_INSENSITIVE);
 
     private DryRunConnectFailureMessageSanitizer() {}

--- a/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/DryRunConnectFailureMessageSanitizerTest.java
+++ b/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/DryRunConnectFailureMessageSanitizerTest.java
@@ -57,6 +57,20 @@ public class DryRunConnectFailureMessageSanitizerTest {
     }
 
     @Test
+    public void testMaskSensitiveQuotedKeys() {
+        String sanitized =
+                sanitize(
+                        "Connection config: {\"username\": \"alice\", "
+                                + "\"password\": \"secret password\", "
+                                + "'api_key': 'secret key'}");
+
+        Assertions.assertEquals(
+                "Connection config: {\"username\": \"alice\", "
+                        + "\"password\": ***, 'api_key': ***}",
+                sanitized);
+    }
+
+    @Test
     public void testReplaceGenericJdbcUrlOutsideKnownFailurePhrases() {
         String sanitized =
                 sanitize(


### PR DESCRIPTION
### Purpose of this pull request

Prevent credentials from appearing in connect dry-run failure messages when sensitive configuration keys are quoted, for example `"password": "secret"` or `'api_key': 'secret'`. The sanitizer now recognizes optional quotes around sensitive keys and keeps masking their values. A regression test covers JSON- and HOCON-style input.

### Does this PR introduce _any_ user-facing change?

Yes. Dry-run CLI failure messages now replace values associated with quoted sensitive keys with `***`, matching the existing behavior for unquoted keys.

### How was this patch tested?

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-common -am -Dskip.spotless=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=DryRunConnectFailureMessageSanitizerTest package`
- `./mvnw -q -DskipTests verify`

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not necessary for this masking fix.
* [x] This PR introduces no incompatible change.
* [x] This PR does not modify connector code.