### PR TITLE
[Improve][Connector-V2] Migrate Cassandra validation to declarative OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-cassandra/src/main/java/org/apache/seatunnel/connectors/seatunnel/cassandra/sink/CassandraSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-cassandra/src/main/java/org/apache/seatunnel/connectors/seatunnel/cassandra/sink/CassandraSinkFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.cassandra.sink;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -40,6 +41,11 @@ import static org.apache.seatunnel.connectors.seatunnel.cassandra.config.Cassand
 
 @AutoService(Factory.class)
 public class CassandraSinkFactory implements TableSinkFactory {
+
+    private static final String CONSISTENCY_LEVEL_REGEX =
+            "^(ANY|ONE|TWO|THREE|QUORUM|ALL|LOCAL_QUORUM|EACH_QUORUM|SERIAL|LOCAL_SERIAL|LOCAL_ONE)$";
+    private static final String BATCH_TYPE_REGEX = "^(LOGGED|UNLOGGED|COUNTER)$";
+
     @Override
     public String factoryIdentifier() {
         return "Cassandra";
@@ -48,10 +54,15 @@ public class CassandraSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(HOST, KEYSPACE, TABLE)
+                .required(HOST, Conditions.notBlank(HOST))
+                .required(KEYSPACE, Conditions.notBlank(KEYSPACE))
+                .required(TABLE, Conditions.notBlank(TABLE))
                 .bundled(USERNAME, PASSWORD)
+                .optional(DATACENTER, FIELDS, BATCH_SIZE, ASYNC_WRITE)
                 .optional(
-                        DATACENTER, CONSISTENCY_LEVEL, FIELDS, BATCH_SIZE, BATCH_TYPE, ASYNC_WRITE)
+                        CONSISTENCY_LEVEL,
+                        Conditions.matches(CONSISTENCY_LEVEL, CONSISTENCY_LEVEL_REGEX))
+                .optional(BATCH_TYPE, Conditions.matches(BATCH_TYPE, BATCH_TYPE_REGEX))
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-cassandra/src/main/java/org/apache/seatunnel/connectors/seatunnel/cassandra/source/CassandraSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-cassandra/src/main/java/org/apache/seatunnel/connectors/seatunnel/cassandra/source/CassandraSourceFactory.java
@@ -17,7 +17,11 @@
 
 package org.apache.seatunnel.connectors.seatunnel.cassandra.source;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
@@ -30,6 +34,8 @@ import org.apache.seatunnel.connectors.seatunnel.cassandra.config.CassandraParam
 import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 import static org.apache.seatunnel.connectors.seatunnel.cassandra.config.CassandraSourceOptions.CONSISTENCY_LEVEL;
 import static org.apache.seatunnel.connectors.seatunnel.cassandra.config.CassandraSourceOptions.CQL;
@@ -41,6 +47,10 @@ import static org.apache.seatunnel.connectors.seatunnel.cassandra.config.Cassand
 
 @AutoService(Factory.class)
 public class CassandraSourceFactory implements TableSourceFactory {
+
+    private static final String CONSISTENCY_LEVEL_REGEX =
+            "^(ANY|ONE|TWO|THREE|QUORUM|ALL|LOCAL_QUORUM|EACH_QUORUM|SERIAL|LOCAL_SERIAL|LOCAL_ONE)$";
+
     @Override
     public String factoryIdentifier() {
         return "Cassandra";
@@ -49,11 +59,46 @@ public class CassandraSourceFactory implements TableSourceFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(HOST, KEYSPACE)
+                .required(HOST, Conditions.notBlank(HOST))
+                .required(KEYSPACE, Conditions.notBlank(KEYSPACE))
                 .exclusive(CQL, ConnectorCommonOptions.TABLE_CONFIGS)
                 .bundled(USERNAME, PASSWORD)
-                .optional(DATACENTER, CONSISTENCY_LEVEL)
+                .optional(CQL, Conditions.notBlank(CQL))
+                .optional(
+                        ConnectorCommonOptions.TABLE_CONFIGS,
+                        Conditions.notEmpty(ConnectorCommonOptions.TABLE_CONFIGS),
+                        Conditions.extension(
+                                ConnectorCommonOptions.TABLE_CONFIGS, new TableConfigsValidator()))
+                .optional(DATACENTER)
+                .optional(
+                        CONSISTENCY_LEVEL,
+                        Conditions.matches(CONSISTENCY_LEVEL, CONSISTENCY_LEVEL_REGEX))
                 .build();
+    }
+
+    static class TableConfigsValidator implements ConditionExtension<List<Map<String, Object>>> {
+
+        @Override
+        public String description() {
+            return "each 'tables_configs' entry must contain a non-blank 'cql'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> entries)
+                throws OptionValidationException {
+            if (entries == null || entries.isEmpty()) {
+                return true;
+            }
+            for (int i = 0; i < entries.size(); i++) {
+                Map<String, Object> tableConfig = entries.get(i);
+                Object cql = tableConfig == null ? null : tableConfig.get(CQL.key());
+                if (!(cql instanceof String) || ((String) cql).trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            "tables_configs[%d]: 'cql' must not be blank", i);
+                }
+            }
+            return true;
+        }
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-cassandra/src/test/java/org/apache/seatunnel/connectors/seatunnel/cassandra/CassandraFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-cassandra/src/test/java/org/apache/seatunnel/connectors/seatunnel/cassandra/CassandraFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.cassandra.config.CassandraSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.cassandra.config.CassandraSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.cassandra.sink.CassandraSinkFactory;
 import org.apache.seatunnel.connectors.seatunnel.cassandra.source.CassandraSourceFactory;
@@ -84,6 +85,173 @@ class CassandraFactoryTest {
         Assertions.assertThrows(
                 OptionValidationException.class,
                 () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(rule));
+    }
+
+    @Test
+    void testSourceOptionRuleWithBlankHostThrows() {
+        Map<String, Object> cfg = sourceConfigWithCql();
+        cfg.put(CassandraSourceOptions.HOST.key(), " ");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithBlankKeyspaceThrows() {
+        Map<String, Object> cfg = sourceConfigWithCql();
+        cfg.put(CassandraSourceOptions.KEYSPACE.key(), "\t");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithBlankRootCqlThrows() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put(CassandraSourceOptions.CQL.key(), "\n");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithEmptyTablesConfigsThrows() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put(ConnectorCommonOptions.TABLE_CONFIGS.key(), Collections.emptyList());
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithTablesConfigsChildMissingCqlThrows() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put(
+                ConnectorCommonOptions.TABLE_CONFIGS.key(),
+                Collections.singletonList(Collections.emptyMap()));
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class,
+                        () ->
+                                ConfigValidator.of(ReadonlyConfig.fromMap(cfg))
+                                        .validate(sourceRule()));
+        Assertions.assertTrue(exception.getMessage().contains("tables_configs[0]: 'cql'"));
+    }
+
+    @Test
+    void testSourceOptionRuleWithTablesConfigsChildBlankCqlThrows() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put(
+                ConnectorCommonOptions.TABLE_CONFIGS.key(),
+                Collections.singletonList(
+                        Collections.singletonMap(CassandraSourceOptions.CQL.key(), "  ")));
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithInvalidConsistencyLevelThrows() {
+        Map<String, Object> cfg = sourceConfigWithCql();
+        cfg.put(CassandraSourceOptions.CONSISTENCY_LEVEL.key(), "LOCAL_ONE ");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithValidRootCqlPasses() {
+        Assertions.assertDoesNotThrow(
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(sourceConfigWithCql()))
+                                .validate(sourceRule()));
+    }
+
+    @Test
+    void testSourceOptionRuleWithValidTablesConfigsChildCqlPasses() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put(
+                ConnectorCommonOptions.TABLE_CONFIGS.key(),
+                Collections.singletonList(
+                        Collections.singletonMap(
+                                CassandraSourceOptions.CQL.key(), "select * from test.table1")));
+        Assertions.assertDoesNotThrow(
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sourceRule()));
+    }
+
+    @Test
+    void testSinkOptionRuleWithBlankHostThrows() {
+        Map<String, Object> cfg = sinkConfig();
+        cfg.put(CassandraSinkOptions.HOST.key(), " ");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sinkRule()));
+    }
+
+    @Test
+    void testSinkOptionRuleWithBlankKeyspaceThrows() {
+        Map<String, Object> cfg = sinkConfig();
+        cfg.put(CassandraSinkOptions.KEYSPACE.key(), "\t");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sinkRule()));
+    }
+
+    @Test
+    void testSinkOptionRuleWithBlankTableThrows() {
+        Map<String, Object> cfg = sinkConfig();
+        cfg.put(CassandraSinkOptions.TABLE.key(), "\n");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sinkRule()));
+    }
+
+    @Test
+    void testSinkOptionRuleWithInvalidConsistencyLevelThrows() {
+        Map<String, Object> cfg = sinkConfig();
+        cfg.put(CassandraSinkOptions.CONSISTENCY_LEVEL.key(), "invalid");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sinkRule()));
+    }
+
+    @Test
+    void testSinkOptionRuleWithInvalidBatchTypeThrows() {
+        Map<String, Object> cfg = sinkConfig();
+        cfg.put(CassandraSinkOptions.BATCH_TYPE.key(), "BATCHED");
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> ConfigValidator.of(ReadonlyConfig.fromMap(cfg)).validate(sinkRule()));
+    }
+
+    @Test
+    void testSinkOptionRuleWithValidConfigPasses() {
+        Assertions.assertDoesNotThrow(
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(sinkConfig()))
+                                .validate(sinkRule()));
+    }
+
+    private OptionRule sourceRule() {
+        return new CassandraSourceFactory().optionRule();
+    }
+
+    private OptionRule sinkRule() {
+        return new CassandraSinkFactory().optionRule();
+    }
+
+    private Map<String, Object> sourceConfigWithCql() {
+        Map<String, Object> cfg = baseConfig();
+        cfg.put(CassandraSourceOptions.CQL.key(), "select * from test.table1");
+        return cfg;
+    }
+
+    private Map<String, Object> sinkConfig() {
+        Map<String, Object> cfg = new HashMap<>();
+        cfg.put(CassandraSinkOptions.HOST.key(), "localhost:9042");
+        cfg.put(CassandraSinkOptions.KEYSPACE.key(), "test");
+        cfg.put(CassandraSinkOptions.TABLE.key(), "table1");
+        return cfg;
     }
 
     private Map<String, Object> baseConfig() {


### PR DESCRIPTION
### Purpose of this pull request

Migrate declarative-eligible Cassandra connector configuration validation to `OptionRule` / `Conditions` as part of #11007.

This change:

- adds declarative non-blank validation for required Cassandra source and sink options
- validates source `cql` when configured
- validates `tables_configs` as non-empty and ensures each nested entry contains a non-blank `cql`
- validates Cassandra consistency levels declaratively
- validates Cassandra sink batch types declaratively
- preserves the existing `cql` / `tables_configs` exclusivity
- preserves username/password bundling

Cassandra-dependent validation such as connectivity, authentication, schema discovery, CQL execution, duplicate resolved tables, and sink target-field validation remains in the existing runtime paths.

### Does this PR introduce _any_ user-facing change?

Yes.

Invalid static Cassandra configurations that can be validated without connecting to Cassandra are now rejected earlier through declarative `OptionRule` validation with `OptionValidationException`.

Runtime validation that depends on Cassandra state remains unchanged.

### How was this patch tested?

Added and ran focused `ConfigValidator` unit tests covering positive and negative source/sink validation cases.

```text
./mvnw test \
  -pl seatunnel-connectors-v2/connector-cassandra \
  -Dtest=CassandraFactoryTest \
  -DfailIfNoTests=false
```

Result: 20 tests passed.

Also verified Spotless and `git diff --check`.

### Check list

* [x] No new Jar binary package is added.
* [x] No connector registration/plugin mapping changes are required because this modifies an existing connector.
* [x] No incompatible configuration option is introduced or removed.
* [x] Unit tests cover the declarative validation changes.

Related #11007
