### PR TITLE
[Feature][CI] Introduce Merge Queue to Keep the dev Baseline Stable

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,6 +50,28 @@ github:
     rebase: false
   pull_requests:
     allow_update_branch: true
+  rulesets:
+    - name: Merge Queue
+      target: branch
+      enforcement: active
+      bypass_actors: []
+      conditions:
+        ref_name:
+          include:
+            - refs/heads/dev
+          exclude: []
+      rules:
+        - type: merge_queue
+          parameters:
+            # Leave time for runner scheduling and status reporting around the 30-minute job.
+            check_response_timeout_minutes: 45
+            grouping_strategy: ALLGREEN
+            max_entries_to_build: 5
+            # Phase one merges each PR immediately instead of waiting to form a batch.
+            max_entries_to_merge: 1
+            merge_method: SQUASH
+            min_entries_to_merge: 1
+            min_entries_to_merge_wait_minutes: 0
   protected_branches:
     dev:
       required_status_checks:

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -21,8 +21,8 @@ name: "Build"
 
 on:
   push:
-    branches:
-    - '**'
+    branches-ignore:
+      - 'gh-readonly-queue/**'
 
 jobs:
   call-build-and-test:

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -42,7 +42,7 @@ jobs:
           distribution: temurin
           java-version: '8'
           cache: maven
-      # Build the default reactor, including seatunnel-dist.
+      # Build the CI reactor without the seatunnel-dist release assembly.
       - name: Compile main and test sources
         uses: nick-fields/retry@v3
         with:
@@ -51,7 +51,7 @@ jobs:
           retry_wait_seconds: 10
           retry_on: error
           command: |
-            ./mvnw -B -T 1C clean install -DskipTests \
+            ./mvnw -B -T 1C -Pci clean install -DskipTests \
               -D"license.skipAddThirdParty"=true -D"skip.ui"=true \
               --no-snapshot-updates
       # Build the opt-in seatunnel-benchmarks module with its dedicated profile.

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -42,7 +42,7 @@ jobs:
           distribution: temurin
           java-version: '8'
           cache: maven
-      # Build the CI reactor without the seatunnel-dist release assembly.
+      # Compile the standard modules with the CI profile.
       - name: Compile main and test sources
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -42,6 +42,7 @@ jobs:
           distribution: temurin
           java-version: '8'
           cache: maven
+      # Build the default reactor, including seatunnel-dist.
       - name: Compile main and test sources
         uses: nick-fields/retry@v3
         with:
@@ -49,4 +50,18 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 10
           retry_on: error
-          command: ./mvnw -B -T 1C clean install -DskipTests
+          command: |
+            ./mvnw -B -T 1C clean install -DskipTests \
+              -D"license.skipAddThirdParty"=true -D"skip.ui"=true \
+              --no-snapshot-updates
+      # Build the opt-in seatunnel-benchmarks module with its dedicated profile.
+      - name: Compile benchmark main and test sources
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 8
+          max_attempts: 3
+          retry_wait_seconds: 10
+          retry_on: error
+          command: |
+            ./mvnw -B -Pbenchmark -pl seatunnel-benchmarks clean install -DskipTests \
+              -D"license.skipAddThirdParty"=true --no-snapshot-updates

--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Merge Queue
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  merge-queue-build:
+    # Reuse the required "Build" context that pull requests already report.
+    # Required checks are shared by pull requests and merge groups.
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout merge group
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+      - name: Compile main and test sources
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 28
+          max_attempts: 3
+          retry_wait_seconds: 10
+          retry_on: error
+          command: ./mvnw -B -T 1C clean install -DskipTests


### PR DESCRIPTION
### Purpose of this pull request

#### Background

Two recent fixes exposed deterministic compilation failures only after related changes had reached `dev`:

