### PR TITLE
[Fix][Connector-CDC] Accept a physical primary key as configured snapshotSplitColumn (#11973)

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -415,20 +415,27 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
                 splitColumnsConfig.getOrDefault(tableId.catalog() + "." + tableId.table(), null);
 
         if (StringUtils.isNotEmpty(tableSc)) {
-            // Is tableSc（table split column） the unique key
-            AtomicBoolean isUniqueKey = new AtomicBoolean(false);
-            dialect.getUniqueKeys(jdbc, tableId)
-                    .forEach(
-                            ck ->
-                                    ck.getColumnNames()
-                                            .forEach(
-                                                    ckc -> {
-                                                        if (tableSc.equals(ckc.getColumnName())) {
-                                                            isUniqueKey.set(true);
-                                                        }
-                                                    }));
+            // Is tableSc（table split column） the primary key or a unique key
+            AtomicBoolean isKey = new AtomicBoolean(false);
+            Optional<PrimaryKey> primaryKey = dialect.getPrimaryKey(jdbc, tableId);
+            if (primaryKey.isPresent()) {
+                isKey.set(primaryKey.get().getColumnNames().contains(tableSc));
+            }
+            if (!isKey.get()) {
+                dialect.getUniqueKeys(jdbc, tableId)
+                        .forEach(
+                                ck ->
+                                        ck.getColumnNames()
+                                                .forEach(
+                                                        ckc -> {
+                                                            if (tableSc.equals(
+                                                                    ckc.getColumnName())) {
+                                                                isKey.set(true);
+                                                            }
+                                                        }));
+            }
 
-            if (isUniqueKey.get()) {
+            if (isKey.get()) {
                 Column column = table.columnWithName(tableSc);
                 if (isEvenlySplitColumn(column)) {
                     return column;
@@ -438,7 +445,9 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
                             tableId);
                 }
             } else {
-                log.warn("Config snapshotSplitColumn not unique key for table {}", tableId);
+                log.warn(
+                        "Config snapshotSplitColumn not primary key or unique key for table {}",
+                        tableId);
             }
         } else {
             log.info("Config snapshotSplitColumn not exists for table {}", tableId);

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -45,8 +45,10 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 class JdbcSourceChunkSplitterTest {
 
@@ -79,6 +81,24 @@ class JdbcSourceChunkSplitterTest {
                         null, new TestSourceDialectWithUniqueKey_2(), new TableId("", "", ""));
         Assertions.assertEquals("int", splitColumn.typeName());
     }
+
+    @Test
+    void splitColumnTestWithPrimaryKeyConfigured() throws SQLException {
+        // Regression test for #11973: a configured split column that is the
+        // physical PRIMARY KEY (not part of getUniqueKeys()) must be accepted.
+        java.util.Map<String, String> splitColumn = new HashMap<>();
+        splitColumn.put("testdb.test_split_column", "id");
+        TestJdbcSourceChunkSplitter testJdbcSourceChunkSplitter =
+                new TestJdbcSourceChunkSplitter(
+                        new PrimaryKeyConfig(splitColumn), new TestSourceDialectWithPrimaryKey());
+        Column splitColumnResult =
+                testJdbcSourceChunkSplitter.getSplitColumn(
+                        null,
+                        new TestSourceDialectWithPrimaryKey(),
+                        new TableId("testdb", "", "test_split_column"));
+        Assertions.assertEquals("bigint", splitColumnResult.typeName());
+    }
+
 
     private class TestJdbcSourceChunkSplitter extends AbstractJdbcSourceChunkSplitter {
 
@@ -329,4 +349,98 @@ class JdbcSourceChunkSplitterTest {
             return keys;
         }
     }
+    /**
+     * A dialect whose physical primary key ("id") is NOT part of any unique key,
+     * mirroring the MySQL-CDC table in #11973 (PRIMARY KEY (id), UNIQUE KEY
+     * uk_business (category, business_key)).
+     */
+    private class TestSourceDialectWithPrimaryKey extends TestSourceDialect {
+
+        @Override
+        public Optional<PrimaryKey> getPrimaryKey(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            return Optional.of(PrimaryKey.of("pkName", Arrays.asList("id")));
+        }
+
+        @Override
+        public List<ConstraintKey> getUniqueKeys(JdbcConnection jdbcConnection, TableId tableId)
+                throws SQLException {
+            List<ConstraintKey> keys = new ArrayList<>();
+            keys.add(
+                    ConstraintKey.of(
+                            ConstraintKey.ConstraintType.UNIQUE_KEY,
+                            "uk_business",
+                            Arrays.asList(
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "category", ConstraintKey.ColumnSortType.ASC),
+                                    ConstraintKey.ConstraintKeyColumn.of(
+                                            "business_key", ConstraintKey.ColumnSortType.ASC))));
+            return keys;
+        }
+
+        @Override
+        public TableChanges.TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId) {
+            Table table =
+                    Table.editor()
+                            .tableId(tableId)
+                            .addColumns(
+                                    Column.editor()
+                                            .name("id")
+                                            .jdbcType(Types.BIGINT)
+                                            .type("bigint")
+                                            .create(),
+                                    Column.editor()
+                                            .name("category")
+                                            .jdbcType(Types.TINYINT)
+                                            .type("tinyint")
+                                            .create(),
+                                    Column.editor()
+                                            .name("business_key")
+                                            .jdbcType(Types.VARCHAR)
+                                            .type("varchar")
+                                            .create())
+                            .create();
+            return new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
+        }
+    }
+
+    /**
+     * A minimal JdbcSourceConfig carrying the user-configured split column map.
+     */
+    private static class PrimaryKeyConfig extends JdbcSourceConfig {
+
+        public PrimaryKeyConfig(java.util.Map<String, String> splitColumn) {
+            super(
+                    null,
+                    null,
+                    null,
+                    null,
+                    8096,
+                    splitColumn,
+                    1.0,
+                    0.05,
+                    1000,
+                    1000,
+                    true,
+                    new Properties(),
+                    null,
+                    null,
+                    0,
+                    null,
+                    null,
+                    null,
+                    1024,
+                    null,
+                    30000L,
+                    3,
+                    20,
+                    false);
+        }
+
+        @Override
+        public RelationalDatabaseConnectorConfig getDbzConnectorConfig() {
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
### Problem

When `snapshotSplitColumn` is explicitly configured with a physical primary key column that is not part of any unique index, `AbstractJdbcSourceChunkSplitter.getSplitColumn()` rejects it. The validation only checks `dialect.getUniqueKeys()`, so a column belonging to `dialect.getPrimaryKey()` alone is silently refused.

For example, given:
```sql
CREATE TABLE t (
    id BIGINT NOT NULL AUTO_INCREMENT,
    category TINYINT NOT NULL,
    PRIMARY KEY (id),
    UNIQUE KEY uk_business (category, business_key)
);
```

Config: `snapshotSplitColumn = "id"`. MySQL's `getUniqueKeys()` returns only `uk_business` (category, business_key), not the primary key. The configured `id` is rejected as "not unique key", and SeaTunnel falls back to automatic selection — choosing `category` (TINYINT has higher sorting priority than BIGINT).

### Fix

In `getSplitColumn()`, when checking a user-configured split column, also accept it if it belongs to the physical primary key returned by `dialect.getPrimaryKey()`. This mirrors the same `getPrimaryKey()` / `getUniqueKeys()` split that the fallback auto-selection already uses.

### Changes

- `AbstractJdbcSourceChunkSplitter.java`: validate against `getPrimaryKey()` first, then `getUniqueKeys()`, before accepting the configured column.
- `JdbcSourceChunkSplitterTest.java`: regression test (`splitColumnTestWithPrimaryKeyConfigured`) exercising the primary-key-only path.

### Verification

- Existing tests (`splitColumnTest`, `splitColumnTestWithUniqueKey`, `splitColumnTestWithUniqueKey_2`) continue to pass (no regression).
- Standalone logic simulation confirms the fix: OLD→category/tinyint, NEW→id/bigint.

Fixes #11973