### PR TITLE
[Bug][Zeta] Reject unknown levels on the runtime log level endpoint

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/log/Log4j2HttpPostCommandProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/log/Log4j2HttpPostCommandProcessor.java
@@ -73,7 +73,7 @@ public class Log4j2HttpPostCommandProcessor extends HttpCommandProcessor<HttpPos
      * <p>your_username&your_password&com.example.logger1&ERROR
      *
      * <p>An unknown level name is rejected with {@code 400} instead of being applied as a {@code
-     * null} level, which log4j2 silently ignores.
+     * null} level, which clears the logger's explicit level rather than leaving it unchanged.
      */
     @SuppressWarnings("MagicNumber")
     private void setLoggerLevel(HttpPostCommand request) {


### PR DESCRIPTION
### Purpose of this pull request

First item of #11981: the runtime log level endpoint reports `SUCCESS` for a level it never applied.

`Log4j2HttpPostCommandProcessor#setLoggerLevel` passed the requested level name straight into
`Configurator.setLevel(logger, Level.getLevel(level))`. `Level.getLevel(...)` returns `null` for an
unregistered name instead of throwing, so the handler answered `{"status":"SUCCESS"}` for a name it
could not resolve. And a `null` level is not a no-op: `Configurator` removes the explicit level of
the logger, so the logger falls back to its parent, and the root logger falls back to `ERROR`.
Because the level name is also case-sensitive, `debug` went down the same path as `DEBUGG`.

This PR resolves the level *before* applying it:

- unknown level name → `400` with the list of valid level names, ordered by severity;
- blank logger name → `400`;
- `{"status":"SUCCESS"}` only once a level was really applied;
- level names are accepted in any letter case (`debug`, `Debug`, ` DEBUG ` all apply `DEBUG`).

Parsing/applying moved into a small `LogLevels` helper, which the `/loggers` endpoints on the v2 REST
plane (items b–d of #11981) reuse in the follow-up PR #11984. No behaviour is removed and no other
endpoint changes.

### Does this PR introduce _any_ user-facing change?

Yes, for `POST /hazelcast/rest/maps/log-level` on the legacy Hazelcast REST plane. The endpoint has
shipped in every release since 2.3.0 (added in 8241ec193, #3025), so this is a released-behaviour
change and it is recorded in `incompatible-changes.md`. It stays undocumented in the REST reference
here; documentation of runtime log levels comes with the v2 `/loggers` endpoints in #11984.

Before:

```
$ curl -X POST -d 'user&pass&org.apache.seatunnel&DEBUGG' http://127.0.0.1:5801/hazelcast/rest/maps/log-level
{"status":"SUCCESS"}      # HTTP 200 — but the level was never applied, and an explicit
                          # level of org.apache.seatunnel was cleared instead

$ curl -X POST -d 'user&pass&org.apache.seatunnel&debug' http://127.0.0.1:5801/hazelcast/rest/maps/log-level
{"status":"SUCCESS"}      # HTTP 200 — same thing, the name is case-sensitive
```

After:

```
$ curl -X POST -d 'user&pass&org.apache.seatunnel&DEBUGG' http://127.0.0.1:5801/hazelcast/rest/maps/log-level
Unknown logger level 'DEBUGG', valid levels are: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL
                          # HTTP 400

$ curl -X POST -d 'user&pass&org.apache.seatunnel&debug' http://127.0.0.1:5801/hazelcast/rest/maps/log-level
{"status":"SUCCESS"}      # HTTP 200 — DEBUG is applied
```

A caller that was sending a valid, correctly-cased level keeps seeing exactly the same response.

### How was this patch tested?

New unit test `LogLevelsTest` in `seatunnel-engine-server`:

- valid names are parsed case-insensitively and with surrounding whitespace (`DEBUG`, `debug`,
  `Debug`, `" DEBUG "`, `"\tdebug\n"`);
- unknown names (`DEBUGG`, `verbose`, `1`, `INFO,DEBUG`), blank names and `null` all resolve to
  `null`, i.e. they can no longer reach `Configurator`;
- `validNames()` lists every level registered in log4j2, and lists them in severity order —
  `Level.values()` reads a hash map, so without sorting the message of a rejected request would
  differ between runs;
- `apply()` really changes the effective level of a logger (asserted through
  `LogManager.getLogger(...).getLevel()`, restored afterwards).

I could not build or run this locally (no JDK/Maven in my environment), so CI is the first real
execution of the suite.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — no new dependency.
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs — the
  endpoint is undocumented today; documentation comes with the v2 `/loggers` endpoints in #11984.
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR — added
  under "API Changes" in `docs/en|zh/introduction/concepts/incompatible-changes.md`: a request that used to answer
  `200`/`SUCCESS` without applying anything now answers `400`.
* [x] If you are contributing the connector code, please check that the following files are updated — not a connector change.