* [#11954](https://github.com/apache/seatunnel/pull/11954) fixed a remaining test reference after a constant had been removed. The stale reference prevented the `seatunnel-engine-server` test sources from compiling.
* [#10998](https://github.com/apache/seatunnel/pull/10998) updated a missed `JdbcHiveIT` call site after a method signature gained a parameter.

These were not flaky tests. A pull request can pass CI against the baseline available at that time and still become incompatible with `dev` or with another pull request merged immediately before it.

This PR introduces a [GitHub Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) gate for `dev`. GitHub validates a temporary `merge_group` containing the latest `dev`, the current pull request, and any pull requests ahead of it before updating `dev`.

#### Implementation

1. Add a dedicated merge-group compilation gate.

   `.github/workflows/merge_queue.yml` listens to `merge_group.checks_requested` and runs two complementary Maven builds:

   ```shell
   # Compile the standard modules with the CI profile.
   ./mvnw -B -T 1C -Pci clean install -DskipTests \
     -D"license.skipAddThirdParty"=true -D"skip.ui"=true \
     --no-snapshot-updates

   # Compile the opt-in seatunnel-benchmarks module.
   ./mvnw -B -Pbenchmark -pl seatunnel-benchmarks clean install -DskipTests \
     -D"license.skipAddThirdParty"=true --no-snapshot-updates
   ```

   The first command uses the repository's `ci` profile to compile and install the standard modules, including the main and test sources under `seatunnel-e2e`, while excluding the `seatunnel-dist` release assembly.

   The benchmark module is opt-in and is not part of the CI reactor, so the second command compiles its main and test sources separately. It intentionally omits `-am` because the first command has already installed its SeaTunnel dependencies in the same runner; rebuilding those modules would only duplicate work.

   The benchmark artifact is installed only in the temporary runner's local Maven repository and is not included in the SeaTunnel distribution.

   `-DskipTests` skips test execution but still compiles main and test sources, so missing symbols and incompatible method signatures are detected. The UI build and third-party license generation are outside this compilation gate and are skipped. Snapshot updates are disabled to reduce unnecessary remote repository access.

   Both Maven steps use the Maven cache and retry up to three times for transient repository failures such as HTTP 403 responses or connection resets. The CI-reactor attempt timeout is 28 minutes and the focused benchmark attempt timeout is 8 minutes, with a 10-second retry delay. The job has a global 30-minute timeout and uses Temurin JDK 8 with read-only repository permissions.

   The job is named `Build` intentionally. `dev` already requires the GitHub Actions `Build` context. Pull-request and merge-group required checks are coupled, so reusing this context lets normal pull requests keep the existing Build validation while the merge group reports the final compilation gate.

2. Manage the queue through `.asf.yaml`.

   The ASF-supported raw repository ruleset activates Merge Queue for the exact `refs/heads/dev` ref with these settings:

   | Setting | Value | Reason |
   | --- | --- | --- |
   | Bypass actors | None | Phase one does not allow direct-merge bypasses, including an administrator bypass list. |
   | Build concurrency | 5 | Dispatch at most five merge-group validations concurrently. Additional entries wait in FIFO order. |
   | Required-check strategy | `ALLGREEN` | Every queue entry must pass the required check. |
   | Minimum merge group size | 1 | A single queued PR can proceed immediately. |
   | Maximum merge group size | 1 | Merge PRs into `dev` individually during phase one. |
   | Wait for minimum group | 0 minutes | Do not delay an available PR to form a batch. |
   | Merge method | `SQUASH` | Match the repository's enabled merge method. |
   | Required-check response timeout | 45 minutes | Allow runner scheduling and status-reporting time around the 30-minute Actions job. |

   Classic `protected_branches.dev` settings remain in place, so the existing approval requirement and required `Build` check continue to apply alongside the Merge Queue ruleset.

3. Avoid duplicate Backend runs for queue branches.

   GitHub owns the `gh-readonly-queue/**` temporary branch namespace. `build_main.yml` now ignores pushes to that namespace so a merge group runs only the dedicated compilation gate instead of also starting the complete existing Backend matrix. Ordinary branch pushes and the final push to `dev` continue to run the existing Build workflow.

#### Queue and failure behavior

* When capacity is available, GitHub dispatches the merge-group build immediately; there is no minimum build concurrency or idle delay.
* A failing or timed-out merge group does not update `dev`. GitHub removes the affected PR from the queue and leaves it open with the failure details.
* After the PR is fixed or rebased, a writer must select `Merge when ready` again.
* If an earlier queued PR fails, GitHub rebuilds later temporary groups without that PR.
* GitHub does not publish a total queue-length limit. Entries beyond the build concurrency remain queued in FIFO order.
* This PR itself must merge through the existing process. Once it reaches `dev`, ASF applies the active ruleset automatically; no separate manual Merge Queue configuration is required under normal operation.

### Does this PR introduce _any_ user-facing change?

No SeaTunnel runtime, connector, configuration, or public API behavior changes. This changes the maintainer workflow for merging pull requests into `dev`.

### How was this patch tested?

The following checks passed locally:

```shell
./mvnw spotless:apply

git diff --check
git diff --cached --check

ruby -e 'require "yaml"; [".asf.yaml", ".github/workflows/build_main.yml", ".github/workflows/merge_queue.yml"].each { |f| YAML.load_file(f); puts "#{f}: valid YAML" }'

actionlint .github/workflows/build_main.yml .github/workflows/merge_queue.yml

asfyaml-validate --repo "$PWD"

./mvnw -B -Pbenchmark -pl seatunnel-benchmarks clean test-compile \
  -DskipTests -D"license.skipAddThirdParty"=true --no-snapshot-updates
```

Validation details:

* `actionlint` version: 1.7.12
* ASF validator source: `apache/infrastructure-asfyaml` at `32076d4b739c35460b6f67091df5e82553e251e5`
* ASF validator result: `.asf.yaml is a valid .asf.yaml file.`
* Maven profile inspection confirmed that the `ci` profile contains the standard modules and `seatunnel-e2e` while excluding `seatunnel-dist`, and that the `benchmark` profile adds `seatunnel-benchmarks` separately.
* The focused benchmark check used JDK 8 and successfully compiled 25 main source files and 8 test source files without executing tests.

`./mvnw verify` and test suites were not run. This PR changes only GitHub Actions and ASF repository-policy YAML; the Merge Queue workflow is the pre-merge compilation integration gate introduced by this change.

### Check list

* [x] No new Jar or binary package is added to the repository or SeaTunnel distribution.
* [x] No connector documentation or incompatible-change documentation is required.
* [x] No connector registration, distribution, or E2E fixture changes are required.