### PR TITLE
[Fix][Connector-V2] Accept primary keys as snapshot split columns

### DIFF
--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/main/java/org/apache/seatunnel/connectors/cdc/base/source/enumerator/splitter/AbstractJdbcSourceChunkSplitter.java
@@ -414,9 +414,14 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
         String tableSc =
                 splitColumnsConfig.getOrDefault(tableId.catalog() + "." + tableId.table(), null);
 
+        Optional<PrimaryKey> primaryKey = dialect.getPrimaryKey(jdbc, tableId);
         if (StringUtils.isNotEmpty(tableSc)) {
-            // Is tableSc（table split column） the unique key
-            AtomicBoolean isUniqueKey = new AtomicBoolean(false);
+            // Is tableSc (table split column) in the primary key or a unique key
+            AtomicBoolean isPrimaryOrUniqueKey =
+                    new AtomicBoolean(
+                            primaryKey
+                                    .map(key -> key.getColumnNames().contains(tableSc))
+                                    .orElse(false));
             dialect.getUniqueKeys(jdbc, tableId)
                     .forEach(
                             ck ->
@@ -424,11 +429,11 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
                                             .forEach(
                                                     ckc -> {
                                                         if (tableSc.equals(ckc.getColumnName())) {
-                                                            isUniqueKey.set(true);
+                                                            isPrimaryOrUniqueKey.set(true);
                                                         }
                                                     }));
 
-            if (isUniqueKey.get()) {
+            if (isPrimaryOrUniqueKey.get()) {
                 Column column = table.columnWithName(tableSc);
                 if (isEvenlySplitColumn(column)) {
                     return column;
@@ -438,13 +443,14 @@ public abstract class AbstractJdbcSourceChunkSplitter implements JdbcSourceChunk
                             tableId);
                 }
             } else {
-                log.warn("Config snapshotSplitColumn not unique key for table {}", tableId);
+                log.warn(
+                        "Config snapshotSplitColumn not primary or unique key for table {}",
+                        tableId);
             }
         } else {
             log.info("Config snapshotSplitColumn not exists for table {}", tableId);
         }
 
-        Optional<PrimaryKey> primaryKey = dialect.getPrimaryKey(jdbc, tableId);
         if (primaryKey.isPresent()) {
             Column firstColumn = table.columnWithName(primaryKey.get().getColumnNames().get(0));
             if (isEvenlySplitColumn(firstColumn)) {

--- a/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-cdc/connector-cdc-base/src/test/java/jdbc/source/JdbcSourceChunkSplitterTest.java
@@ -45,8 +45,12 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class JdbcSourceChunkSplitterTest {
 
@@ -78,6 +82,20 @@ class JdbcSourceChunkSplitterTest {
                 testJdbcSourceChunkSplitter.getSplitColumn(
                         null, new TestSourceDialectWithUniqueKey_2(), new TableId("", "", ""));
         Assertions.assertEquals("int", splitColumn.typeName());
+    }
+
+    @Test
+    void splitColumnTestWithConfiguredPrimaryKey() throws SQLException {
+        JdbcSourceConfig sourceConfig = mock(JdbcSourceConfig.class);
+        when(sourceConfig.getSplitColumn()).thenReturn(Collections.singletonMap(".", "bigint_col"));
+        TestSourceDialect dialect = new TestSourceDialect();
+        TestJdbcSourceChunkSplitter testJdbcSourceChunkSplitter =
+                new TestJdbcSourceChunkSplitter(sourceConfig, dialect);
+
+        Column splitColumn =
+                testJdbcSourceChunkSplitter.getSplitColumn(null, dialect, new TableId("", "", ""));
+
+        Assertions.assertEquals("bigint", splitColumn.typeName());
     }
 
     private class TestJdbcSourceChunkSplitter extends AbstractJdbcSourceChunkSplitter {


### PR DESCRIPTION
## Purpose

Fixes #11973.

## Changes

- Accept an explicitly configured `snapshotSplitColumn` when it belongs to the physical primary key.
- Keep unique-key validation and automatic split-column selection unchanged.
- Add regression coverage for a configured physical primary key without a unique index.

## Test

- `./mvnw -pl :connector-cdc-base -Dtest=jdbc.source.JdbcSourceChunkSplitterTest test`