### PR TITLE
[Fix][Connector-V2][InfluxDB] Fix NPE when query returns empty result

### DIFF
--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSource.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSource.java
@@ -31,6 +31,8 @@ import org.apache.seatunnel.connectors.seatunnel.influxdb.exception.InfluxdbConn
 import org.apache.seatunnel.connectors.seatunnel.influxdb.exception.InfluxdbConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.influxdb.state.InfluxDBSourceState;
 
+import org.apache.commons.collections4.CollectionUtils;
+
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
@@ -112,7 +114,20 @@ public class InfluxDBSource
         try {
             QueryResult queryResult = influxdb.query(new Query(query, sourceConfig.getDatabase()));
 
-            List<QueryResult.Series> serieList = queryResult.getResults().get(0).getSeries();
+            List<QueryResult.Result> results = queryResult.getResults();
+            if (CollectionUtils.isEmpty(results)) {
+                log.warn(
+                        "InfluxDB query returned empty results, using default column index mapping.");
+                return buildDefaultColumnsIndex();
+            }
+
+            List<QueryResult.Series> serieList = results.get(0).getSeries();
+            if (CollectionUtils.isEmpty(serieList)) {
+                log.warn(
+                        "InfluxDB query returned no series (empty data), using default column index mapping.");
+                return buildDefaultColumnsIndex();
+            }
+
             List<String> fieldNames = new ArrayList<>(serieList.get(0).getColumns());
 
             return Arrays.stream(catalogTable.getSeaTunnelRowType().getFieldNames())
@@ -124,6 +139,19 @@ public class InfluxDBSource
                     "Get column index of query result exception",
                     e);
         }
+    }
+
+    /**
+     * Builds a default column index list based on the catalog table schema. Used when the query
+     * returns no data, where actual column indices are not needed since no rows will be read.
+     */
+    private List<Integer> buildDefaultColumnsIndex() {
+        int fieldCount = catalogTable.getSeaTunnelRowType().getTotalFields();
+        List<Integer> defaultIndexList = new ArrayList<>(fieldCount);
+        for (int i = 0; i < fieldCount; i++) {
+            defaultIndexList.add(i);
+        }
+        return defaultIndexList;
     }
 
     private static int containTzFunction(String sql) {

--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxdbSourceReader.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxdbSourceReader.java
@@ -135,7 +135,12 @@ public class InfluxdbSourceReader implements SourceReader<SeaTunnelRow, InfluxDB
 
     private void read(InfluxDBSourceSplit split, Collector<SeaTunnelRow> output) {
         QueryResult queryResult = influxdb.query(new Query(split.getQuery(), config.getDatabase()));
-        for (QueryResult.Result result : queryResult.getResults()) {
+        List<QueryResult.Result> results = queryResult.getResults();
+        if (CollectionUtils.isEmpty(results)) {
+            log.debug("split[{}] reader influxDB query result is empty.", split.splitId());
+            return;
+        }
+        for (QueryResult.Result result : results) {
             List<QueryResult.Series> serieList = result.getSeries();
             if (CollectionUtils.isNotEmpty(serieList)) {
                 for (QueryResult.Series series : serieList) {


### PR DESCRIPTION
<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

**Title:** `[Fix][Connector-V2][InfluxDB] Fix NPE when query returns empty result`

### Purpose of this pull request

Fix NullPointerException in InfluxDB source connector when the query returns empty results.

When an InfluxDB (v2.7.12) query returns no matching data, the response JSON looks like:

```json
{
    "results": [
        {
            "statement_id": 0
        }
    ]
}
```

In this case, `Result.getSeries()` returns `null` (the `series` field is absent from the JSON),
causing `NullPointerException` in `InfluxDBSource.initColumnsIndex()`:

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.List.get(int)" because "serieList" is null
    at InfluxDBSource.initColumnsIndex(InfluxDBSource.java:116)
    at InfluxDBSource.createReader(InfluxDBSource.java:76)
```

Additionally, `InfluxdbSourceReader.read()` did not guard against null `queryResult.getResults()`,
which could also cause NPE during data reading.

Changes:
- `InfluxDBSource.java`: Added null checks for `results` and `serieList` in `initColumnsIndex()`,
  returning a default column index mapping when query returns no data.
- `InfluxdbSourceReader.java`: Added null check for `queryResult.getResults()` in `read()` method,
  logging a debug message and returning early when results are empty.

### Does this PR introduce _any_ user-facing change?

No. This is an internal bug fix that prevents task failure when InfluxDB queries return empty results.
No user-facing configuration or behavior is changed.

### How was this patch tested?

Locally compiled and verified with:

```bash
mvn package -pl seatunnel-connectors-v2/connector-influxdb -am -DskipTests
```

Tested against InfluxDB v2.7.12 with queries that return empty results to confirm the NPE no longer occurs.

Job finished successfully with `FINISHED` state and no errors:

```
2026-08-26 10:23:10,922 INFO  - Job (1144819293649633281) end with state FINISHED

***********************************************
           Job Statistic Information
***********************************************
Start Time                : 2026-08-26 10:23:09
End Time                  : 2026-08-26 10:23:10
Total Time(s)             :                   1
Total Read Count          :                   0
Total Write Count         :                   0
Total Failed Count        :                   0
***********************************************
```

### Check list

* [x]  No new Jar binary package is added.
* [x]  No connector registration/plugin mapping changes are required because this modifies an existing connector.
* [x]  No incompatible configuration option is introduced or removed.
