### PR TITLE
[Connector-V2] Lazily assign MaxCompute source splits

### DIFF
--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/source/SourceReader.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/source/SourceReader.java
@@ -93,6 +93,11 @@ public interface SourceReader<T, SplitT extends SourceSplit>
         /** @return boundedness of this reader. */
         Boundedness getBoundedness();
 
+        /** @return whether the engine enables checkpointing for this job. */
+        default boolean isCheckpointEnabled() {
+            return true;
+        }
+
         /** Indicator that the input has reached the end of data. Then will cancel this reader. */
         void signalNoMoreElement();
 

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceReader.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceReader.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.maxcompute.exception.MaxcomputeConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.maxcompute.source.event.MaxcomputeCompletedSplitsReportEvent;
 import org.apache.seatunnel.connectors.seatunnel.maxcompute.util.MaxcomputeTypeMapper;
 import org.apache.seatunnel.connectors.seatunnel.maxcompute.util.MaxcomputeUtil;
 
@@ -34,18 +35,50 @@ import com.aliyun.odps.tunnel.io.TunnelRecordReader;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.stream.Collectors;
 
 @Slf4j
+/**
+ * Reads bounded MaxCompute split batches and reports durable completion to the enumerator.
+ *
+ * <p>Checkpoint-enabled jobs retain completed splits in reader state until checkpoint success.
+ * Batch jobs without checkpoints report in bounded batches because they restart from the start
+ * after a failure.
+ */
 public class MaxcomputeSourceReader implements SourceReader<SeaTunnelRow, MaxcomputeSourceSplit> {
+    /** Maximum completion report size for jobs without checkpointing. */
+    private static final int COMPLETED_SPLIT_REPORT_BATCH_SIZE = 100;
+
+    /** Source runtime context used for split requests, state, and completion events. */
     private final SourceReader.Context context;
+
+    /** Bounded queue of split batches assigned by the enumerator. */
     private final Queue<MaxcomputeSourceSplit> sourceSplits;
+
+    /** Connector configuration used to open MaxCompute download sessions. */
     private final ReadonlyConfig readonlyConfig;
+
     private volatile boolean noMoreSplit;
+
+    /** Source metadata required to map a split to its download session and row type. */
     private final Map<TablePath, SourceTableInfo> sourceTableInfos;
+
+    /** Serializes current/completed split state with checkpoint snapshots. */
+    private final Object splitStateLock = new Object();
+
+    /** Completed split metadata retained until it can be safely released by the enumerator. */
+    private final List<MaxcomputeSourceSplit> completedSplits;
+
+    /** Completed split snapshots keyed by the checkpoint that first recorded them. */
+    private final Map<Long, List<MaxcomputeSourceSplit>> completedSplitsByCheckpoint;
+
+    /** Split currently being read and therefore required in a concurrent checkpoint snapshot. */
+    private volatile MaxcomputeSourceSplit currentProcessingSplit;
 
     public MaxcomputeSourceReader(
             ReadonlyConfig readonlyConfig,
@@ -55,6 +88,8 @@ public class MaxcomputeSourceReader implements SourceReader<SeaTunnelRow, Maxcom
         this.context = context;
         this.sourceSplits = new ConcurrentLinkedDeque<>();
         this.sourceTableInfos = sourceTableInfos;
+        this.completedSplits = new ArrayList<>();
+        this.completedSplitsByCheckpoint = new HashMap<>();
     }
 
     @Override
@@ -66,7 +101,11 @@ public class MaxcomputeSourceReader implements SourceReader<SeaTunnelRow, Maxcom
     @Override
     public void pollNext(Collector<SeaTunnelRow> output) throws Exception {
         MaxcomputeSourceSplit split = sourceSplits.poll();
+        boolean shouldReportCompletedSplits = false;
         if (split != null) {
+            synchronized (splitStateLock) {
+                currentProcessingSplit = split;
+            }
             synchronized (output.getCheckpointLock()) {
                 try {
                     TableTunnel.DownloadSession session =
@@ -102,11 +141,20 @@ public class MaxcomputeSourceReader implements SourceReader<SeaTunnelRow, Maxcom
                     throw new MaxcomputeConnectorException(
                             CommonErrorCodeDeprecated.READER_OPERATION_FAILED, e);
                 }
+                // Mark completion before releasing the barrier lock so its rows and split state
+                // always belong to the same checkpoint.
+                shouldReportCompletedSplits = completeSplit(split);
             }
+        }
+        if (shouldReportCompletedSplits) {
+            reportCompletedSplits();
         }
         if (this.sourceSplits.isEmpty()
                 && this.noMoreSplit
                 && Boundedness.BOUNDED.equals(context.getBoundedness())) {
+            if (!context.isCheckpointEnabled()) {
+                reportCompletedSplits();
+            }
             // signal to the source that we have reached the end of the data.
             log.info("Closed the bounded Maxcompute source");
             context.signalNoMoreElement();
@@ -117,7 +165,25 @@ public class MaxcomputeSourceReader implements SourceReader<SeaTunnelRow, Maxcom
 
     @Override
     public List<MaxcomputeSourceSplit> snapshotState(long checkpointId) throws Exception {
-        return new ArrayList<>(sourceSplits);
+        List<MaxcomputeSourceSplit> snapshot;
+        synchronized (splitStateLock) {
+            List<MaxcomputeSourceSplit> completedSplitsAtCheckpoint =
+                    new ArrayList<>(completedSplits);
+            if (context.isCheckpointEnabled()) {
+                completedSplitsByCheckpoint.put(checkpointId, completedSplitsAtCheckpoint);
+            }
+            snapshot =
+                    new ArrayList<>(
+                            sourceSplits.size()
+                                    + completedSplitsAtCheckpoint.size()
+                                    + (currentProcessingSplit == null ? 0 : 1));
+            if (currentProcessingSplit != null) {
+                snapshot.add(currentProcessingSplit);
+            }
+            snapshot.addAll(completedSplitsAtCheckpoint);
+        }
+        snapshot.addAll(sourceSplits);
+        return snapshot;
     }
 
     @Override
@@ -131,5 +197,86 @@ public class MaxcomputeSourceReader implements SourceReader<SeaTunnelRow, Maxcom
     }
 
     @Override
-    public void notifyCheckpointComplete(long checkpointId) {}
+    public void notifyCheckpointComplete(long checkpointId) {
+        reportCompletedSplits(checkpointId);
+    }
+
+    /** Discards completion markers for a checkpoint that did not become durable. */
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        synchronized (splitStateLock) {
+            completedSplitsByCheckpoint.remove(checkpointId);
+        }
+    }
+
+    /**
+     * Records a completed split until the completion is durable for the current job mode.
+     *
+     * <p>Checkpoint-enabled jobs retain a finished reader-state marker until checkpoint success;
+     * jobs without checkpoints report bounded completion batches immediately.
+     *
+     * @param split fully processed split
+     */
+    private boolean completeSplit(MaxcomputeSourceSplit split) {
+        synchronized (splitStateLock) {
+            if (context.isCheckpointEnabled()) {
+                split.setFinished(true);
+            }
+            completedSplits.add(split);
+            currentProcessingSplit = null;
+            return !context.isCheckpointEnabled()
+                    && completedSplits.size() >= COMPLETED_SPLIT_REPORT_BATCH_SIZE;
+        }
+    }
+
+    /** Reports all completion references for jobs that do not use checkpoints. */
+    private void reportCompletedSplits() {
+        List<MaxcomputeSourceSplit> splitsToReport;
+        synchronized (splitStateLock) {
+            splitsToReport = new ArrayList<>(completedSplits);
+        }
+        reportCompletedSplits(splitsToReport);
+    }
+
+    /**
+     * Reports only completed splits included by a successful checkpoint snapshot.
+     *
+     * <p>Splits completed after that checkpoint's snapshot stay in reader state until a later
+     * checkpoint records them, preventing source progress from being skipped during recovery.
+     *
+     * @param checkpointId successful checkpoint identifier
+     */
+    private void reportCompletedSplits(long checkpointId) {
+        List<MaxcomputeSourceSplit> splitsToReport;
+        synchronized (splitStateLock) {
+            splitsToReport = completedSplitsByCheckpoint.remove(checkpointId);
+        }
+        reportCompletedSplits(splitsToReport);
+    }
+
+    /**
+     * Synchronously reports completed split identifiers before releasing reader-side references.
+     *
+     * <p>The event operation waits until the enumerator has removed its matching assignment, which
+     * keeps the two state snapshots consistent for the next checkpoint.
+     *
+     * @param splitsToReport completed splits safe to release
+     */
+    private void reportCompletedSplits(List<MaxcomputeSourceSplit> splitsToReport) {
+        if (splitsToReport == null || splitsToReport.isEmpty()) {
+            return;
+        }
+
+        context.sendSourceEventToEnumerator(
+                new MaxcomputeCompletedSplitsReportEvent(
+                        splitsToReport.stream()
+                                .map(MaxcomputeSourceSplit::splitId)
+                                .collect(Collectors.toList())));
+        synchronized (splitStateLock) {
+            completedSplits.removeAll(splitsToReport);
+            completedSplitsByCheckpoint
+                    .values()
+                    .forEach(checkpointSplits -> checkpointSplits.removeAll(splitsToReport));
+        }
+    }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplit.java
@@ -26,13 +26,21 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@EqualsAndHashCode
+@EqualsAndHashCode(of = {"rowStart", "rowNum", "tablePath"})
 public class MaxcomputeSourceSplit implements SourceSplit {
     private static final long serialVersionUID = 573028372948731375L;
     private final long rowStart;
     private final long rowNum;
     private final TablePath tablePath;
     private final int index;
+
+    /**
+     * Marks a split that was completed before the reader checkpoint snapshot.
+     *
+     * <p>The marker lets restoration remove the enumerator's assignment without replaying data
+     * already covered by that checkpoint.
+     */
+    private boolean finished;
 
     public MaxcomputeSourceSplit(long rowStart, long rowNum, TablePath tablePath, int index) {
         this.rowStart = rowStart;
@@ -43,6 +51,6 @@ public class MaxcomputeSourceSplit implements SourceSplit {
 
     @Override
     public String splitId() {
-        return tablePath.toString() + "_" + index + "_" + rowStart;
+        return tablePath.getFullName() + ":" + rowStart + ":" + rowNum;
     }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitEnumerator.java
@@ -18,9 +18,11 @@
 package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.SourceEvent;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.connectors.seatunnel.maxcompute.config.MaxcomputeSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.maxcompute.source.event.MaxcomputeCompletedSplitsReportEvent;
 import org.apache.seatunnel.connectors.seatunnel.maxcompute.util.MaxcomputeUtil;
 
 import com.aliyun.odps.tunnel.TableTunnel;
@@ -30,22 +32,64 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 @Slf4j
+/**
+ * Lazily assigns bounded MaxCompute source splits.
+ *
+ * <p>Only a small batch is materialized for each reader request. This prevents split metadata from
+ * growing with the full source row count.
+ */
 public class MaxcomputeSourceSplitEnumerator
         implements SourceSplitEnumerator<MaxcomputeSourceSplit, MaxcomputeSourceState> {
+    /** Maximum number of split metadata objects sent to one reader for a request. */
+    private static final int SPLIT_BATCH_SIZE = 100;
+
+    /** Runtime bridge used to assign split batches and signal source completion. */
     private final Context<MaxcomputeSourceSplit> enumeratorContext;
+
+    /** Reader-returned splits waiting to be reassigned after recovery. */
     private final Map<Integer, Set<MaxcomputeSourceSplit>> pendingSplits;
-    private Set<MaxcomputeSourceSplit> assignedSplits;
+
+    /** In-flight split metadata retained only until completion is safely reported. */
+    private final Set<MaxcomputeSourceSplit> assignedSplits;
+
+    /** Connector configuration used to open MaxCompute download sessions. */
     private final ReadonlyConfig readonlyConfig;
-    private final Map<TablePath, SourceTableInfo> sourceTableInfos;
+
+    /** Stable source-table order used by the persisted lazy split cursor. */
+    private final List<SourceTableInfo> orderedSourceTableInfos;
+
+    /** Source row counts resolved once before lazy split generation begins. */
+    private final Map<TablePath, Long> tableRecordCounts;
+
+    /** Serializes split assignment, completion events, and state snapshots. */
     private final Object stateLock = new Object();
+
+    /** Next source table cursor for lazy split generation. */
+    private int nextTableIndex;
+
+    /** Next row offset within {@link #nextTableIndex}. */
+    private long nextRowStart;
+
+    /** Whether source row counts and the lazy generator are ready for reader requests. */
+    private boolean splitDiscoveryComplete;
+
+    /**
+     * Identifies an eager checkpoint written before lazy assignment existed.
+     *
+     * <p>Its enumerator state cannot distinguish processed from unprocessed assigned splits, so
+     * only reader-returned splits are safe to restore.
+     */
+    private boolean legacyEagerState;
 
     public MaxcomputeSourceSplitEnumerator(
             SourceSplitEnumerator.Context<MaxcomputeSourceSplit> enumeratorContext,
@@ -53,9 +97,13 @@ public class MaxcomputeSourceSplitEnumerator
             Map<TablePath, SourceTableInfo> sourceTableInfos) {
         this.enumeratorContext = enumeratorContext;
         this.readonlyConfig = readonlyConfig;
-        this.sourceTableInfos = sourceTableInfos;
         this.pendingSplits = new HashMap<>();
         this.assignedSplits = new HashSet<>();
+        this.orderedSourceTableInfos = new ArrayList<>(sourceTableInfos.values());
+        this.orderedSourceTableInfos.sort(
+                Comparator.comparing(
+                        tableInfo -> tableInfo.getCatalogTable().getTablePath().getFullName()));
+        this.tableRecordCounts = new HashMap<>();
     }
 
     public MaxcomputeSourceSplitEnumerator(
@@ -64,7 +112,13 @@ public class MaxcomputeSourceSplitEnumerator
             Map<TablePath, SourceTableInfo> sourceTableInfos,
             MaxcomputeSourceState sourceState) {
         this(enumeratorContext, readonlyConfig, sourceTableInfos);
-        this.assignedSplits = sourceState.getAssignedSplit();
+        this.legacyEagerState = !sourceState.isLazySplitAssignment();
+        if (!legacyEagerState) {
+            this.assignedSplits.addAll(sourceState.getAssignedSplit());
+            restoreAssignedSplits(sourceState.getAssignedSplit());
+        }
+        this.nextTableIndex = sourceState.getNextTableIndex();
+        this.nextRowStart = sourceState.getNextRowStart();
     }
 
     @Override
@@ -73,10 +127,10 @@ public class MaxcomputeSourceSplitEnumerator
     @Override
     public void run() throws Exception {
         synchronized (stateLock) {
-            discoverySplits();
-        }
-        synchronized (stateLock) {
-            assignPendingSplits();
+            initializeSplitDiscovery();
+            for (int readerId : enumeratorContext.registeredReaders()) {
+                assignSplitBatch(readerId);
+            }
         }
     }
 
@@ -85,12 +139,30 @@ public class MaxcomputeSourceSplitEnumerator
 
     @Override
     public void addSplitsBack(List<MaxcomputeSourceSplit> splits, int subtaskId) {
-        addSplitChangeToPendingAssignments(splits);
+        synchronized (stateLock) {
+            for (MaxcomputeSourceSplit split : splits) {
+                if (!legacyEagerState) {
+                    removePendingSplit(split);
+                }
+                if (split.isFinished()) {
+                    assignedSplits.remove(split);
+                    continue;
+                }
+                if (!legacyEagerState) {
+                    assignedSplits.add(split);
+                }
+                pendingSplits
+                        .computeIfAbsent(subtaskId, ignored -> new LinkedHashSet<>())
+                        .add(split);
+            }
+        }
     }
 
     @Override
     public int currentUnassignedSplitSize() {
-        return pendingSplits.size();
+        synchronized (stateLock) {
+            return pendingSplits.values().stream().mapToInt(Set::size).sum();
+        }
     }
 
     @Override
@@ -99,7 +171,7 @@ public class MaxcomputeSourceSplitEnumerator
     @Override
     public MaxcomputeSourceState snapshotState(long checkpointId) {
         synchronized (stateLock) {
-            return new MaxcomputeSourceState(assignedSplits);
+            return new MaxcomputeSourceState(assignedSplits, nextTableIndex, nextRowStart);
         }
     }
 
@@ -107,7 +179,38 @@ public class MaxcomputeSourceSplitEnumerator
     public void notifyCheckpointComplete(long checkpointId) {}
 
     @Override
-    public void handleSplitRequest(int subtaskId) {}
+    public void handleSplitRequest(int subtaskId) {
+        synchronized (stateLock) {
+            if (!splitDiscoveryComplete) {
+                throw new IllegalStateException(
+                        "MaxCompute split discovery has not been initialized");
+            }
+            assignSplitBatch(subtaskId);
+        }
+    }
+
+    @Override
+    public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+        if (!(sourceEvent instanceof MaxcomputeCompletedSplitsReportEvent)) {
+            return;
+        }
+
+        MaxcomputeCompletedSplitsReportEvent reportEvent =
+                (MaxcomputeCompletedSplitsReportEvent) sourceEvent;
+        if (reportEvent.getCompletedSplits() == null
+                || reportEvent.getCompletedSplits().isEmpty()) {
+            return;
+        }
+
+        Set<String> completedSplitIds = new HashSet<>(reportEvent.getCompletedSplits());
+        synchronized (stateLock) {
+            assignedSplits.removeIf(split -> completedSplitIds.contains(split.splitId()));
+        }
+        log.debug(
+                "Reader {} reported {} completed MaxCompute splits",
+                subtaskId,
+                completedSplitIds.size());
+    }
 
     // visible for testing
     static Set<MaxcomputeSourceSplit> computeSplits(
@@ -137,10 +240,17 @@ public class MaxcomputeSourceSplitEnumerator
         return allSplit;
     }
 
-    private void discoverySplits() throws TunnelException {
-        int numReaders = enumeratorContext.currentParallelism();
-        Map<TablePath, Long> tableRecordCounts = new HashMap<>();
-        for (SourceTableInfo sourceTableInfo : sourceTableInfos.values()) {
+    /**
+     * Resolves source row counts and converts legacy eager state before any split request.
+     *
+     * <p>Legacy assignment state includes completed splits, so the reader's restored split state is
+     * the only safe source of unfinished work.
+     */
+    private void initializeSplitDiscovery() throws TunnelException {
+        if (splitDiscoveryComplete) {
+            return;
+        }
+        for (SourceTableInfo sourceTableInfo : orderedSourceTableInfos) {
             TableTunnel.DownloadSession session =
                     MaxcomputeUtil.getDownloadSession(
                             readonlyConfig,
@@ -149,42 +259,117 @@ public class MaxcomputeSourceSplitEnumerator
             tableRecordCounts.put(
                     sourceTableInfo.getCatalogTable().getTablePath(), session.getRecordCount());
         }
-
-        Set<MaxcomputeSourceSplit> allSplit =
-                computeSplits(numReaders, sourceTableInfos.values(), tableRecordCounts);
-        assignedSplits.forEach(allSplit::remove);
-
-        addSplitChangeToPendingAssignments(allSplit);
-        log.debug("Assigned {} to {} readers.", allSplit, numReaders);
-        log.info("Calculated splits successfully, the size of splits is {}.", allSplit.size());
-    }
-
-    private void addSplitChangeToPendingAssignments(Collection<MaxcomputeSourceSplit> newSplits) {
-        for (MaxcomputeSourceSplit split : newSplits) {
-            int ownerReader = split.getIndex() % enumeratorContext.currentParallelism();
-            pendingSplits.computeIfAbsent(ownerReader, r -> new LinkedHashSet<>()).add(split);
+        if (legacyEagerState) {
+            // Reader state is the only reliable unfinished-split source for legacy checkpoints.
+            nextTableIndex = orderedSourceTableInfos.size();
+            nextRowStart = 0;
+            assignedSplits.clear();
+            legacyEagerState = false;
         }
+        splitDiscoveryComplete = true;
     }
 
-    private void assignPendingSplits() {
-        // Check if there's any pending splits for given readers
-        for (int pendingReader : enumeratorContext.registeredReaders()) {
-            // Remove pending assignment for the reader
-            final Set<MaxcomputeSourceSplit> pendingAssignmentForReader =
-                    pendingSplits.remove(pendingReader);
-
-            if (pendingAssignmentForReader != null && !pendingAssignmentForReader.isEmpty()) {
-                // Mark pending splits as already assigned
-                assignedSplits.addAll(pendingAssignmentForReader);
-                // Assign pending splits to reader
-                log.info(
-                        "Assigning splits to readers {} {}",
-                        pendingReader,
-                        pendingAssignmentForReader);
-                enumeratorContext.assignSplit(
-                        pendingReader, new ArrayList<>(pendingAssignmentForReader));
+    /**
+     * Assigns at most one bounded split batch to a reader.
+     *
+     * @param readerId reader subtask requesting work
+     */
+    private void assignSplitBatch(int readerId) {
+        List<MaxcomputeSourceSplit> splits = pollPendingSplits(readerId, SPLIT_BATCH_SIZE);
+        assignedSplits.addAll(splits);
+        while (splits.size() < SPLIT_BATCH_SIZE) {
+            MaxcomputeSourceSplit split = nextSplit(readerId);
+            if (split == null) {
+                break;
             }
-            enumeratorContext.signalNoMoreSplits(pendingReader);
+            assignedSplits.add(split);
+            splits.add(split);
         }
+
+        if (!splits.isEmpty()) {
+            log.debug("Assigning {} MaxCompute splits to reader {}", splits.size(), readerId);
+            enumeratorContext.assignSplit(readerId, splits);
+            return;
+        }
+        enumeratorContext.signalNoMoreSplits(readerId);
+    }
+
+    /**
+     * Returns restored splits for a reader before generating new split metadata.
+     *
+     * @param readerId reader subtask requesting work
+     * @param maxSplits maximum number of splits to return
+     * @return pending split batch for the reader
+     */
+    private List<MaxcomputeSourceSplit> pollPendingSplits(int readerId, int maxSplits) {
+        Set<MaxcomputeSourceSplit> pendingForReader = pendingSplits.get(readerId);
+        if (pendingForReader == null || pendingForReader.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<MaxcomputeSourceSplit> splits =
+                new ArrayList<>(Math.min(maxSplits, pendingForReader.size()));
+        Iterator<MaxcomputeSourceSplit> iterator = pendingForReader.iterator();
+        while (iterator.hasNext() && splits.size() < maxSplits) {
+            splits.add(iterator.next());
+            iterator.remove();
+        }
+        if (pendingForReader.isEmpty()) {
+            pendingSplits.remove(readerId);
+        }
+        return splits;
+    }
+
+    /**
+     * Places lazy checkpoint assignments back into bounded pending queues.
+     *
+     * @param splits in-flight splits from a lazy checkpoint
+     */
+    private void restoreAssignedSplits(Collection<MaxcomputeSourceSplit> splits) {
+        for (MaxcomputeSourceSplit split : splits) {
+            int readerId = split.getIndex() % enumeratorContext.currentParallelism();
+            pendingSplits.computeIfAbsent(readerId, ignored -> new LinkedHashSet<>()).add(split);
+        }
+    }
+
+    /**
+     * Removes a restored split before replacing it with the reader's authoritative state.
+     *
+     * @param split split being returned by a restored reader
+     */
+    private void removePendingSplit(MaxcomputeSourceSplit split) {
+        pendingSplits.values().forEach(splits -> splits.remove(split));
+    }
+
+    /**
+     * Materializes the next split from the persistent table and row cursors.
+     *
+     * @param readerId reader that will own the newly materialized split
+     * @return the next split, or null once all source tables are exhausted
+     */
+    private MaxcomputeSourceSplit nextSplit(int readerId) {
+        while (nextTableIndex < orderedSourceTableInfos.size()) {
+            SourceTableInfo sourceTableInfo = orderedSourceTableInfos.get(nextTableIndex);
+            TablePath tablePath = sourceTableInfo.getCatalogTable().getTablePath();
+            long recordCount = tableRecordCounts.get(tablePath);
+            if (nextRowStart >= recordCount) {
+                nextTableIndex++;
+                nextRowStart = 0;
+                continue;
+            }
+
+            int splitRow = MaxcomputeSourceOptions.SPLIT_ROW.defaultValue();
+            if (sourceTableInfo.getSplitRow() != null && sourceTableInfo.getSplitRow() > 0) {
+                splitRow = sourceTableInfo.getSplitRow();
+            }
+            long rowStart = nextRowStart;
+            long rowNum = Math.min((long) splitRow, recordCount - rowStart);
+            nextRowStart += rowNum;
+
+            MaxcomputeSourceSplit split =
+                    new MaxcomputeSourceSplit(rowStart, rowNum, tablePath, readerId);
+            return split;
+        }
+        return null;
     }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceState.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceState.java
@@ -18,17 +18,90 @@
 package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Persisted MaxCompute split assignment state.
+ *
+ * <p>Older checkpoints do not contain the lazy-assignment marker and therefore deserialize as
+ * legacy eager state. They are restored only from reader-returned unfinished splits.
+ */
 public class MaxcomputeSourceState implements Serializable {
     private static final long serialVersionUID = 3097170139569235106L;
-    private Set<MaxcomputeSourceSplit> assignedSplit;
 
+    /** Splits assigned when the state was snapshotted. */
+    private final Set<MaxcomputeSourceSplit> assignedSplit;
+
+    /** Index of the next source table to split lazily. */
+    private final int nextTableIndex;
+
+    /** Inclusive row offset for the next lazily generated split. */
+    private final long nextRowStart;
+
+    /** Whether this state was produced by the lazy assignment implementation. */
+    private final boolean lazySplitAssignment;
+
+    /**
+     * Constructs a legacy eager-assignment state for deserialization compatibility.
+     *
+     * @param assignedSplit assigned splits recorded by an older implementation
+     */
     public MaxcomputeSourceState(Set<MaxcomputeSourceSplit> assignedSplit) {
-        this.assignedSplit = assignedSplit;
+        this(assignedSplit, 0, 0L, false);
+    }
+
+    /**
+     * Constructs a lazy-assignment state.
+     *
+     * @param assignedSplit currently assigned split metadata
+     * @param nextTableIndex next source table index
+     * @param nextRowStart next row offset in the source table
+     */
+    public MaxcomputeSourceState(
+            Set<MaxcomputeSourceSplit> assignedSplit, int nextTableIndex, long nextRowStart) {
+        this(assignedSplit, nextTableIndex, nextRowStart, true);
+    }
+
+    private MaxcomputeSourceState(
+            Set<MaxcomputeSourceSplit> assignedSplit,
+            int nextTableIndex,
+            long nextRowStart,
+            boolean lazySplitAssignment) {
+        this.assignedSplit = assignedSplit == null ? new HashSet<>() : new HashSet<>(assignedSplit);
+        this.nextTableIndex = nextTableIndex;
+        this.nextRowStart = nextRowStart;
+        this.lazySplitAssignment = lazySplitAssignment;
     }
 
     public Set<MaxcomputeSourceSplit> getAssignedSplit() {
         return assignedSplit;
+    }
+
+    /**
+     * Returns the next source table cursor.
+     *
+     * @return zero-based source table index
+     */
+    public int getNextTableIndex() {
+        return nextTableIndex;
+    }
+
+    /**
+     * Returns the row offset for the next lazy split.
+     *
+     * @return next row offset in the current table
+     */
+    public long getNextRowStart() {
+        return nextRowStart;
+    }
+
+    /**
+     * Returns whether this state uses the lazy split cursor introduced after eager checkpoints.
+     *
+     * @return true for lazy state; false for legacy eager state
+     */
+    public boolean isLazySplitAssignment() {
+        return lazySplitAssignment;
     }
 }

--- a/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/event/MaxcomputeCompletedSplitsReportEvent.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/main/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/event/MaxcomputeCompletedSplitsReportEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.maxcompute.source.event;
+
+import org.apache.seatunnel.api.source.SourceEvent;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+/**
+ * Reports MaxCompute splits that a reader has fully processed after their state is durable.
+ *
+ * <p>The enumerator removes only the matching connector-local runtime metadata after receiving this
+ * event.
+ */
+@Getter
+@ToString
+@AllArgsConstructor
+public class MaxcomputeCompletedSplitsReportEvent implements SourceEvent {
+    private static final long serialVersionUID = 1L;
+
+    /** Stable identifiers of the completed MaxCompute source splits. */
+    private final List<String> completedSplits;
+}

--- a/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitLifecycleTest.java
+++ b/seatunnel-connectors-v2/connector-maxcompute/src/test/java/org/apache/seatunnel/connectors/seatunnel/maxcompute/source/MaxcomputeSourceSplitLifecycleTest.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.maxcompute.source;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.connectors.seatunnel.maxcompute.source.event.MaxcomputeCompletedSplitsReportEvent;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Tests lazy MaxCompute split assignment and checkpoint-safe split completion recovery. */
+class MaxcomputeSourceSplitLifecycleTest {
+
+    @Test
+    void testSplitIdentityUsesLogicalRangeInsteadOfReaderAssignment() {
+        MaxcomputeSourceSplit first =
+                new MaxcomputeSourceSplit(0, 100, TablePath.of("app_data", "orders"), 0);
+        MaxcomputeSourceSplit second =
+                new MaxcomputeSourceSplit(0, 100, TablePath.of("app_data", "orders"), 1);
+
+        Assertions.assertEquals(first, second);
+        Assertions.assertEquals(first.splitId(), second.splitId());
+    }
+
+    @Test
+    void testReaderSnapshotStateKeepsCurrentSplit() throws Exception {
+        SourceReader.Context context = Mockito.mock(SourceReader.Context.class);
+        MaxcomputeSourceReader reader =
+                new MaxcomputeSourceReader(
+                        Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                        context,
+                        Collections.emptyMap());
+        MaxcomputeSourceSplit currentSplit =
+                new MaxcomputeSourceSplit(0, 100, TablePath.of("app_data", "orders"), 0);
+        MaxcomputeSourceSplit pendingSplit =
+                new MaxcomputeSourceSplit(100, 100, TablePath.of("app_data", "orders"), 0);
+        reader.addSplits(Collections.singletonList(pendingSplit));
+        writeField(reader, "currentProcessingSplit", currentSplit);
+
+        List<MaxcomputeSourceSplit> snapshot = reader.snapshotState(1L);
+
+        Assertions.assertEquals(2, snapshot.size());
+        Assertions.assertEquals(currentSplit, snapshot.get(0));
+        Assertions.assertEquals(pendingSplit, snapshot.get(1));
+    }
+
+    @Test
+    void testCompletedSplitsReleaseAssignedSplitReferences() {
+        MaxcomputeSourceSplit split = split();
+        MaxcomputeSourceSplitEnumerator enumerator = enumeratorWithAssignedSplit(split);
+
+        enumerator.handleSourceEvent(
+                0,
+                new MaxcomputeCompletedSplitsReportEvent(
+                        Collections.singletonList(split.splitId())));
+
+        Assertions.assertTrue(enumerator.snapshotState(11L).getAssignedSplit().isEmpty());
+    }
+
+    @Test
+    void testCompletedSplitsCanBeReturnedForRecovery() {
+        MaxcomputeSourceSplit split = split();
+        MaxcomputeSourceSplitEnumerator enumerator = enumeratorWithAssignedSplit(split);
+
+        enumerator.handleSourceEvent(
+                0,
+                new MaxcomputeCompletedSplitsReportEvent(
+                        Collections.singletonList(split.splitId())));
+        enumerator.addSplitsBack(Collections.singletonList(split), 0);
+
+        Assertions.assertEquals(1, enumerator.currentUnassignedSplitSize());
+        Assertions.assertEquals(
+                Collections.singleton(split), enumerator.snapshotState(11L).getAssignedSplit());
+    }
+
+    @Test
+    void testStateKeepsLazySplitCursor() {
+        MaxcomputeSourceState state = new MaxcomputeSourceState(Collections.emptySet(), 2, 300L);
+
+        Assertions.assertEquals(2, state.getNextTableIndex());
+        Assertions.assertEquals(300L, state.getNextRowStart());
+        Assertions.assertTrue(state.isLazySplitAssignment());
+    }
+
+    @Test
+    void testLazyAssignmentMaterializesOnlyRequestedBatch() throws Exception {
+        TablePath tablePath = TablePath.of("app_data", "orders");
+        TestingEnumeratorContext context = new TestingEnumeratorContext();
+        MaxcomputeSourceSplitEnumerator enumerator =
+                new MaxcomputeSourceSplitEnumerator(
+                        context,
+                        Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                        Collections.singletonMap(tablePath, sourceTableInfo(tablePath, 10000)));
+        writeField(enumerator, "splitDiscoveryComplete", true);
+        tableRecordCounts(enumerator).put(tablePath, 1010000L);
+
+        enumerator.handleSplitRequest(0);
+
+        Assertions.assertEquals(100, context.getAssignedSplits().size());
+        Assertions.assertEquals(100, enumerator.snapshotState(1L).getAssignedSplit().size());
+    }
+
+    @Test
+    void testCheckpointCompletionReportsOnlySnapshottedSplits() throws Exception {
+        SourceReader.Context context = Mockito.mock(SourceReader.Context.class);
+        Mockito.when(context.isCheckpointEnabled()).thenReturn(true);
+        MaxcomputeSourceReader reader =
+                new MaxcomputeSourceReader(
+                        Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                        context,
+                        Collections.emptyMap());
+        MaxcomputeSourceSplit beforeCheckpoint = split();
+        beforeCheckpoint.setFinished(true);
+        MaxcomputeSourceSplit afterCheckpoint =
+                new MaxcomputeSourceSplit(100, 100, TablePath.of("app_data", "orders"), 0);
+        afterCheckpoint.setFinished(true);
+        completedSplits(reader).add(beforeCheckpoint);
+
+        reader.snapshotState(1L);
+        completedSplits(reader).add(afterCheckpoint);
+        reader.notifyCheckpointComplete(1L);
+
+        Assertions.assertEquals(
+                Collections.singletonList(beforeCheckpoint.splitId()), completedSplitIds(context));
+        Mockito.clearInvocations(context);
+
+        reader.snapshotState(2L);
+        reader.notifyCheckpointComplete(2L);
+
+        Assertions.assertEquals(
+                Collections.singletonList(afterCheckpoint.splitId()), completedSplitIds(context));
+    }
+
+    @Test
+    void testLazyStateRestoresAssignedSplits() throws Exception {
+        MaxcomputeSourceSplit split = split();
+        TestingEnumeratorContext context = new TestingEnumeratorContext();
+        MaxcomputeSourceSplitEnumerator enumerator =
+                new MaxcomputeSourceSplitEnumerator(
+                        context,
+                        Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                        Collections.emptyMap(),
+                        new MaxcomputeSourceState(Collections.singleton(split), 0, 0L));
+
+        enumerator.run();
+
+        Assertions.assertEquals(Collections.singletonList(split), context.getAssignedSplits());
+    }
+
+    @Test
+    void testLegacyStateRestoresOnlyReaderReturnedSplits() throws Exception {
+        MaxcomputeSourceSplit completed = split();
+        MaxcomputeSourceSplit remaining =
+                new MaxcomputeSourceSplit(100, 100, TablePath.of("app_data", "orders"), 0);
+        TestingEnumeratorContext context = new TestingEnumeratorContext();
+        MaxcomputeSourceSplitEnumerator enumerator =
+                new MaxcomputeSourceSplitEnumerator(
+                        context,
+                        Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                        Collections.emptyMap(),
+                        new MaxcomputeSourceState(
+                                new HashSet<>(Arrays.asList(completed, remaining))));
+
+        enumerator.addSplitsBack(Collections.singletonList(remaining), 0);
+
+        Assertions.assertTrue(enumerator.snapshotState(1L).getAssignedSplit().isEmpty());
+        Assertions.assertEquals(1, enumerator.currentUnassignedSplitSize());
+        enumerator.run();
+
+        Assertions.assertEquals(Collections.singletonList(remaining), context.getAssignedSplits());
+        Assertions.assertEquals(
+                Collections.singleton(remaining), enumerator.snapshotState(1L).getAssignedSplit());
+    }
+
+    @Test
+    void testFinishedReaderStateRemovesLazyAssignmentOnRestore() {
+        MaxcomputeSourceSplit assigned = split();
+        MaxcomputeSourceSplit finished = split();
+        finished.setFinished(true);
+        MaxcomputeSourceSplitEnumerator enumerator =
+                new MaxcomputeSourceSplitEnumerator(
+                        new TestingEnumeratorContext(),
+                        Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                        Collections.emptyMap(),
+                        new MaxcomputeSourceState(Collections.singleton(assigned), 0, 0L));
+
+        enumerator.addSplitsBack(Collections.singletonList(finished), 0);
+
+        Assertions.assertTrue(enumerator.snapshotState(1L).getAssignedSplit().isEmpty());
+        Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
+    }
+
+    private static MaxcomputeSourceSplit split() {
+        return new MaxcomputeSourceSplit(0, 100, TablePath.of("app_data", "orders"), 0);
+    }
+
+    private static SourceTableInfo sourceTableInfo(TablePath tablePath, int splitRow) {
+        CatalogTable catalogTable = Mockito.mock(CatalogTable.class);
+        Mockito.when(catalogTable.getTablePath()).thenReturn(tablePath);
+        return new SourceTableInfo(catalogTable, null, splitRow);
+    }
+
+    private static MaxcomputeSourceSplitEnumerator enumeratorWithAssignedSplit(
+            MaxcomputeSourceSplit split) {
+        return new MaxcomputeSourceSplitEnumerator(
+                new TestingEnumeratorContext(),
+                Mockito.mock(org.apache.seatunnel.api.configuration.ReadonlyConfig.class),
+                Collections.emptyMap(),
+                new MaxcomputeSourceState(Collections.singleton(split), 0, 0L));
+    }
+
+    private static void writeField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static List<String> completedSplitIds(SourceReader.Context context) {
+        ArgumentCaptor<SourceEvent> eventCaptor = ArgumentCaptor.forClass(SourceEvent.class);
+        Mockito.verify(context).sendSourceEventToEnumerator(eventCaptor.capture());
+        return ((MaxcomputeCompletedSplitsReportEvent) eventCaptor.getValue()).getCompletedSplits();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<MaxcomputeSourceSplit> completedSplits(MaxcomputeSourceReader reader)
+            throws Exception {
+        Field field = reader.getClass().getDeclaredField("completedSplits");
+        field.setAccessible(true);
+        return (List<MaxcomputeSourceSplit>) field.get(reader);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<TablePath, Long> tableRecordCounts(
+            MaxcomputeSourceSplitEnumerator enumerator) throws Exception {
+        Field field = enumerator.getClass().getDeclaredField("tableRecordCounts");
+        field.setAccessible(true);
+        return (Map<TablePath, Long>) field.get(enumerator);
+    }
+
+    private static final class TestingEnumeratorContext
+            implements SourceSplitEnumerator.Context<MaxcomputeSourceSplit> {
+        private final List<MaxcomputeSourceSplit> assignedSplits = new ArrayList<>();
+
+        @Override
+        public int currentParallelism() {
+            return 1;
+        }
+
+        @Override
+        public Set<Integer> registeredReaders() {
+            return Collections.singleton(0);
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, List<MaxcomputeSourceSplit> splits) {
+            assignedSplits.addAll(splits);
+        }
+
+        private List<MaxcomputeSourceSplit> getAssignedSplits() {
+            return assignedSplits;
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {}
+
+        @Override
+        public void sendEventToSourceReader(
+                int subtaskId, org.apache.seatunnel.api.source.SourceEvent event) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelTask.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.tracing.MDCTracer;
 import org.apache.seatunnel.common.utils.function.ConsumerWithException;
 import org.apache.seatunnel.engine.common.Constant;
+import org.apache.seatunnel.engine.common.config.JobConfig;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.checkpoint.InternalCheckpointListener;
 import org.apache.seatunnel.engine.core.dag.actions.Action;
@@ -82,6 +83,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import static org.apache.seatunnel.api.options.EnvCommonOptions.CHECKPOINT_INTERVAL;
+import static org.apache.seatunnel.common.constants.JobMode.BATCH;
 import static org.apache.seatunnel.engine.common.utils.ExceptionUtil.sneaky;
 import static org.apache.seatunnel.engine.common.utils.ExceptionUtil.sneakyThrow;
 import static org.apache.seatunnel.engine.server.task.statemachine.SeaTunnelTaskState.CANCELED;
@@ -196,30 +199,53 @@ public abstract class SeaTunnelTask extends AbstractTask {
     }
 
     public Map<String, Object> getJobEnvOptions() {
+        JobConfig jobConfig = resolveJobConfig();
+        return jobConfig == null ? Collections.emptyMap() : jobConfig.getEnvOptions();
+    }
+
+    /**
+     * Returns whether this job can receive checkpoint completion notifications.
+     *
+     * <p>The decision intentionally matches the coordinator's batch-job checkpoint policy so a
+     * source reader does not retain completion metadata forever when checkpoints are disabled.
+     *
+     * @return true when checkpoint lifecycle callbacks are enabled for the job
+     */
+    public boolean isCheckpointEnabled() {
+        JobConfig jobConfig = resolveJobConfig();
+        if (jobConfig == null || jobConfig.getJobContext() == null) {
+            // Preserve checkpoint-safe behavior when runtime job metadata cannot be resolved.
+            return true;
+        }
+        return jobConfig.getJobContext().getJobMode() != BATCH
+                || jobConfig.getEnvOptions().containsKey(CHECKPOINT_INTERVAL.key());
+    }
+
+    private JobConfig resolveJobConfig() {
         try {
             if (executionContext == null
                     || executionContext.getTaskExecutionService() == null
                     || executionContext.getTaskExecutionService().getNodeEngine() == null) {
-                return Collections.emptyMap();
+                return null;
             }
             NodeEngineImpl nodeEngine = executionContext.getTaskExecutionService().getNodeEngine();
             IMap<Long, JobInfo> jobInfoMap =
                     nodeEngine.getHazelcastInstance().getMap(Constant.IMAP_RUNNING_JOB_INFO);
             JobInfo jobInfo = jobInfoMap.get(jobID);
             if (jobInfo == null || jobInfo.getJobImmutableInformation() == null) {
-                return Collections.emptyMap();
+                return null;
             }
             JobImmutableInformation immutable =
                     nodeEngine
                             .getSerializationService()
                             .toObject(jobInfo.getJobImmutableInformation());
             if (immutable == null || immutable.getJobConfig() == null) {
-                return Collections.emptyMap();
+                return null;
             }
-            return immutable.getJobConfig().getEnvOptions();
+            return immutable.getJobConfig();
         } catch (Throwable t) {
             log.debug("Resolve job env options failed, jobId={}", jobID, t);
-            return Collections.emptyMap();
+            return null;
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/context/SourceReaderContext.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/context/SourceReaderContext.java
@@ -30,6 +30,9 @@ public class SourceReaderContext implements SourceReader.Context {
 
     private final Boundedness boundedness;
 
+    /** Whether the owning job will invoke checkpoint completion callbacks. */
+    private final boolean checkpointEnabled;
+
     private final SourceFlowLifeCycle<?, ?> sourceActionLifeCycle;
 
     private final MetricsContext metricsContext;
@@ -38,11 +41,13 @@ public class SourceReaderContext implements SourceReader.Context {
     public SourceReaderContext(
             int index,
             Boundedness boundedness,
+            boolean checkpointEnabled,
             SourceFlowLifeCycle<?, ?> sourceActionLifeCycle,
             MetricsContext metricsContext,
             EventListener eventListener) {
         this.index = index;
         this.boundedness = boundedness;
+        this.checkpointEnabled = checkpointEnabled;
         this.sourceActionLifeCycle = sourceActionLifeCycle;
         this.metricsContext = metricsContext;
         this.eventListener = eventListener;
@@ -56,6 +61,16 @@ public class SourceReaderContext implements SourceReader.Context {
     @Override
     public Boundedness getBoundedness() {
         return boundedness;
+    }
+
+    /**
+     * Returns the checkpoint capability calculated from the owning job configuration.
+     *
+     * @return true when checkpoint completion callbacks are enabled
+     */
+    @Override
+    public boolean isCheckpointEnabled() {
+        return checkpointEnabled;
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SourceFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SourceFlowLifeCycle.java
@@ -161,6 +161,7 @@ public class SourceFlowLifeCycle<T, SplitT extends SourceSplit> extends ActionFl
                 new SourceReaderContext(
                         indexID,
                         sourceAction.getSource().getBoundedness(),
+                        runningTask.isCheckpointEnabled(),
                         this,
                         metricsContext,
                         eventListener);


### PR DESCRIPTION
## Purpose

Bound MaxCompute source split metadata so a small `split_row` cannot materialize and retain every source split in coordinator memory.

## Changes

- Lazily materialize at most 100 splits for each reader request.
- Release completion metadata in bounded batches for batch jobs without checkpointing.
- Keep checkpoint recovery safe: only completions captured by a successful checkpoint are released.
- Restore old eager checkpoint state from reader-returned unfinished splits without replaying completed data.
- Keep the completion event inside the MaxCompute connector; the engine uses the connector task classloader for source events.

## Verification

- `./mvnw spotless:apply -pl seatunnel-api,seatunnel-engine/seatunnel-engine-server,seatunnel-connectors-v2/connector-maxcompute -am`
- `./mvnw -q spotless:check -pl seatunnel-api,seatunnel-engine/seatunnel-engine-server,seatunnel-connectors-v2/connector-maxcompute -am`
- `git diff --check`
- Independent maintainer review: PASS

Local compilation and tests were not run under the SeaTunnel local-validation policy. GitHub CI is the required validation and is pending.