### PR TITLE
[Feature][Connector-V2] Add SNMP source connector

### DIFF
--- a/config/plugin_config
+++ b/config/plugin_config
@@ -107,6 +107,7 @@ connector-sensorsdata
 connector-hugegraph
 connector-lance
 connector-mqtt
+connector-snmp
 connector-python
 connector-bigquery
 connector-nats-jetstream

--- a/docs/en/connectors/changelog/connector-snmp.md
+++ b/docs/en/connectors/changelog/connector-snmp.md
@@ -1,0 +1,7 @@
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+| [Feature][Connector-V2] Add SNMPv2c polling source connector | - | Next |
+
+</details>

--- a/docs/en/connectors/source/SNMP.md
+++ b/docs/en/connectors/source/SNMP.md
@@ -1,0 +1,124 @@
+import ChangeLog from '../changelog/connector-snmp.md';
+
+# SNMP
+
+> SNMPv2c polling source connector
+
+## Description
+
+The SNMP source polls an SNMP agent over UDP by sending an SNMPv2c GET request for an explicit list of numeric OIDs.
+Each returned variable binding becomes one row. This first version does not perform WALK, GETNEXT, or GETBULK.
+
+Batch jobs perform exactly one poll and then finish. Streaming jobs repeat the same GET request after
+`poll_interval_millis`. The source uses one split, so its parallelism must be 1.
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
+
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+
+## Supported DataSource Info
+
+The connector uses SNMP4J and supports SNMPv2c agents reachable over UDP.
+
+| Datasource | Supported Versions | Dependency |
+|------------|--------------------|------------|
+| SNMP agent | SNMPv2c            | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-snmp) |
+
+## Source Options
+
+| Name                 | Type         | Required | Default | Description |
+|----------------------|--------------|----------|---------|-------------|
+| host                 | String       | Yes      | -       | SNMP agent host name or IP address. Do not include a protocol or port. |
+| port                 | Int          | No       | 161     | SNMP agent UDP port. |
+| community            | String       | Yes      | -       | SNMPv2c community credential. The connector does not write this value to its logs or errors. |
+| oids                 | List\<String\> | Yes   | -       | Explicit numeric OIDs sent in the GET request. Leading dots are accepted. Duplicate and symbolic OIDs are rejected. |
+| timeout_millis       | Long         | No       | 5000    | Timeout in milliseconds for each request attempt. |
+| retries              | Int          | No       | 1       | Number of retries after the initial request attempt. A value of `0` sends one attempt. |
+| poll_interval_millis | Long         | No       | 60000   | Delay in milliseconds between completed streaming polls. Ignored by batch jobs. |
+
+## Output Schema
+
+The output schema is fixed and must not be configured with a `schema` option.
+
+| Field      | Type   | Description |
+|------------|--------|-------------|
+| agent      | string | Polled agent in `host:port` form. |
+| oid        | string | Numeric OID returned by the agent. |
+| value      | string | SNMP4J string representation of the returned value. |
+| value_type | string | SMI type name, such as `Integer32`, `OctetString`, `TimeTicks`, or `noSuchInstance`. |
+| poll_time  | long   | Epoch time in milliseconds captured when the poll starts. All rows from one poll share this value. |
+
+SNMP values use different SMI types. V1 preserves the type name and exposes SNMP4J's textual representation
+instead of coercing all values into one numeric type. Binary values may not round-trip byte-for-byte through the
+`value` field.
+
+## Batch Example
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  SNMP {
+    plugin_output = "snmp_metrics"
+    host = "192.0.2.10"
+    port = 161
+    community = ${SNMP_COMMUNITY}
+    oids = [
+      "1.3.6.1.2.1.1.3.0",
+      "1.3.6.1.2.1.1.5.0"
+    ]
+    timeout_millis = 3000
+    retries = 1
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+## Streaming Example
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+}
+
+source {
+  SNMP {
+    plugin_output = "snmp_metrics"
+    host = "192.0.2.10"
+    community = ${SNMP_COMMUNITY}
+    oids = ["1.3.6.1.2.1.1.3.0"]
+    timeout_millis = 3000
+    retries = 2
+    poll_interval_millis = 30000
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+## Failure and Security Behavior
+
+- A timeout after all configured attempts fails the source task.
+- A non-zero SNMP response error status fails the source task; partial response rows are not emitted.
+- Closing or cancelling the source closes the SNMP transport and stops later polls.
+- Treat `community` as a credential. Supply it through configuration substitution or another secret-management path,
+  and do not place a real value in job files committed to source control.
+
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-snmp.md
+++ b/docs/zh/connectors/changelog/connector-snmp.md
@@ -1,0 +1,7 @@
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+| [Feature][Connector-V2] Add SNMPv2c polling source connector | - | Next |
+
+</details>

--- a/docs/zh/connectors/source/SNMP.md
+++ b/docs/zh/connectors/source/SNMP.md
@@ -1,0 +1,119 @@
+import ChangeLog from '../changelog/connector-snmp.md';
+
+# SNMP
+
+> SNMPv2c 轮询 Source 连接器
+
+## 描述
+
+SNMP Source 通过 UDP 向 SNMP Agent 发送 SNMPv2c GET 请求，轮询显式配置的数字 OID 列表。每个返回的变量绑定会转换为一行数据。首个版本不支持 WALK、GETNEXT 或 GETBULK。
+
+批处理作业只执行一次轮询，然后结束。流处理作业按照 `poll_interval_millis` 重复执行相同的 GET 请求。该 Source 使用单个 split，因此并行度必须为 1。
+
+## 支持的引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 主要特性
+
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+
+## 支持的数据源信息
+
+该连接器使用 SNMP4J，支持通过 UDP 访问的 SNMPv2c Agent。
+
+| 数据源 | 支持的版本 | 依赖 |
+|--------|------------|------|
+| SNMP Agent | SNMPv2c | [下载](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-snmp) |
+
+## Source 参数
+
+| 名称                 | 类型         | 必填 | 默认值 | 描述 |
+|----------------------|--------------|------|--------|------|
+| host                 | String       | 是   | -      | SNMP Agent 主机名或 IP 地址，不要包含协议或端口。 |
+| port                 | Int          | 否   | 161    | SNMP Agent 的 UDP 端口。 |
+| community            | String       | 是   | -      | SNMPv2c community 凭证。连接器不会把该值写入日志或错误信息。 |
+| oids                 | List\<String\> | 是 | -      | GET 请求中的数字 OID 列表。允许前导点；不允许重复 OID 或符号 OID。 |
+| timeout_millis       | Long         | 否   | 5000   | 每次请求尝试的超时时间，单位为毫秒。 |
+| retries              | Int          | 否   | 1      | 首次请求失败后的重试次数。`0` 表示总共只发送一次请求。 |
+| poll_interval_millis | Long         | 否   | 60000  | 两次流式轮询之间的延迟，单位为毫秒。批处理作业忽略此参数。 |
+
+## 输出 Schema
+
+输出 Schema 固定，不能通过 `schema` 参数修改。
+
+| 字段       | 类型   | 描述 |
+|------------|--------|------|
+| agent      | string | 被轮询的 Agent，格式为 `host:port`。 |
+| oid        | string | Agent 返回的数字 OID。 |
+| value      | string | SNMP4J 对返回值的字符串表示。 |
+| value_type | string | SMI 类型名称，例如 `Integer32`、`OctetString`、`TimeTicks` 或 `noSuchInstance`。 |
+| poll_time  | long   | 轮询开始时的 Unix 纪元毫秒时间。同一次轮询的所有行使用相同值。 |
+
+SNMP 值可能属于不同的 SMI 类型。V1 保留类型名称并输出 SNMP4J 的文本表示，不会把所有值强制转换为同一种数值类型。二进制值通过 `value` 字段传递时不保证可以逐字节还原。
+
+## 批处理示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  SNMP {
+    plugin_output = "snmp_metrics"
+    host = "192.0.2.10"
+    port = 161
+    community = ${SNMP_COMMUNITY}
+    oids = [
+      "1.3.6.1.2.1.1.3.0",
+      "1.3.6.1.2.1.1.5.0"
+    ]
+    timeout_millis = 3000
+    retries = 1
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+## 流处理示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+}
+
+source {
+  SNMP {
+    plugin_output = "snmp_metrics"
+    host = "192.0.2.10"
+    community = ${SNMP_COMMUNITY}
+    oids = ["1.3.6.1.2.1.1.3.0"]
+    timeout_millis = 3000
+    retries = 2
+    poll_interval_millis = 30000
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+## 失败与安全行为
+
+- 用尽配置的所有请求尝试后仍超时，Source Task 会失败。
+- SNMP 响应包含非零错误状态时，Source Task 会失败，并且不会输出部分响应行。
+- 关闭或取消 Source 会关闭 SNMP transport，并停止后续轮询。
+- `community` 是凭证。请通过配置替换或其他密钥管理方式提供，不要把真实值写入提交到版本控制的作业文件。
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -149,6 +149,7 @@ seatunnel.sink.Milvus = connector-milvus
 seatunnel.sink.ActiveMQ = connector-activemq
 seatunnel.source.MQTT = connector-mqtt
 seatunnel.sink.MQTT = connector-mqtt
+seatunnel.source.SNMP = connector-snmp
 seatunnel.source.Python = connector-python
 seatunnel.source.Prometheus = connector-prometheus
 seatunnel.sink.Prometheus = connector-prometheus

--- a/seatunnel-connectors-v2/connector-snmp/pom.xml
+++ b/seatunnel-connectors-v2/connector-snmp/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-snmp</artifactId>
+    <name>SeaTunnel : Connectors V2 : SNMP</name>
+
+    <properties>
+        <snmp4j.version>2.8.18</snmp4j.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.snmp4j</groupId>
+            <artifactId>snmp4j</artifactId>
+            <version>${snmp4j.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceConfig.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+/** Validated runtime configuration for the SNMP source connector. */
 public final class SnmpSourceConfig implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -43,6 +44,7 @@ public final class SnmpSourceConfig implements Serializable {
     private final int retries;
     private final long pollIntervalMillis;
 
+    /** Creates an SNMP source configuration from connector options. */
     public SnmpSourceConfig(ReadonlyConfig config) {
         String configuredHost = config.get(SnmpSourceOptions.HOST);
         if (isBlank(configuredHost)) {

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.snmp4j.smi.OID;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public final class SnmpSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Pattern NUMERIC_OID = Pattern.compile("^\\.?[0-9]+(\\.[0-9]+)+$");
+
+    private final String host;
+    private final int port;
+    private final String community;
+    private final List<OID> oids;
+    private final long timeoutMillis;
+    private final int retries;
+    private final long pollIntervalMillis;
+
+    public SnmpSourceConfig(ReadonlyConfig config) {
+        String configuredHost = config.get(SnmpSourceOptions.HOST);
+        if (isBlank(configuredHost)) {
+            throw new IllegalArgumentException("SNMP source host must not be blank");
+        }
+        this.host = configuredHost.trim();
+        this.port = config.get(SnmpSourceOptions.PORT);
+        this.community = config.get(SnmpSourceOptions.COMMUNITY);
+        this.oids = parseOids(config.get(SnmpSourceOptions.OIDS));
+        this.timeoutMillis = config.get(SnmpSourceOptions.TIMEOUT_MILLIS);
+        this.retries = config.get(SnmpSourceOptions.RETRIES);
+        this.pollIntervalMillis = config.get(SnmpSourceOptions.POLL_INTERVAL_MILLIS);
+        validate();
+    }
+
+    private void validate() {
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("SNMP source port must be between 1 and 65535");
+        }
+        if (isBlank(community)) {
+            throw new IllegalArgumentException("SNMP source community must not be blank");
+        }
+        if (timeoutMillis <= 0) {
+            throw new IllegalArgumentException("SNMP source timeout_millis must be greater than 0");
+        }
+        if (retries < 0) {
+            throw new IllegalArgumentException("SNMP source retries must not be negative");
+        }
+        if (pollIntervalMillis <= 0) {
+            throw new IllegalArgumentException(
+                    "SNMP source poll_interval_millis must be greater than 0");
+        }
+    }
+
+    private static List<OID> parseOids(List<String> configuredOids) {
+        if (configuredOids == null || configuredOids.isEmpty()) {
+            throw new IllegalArgumentException("SNMP source oids must not be empty");
+        }
+
+        List<OID> parsed = new ArrayList<>(configuredOids.size());
+        Set<String> unique = new LinkedHashSet<>();
+        for (String configuredOid : configuredOids) {
+            String value = configuredOid == null ? null : configuredOid.trim();
+            if (value == null || !NUMERIC_OID.matcher(value).matches()) {
+                throw new IllegalArgumentException(
+                        "SNMP source oids must contain only numeric OIDs: " + configuredOid);
+            }
+            if (value.charAt(0) == '.') {
+                value = value.substring(1);
+            }
+            OID oid;
+            try {
+                oid = new OID(value);
+            } catch (RuntimeException e) {
+                throw new IllegalArgumentException("Invalid SNMP source OID: " + value, e);
+            }
+            String normalized = oid.toString();
+            if (!unique.add(normalized)) {
+                throw new IllegalArgumentException("Duplicate SNMP source OID: " + normalized);
+            }
+            parsed.add(oid);
+        }
+        return Collections.unmodifiableList(parsed);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getCommunity() {
+        return community;
+    }
+
+    public List<OID> getOids() {
+        return oids;
+    }
+
+    public long getTimeoutMillis() {
+        return timeoutMillis;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public long getPollIntervalMillis() {
+        return pollIntervalMillis;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceOptions.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.util.List;
+
+public final class SnmpSourceOptions {
+
+    public static final String CONNECTOR_IDENTITY = "SNMP";
+
+    public static final Option<String> HOST =
+            Options.key("host")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("SNMP agent host name or IP address");
+
+    public static final Option<Integer> PORT =
+            Options.key("port").intType().defaultValue(161).withDescription("SNMP agent UDP port");
+
+    public static final Option<String> COMMUNITY =
+            Options.key("community")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("SNMPv2c community credential");
+
+    public static final Option<List<String>> OIDS =
+            Options.key("oids")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Numeric OIDs to retrieve with SNMP GET");
+
+    public static final Option<Long> TIMEOUT_MILLIS =
+            Options.key("timeout_millis")
+                    .longType()
+                    .defaultValue(5000L)
+                    .withDescription("Timeout in milliseconds for each SNMP request attempt");
+
+    public static final Option<Integer> RETRIES =
+            Options.key("retries")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("Number of retries after the initial SNMP request attempt");
+
+    public static final Option<Long> POLL_INTERVAL_MILLIS =
+            Options.key("poll_interval_millis")
+                    .longType()
+                    .defaultValue(60000L)
+                    .withDescription("Interval in milliseconds between streaming polls");
+
+    private SnmpSourceOptions() {}
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/exception/SnmpConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/exception/SnmpConnectorErrorCode.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+
+public enum SnmpConnectorErrorCode implements SeaTunnelErrorCode {
+    CONNECTION_FAILED("SNMP-01", "SNMP client initialization failed"),
+    POLL_FAILED("SNMP-02", "SNMP poll failed");
+
+    private final String code;
+    private final String description;
+
+    SnmpConnectorErrorCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/exception/SnmpConnectorException.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/exception/SnmpConnectorException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+public class SnmpConnectorException extends SeaTunnelRuntimeException {
+
+    public SnmpConnectorException(SeaTunnelErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public SnmpConnectorException(SeaTunnelErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/Snmp4jClient.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/Snmp4jClient.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+/** SNMPv2c client backed by SNMP4J. */
 final class Snmp4jClient implements SnmpClient {
 
     private final SnmpSourceConfig config;

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/Snmp4jClient.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/Snmp4jClient.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceConfig;
+
+import org.snmp4j.CommunityTarget;
+import org.snmp4j.PDU;
+import org.snmp4j.Snmp;
+import org.snmp4j.Target;
+import org.snmp4j.event.ResponseEvent;
+import org.snmp4j.mp.SnmpConstants;
+import org.snmp4j.smi.OID;
+import org.snmp4j.smi.OctetString;
+import org.snmp4j.smi.UdpAddress;
+import org.snmp4j.smi.Variable;
+import org.snmp4j.smi.VariableBinding;
+import org.snmp4j.transport.DefaultUdpTransportMapping;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+final class Snmp4jClient implements SnmpClient {
+
+    private final SnmpSourceConfig config;
+    private final Snmp snmp;
+    private final Target target;
+
+    Snmp4jClient(SnmpSourceConfig config) throws IOException {
+        this(config, new Snmp(new DefaultUdpTransportMapping()));
+    }
+
+    Snmp4jClient(SnmpSourceConfig config, Snmp snmp) throws IOException {
+        this.config = config;
+        this.target = buildTarget(config);
+        try {
+            snmp.listen();
+        } catch (IOException e) {
+            try {
+                snmp.close();
+            } catch (IOException closeException) {
+                e.addSuppressed(closeException);
+            }
+            throw e;
+        }
+        this.snmp = snmp;
+    }
+
+    @Override
+    public List<SnmpRecord> get(List<OID> oids) throws IOException {
+        ResponseEvent event = snmp.send(buildGetRequest(oids), target);
+        if (event == null || event.getResponse() == null) {
+            throw new IOException(
+                    "SNMP request timed out for agent "
+                            + config.getHost()
+                            + ":"
+                            + config.getPort());
+        }
+
+        PDU response = event.getResponse();
+        if (response.getErrorStatus() != PDU.noError) {
+            throw new IOException(
+                    "SNMP agent returned error status "
+                            + response.getErrorStatus()
+                            + " ("
+                            + response.getErrorStatusText()
+                            + ") at index "
+                            + response.getErrorIndex());
+        }
+        return extractRecords(response);
+    }
+
+    @Override
+    public void close() throws IOException {
+        snmp.close();
+    }
+
+    static PDU buildGetRequest(List<OID> oids) {
+        PDU pdu = new PDU();
+        pdu.setType(PDU.GET);
+        for (OID oid : oids) {
+            pdu.add(new VariableBinding(oid));
+        }
+        return pdu;
+    }
+
+    static Target buildTarget(SnmpSourceConfig config) {
+        CommunityTarget target = new CommunityTarget();
+        target.setAddress(new UdpAddress(config.getHost() + "/" + config.getPort()));
+        target.setCommunity(new OctetString(config.getCommunity()));
+        target.setVersion(SnmpConstants.version2c);
+        target.setTimeout(config.getTimeoutMillis());
+        target.setRetries(config.getRetries());
+        return target;
+    }
+
+    static List<SnmpRecord> extractRecords(PDU response) {
+        List<SnmpRecord> records = new ArrayList<>(response.size());
+        for (VariableBinding binding : response.getVariableBindings()) {
+            Variable variable = binding.getVariable();
+            records.add(
+                    new SnmpRecord(
+                            binding.getOid().toString(),
+                            variable.toString(),
+                            variable.getSyntaxString()));
+        }
+        return records;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpClient.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpClient.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.snmp4j.smi.OID;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+interface SnmpClient extends Closeable {
+
+    List<SnmpRecord> get(List<OID> oids) throws IOException;
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpRecord.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpRecord.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+final class SnmpRecord {
+
+    private final String oid;
+    private final String value;
+    private final String valueType;
+
+    SnmpRecord(String oid, String value, String valueType) {
+        this.oid = oid;
+        this.value = value;
+        this.valueType = valueType;
+    }
+
+    String getOid() {
+        return oid;
+    }
+
+    String getValue() {
+        return value;
+    }
+
+    String getValueType() {
+        return valueType;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSource.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSource.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitSource;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceOptions;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SnmpSource extends AbstractSingleSplitSource<SeaTunnelRow> {
+
+    static final String FIELD_AGENT = "agent";
+    static final String FIELD_OID = "oid";
+    static final String FIELD_VALUE = "value";
+    static final String FIELD_VALUE_TYPE = "value_type";
+    static final String FIELD_POLL_TIME = "poll_time";
+
+    private final SnmpSourceConfig config;
+    private final CatalogTable catalogTable;
+    private JobContext jobContext;
+
+    public SnmpSource(SnmpSourceConfig config) {
+        this.config = config;
+        this.catalogTable = createCatalogTable();
+    }
+
+    @Override
+    public String getPluginName() {
+        return SnmpSourceOptions.CONNECTOR_IDENTITY;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return jobContext != null && JobMode.STREAMING.equals(jobContext.getJobMode())
+                ? Boundedness.UNBOUNDED
+                : Boundedness.BOUNDED;
+    }
+
+    @Override
+    public void setJobContext(JobContext jobContext) {
+        this.jobContext = jobContext;
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(catalogTable);
+    }
+
+    @Override
+    public AbstractSingleSplitReader<SeaTunnelRow> createReader(
+            SingleSplitReaderContext readerContext) {
+        return new SnmpSourceReader(config, readerContext);
+    }
+
+    static CatalogTable createCatalogTable() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(
+                                PhysicalColumn.of(
+                                        FIELD_AGENT, BasicType.STRING_TYPE, 0, false, null, null))
+                        .column(
+                                PhysicalColumn.of(
+                                        FIELD_OID, BasicType.STRING_TYPE, 0, false, null, null))
+                        .column(
+                                PhysicalColumn.of(
+                                        FIELD_VALUE, BasicType.STRING_TYPE, 0, false, null, null))
+                        .column(
+                                PhysicalColumn.of(
+                                        FIELD_VALUE_TYPE,
+                                        BasicType.STRING_TYPE,
+                                        0,
+                                        false,
+                                        null,
+                                        null))
+                        .column(
+                                PhysicalColumn.of(
+                                        FIELD_POLL_TIME, BasicType.LONG_TYPE, 0, false, null, null))
+                        .build();
+        return CatalogTable.of(
+                TableIdentifier.of("default", "default", "snmp"),
+                schema,
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                "SNMP source output");
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceFactory.java
@@ -31,6 +31,7 @@ import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
 
+/** Creates SNMP source connectors from table factory configuration. */
 @AutoService(Factory.class)
 public class SnmpSourceFactory implements TableSourceFactory {
 

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceOptions;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+
+@AutoService(Factory.class)
+public class SnmpSourceFactory implements TableSourceFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return SnmpSourceOptions.CONNECTOR_IDENTITY;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        SnmpSourceOptions.HOST, SnmpSourceOptions.COMMUNITY, SnmpSourceOptions.OIDS)
+                .optional(
+                        SnmpSourceOptions.PORT,
+                        SnmpSourceOptions.TIMEOUT_MILLIS,
+                        SnmpSourceOptions.RETRIES,
+                        SnmpSourceOptions.POLL_INTERVAL_MILLIS)
+                .build();
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        SnmpSourceConfig config = new SnmpSourceConfig(context.getOptions());
+        return () -> (SeaTunnelSource<T, SplitT, StateT>) new SnmpSource(config);
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return SnmpSource.class;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceReader.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.function.LongSupplier;
 
+/** Polls a configured SNMP agent and emits one row for each requested OID. */
 public class SnmpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SnmpSourceReader.class);
@@ -47,6 +48,7 @@ public class SnmpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
     private SnmpClient client;
     private long nextPollTimeMillis;
 
+    /** Creates a reader for the supplied SNMP agent configuration. */
     public SnmpSourceReader(SnmpSourceConfig config, SingleSplitReaderContext context) {
         this(config, context, Snmp4jClient::new, System::currentTimeMillis);
     }

--- a/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceReader.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/main/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceReader.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.snmp.exception.SnmpConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.snmp.exception.SnmpConnectorException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.LongSupplier;
+
+public class SnmpSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SnmpSourceReader.class);
+    private static final long MAX_IDLE_WAIT_MILLIS = 200L;
+
+    private final SnmpSourceConfig config;
+    private final SingleSplitReaderContext context;
+    private final SnmpClientFactory clientFactory;
+    private final LongSupplier currentTimeMillis;
+
+    private volatile boolean closed;
+    private SnmpClient client;
+    private long nextPollTimeMillis;
+
+    public SnmpSourceReader(SnmpSourceConfig config, SingleSplitReaderContext context) {
+        this(config, context, Snmp4jClient::new, System::currentTimeMillis);
+    }
+
+    SnmpSourceReader(
+            SnmpSourceConfig config,
+            SingleSplitReaderContext context,
+            SnmpClientFactory clientFactory,
+            LongSupplier currentTimeMillis) {
+        this.config = config;
+        this.context = context;
+        this.clientFactory = clientFactory;
+        this.currentTimeMillis = currentTimeMillis;
+    }
+
+    @Override
+    public void open() {
+        try {
+            client = clientFactory.create(config);
+            LOG.info(
+                    "SNMP source reader opened for agent [{}:{}] with [{}] OIDs",
+                    config.getHost(),
+                    config.getPort(),
+                    config.getOids().size());
+        } catch (IOException e) {
+            throw new SnmpConnectorException(
+                    SnmpConnectorErrorCode.CONNECTION_FAILED,
+                    "Failed to initialize SNMP client for agent "
+                            + config.getHost()
+                            + ":"
+                            + config.getPort(),
+                    e);
+        }
+    }
+
+    @Override
+    public void pollNext(Collector<SeaTunnelRow> output) throws Exception {
+        if (closed || noMoreSplits) {
+            return;
+        }
+
+        if (Boundedness.UNBOUNDED.equals(context.getBoundedness())) {
+            long waitMillis = nextPollTimeMillis - currentTimeMillis.getAsLong();
+            if (waitMillis > 0) {
+                Thread.sleep(Math.min(waitMillis, MAX_IDLE_WAIT_MILLIS));
+                return;
+            }
+        }
+
+        long pollTime = currentTimeMillis.getAsLong();
+        List<SnmpRecord> records;
+        try {
+            records = client.get(config.getOids());
+        } catch (IOException e) {
+            if (closed) {
+                return;
+            }
+            throw new SnmpConnectorException(
+                    SnmpConnectorErrorCode.POLL_FAILED,
+                    "Failed to poll SNMP agent " + config.getHost() + ":" + config.getPort(),
+                    e);
+        }
+
+        if (closed) {
+            return;
+        }
+        synchronized (output.getCheckpointLock()) {
+            for (SnmpRecord record : records) {
+                output.collect(
+                        new SeaTunnelRow(
+                                new Object[] {
+                                    config.getHost() + ":" + config.getPort(),
+                                    record.getOid(),
+                                    record.getValue(),
+                                    record.getValueType(),
+                                    pollTime
+                                }));
+            }
+        }
+
+        if (Boundedness.BOUNDED.equals(context.getBoundedness())) {
+            noMoreSplits = true;
+            context.signalNoMoreElement();
+        } else {
+            nextPollTimeMillis = currentTimeMillis.getAsLong() + config.getPollIntervalMillis();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        if (client != null) {
+            client.close();
+        }
+        LOG.info("SNMP source reader closed for agent [{}:{}]", config.getHost(), config.getPort());
+    }
+
+    interface SnmpClientFactory {
+        SnmpClient create(SnmpSourceConfig config) throws IOException;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceConfigTest.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/config/SnmpSourceConfigTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+class SnmpSourceConfigTest {
+
+    @Test
+    void testDefaultsAndOidNormalization() {
+        SnmpSourceConfig config = new SnmpSourceConfig(ReadonlyConfig.fromMap(baseConfig()));
+
+        Assertions.assertEquals("127.0.0.1", config.getHost());
+        Assertions.assertEquals(161, config.getPort());
+        Assertions.assertEquals("monitoring-community", config.getCommunity());
+        Assertions.assertEquals("1.3.6.1.2.1.1.3.0", config.getOids().get(0).toString());
+        Assertions.assertEquals("1.3.6.1.2.1.1.5.0", config.getOids().get(1).toString());
+        Assertions.assertEquals(5000L, config.getTimeoutMillis());
+        Assertions.assertEquals(1, config.getRetries());
+        Assertions.assertEquals(60000L, config.getPollIntervalMillis());
+    }
+
+    @Test
+    void testTrimsHost() {
+        Map<String, Object> values = baseConfig();
+        values.put("host", " 127.0.0.1 ");
+
+        SnmpSourceConfig config = new SnmpSourceConfig(ReadonlyConfig.fromMap(values));
+
+        Assertions.assertEquals("127.0.0.1", config.getHost());
+    }
+
+    @Test
+    void testExplicitRequestSettings() {
+        Map<String, Object> values = baseConfig();
+        values.put("port", 1161);
+        values.put("timeout_millis", 1200L);
+        values.put("retries", 3);
+        values.put("poll_interval_millis", 15000L);
+
+        SnmpSourceConfig config = new SnmpSourceConfig(ReadonlyConfig.fromMap(values));
+
+        Assertions.assertEquals(1161, config.getPort());
+        Assertions.assertEquals(1200L, config.getTimeoutMillis());
+        Assertions.assertEquals(3, config.getRetries());
+        Assertions.assertEquals(15000L, config.getPollIntervalMillis());
+    }
+
+    @Test
+    void testInvalidValuesFailWithoutDisclosingCommunity() {
+        Map<String, Object> values = baseConfig();
+        values.put("port", 0);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new SnmpSourceConfig(ReadonlyConfig.fromMap(values)));
+
+        Assertions.assertFalse(exception.getMessage().contains("monitoring-community"));
+    }
+
+    @Test
+    void testInvalidAndDuplicateOidsFail() {
+        Map<String, Object> invalid = baseConfig();
+        invalid.put("oids", Arrays.asList("SNMPv2-MIB::sysName.0"));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SnmpSourceConfig(ReadonlyConfig.fromMap(invalid)));
+
+        Map<String, Object> duplicate = baseConfig();
+        duplicate.put("oids", Arrays.asList(".1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.3.0"));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SnmpSourceConfig(ReadonlyConfig.fromMap(duplicate)));
+    }
+
+    @Test
+    void testRequestBoundsFail() {
+        Map<String, Object> timeout = baseConfig();
+        timeout.put("timeout_millis", 0);
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SnmpSourceConfig(ReadonlyConfig.fromMap(timeout)));
+
+        Map<String, Object> retries = baseConfig();
+        retries.put("retries", -1);
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SnmpSourceConfig(ReadonlyConfig.fromMap(retries)));
+
+        Map<String, Object> interval = baseConfig();
+        interval.put("poll_interval_millis", 0);
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new SnmpSourceConfig(ReadonlyConfig.fromMap(interval)));
+    }
+
+    static Map<String, Object> baseConfig() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("host", "127.0.0.1");
+        values.put("community", "monitoring-community");
+        values.put("oids", Arrays.asList(".1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"));
+        return values;
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/Snmp4jClientTest.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/Snmp4jClientTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.snmp4j.CommandResponderEvent;
+import org.snmp4j.CommunityTarget;
+import org.snmp4j.MessageException;
+import org.snmp4j.PDU;
+import org.snmp4j.Snmp;
+import org.snmp4j.Target;
+import org.snmp4j.mp.SnmpConstants;
+import org.snmp4j.mp.StatusInformation;
+import org.snmp4j.smi.Integer32;
+import org.snmp4j.smi.OID;
+import org.snmp4j.smi.UdpAddress;
+import org.snmp4j.smi.VariableBinding;
+import org.snmp4j.transport.DefaultUdpTransportMapping;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+class Snmp4jClientTest {
+
+    @Test
+    void testBuildsSnmpV2cGetRequestAndTarget() {
+        SnmpSourceConfig config = config();
+
+        PDU request = Snmp4jClient.buildGetRequest(config.getOids());
+        Target target = Snmp4jClient.buildTarget(config);
+
+        Assertions.assertEquals(PDU.GET, request.getType());
+        Assertions.assertEquals(2, request.size());
+        Assertions.assertEquals("1.3.6.1.2.1.1.3.0", request.get(0).getOid().toString());
+        Assertions.assertEquals(SnmpConstants.version2c, target.getVersion());
+        Assertions.assertEquals(2500L, target.getTimeout());
+        Assertions.assertEquals(2, target.getRetries());
+        Assertions.assertEquals("127.0.0.1/1161", target.getAddress().toString());
+        Assertions.assertEquals(
+                "unit-test-community", ((CommunityTarget) target).getCommunity().toString());
+    }
+
+    @Test
+    void testExtractsStableRecordFields() {
+        PDU response = new PDU();
+        response.add(new VariableBinding(new OID("1.3.6.1.2.1.1.3.0"), new Integer32(42)));
+
+        List<SnmpRecord> records = Snmp4jClient.extractRecords(response);
+
+        Assertions.assertEquals(1, records.size());
+        Assertions.assertEquals("1.3.6.1.2.1.1.3.0", records.get(0).getOid());
+        Assertions.assertEquals("42", records.get(0).getValue());
+        Assertions.assertEquals("Integer32", records.get(0).getValueType());
+    }
+
+    @Test
+    void testClosesTransportWhenListenFails() throws Exception {
+        FailingSnmp snmp = new FailingSnmp();
+
+        IOException exception =
+                Assertions.assertThrows(IOException.class, () -> new Snmp4jClient(config(), snmp));
+
+        Assertions.assertEquals("listen failed", exception.getMessage());
+        Assertions.assertTrue(snmp.closed);
+    }
+
+    @Test
+    void testPollsLocalSnmpV2cAgent() throws Exception {
+        DefaultUdpTransportMapping transport =
+                new DefaultUdpTransportMapping(new UdpAddress(InetAddress.getLoopbackAddress(), 0));
+        AtomicReference<MessageException> responseFailure = new AtomicReference<>();
+        Snmp agent = new Snmp(transport);
+        try {
+            agent.addCommandResponder(event -> respond(event, responseFailure));
+            agent.listen();
+
+            Map<String, Object> values = baseConfig();
+            values.put("port", transport.getListenAddress().getPort());
+            try (Snmp4jClient client =
+                    new Snmp4jClient(new SnmpSourceConfig(ReadonlyConfig.fromMap(values)))) {
+                List<SnmpRecord> records =
+                        client.get(
+                                Arrays.asList(
+                                        new OID("1.3.6.1.2.1.1.3.0"),
+                                        new OID("1.3.6.1.2.1.1.5.0")));
+
+                Assertions.assertEquals(2, records.size());
+                Assertions.assertEquals("123", records.get(0).getValue());
+                Assertions.assertEquals("Integer32", records.get(0).getValueType());
+                Assertions.assertNull(responseFailure.get());
+            }
+        } finally {
+            agent.close();
+        }
+    }
+
+    private static void respond(
+            CommandResponderEvent event, AtomicReference<MessageException> responseFailure) {
+        PDU response = new PDU(event.getPDU());
+        response.setType(PDU.RESPONSE);
+        for (int index = 0; index < response.size(); index++) {
+            response.get(index).setVariable(new Integer32(123 + index));
+        }
+        try {
+            event.getMessageDispatcher()
+                    .returnResponsePdu(
+                            event.getMessageProcessingModel(),
+                            event.getSecurityModel(),
+                            event.getSecurityName(),
+                            event.getSecurityLevel(),
+                            response,
+                            event.getMaxSizeResponsePDU(),
+                            event.getStateReference(),
+                            new StatusInformation());
+            event.setProcessed(true);
+        } catch (MessageException e) {
+            responseFailure.set(e);
+        }
+    }
+
+    private static SnmpSourceConfig config() {
+        Map<String, Object> values = baseConfig();
+        values.put("timeout_millis", 2500L);
+        values.put("retries", 2);
+        return new SnmpSourceConfig(ReadonlyConfig.fromMap(values));
+    }
+
+    private static Map<String, Object> baseConfig() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("host", "127.0.0.1");
+        values.put("port", 1161);
+        values.put("community", "unit-test-community");
+        values.put("oids", Arrays.asList("1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"));
+        return values;
+    }
+
+    private static class FailingSnmp extends Snmp {
+        private boolean closed;
+
+        @Override
+        public void listen() throws IOException {
+            throw new IOException("listen failed");
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+class SnmpSourceFactoryTest {
+
+    @Test
+    void testFactoryIdentityAndOptions() {
+        SnmpSourceFactory factory = new SnmpSourceFactory();
+
+        Assertions.assertEquals(SnmpSourceOptions.CONNECTOR_IDENTITY, factory.factoryIdentifier());
+        Assertions.assertEquals(SnmpSource.class, factory.getSourceClass());
+
+        OptionRule rule = factory.optionRule();
+        List<Option<?>> required =
+                rule.getRequiredOptions().stream()
+                        .flatMap(group -> group.getOptions().stream())
+                        .collect(Collectors.toList());
+        Assertions.assertTrue(required.contains(SnmpSourceOptions.HOST));
+        Assertions.assertTrue(required.contains(SnmpSourceOptions.COMMUNITY));
+        Assertions.assertTrue(required.contains(SnmpSourceOptions.OIDS));
+        Assertions.assertTrue(rule.getOptionalOptions().contains(SnmpSourceOptions.PORT));
+        Assertions.assertTrue(rule.getOptionalOptions().contains(SnmpSourceOptions.TIMEOUT_MILLIS));
+        Assertions.assertTrue(rule.getOptionalOptions().contains(SnmpSourceOptions.RETRIES));
+        Assertions.assertTrue(
+                rule.getOptionalOptions().contains(SnmpSourceOptions.POLL_INTERVAL_MILLIS));
+    }
+}

--- a/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceTest.java
+++ b/seatunnel-connectors-v2/connector-snmp/src/test/java/org/apache/seatunnel/connectors/seatunnel/snmp/source/SnmpSourceTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.snmp.source;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.common.utils.SerializationUtils;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+import org.apache.seatunnel.connectors.seatunnel.snmp.config.SnmpSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.snmp.exception.SnmpConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.snmp4j.smi.OID;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+class SnmpSourceTest {
+
+    @Test
+    void testSourceMetadataAndBoundedness() {
+        SnmpSource source = new SnmpSource(config());
+
+        Assertions.assertEquals("SNMP", source.getPluginName());
+        Assertions.assertEquals(Boundedness.BOUNDED, source.getBoundedness());
+
+        source.setJobContext(new JobContext().setJobMode(JobMode.STREAMING));
+        Assertions.assertEquals(Boundedness.UNBOUNDED, source.getBoundedness());
+    }
+
+    @Test
+    void testFixedOutputSchema() {
+        CatalogTable table = SnmpSource.createCatalogTable();
+
+        Assertions.assertArrayEquals(
+                new String[] {"agent", "oid", "value", "value_type", "poll_time"},
+                table.getSeaTunnelRowType().getFieldNames());
+        Assertions.assertArrayEquals(
+                new Object[] {
+                    BasicType.STRING_TYPE,
+                    BasicType.STRING_TYPE,
+                    BasicType.STRING_TYPE,
+                    BasicType.STRING_TYPE,
+                    BasicType.LONG_TYPE
+                },
+                table.getSeaTunnelRowType().getFieldTypes());
+    }
+
+    @Test
+    void testSourceSerializationForWorkerExecution() {
+        SnmpSource source = new SnmpSource(config());
+
+        SnmpSource restored = SerializationUtils.deserialize(SerializationUtils.serialize(source));
+
+        Assertions.assertEquals("SNMP", restored.getPluginName());
+        Assertions.assertArrayEquals(
+                source.getProducedCatalogTables().get(0).getSeaTunnelRowType().getFieldNames(),
+                restored.getProducedCatalogTables().get(0).getSeaTunnelRowType().getFieldNames());
+    }
+
+    @Test
+    void testBoundedReaderPollsOnceAndSignalsCompletion() throws Exception {
+        TestReaderContext testContext = new TestReaderContext(Boundedness.BOUNDED);
+        SingleSplitReaderContext context = new SingleSplitReaderContext(testContext);
+        FakeSnmpClient client = new FakeSnmpClient();
+        SnmpSourceReader reader = reader(context, client, new AtomicLong(1234L));
+        RecordingCollector collector = new RecordingCollector();
+        reader.open();
+
+        reader.pollNext(collector);
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(1, client.pollCount);
+        Assertions.assertEquals(2, collector.rows.size());
+        Assertions.assertArrayEquals(
+                new Object[] {"127.0.0.1:161", "1.3.6.1.2.1.1.3.0", "42", "TimeTicks", 1234L},
+                collector.rows.get(0).getFields());
+        Assertions.assertTrue(testContext.noMoreElements);
+    }
+
+    @Test
+    void testStreamingReaderHonorsPollInterval() throws Exception {
+        TestReaderContext testContext = new TestReaderContext(Boundedness.UNBOUNDED);
+        SingleSplitReaderContext context = new SingleSplitReaderContext(testContext);
+        FakeSnmpClient client = new FakeSnmpClient();
+        AtomicLong clock = new AtomicLong(1000L);
+        SnmpSourceReader reader = reader(context, client, clock);
+        RecordingCollector collector = new RecordingCollector();
+        reader.open();
+
+        reader.pollNext(collector);
+        clock.set(1099L);
+        reader.pollNext(collector);
+        Assertions.assertEquals(1, client.pollCount);
+
+        clock.set(1100L);
+        reader.pollNext(collector);
+        Assertions.assertEquals(2, client.pollCount);
+        Assertions.assertFalse(testContext.noMoreElements);
+    }
+
+    @Test
+    void testCloseStopsPollingAndClosesClient() throws Exception {
+        SingleSplitReaderContext context =
+                new SingleSplitReaderContext(new TestReaderContext(Boundedness.UNBOUNDED));
+        FakeSnmpClient client = new FakeSnmpClient();
+        SnmpSourceReader reader = reader(context, client, new AtomicLong(1000L));
+        reader.open();
+
+        reader.close();
+        reader.pollNext(new RecordingCollector());
+
+        Assertions.assertTrue(client.closed);
+        Assertions.assertEquals(0, client.pollCount);
+    }
+
+    @Test
+    void testPollFailureDoesNotDiscloseCommunity() throws Exception {
+        SingleSplitReaderContext context =
+                new SingleSplitReaderContext(new TestReaderContext(Boundedness.BOUNDED));
+        FakeSnmpClient client = new FakeSnmpClient();
+        client.failure = new IOException("request failed");
+        SnmpSourceReader reader = reader(context, client, new AtomicLong(1000L));
+        reader.open();
+
+        SnmpConnectorException exception =
+                Assertions.assertThrows(
+                        SnmpConnectorException.class,
+                        () -> reader.pollNext(new RecordingCollector()));
+
+        Assertions.assertFalse(exception.getMessage().contains("unit-test-community"));
+    }
+
+    private static SnmpSourceReader reader(
+            SingleSplitReaderContext context, FakeSnmpClient client, AtomicLong clock) {
+        return new SnmpSourceReader(config(), context, ignored -> client, clock::get);
+    }
+
+    private static SnmpSourceConfig config() {
+        Map<String, Object> values = new HashMap<>();
+        values.put("host", "127.0.0.1");
+        values.put("community", "unit-test-community");
+        values.put("oids", Arrays.asList("1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"));
+        values.put("poll_interval_millis", 100L);
+        return new SnmpSourceConfig(ReadonlyConfig.fromMap(values));
+    }
+
+    private static class FakeSnmpClient implements SnmpClient {
+        private int pollCount;
+        private boolean closed;
+        private IOException failure;
+
+        @Override
+        public List<SnmpRecord> get(List<OID> oids) throws IOException {
+            pollCount++;
+            if (failure != null) {
+                throw failure;
+            }
+            return Arrays.asList(
+                    new SnmpRecord(oids.get(0).toString(), "42", "TimeTicks"),
+                    new SnmpRecord(oids.get(1).toString(), "router-1", "OctetString"));
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+
+    private static class RecordingCollector implements Collector<SeaTunnelRow> {
+        private final Object checkpointLock = new Object();
+        private final List<SeaTunnelRow> rows = new ArrayList<>();
+
+        @Override
+        public void collect(SeaTunnelRow record) {
+            rows.add(record);
+        }
+
+        @Override
+        public Object getCheckpointLock() {
+            return checkpointLock;
+        }
+    }
+
+    private static class TestReaderContext implements SourceReader.Context {
+        private final Boundedness boundedness;
+        private boolean noMoreElements;
+
+        private TestReaderContext(Boundedness boundedness) {
+            this.boundedness = boundedness;
+        }
+
+        @Override
+        public int getIndexOfSubtask() {
+            return 0;
+        }
+
+        @Override
+        public Boundedness getBoundedness() {
+            return boundedness;
+        }
+
+        @Override
+        public void signalNoMoreElement() {
+            noMoreElements = true;
+        }
+
+        @Override
+        public void sendSplitRequest() {}
+
+        @Override
+        public void sendSourceEventToEnumerator(SourceEvent sourceEvent) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -59,6 +59,7 @@
         <module>connector-mongodb</module>
         <module>connector-couchbase</module>
         <module>connector-mqtt</module>
+        <module>connector-snmp</module>
         <module>connector-python</module>
         <module>connector-iceberg</module>
         <module>connector-influxdb</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -340,6 +340,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-snmp</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-python</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>

--- a/seatunnel-dist/release-docs/NOTICE
+++ b/seatunnel-dist/release-docs/NOTICE
@@ -873,3 +873,12 @@ The initial codebase was donated to the ASF by HugeGraph Authors, copyright 2017
  + com.couchbase.client:java-client (https://github.com/couchbase/couchbase-jvm-clients)
  + Copyright 2019-2024 Couchbase, Inc.
  + Licensed under the Apache License, Version 2.0
+
+=========================================================================
+
+ +===============================================================================
+ + Third-party dependencies for SNMP connector:
+ +===============================================================================
+ + org.snmp4j:snmp4j (https://www.snmp4j.org/)
+ + Copyright Frank Fock and Jochen Katz
+ + Licensed under the Apache License, Version 2.0

--- a/seatunnel-dist/release-docs/licenses/LICENSE-snmp4j.txt
+++ b/seatunnel-dist/release-docs/licenses/LICENSE-snmp4j.txt
@@ -1,0 +1,1 @@
+License: {Name: The Apache Software License, Version 2.0, URL: https://www.apache.org/licenses/LICENSE-2.0.txt, Distribution: repo, Comments: SNMP4J (org.snmp4j:snmp4j) }

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -133,4 +133,3 @@ seatunnel-shade-jetty-9.4.56.v20240826-3.0.0.jar
 seatunnel-shade-scala-compiler-2.12-3.0.0.jar
 seatunnel-shade-calcite-1.38.0-3.0.0.jar
 seatunnel-shade-jackson-yaml-2.15.4-3.0.0.jar
-snmp4j-2.8.18.jar

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -133,3 +133,4 @@ seatunnel-shade-jetty-9.4.56.v20240826-3.0.0.jar
 seatunnel-shade-scala-compiler-2.12-3.0.0.jar
 seatunnel-shade-calcite-1.38.0-3.0.0.jar
 seatunnel-shade-jackson-yaml-2.15.4-3.0.0.jar
+snmp4j-2.8.18.jar


### PR DESCRIPTION

### Purpose of this pull request

Related to #10753.

This adds the first SNMP Source slice.

- Polls explicit numeric OIDs with SNMPv2c GET over UDP
- Performs one poll in batch jobs and periodic polling in streaming jobs
- Exposes a fixed schema with agent, OID, value, SMI type, and poll timestamp
- Supports timeout, retry, and polling interval options
- Closes transport resources on cancellation and keeps the community value out of logs and errors
- Registers the connector and adds English and Chinese documentation and SNMP4J license metadata

SNMP WALK, GETNEXT, GETBULK, SNMPv3, traps, and sink support are outside the scope of this PR.

### Does this PR introduce _any_ user-facing change?

Yes. Users can configure `SNMP` as a source for polling SNMPv2c agents. Existing connectors are unchanged.

### How was this patch tested?

Added tests for configuration validation, factory options, batch and streaming reader behavior, cleanup, error handling, worker serialization, response conversion, and a local UDP SNMPv2c request/response round trip.

Verified on JDK 8 and JDK 11:

```shell
./mvnw -pl seatunnel-connectors-v2/connector-snmp test
./mvnw -pl seatunnel-connectors-v2/connector-snmp -am -DskipTests verify
```

Both focused runs passed with 18 tests. The scoped reactor verification also passed. The protocol test uses a local loopback SNMP agent and does not require an external device.

### Check list

* [x] Added the SNMP4J license and NOTICE information for the new runtime JAR.
* [x] Added English and Chinese connector documentation.
* [x] No update to `incompatible-changes.md` is required because this only adds a new connector.
* [x] Connector packaging was reviewed:
  1. Updated `plugin-mapping.properties`
  2. Updated `seatunnel-dist/pom.xml`
  3. Existing connector label scope covers the new module
  4. A self-contained local protocol integration test covers the request and response path
  5. Updated `config/plugin_config`