### PR TITLE
[Feature][Zeta] Add intermediate queue comparison benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,6 +35,7 @@ on:
         options:
           - '.*'
           - 'SeaTunnelRowBenchmark'
+          - 'IntermediateQueueBenchmark'
           - 'SeaTunnelPipelineBenchmark'
           - 'sourceSink$'
           - 'sourceTransformSink$'

--- a/seatunnel-benchmarks/pom.xml
+++ b/seatunnel-benchmarks/pom.xml
@@ -61,6 +61,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>seatunnel-shade-hazelcast</artifactId>
         </dependency>

--- a/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmark.java
+++ b/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmark.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.benchmark;
+
+import org.apache.seatunnel.engine.common.config.server.QueueType;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.TimeUnit;
+
+/** Compares record handoff throughput of the two production intermediate queue implementations. */
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Threads(1)
+public class IntermediateQueueBenchmark extends BenchmarkBase {
+
+    public static void main(String[] args) throws RunnerException {
+        Options options =
+                new OptionsBuilder()
+                        .verbosity(VerboseMode.NORMAL)
+                        .include(".*" + IntermediateQueueBenchmark.class.getCanonicalName() + ".*")
+                        .build();
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    public long blockingQueueRecordHandoff(BlockingQueueState state) {
+        return state.publish();
+    }
+
+    @Benchmark
+    public long disruptorRecordHandoff(DisruptorQueueState state) {
+        return state.publish();
+    }
+
+    @State(Scope.Thread)
+    public static class BlockingQueueState {
+
+        @Param({"1024"})
+        private int capacity;
+
+        @Param({"4096"})
+        private int recordPoolSize;
+
+        private IntermediateQueueBenchmarkState delegate;
+
+        @Setup(Level.Trial)
+        public void setUp() throws Exception {
+            delegate =
+                    new IntermediateQueueBenchmarkState(
+                            QueueType.BLOCKINGQUEUE, capacity, recordPoolSize);
+            delegate.setUp();
+        }
+
+        long publish() {
+            return delegate.publish();
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws Exception {
+            delegate.tearDown();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class DisruptorQueueState {
+
+        @Param({"1024"})
+        private int capacity;
+
+        @Param({"4096"})
+        private int recordPoolSize;
+
+        private IntermediateQueueBenchmarkState delegate;
+
+        @Setup(Level.Trial)
+        public void setUp() throws Exception {
+            delegate =
+                    new IntermediateQueueBenchmarkState(
+                            QueueType.DISRUPTOR, capacity, recordPoolSize);
+            delegate.setUp();
+        }
+
+        long publish() {
+            return delegate.publish();
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() throws Exception {
+            delegate.tearDown();
+        }
+    }
+}

--- a/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkState.java
+++ b/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkState.java
@@ -138,6 +138,8 @@ final class IntermediateQueueBenchmarkState {
         if (capacity <= 0 || Integer.bitCount(capacity) != 1) {
             throw new IllegalArgumentException("capacity must be a positive power of two");
         }
+        // Keep at least one reusable record per queue slot so a saturated queue does not contain
+        // duplicate record instances. Records remain read-only after trial setup.
         if (recordPoolSize < capacity || Integer.bitCount(recordPoolSize) != 1) {
             throw new IllegalArgumentException(
                     "recordPoolSize must be a power of two and at least capacity");

--- a/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkState.java
+++ b/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkState.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.benchmark;
+
+import org.apache.seatunnel.api.common.metrics.Counter;
+import org.apache.seatunnel.api.common.metrics.ThreadSafeCounter;
+import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.transform.Collector;
+import org.apache.seatunnel.engine.common.config.server.QueueType;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.server.task.flow.IntermediateQueueFlowLifeCycle;
+import org.apache.seatunnel.engine.server.task.group.queue.AbstractIntermediateQueue;
+import org.apache.seatunnel.engine.server.task.group.queue.IntermediateBlockingQueue;
+import org.apache.seatunnel.engine.server.task.group.queue.IntermediateDisruptor;
+import org.apache.seatunnel.engine.server.task.group.queue.disruptor.RecordEvent;
+import org.apache.seatunnel.engine.server.task.group.queue.disruptor.RecordEventFactory;
+
+import com.lmax.disruptor.YieldingWaitStrategy;
+import com.lmax.disruptor.dsl.Disruptor;
+import com.lmax.disruptor.dsl.ProducerType;
+import com.lmax.disruptor.util.DaemonThreadFactory;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+/** Owns the queue lifecycle and reusable records shared by the queue comparison benchmarks. */
+final class IntermediateQueueBenchmarkState {
+
+    private static final int PAYLOAD_SIZE = 256;
+    private static final long CONSUMER_DRAIN_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(10);
+
+    private final QueueType queueType;
+    private final int capacity;
+    private final int recordPoolSize;
+    private final AtomicLong consumedRecords = new AtomicLong();
+    private final AtomicLong consumedChecksum = new AtomicLong();
+    private final AtomicReference<Throwable> consumerFailure = new AtomicReference<>();
+
+    private Record<?>[] records;
+    private AbstractIntermediateQueue<?> queue;
+    private IntermediateQueueFlowLifeCycle<?> flowLifeCycle;
+    private Thread blockingQueueConsumer;
+    private long publishedRecords;
+
+    IntermediateQueueBenchmarkState(QueueType queueType, int capacity, int recordPoolSize) {
+        this.queueType = queueType;
+        this.capacity = capacity;
+        this.recordPoolSize = recordPoolSize;
+    }
+
+    void setUp() throws Exception {
+        validateParameters();
+        records = createRecords(recordPoolSize);
+        queue = createQueue();
+        flowLifeCycle =
+                new IntermediateQueueFlowLifeCycle<>(null, new CompletableFuture<>(), queue);
+
+        if (queueType == QueueType.BLOCKINGQUEUE) {
+            startBlockingQueueConsumer();
+        } else {
+            flowLifeCycle.collect(new BenchmarkCollector());
+        }
+    }
+
+    long publish() {
+        checkConsumerFailure();
+        Record<?> record = records[(int) (publishedRecords & (recordPoolSize - 1))];
+        flowLifeCycle.received(record);
+        return ++publishedRecords;
+    }
+
+    void tearDown() throws Exception {
+        Throwable failure = null;
+        try {
+            awaitConsumerDrain();
+            checkConsumerFailure();
+        } catch (Throwable throwable) {
+            failure = throwable;
+        }
+
+        if (blockingQueueConsumer != null) {
+            blockingQueueConsumer.interrupt();
+            try {
+                blockingQueueConsumer.join(TimeUnit.SECONDS.toMillis(1));
+                if (blockingQueueConsumer.isAlive()) {
+                    throw new IllegalStateException("Blocking queue consumer did not stop");
+                }
+            } catch (Throwable throwable) {
+                failure = combineFailures(failure, throwable);
+            }
+        }
+
+        if (flowLifeCycle != null) {
+            try {
+                flowLifeCycle.close();
+            } catch (Throwable throwable) {
+                failure = combineFailures(failure, throwable);
+            }
+        }
+
+        if (failure != null) {
+            rethrow(failure);
+        }
+    }
+
+    long getPublishedRecords() {
+        return publishedRecords;
+    }
+
+    long getConsumedRecords() {
+        return consumedRecords.get();
+    }
+
+    long getConsumedChecksum() {
+        return consumedChecksum.get();
+    }
+
+    private void validateParameters() {
+        if (capacity <= 0 || Integer.bitCount(capacity) != 1) {
+            throw new IllegalArgumentException("capacity must be a positive power of two");
+        }
+        if (recordPoolSize < capacity || Integer.bitCount(recordPoolSize) != 1) {
+            throw new IllegalArgumentException(
+                    "recordPoolSize must be a power of two and at least capacity");
+        }
+    }
+
+    private AbstractIntermediateQueue<?> createQueue() {
+        Counter totalQueueSize = new ThreadSafeCounter("totalQueueSize");
+        Counter queueSize = new ThreadSafeCounter("queueSize");
+        Counter putBlockedNs = new ThreadSafeCounter("putBlockedNs");
+        Counter flushSuccess = new ThreadSafeCounter("flushSuccess");
+        Counter flushFailure = new ThreadSafeCounter("flushFailure");
+
+        if (queueType == QueueType.BLOCKINGQUEUE) {
+            return new IntermediateBlockingQueue(
+                    new ArrayBlockingQueue<>(capacity),
+                    totalQueueSize,
+                    queueSize,
+                    putBlockedNs,
+                    flushSuccess,
+                    flushFailure);
+        }
+
+        Disruptor<RecordEvent> disruptor =
+                new Disruptor<>(
+                        new RecordEventFactory(),
+                        capacity,
+                        DaemonThreadFactory.INSTANCE,
+                        ProducerType.SINGLE,
+                        new YieldingWaitStrategy());
+        return new IntermediateDisruptor(
+                disruptor, totalQueueSize, queueSize, putBlockedNs, flushSuccess, flushFailure);
+    }
+
+    private static Record<?>[] createRecords(int size) {
+        Record<?>[] recordPool = new Record<?>[size];
+        for (int i = 0; i < size; i++) {
+            byte[] payload = new byte[PAYLOAD_SIZE];
+            for (int j = 0; j < payload.length; j++) {
+                payload[j] = (byte) (i + j);
+            }
+            recordPool[i] =
+                    new Record<>(
+                            new SeaTunnelRow(
+                                    new Object[] {
+                                        (long) i, "queue-benchmark-" + i, payload, i % 128
+                                    }));
+        }
+        return recordPool;
+    }
+
+    private void startBlockingQueueConsumer() {
+        blockingQueueConsumer =
+                new Thread(
+                        () -> {
+                            try {
+                                while (!Thread.currentThread().isInterrupted()) {
+                                    flowLifeCycle.collect(new BenchmarkCollector());
+                                }
+                            } catch (InterruptedException ignored) {
+                                Thread.currentThread().interrupt();
+                            } catch (Throwable throwable) {
+                                consumerFailure.compareAndSet(null, throwable);
+                            }
+                        },
+                        "intermediate-blocking-queue-benchmark-consumer");
+        blockingQueueConsumer.setDaemon(true);
+        blockingQueueConsumer.start();
+    }
+
+    private void consume(Record<?> record) {
+        SeaTunnelRow row = (SeaTunnelRow) record.getData();
+        byte[] payload = (byte[]) row.getField(2);
+        long checksum =
+                (Long) row.getField(0)
+                        + ((String) row.getField(1)).length()
+                        + Byte.toUnsignedInt(payload[0])
+                        + Byte.toUnsignedInt(payload[payload.length - 1])
+                        + (Integer) row.getField(3);
+        consumedChecksum.addAndGet(checksum);
+        consumedRecords.incrementAndGet();
+    }
+
+    private void awaitConsumerDrain() {
+        long deadline = System.nanoTime() + CONSUMER_DRAIN_TIMEOUT_NANOS;
+        while (consumedRecords.get() != publishedRecords && System.nanoTime() < deadline) {
+            checkConsumerFailure();
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+        }
+        if (consumedRecords.get() != publishedRecords) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Timed out waiting for %s: published=%d, consumed=%d",
+                            queueType, publishedRecords, consumedRecords.get()));
+        }
+    }
+
+    private void checkConsumerFailure() {
+        Throwable failure = consumerFailure.get();
+        if (failure != null) {
+            throw new IllegalStateException("Queue consumer failed", failure);
+        }
+    }
+
+    private static Throwable combineFailures(Throwable first, Throwable second) {
+        if (first == null) {
+            return second;
+        }
+        first.addSuppressed(second);
+        return first;
+    }
+
+    private static void rethrow(Throwable failure) throws Exception {
+        if (failure instanceof Exception) {
+            throw (Exception) failure;
+        }
+        throw (Error) failure;
+    }
+
+    private final class BenchmarkCollector implements Collector<Record<?>> {
+
+        @Override
+        public void collect(Record<?> record) {
+            consume(record);
+        }
+
+        @Override
+        public void close() {
+            // Nothing to close.
+        }
+    }
+}

--- a/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkTest.java
+++ b/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkTest.java
@@ -49,10 +49,12 @@ class IntermediateQueueBenchmarkTest {
     }
 
     @Test
-    void shouldRejectCapacityThatDisruptorCannotUse() {
-        IntermediateQueueBenchmarkState state =
-                new IntermediateQueueBenchmarkState(QueueType.DISRUPTOR, 1000, 4096);
+    void shouldRejectNonPowerOfTwoCapacityForEachQueueType() {
+        for (QueueType queueType : QueueType.values()) {
+            IntermediateQueueBenchmarkState state =
+                    new IntermediateQueueBenchmarkState(queueType, 1000, 4096);
 
-        assertThrows(IllegalArgumentException.class, state::setUp);
+            assertThrows(IllegalArgumentException.class, state::setUp);
+        }
     }
 }

--- a/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkTest.java
+++ b/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/IntermediateQueueBenchmarkTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.benchmark;
+
+import org.apache.seatunnel.engine.common.config.server.QueueType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IntermediateQueueBenchmarkTest {
+
+    private static final int RECORD_COUNT = 10_000;
+
+    @Test
+    void shouldTransferAllRecordsThroughEachQueueImplementation() throws Exception {
+        for (QueueType queueType : QueueType.values()) {
+            IntermediateQueueBenchmarkState state =
+                    new IntermediateQueueBenchmarkState(queueType, 1024, 4096);
+            state.setUp();
+            try {
+                for (int i = 0; i < RECORD_COUNT; i++) {
+                    state.publish();
+                }
+            } finally {
+                state.tearDown();
+            }
+
+            assertEquals(RECORD_COUNT, state.getPublishedRecords());
+            assertEquals(RECORD_COUNT, state.getConsumedRecords());
+            assertEquals(21_783_822L, state.getConsumedChecksum());
+        }
+    }
+
+    @Test
+    void shouldRejectCapacityThatDisruptorCannotUse() {
+        IntermediateQueueBenchmarkState state =
+                new IntermediateQueueBenchmarkState(QueueType.DISRUPTOR, 1000, 4096);
+
+        assertThrows(IllegalArgumentException.class, state::setUp);
+    }
+}


### PR DESCRIPTION
### Purpose

Part of #11598.

Add a focused JMH benchmark for comparing the production intermediate BlockingQueue and Disruptor record-handoff paths.

### Changes

- Add two separately reported JMH benchmarks:
  - `blockingQueueRecordHandoff`
  - `disruptorRecordHandoff`
- Use independent JMH states and consumers so the two implementations do not interfere with each other.
- Exercise the production `IntermediateBlockingQueue`, `IntermediateDisruptor`, and `IntermediateQueueFlowLifeCycle` paths.
- Reuse 4,096 varied `SeaTunnelRow` records containing an ID, string field, 256-byte payload, and partition value.
- Read multiple row fields and calculate a checksum on the consumer side.
- Add a deterministic test that transfers 10,000 records through both queue implementations and verifies:
  - published record count
  - consumed record count
  - consumed checksum
- Add `IntermediateQueueBenchmark` to the manual GitHub Actions selector.
- Scheduled benchmark runs already use `.*`, so both methods will also run daily on Java 8 and Java 11.
- Declare Disruptor as a direct dependency because the benchmark constructs the production RingBuffer configuration directly.

### Benchmark scope

The measured operation is one record handoff from the producer into the selected production intermediate queue.

A dedicated consumer reads the row and updates the verification checksum. Record construction and queue startup happen during trial setup and are excluded from the measured operation.

Default parameters:

- Queue capacity: `1024`
- Record pool size: `4096`
- Producer threads: `1`

A short local smoke run produced approximately:

- BlockingQueue: 3.08 million ops/s
- Disruptor: 6.60 million ops/s

These numbers only verify that the two benchmarks run and report independently. Scheduled multi-fork results should be used for performance analysis.

### Verification

```bash
./mvnw -Pbenchmark -pl seatunnel-benchmarks spotless:apply

./mvnw -Pbenchmark -pl seatunnel-benchmarks \
  -DskipIT -DskipUT=false \
  -Dtest=IntermediateQueueBenchmarkTest test

./mvnw -Pbenchmark -pl seatunnel-benchmarks -DskipTests package

java -jar seatunnel-benchmarks/target/benchmarks.jar \
  -l 'IntermediateQueueBenchmark'

java -jar seatunnel-benchmarks/target/benchmarks.jar \
  'IntermediateQueueBenchmark.*RecordHandoff$' \
  -p capacity=1024 \
  -p recordPoolSize=4096 \
  -f 1 -wi 1 -i 2 -w 1s -r 1s