### PR TITLE
[Improve][Common] Add HashUtils.bucketIndex for hash-to-bucket routing

### DIFF
--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/HashUtils.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/HashUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.common.utils;
+
+/** Utilities for mapping hash codes onto a fixed number of buckets. */
+public class HashUtils {
+
+    private HashUtils() {}
+
+    /**
+     * Maps an arbitrary hash code onto {@code [0, bucketCount)}.
+     *
+     * <p>Plain {@code hash % bucketCount} is not usable for bucket routing: {@code %} keeps the
+     * sign of its left operand, so a negative hash yields a negative index for every hash that is
+     * not an exact multiple of {@code bucketCount}. {@code Math.abs(hash) % bucketCount} is not a
+     * fix either, because {@code Math.abs(Integer.MIN_VALUE)} overflows back to {@code
+     * Integer.MIN_VALUE} and still leaves the result negative. Clearing the sign bit has neither
+     * problem.
+     *
+     * <p>Note that this is deliberately <em>not</em> equivalent to {@code Math.floorMod(hash,
+     * bucketCount)}. Masking clears the sign bit before the division, which adds {@code 2^31} to a
+     * negative hash, so the two agree only when {@code bucketCount} is a power of two: for {@code
+     * hash = -5} and {@code bucketCount = 3} masking yields {@code 0} while {@code floorMod} yields
+     * {@code 1}. Call sites that route splits or partitions by hash must not be switched between
+     * the two spellings, as that would silently reassign ownership across a version upgrade.
+     *
+     * @param hash any hash code, including negative values and {@link Integer#MIN_VALUE}
+     * @param bucketCount the number of buckets, must be greater than zero
+     * @return a bucket index in {@code [0, bucketCount)}
+     * @throws IllegalArgumentException if {@code bucketCount} is not greater than zero
+     */
+    public static int nonNegativeMod(int hash, int bucketCount) {
+        if (bucketCount <= 0) {
+            throw new IllegalArgumentException(
+                    "bucketCount must be greater than zero, but was " + bucketCount);
+        }
+        return (hash & Integer.MAX_VALUE) % bucketCount;
+    }
+}

--- a/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/HashUtils.java
+++ b/seatunnel-common/src/main/java/org/apache/seatunnel/common/utils/HashUtils.java
@@ -18,7 +18,7 @@
 package org.apache.seatunnel.common.utils;
 
 /** Utilities for mapping hash codes onto a fixed number of buckets. */
-public class HashUtils {
+public final class HashUtils {
 
     private HashUtils() {}
 
@@ -44,11 +44,36 @@ public class HashUtils {
      * @return a bucket index in {@code [0, bucketCount)}
      * @throws IllegalArgumentException if {@code bucketCount} is not greater than zero
      */
-    public static int nonNegativeMod(int hash, int bucketCount) {
+    public static int bucketIndex(int hash, int bucketCount) {
+        checkBucketCount(bucketCount);
+        return (hash & Integer.MAX_VALUE) % bucketCount;
+    }
+
+    /**
+     * Maps an arbitrary 64-bit hash onto {@code [0, bucketCount)}.
+     *
+     * <p>Behaves as {@link #bucketIndex(int, int)} does, clearing the sign bit before the division
+     * so that {@link Long#MIN_VALUE} is handled without overflow. The result always fits in an
+     * {@code int} because it is smaller than {@code bucketCount}.
+     *
+     * <p>This is a distinct mapping from the {@code int} overload rather than a widening of it: a
+     * 64-bit hash and its truncation to 32 bits generally land in different buckets, so a call site
+     * must not be switched between the two overloads.
+     *
+     * @param hash any 64-bit hash, including negative values and {@link Long#MIN_VALUE}
+     * @param bucketCount the number of buckets, must be greater than zero
+     * @return a bucket index in {@code [0, bucketCount)}
+     * @throws IllegalArgumentException if {@code bucketCount} is not greater than zero
+     */
+    public static int bucketIndex(long hash, int bucketCount) {
+        checkBucketCount(bucketCount);
+        return (int) ((hash & Long.MAX_VALUE) % bucketCount);
+    }
+
+    private static void checkBucketCount(int bucketCount) {
         if (bucketCount <= 0) {
             throw new IllegalArgumentException(
                     "bucketCount must be greater than zero, but was " + bucketCount);
         }
-        return (hash & Integer.MAX_VALUE) % bucketCount;
     }
 }

--- a/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/HashUtilsTest.java
+++ b/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/HashUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.common.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HashUtilsTest {
+
+    @Test
+    public void testIntegerMinValueIsMappedIntoRange() {
+        // Math.abs(Integer.MIN_VALUE) overflows back to Integer.MIN_VALUE, so the naive
+        // Math.abs(hash) % bucketCount spelling still returns a negative index here.
+        Assertions.assertTrue(Math.abs(Integer.MIN_VALUE) % 3 < 0);
+
+        // Clearing the sign bit leaves 0, which is in range for every bucket count.
+        for (int bucketCount : new int[] {1, 2, 3, 7, 8, 100}) {
+            Assertions.assertEquals(0, HashUtils.nonNegativeMod(Integer.MIN_VALUE, bucketCount));
+        }
+        Assertions.assertEquals(1, HashUtils.nonNegativeMod(Integer.MIN_VALUE + 1, 3));
+    }
+
+    @Test
+    public void testNegativeHashesStayInRange() {
+        for (int bucketCount : new int[] {1, 2, 3, 7, 8, 100}) {
+            for (int hash :
+                    new int[] {-1, -5, -31, -12345, Integer.MIN_VALUE, Integer.MIN_VALUE + 1}) {
+                int bucket = HashUtils.nonNegativeMod(hash, bucketCount);
+                Assertions.assertTrue(
+                        bucket >= 0 && bucket < bucketCount,
+                        "hash=" + hash + " bucketCount=" + bucketCount + " bucket=" + bucket);
+            }
+        }
+    }
+
+    @Test
+    public void testMatchesExistingMaskedSpelling() {
+        for (int hash = -1000; hash <= 1000; hash++) {
+            for (int bucketCount : new int[] {1, 2, 3, 7, 8, 16, 100}) {
+                Assertions.assertEquals(
+                        (hash & Integer.MAX_VALUE) % bucketCount,
+                        HashUtils.nonNegativeMod(hash, bucketCount),
+                        "hash=" + hash + " bucketCount=" + bucketCount);
+            }
+        }
+    }
+
+    @Test
+    public void testSingleBucketAlwaysZero() {
+        Assertions.assertEquals(0, HashUtils.nonNegativeMod(Integer.MIN_VALUE, 1));
+        Assertions.assertEquals(0, HashUtils.nonNegativeMod(Integer.MAX_VALUE, 1));
+        Assertions.assertEquals(0, HashUtils.nonNegativeMod(0, 1));
+    }
+
+    @Test
+    public void testNonPositiveBucketCountRejected() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> HashUtils.nonNegativeMod(42, 0));
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> HashUtils.nonNegativeMod(42, -1));
+    }
+
+    @Test
+    public void testNotEquivalentToFloorModForNonPowerOfTwo() {
+        // Guards the invariant that made this a helper rather than a mechanical rename:
+        // masking and floorMod agree only when bucketCount is a power of two.
+        Assertions.assertEquals(0, HashUtils.nonNegativeMod(-5, 3));
+        Assertions.assertEquals(1, Math.floorMod(-5, 3));
+
+        for (int bucketCount : new int[] {2, 4, 8, 16, 1024}) {
+            for (int hash = -500; hash <= 500; hash++) {
+                Assertions.assertEquals(
+                        Math.floorMod(hash, bucketCount),
+                        HashUtils.nonNegativeMod(hash, bucketCount),
+                        "hash=" + hash + " bucketCount=" + bucketCount);
+            }
+        }
+    }
+}

--- a/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/HashUtilsTest.java
+++ b/seatunnel-common/src/test/java/org/apache/seatunnel/common/utils/HashUtilsTest.java
@@ -30,9 +30,9 @@ public class HashUtilsTest {
 
         // Clearing the sign bit leaves 0, which is in range for every bucket count.
         for (int bucketCount : new int[] {1, 2, 3, 7, 8, 100}) {
-            Assertions.assertEquals(0, HashUtils.nonNegativeMod(Integer.MIN_VALUE, bucketCount));
+            Assertions.assertEquals(0, HashUtils.bucketIndex(Integer.MIN_VALUE, bucketCount));
         }
-        Assertions.assertEquals(1, HashUtils.nonNegativeMod(Integer.MIN_VALUE + 1, 3));
+        Assertions.assertEquals(1, HashUtils.bucketIndex(Integer.MIN_VALUE + 1, 3));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class HashUtilsTest {
         for (int bucketCount : new int[] {1, 2, 3, 7, 8, 100}) {
             for (int hash :
                     new int[] {-1, -5, -31, -12345, Integer.MIN_VALUE, Integer.MIN_VALUE + 1}) {
-                int bucket = HashUtils.nonNegativeMod(hash, bucketCount);
+                int bucket = HashUtils.bucketIndex(hash, bucketCount);
                 Assertions.assertTrue(
                         bucket >= 0 && bucket < bucketCount,
                         "hash=" + hash + " bucketCount=" + bucketCount + " bucket=" + bucket);
@@ -54,7 +54,7 @@ public class HashUtilsTest {
             for (int bucketCount : new int[] {1, 2, 3, 7, 8, 16, 100}) {
                 Assertions.assertEquals(
                         (hash & Integer.MAX_VALUE) % bucketCount,
-                        HashUtils.nonNegativeMod(hash, bucketCount),
+                        HashUtils.bucketIndex(hash, bucketCount),
                         "hash=" + hash + " bucketCount=" + bucketCount);
             }
         }
@@ -62,33 +62,79 @@ public class HashUtilsTest {
 
     @Test
     public void testSingleBucketAlwaysZero() {
-        Assertions.assertEquals(0, HashUtils.nonNegativeMod(Integer.MIN_VALUE, 1));
-        Assertions.assertEquals(0, HashUtils.nonNegativeMod(Integer.MAX_VALUE, 1));
-        Assertions.assertEquals(0, HashUtils.nonNegativeMod(0, 1));
+        Assertions.assertEquals(0, HashUtils.bucketIndex(Integer.MIN_VALUE, 1));
+        Assertions.assertEquals(0, HashUtils.bucketIndex(Integer.MAX_VALUE, 1));
+        Assertions.assertEquals(0, HashUtils.bucketIndex(0, 1));
     }
 
     @Test
     public void testNonPositiveBucketCountRejected() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> HashUtils.bucketIndex(42, 0));
         Assertions.assertThrows(
-                IllegalArgumentException.class, () -> HashUtils.nonNegativeMod(42, 0));
-        Assertions.assertThrows(
-                IllegalArgumentException.class, () -> HashUtils.nonNegativeMod(42, -1));
+                IllegalArgumentException.class, () -> HashUtils.bucketIndex(42, -1));
     }
 
     @Test
     public void testNotEquivalentToFloorModForNonPowerOfTwo() {
         // Guards the invariant that made this a helper rather than a mechanical rename:
         // masking and floorMod agree only when bucketCount is a power of two.
-        Assertions.assertEquals(0, HashUtils.nonNegativeMod(-5, 3));
+        Assertions.assertEquals(0, HashUtils.bucketIndex(-5, 3));
         Assertions.assertEquals(1, Math.floorMod(-5, 3));
 
         for (int bucketCount : new int[] {2, 4, 8, 16, 1024}) {
             for (int hash = -500; hash <= 500; hash++) {
                 Assertions.assertEquals(
                         Math.floorMod(hash, bucketCount),
-                        HashUtils.nonNegativeMod(hash, bucketCount),
+                        HashUtils.bucketIndex(hash, bucketCount),
                         "hash=" + hash + " bucketCount=" + bucketCount);
             }
         }
+    }
+
+    @Test
+    public void testLongHashesStayInRange() {
+        for (int bucketCount : new int[] {1, 2, 3, 7, 8, 100}) {
+            for (long hash :
+                    new long[] {
+                        -1L, -5L, -31L, -12345L, Long.MIN_VALUE, Long.MIN_VALUE + 1, Long.MAX_VALUE
+                    }) {
+                int bucket = HashUtils.bucketIndex(hash, bucketCount);
+                Assertions.assertTrue(
+                        bucket >= 0 && bucket < bucketCount,
+                        "hash=" + hash + " bucketCount=" + bucketCount + " bucket=" + bucket);
+            }
+        }
+    }
+
+    @Test
+    public void testLongMatchesExistingMaskedSpelling() {
+        // The clickhouse shard router already spelled this out inline; the helper must not
+        // change which shard a value routes to.
+        for (long hash = -1000L; hash <= 1000L; hash++) {
+            for (int bucketCount : new int[] {1, 2, 3, 7, 8, 16, 100}) {
+                Assertions.assertEquals(
+                        (int) ((hash & Long.MAX_VALUE) % bucketCount),
+                        HashUtils.bucketIndex(hash, bucketCount),
+                        "hash=" + hash + " bucketCount=" + bucketCount);
+            }
+        }
+        Assertions.assertEquals(0, HashUtils.bucketIndex(Long.MIN_VALUE, 3));
+    }
+
+    @Test
+    public void testLongOverloadIsDistinctFromIntOverload() {
+        // A 64-bit hash and its truncation to 32 bits generally land in different buckets,
+        // so the two overloads are separate mappings and call sites must not be switched.
+        long hash = 1L << 32;
+        Assertions.assertEquals(1, HashUtils.bucketIndex(hash, 3));
+        Assertions.assertEquals(0, HashUtils.bucketIndex((int) hash, 3));
+    }
+
+    @Test
+    public void testLongNonPositiveBucketCountRejected() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> HashUtils.bucketIndex(42L, 0));
+        Assertions.assertThrows(
+                IllegalArgumentException.class, () -> HashUtils.bucketIndex(42L, -1));
     }
 }

--- a/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/client/ShardRouter.java
+++ b/seatunnel-connectors-v2/connector-clickhouse/src/main/java/org/apache/seatunnel/connectors/seatunnel/clickhouse/sink/client/ShardRouter.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.connectors.seatunnel.clickhouse.sink.client;
 
 import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.clickhouse.exception.ClickhouseConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.clickhouse.exception.ClickhouseConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.clickhouse.shard.Shard;
@@ -112,15 +113,12 @@ public class ShardRouter implements Serializable {
             return shards.lowerEntry(threadLocalRandom.nextInt(shardWeightCount) + 1).getValue();
         }
         int offset =
-                (int)
-                        ((HASH_INSTANCE.hash(
-                                                ByteBuffer.wrap(
-                                                        shardValue
-                                                                .toString()
-                                                                .getBytes(StandardCharsets.UTF_8)),
-                                                0)
-                                        & Long.MAX_VALUE)
-                                % shardWeightCount);
+                HashUtils.bucketIndex(
+                        HASH_INSTANCE.hash(
+                                ByteBuffer.wrap(
+                                        shardValue.toString().getBytes(StandardCharsets.UTF_8)),
+                                0),
+                        shardWeightCount);
         return shards.lowerEntry(offset + 1).getValue();
     }
 

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumerator.java
@@ -18,6 +18,7 @@ package org.apache.seatunnel.connectors.seatunnel.fluss.source;
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.fluss.config.StartMode;
 
 import com.alibaba.fluss.client.table.scanner.log.LogScanner;
@@ -169,7 +170,7 @@ public class FlussSourceSplitEnumerator
 
     private static int getSplitOwner(FlussSourceSplit split, int parallelism) {
         int hash = split.getTablePath().getFullName().hashCode() * 31 + split.getBucketId();
-        return (hash & Integer.MAX_VALUE) % parallelism;
+        return HashUtils.nonNegativeMod(hash, parallelism);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-fluss/src/main/java/org/apache/seatunnel/connectors/seatunnel/fluss/source/FlussSourceSplitEnumerator.java
@@ -170,7 +170,7 @@ public class FlussSourceSplitEnumerator
 
     private static int getSplitOwner(FlussSourceSplit split, int parallelism) {
         int hash = split.getTablePath().getFullName().hashCode() * 31 + split.getBucketId();
-        return HashUtils.nonNegativeMod(hash, parallelism);
+        return HashUtils.bucketIndex(hash, parallelism);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumerator.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.bigtable.source;
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.bigtable.client.BigtableClient;
 import org.apache.seatunnel.connectors.seatunnel.bigtable.config.BigtableParameters;
 
@@ -383,8 +384,8 @@ public class BigtableSourceSplitEnumerator
         } else {
             for (BigtableSourceSplit split : pendingSplits) {
                 int owner =
-                        (split.splitId().hashCode() & Integer.MAX_VALUE)
-                                % context.currentParallelism();
+                        HashUtils.nonNegativeMod(
+                                split.splitId().hashCode(), context.currentParallelism());
                 if (owner == taskId) {
                     toAssign.add(split);
                 }

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/main/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumerator.java
@@ -384,7 +384,7 @@ public class BigtableSourceSplitEnumerator
         } else {
             for (BigtableSourceSplit split : pendingSplits) {
                 int owner =
-                        HashUtils.nonNegativeMod(
+                        HashUtils.bucketIndex(
                                 split.splitId().hashCode(), context.currentParallelism());
                 if (owner == taskId) {
                     toAssign.add(split);

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumeratorTest.java
@@ -288,7 +288,7 @@ public class BigtableSourceSplitEnumeratorTest {
         // Each split's owner must match hash(splitId) % parallelism.
         for (int i = 0; i < parallelism; i++) {
             for (BigtableSourceSplit split : context.getAssignedSplits(i)) {
-                int expected = HashUtils.nonNegativeMod(split.splitId().hashCode(), parallelism);
+                int expected = HashUtils.bucketIndex(split.splitId().hashCode(), parallelism);
                 assertEquals(
                         expected,
                         i,

--- a/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-google-bigtable/src/test/java/org/apache/seatunnel/connectors/seatunnel/bigtable/source/BigtableSourceSplitEnumeratorTest.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.event.EventListener;
 import org.apache.seatunnel.api.source.SourceEvent;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.bigtable.client.BigtableClient;
 import org.apache.seatunnel.connectors.seatunnel.bigtable.config.BigtableParameters;
 import org.apache.seatunnel.connectors.seatunnel.bigtable.exception.BigtableConnectorErrorCode;
@@ -287,7 +288,7 @@ public class BigtableSourceSplitEnumeratorTest {
         // Each split's owner must match hash(splitId) % parallelism.
         for (int i = 0; i < parallelism; i++) {
             for (BigtableSourceSplit split : context.getAssignedSplits(i)) {
-                int expected = (split.splitId().hashCode() & Integer.MAX_VALUE) % parallelism;
+                int expected = HashUtils.nonNegativeMod(split.splitId().hashCode(), parallelism);
                 assertEquals(
                         expected,
                         i,

--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
@@ -21,6 +21,7 @@ package org.apache.seatunnel.connectors.seatunnel.hbase.source;
 import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.hbase.client.HbaseClient;
 import org.apache.seatunnel.connectors.seatunnel.hbase.config.HbaseParameters;
 import org.apache.seatunnel.connectors.seatunnel.hbase.exception.HbaseConnectorErrorCode;
@@ -320,6 +321,6 @@ public class HbaseSourceSplitEnumerator
 
     /** Hash algorithm for assigning splits to readers */
     private static int getSplitOwner(String tp, int numReaders) {
-        return (tp.hashCode() & Integer.MAX_VALUE) % numReaders;
+        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-hbase/src/main/java/org/apache/seatunnel/connectors/seatunnel/hbase/source/HbaseSourceSplitEnumerator.java
@@ -321,6 +321,6 @@ public class HbaseSourceSplitEnumerator
 
     /** Hash algorithm for assigning splits to readers */
     private static int getSplitOwner(String tp, int numReaders) {
-        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
+        return HashUtils.bucketIndex(tp.hashCode(), numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/AbstractSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/AbstractSplitEnumerator.java
@@ -191,7 +191,7 @@ public abstract class AbstractSplitEnumerator
     }
 
     private static int getSplitOwner(String splitId, int numReaders) {
-        return HashUtils.nonNegativeMod(splitId.hashCode(), numReaders);
+        return HashUtils.bucketIndex(splitId.hashCode(), numReaders);
     }
 
     protected void addPendingSplits(Collection<IcebergFileScanTaskSplit> newSplits) {

--- a/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/AbstractSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-iceberg/src/main/java/org/apache/seatunnel/connectors/seatunnel/iceberg/source/enumerator/AbstractSplitEnumerator.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.iceberg.IcebergCatalogLoader;
 import org.apache.seatunnel.connectors.seatunnel.iceberg.config.IcebergSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.iceberg.source.split.IcebergFileScanTaskSplit;
@@ -190,7 +191,7 @@ public abstract class AbstractSplitEnumerator
     }
 
     private static int getSplitOwner(String splitId, int numReaders) {
-        return (splitId.hashCode() & Integer.MAX_VALUE) % numReaders;
+        return HashUtils.nonNegativeMod(splitId.hashCode(), numReaders);
     }
 
     protected void addPendingSplits(Collection<IcebergFileScanTaskSplit> newSplits) {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
@@ -174,6 +174,6 @@ public class JdbcSourceSplitEnumerator
     }
 
     private static int getSplitOwner(String tp, int numReaders) {
-        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
+        return HashUtils.bucketIndex(tp.hashCode(), numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumerator.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.jdbc.source;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.state.JdbcSourceState;
@@ -173,6 +174,6 @@ public class JdbcSourceSplitEnumerator
     }
 
     private static int getSplitOwner(String tp, int numReaders) {
-        return (tp.hashCode() & Integer.MAX_VALUE) % numReaders;
+        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
@@ -195,7 +195,7 @@ class JdbcSourceSplitEnumeratorTest {
         Assertions.assertEquals(tables.size(), assignedSplitOwners.size());
         assignedSplitOwners.forEach(
                 (splitId, owner) -> {
-                    int expectedOwner = HashUtils.nonNegativeMod(splitId.hashCode(), parallelism);
+                    int expectedOwner = HashUtils.bucketIndex(splitId.hashCode(), parallelism);
                     Assertions.assertEquals(expectedOwner, owner);
                 });
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/JdbcSourceSplitEnumeratorTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcConnectionConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
 
@@ -194,7 +195,7 @@ class JdbcSourceSplitEnumeratorTest {
         Assertions.assertEquals(tables.size(), assignedSplitOwners.size());
         assignedSplitOwners.forEach(
                 (splitId, owner) -> {
-                    int expectedOwner = (splitId.hashCode() & Integer.MAX_VALUE) % parallelism;
+                    int expectedOwner = HashUtils.nonNegativeMod(splitId.hashCode(), parallelism);
                     Assertions.assertEquals(expectedOwner, owner);
                 });
 

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/MessageContentPartitioner.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/MessageContentPartitioner.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.connectors.seatunnel.kafka.sink;
 
+import org.apache.seatunnel.common.utils.HashUtils;
+
 import org.apache.kafka.clients.producer.Partitioner;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
@@ -49,7 +51,7 @@ public class MessageContentPartitioner implements Partitioner {
             }
         }
         // Choose one of the remaining partitions according to the hashcode.
-        return ((message.hashCode() & Integer.MAX_VALUE) % (numPartitions - assignPartitionsSize))
+        return HashUtils.nonNegativeMod(message.hashCode(), numPartitions - assignPartitionsSize)
                 + assignPartitionsSize;
     }
 

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/MessageContentPartitioner.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/sink/MessageContentPartitioner.java
@@ -51,7 +51,7 @@ public class MessageContentPartitioner implements Partitioner {
             }
         }
         // Choose one of the remaining partitions according to the hashcode.
-        return HashUtils.nonNegativeMod(message.hashCode(), numPartitions - assignPartitionsSize)
+        return HashUtils.bucketIndex(message.hashCode(), numPartitions - assignPartitionsSize)
                 + assignPartitionsSize;
     }
 

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTestin
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.common.config.Common;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.kafka.KafkaClientUtils;
 import org.apache.seatunnel.connectors.seatunnel.kafka.exception.KafkaConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.kafka.exception.KafkaConnectorException;
@@ -446,7 +447,7 @@ public class KafkaSourceSplitEnumerator
     }
 
     private static int getSplitOwner(TopicPartition tp, int numReaders) {
-        int startIndex = ((tp.topic().hashCode() * 31) & 0x7FFFFFFF) % numReaders;
+        int startIndex = HashUtils.nonNegativeMod(tp.topic().hashCode() * 31, numReaders);
         return (startIndex + tp.partition()) % numReaders;
     }
 

--- a/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-kafka/src/main/java/org/apache/seatunnel/connectors/seatunnel/kafka/source/KafkaSourceSplitEnumerator.java
@@ -447,7 +447,7 @@ public class KafkaSourceSplitEnumerator
     }
 
     private static int getSplitOwner(TopicPartition tp, int numReaders) {
-        int startIndex = HashUtils.nonNegativeMod(tp.topic().hashCode() * 31, numReaders);
+        int startIndex = HashUtils.bucketIndex(tp.topic().hashCode() * 31, numReaders);
         return (startIndex + tp.partition()) % numReaders;
     }
 

--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/enumerator/MongodbSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/enumerator/MongodbSplitEnumerator.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.mongodb.exception.MongodbConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.mongodb.internal.MongodbClientProvider;
 import org.apache.seatunnel.connectors.seatunnel.mongodb.source.split.MongoSplit;
@@ -167,6 +168,6 @@ public class MongodbSplitEnumerator
     }
 
     private static int getSplitOwner(String tp, int numReaders) {
-        return (tp.hashCode() & Integer.MAX_VALUE) % numReaders;
+        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/enumerator/MongodbSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-mongodb/src/main/java/org/apache/seatunnel/connectors/seatunnel/mongodb/source/enumerator/MongodbSplitEnumerator.java
@@ -168,6 +168,6 @@ public class MongodbSplitEnumerator
     }
 
     private static int getSplitOwner(String tp, int numReaders) {
-        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
+        return HashUtils.bucketIndex(tp.hashCode(), numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/enumerator/AbstractSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/enumerator/AbstractSplitEnumerator.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.com.google.common.util.concurrent.ThreadFactor
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.common.utils.SeaTunnelException;
 import org.apache.seatunnel.connectors.seatunnel.paimon.source.PaimonSourceSplit;
 import org.apache.seatunnel.connectors.seatunnel.paimon.source.PaimonSourceSplitGenerator;
@@ -237,7 +238,7 @@ public abstract class AbstractSplitEnumerator
 
     /** Hash algorithm for assigning splits to readers */
     protected static int getSplitOwner(String tp, int numReaders) {
-        return (tp.hashCode() & Integer.MAX_VALUE) % numReaders;
+        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
     }
 
     // ------------------------------------------------------------------------

--- a/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/enumerator/AbstractSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/source/enumerator/AbstractSplitEnumerator.java
@@ -238,7 +238,7 @@ public abstract class AbstractSplitEnumerator
 
     /** Hash algorithm for assigning splits to readers */
     protected static int getSplitOwner(String tp, int numReaders) {
-        return HashUtils.nonNegativeMod(tp.hashCode(), numReaders);
+        return HashUtils.bucketIndex(tp.hashCode(), numReaders);
     }
 
     // ------------------------------------------------------------------------

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
@@ -21,6 +21,7 @@ import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarAdminConfig;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.config.PulsarConfigUtil;
 import org.apache.seatunnel.connectors.seatunnel.pulsar.exception.PulsarConnectorException;
@@ -229,7 +230,7 @@ public class PulsarSplitEnumerator
     }
 
     static int getSplitOwner(TopicPartition tp, int numReaders) {
-        int startIndex = ((tp.getTopic().hashCode() * 31) & 0x7FFFFFFF) % numReaders;
+        int startIndex = HashUtils.nonNegativeMod(tp.getTopic().hashCode() * 31, numReaders);
 
         // here, the assumption is that the id of pulsar partitions are always ascending
         // starting from 0, and therefore can be used directly as the offset clockwise from the

--- a/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-pulsar/src/main/java/org/apache/seatunnel/connectors/seatunnel/pulsar/source/enumerator/PulsarSplitEnumerator.java
@@ -230,7 +230,7 @@ public class PulsarSplitEnumerator
     }
 
     static int getSplitOwner(TopicPartition tp, int numReaders) {
-        int startIndex = HashUtils.nonNegativeMod(tp.getTopic().hashCode() * 31, numReaders);
+        int startIndex = HashUtils.bucketIndex(tp.getTopic().hashCode() * 31, numReaders);
 
         // here, the assumption is that the id of pulsar partitions are always ascending
         // starting from 0, and therefore can be used directly as the offset clockwise from the

--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.com.google.common.collect.Sets;
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
 import org.apache.seatunnel.common.config.Common;
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.connectors.seatunnel.rocketmq.common.RocketMqAdminUtil;
 import org.apache.seatunnel.connectors.seatunnel.rocketmq.common.StartMode;
 import org.apache.seatunnel.connectors.seatunnel.rocketmq.exception.RocketMqConnectorErrorCode;
@@ -135,7 +136,7 @@ public class RocketMqSourceSplitEnumerator
     }
 
     private static int getSplitOwner(MessageQueue messageQueue, int numReaders) {
-        int startIndex = ((messageQueue.getQueueId() * 31) & 0x7FFFFFFF) % numReaders;
+        int startIndex = HashUtils.nonNegativeMod(messageQueue.getQueueId() * 31, numReaders);
         return (startIndex + messageQueue.getQueueId()) % numReaders;
     }
 

--- a/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-rocketmq/src/main/java/org/apache/seatunnel/connectors/seatunnel/rocketmq/source/RocketMqSourceSplitEnumerator.java
@@ -136,7 +136,7 @@ public class RocketMqSourceSplitEnumerator
     }
 
     private static int getSplitOwner(MessageQueue messageQueue, int numReaders) {
-        int startIndex = HashUtils.nonNegativeMod(messageQueue.getQueueId() * 31, numReaders);
+        int startIndex = HashUtils.bucketIndex(messageQueue.getQueueId() * 31, numReaders);
         return (startIndex + messageQueue.getQueueId()) % numReaders;
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/metrics/hazelcast/HazelcastMetricsSnapshotStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/metrics/hazelcast/HazelcastMetricsSnapshotStateStore.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.common.statestore.metrics.hazelcast;
 
+import org.apache.seatunnel.common.utils.HashUtils;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.MetricsSnapshotStateStore;
 import org.apache.seatunnel.engine.server.dag.physical.PipelineLocation;
 import org.apache.seatunnel.engine.server.execution.TaskLocation;
@@ -167,7 +168,7 @@ public class HazelcastMetricsSnapshotStateStore
     }
 
     private long partition(TaskLocation taskLocation) {
-        return (taskLocation.hashCode() & Integer.MAX_VALUE) % partitionCount;
+        return HashUtils.nonNegativeMod(taskLocation.hashCode(), partitionCount);
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/metrics/hazelcast/HazelcastMetricsSnapshotStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/common/statestore/metrics/hazelcast/HazelcastMetricsSnapshotStateStore.java
@@ -168,7 +168,7 @@ public class HazelcastMetricsSnapshotStateStore
     }
 
     private long partition(TaskLocation taskLocation) {
-        return HashUtils.nonNegativeMod(taskLocation.hashCode(), partitionCount);
+        return HashUtils.bucketIndex(taskLocation.hashCode(), partitionCount);
     }
 
     @Override


### PR DESCRIPTION
### Purpose of this pull request

Relates to #11976. Deliberately not `Closes`: the `MultiTableSinkWriter` site tracked by that
issue is fixed in #11721 and migrated onto this helper in a trailing follow-up, so the issue
should stay open until that last site converges.

Hash-to-bucket routing is currently spelled four different ways across the codebase. This PR introduces a single helper and migrates the call sites that genuinely perform hash-to-bucket routing.

Before this PR:

| Spelling | Sites |
| --- | --- |
| `(h & Integer.MAX_VALUE) % n` | 9 |
| `((h * 31) & 0x7FFFFFFF) % n` | 3 |
| `(h & Long.MAX_VALUE) % n` | 1 (`ShardRouter`) |
| `Math.abs(h) % n` | 1 (fixed separately in #11721) |

After this PR, only two remain: the `Math.abs` one, which #11721 owns, and `FileSourceDocumentRouting`, which uses `Math.floorMod` correctly and must keep it.

The new helper lives in `seatunnel-common`:

```java
public static int bucketIndex(int hash, int bucketCount) {
    checkBucketCount(bucketCount);
    return (hash & Integer.MAX_VALUE) % bucketCount;
}

public static int bucketIndex(long hash, int bucketCount) {
    checkBucketCount(bucketCount);
    return (int) ((hash & Long.MAX_VALUE) % bucketCount);
}
```

`seatunnel-common` is already on the compile classpath of every module touched here, so no `pom.xml` changes were needed.

The name is `bucketIndex` rather than `nonNegativeMod` because the method does not compute a modulo in the mathematical sense. `nonNegativeMod` invites the reader to assume `Math.floorMod` and swap one for the other, which would change routing. `bucketIndex` names the result instead of a formula, and the contract it advertises (an index in `[0, bucketCount)`) is exactly the one the method actually guarantees. Thanks to @nzw921rx for pushing on this.

The `long` overload is a distinct mapping, not a widening of the `int` one: a 64-bit hash and its truncation to 32 bits generally land in different buckets, so a call site must not be switched between the two overloads. `HashUtilsTest#testLongOverloadIsDistinctFromIntOverload` pins that with `1L << 32`, which maps to bucket `1` through the `long` overload and bucket `0` through the `int` one at `bucketCount = 3`.

### Behaviour is bit-for-bit unchanged

Every migrated site keeps the exact masking semantics it already had.

The three `((h * 31) & 0x7FFFFFFF) % n` sites become `bucketIndex(h * 31, n)`. `0x7FFFFFFF` and `Integer.MAX_VALUE` are the same constant, and the `* 31` is part of the hash rather than part of the bucketing, so the multiply moves inside the call unchanged.

`ShardRouter` hashes with `XXHash64` and already masked with `& Long.MAX_VALUE`, so it maps onto the `long` overload with the same arithmetic it had before. The shard a value routes to is unchanged.

Deliberately **not** switched to `Math.floorMod`. Masking and `floorMod` agree only when `bucketCount` is a power of two, because masking adds `2^31` to a negative hash instead of preserving its magnitude. For `hash = -5` and `bucketCount = 3`, masking yields `0` and `floorMod` yields `1`. Standardising on `floorMod` would look like a rename but would silently reassign split ownership across an upgrade at the source enumerators. `HashUtilsTest#testNotEquivalentToFloorModForNonPowerOfTwo` pins this invariant so a future refactor cannot quietly cross the two.

### Scope

Following the boundaries agreed on #11976:

- **One helper**, two overloads, with an explicit `bucketCount > 0` contract shared by both.
- **#11721 stays separate.** `MultiTableSinkWriter` is the one live bug (`Math.abs(hash) % n` returns a negative index for `Integer.MIN_VALUE`) and is fixed in #11721. It is untouched here to avoid a conflict; migrating it onto the helper is a trailing follow-up once #11721 merges.
- **Only genuine hash-to-bucket routing sites** were migrated, not a mechanical sweep of every `%` in the tree.

One site was considered and deliberately left alone: `FileSourceDocumentRouting.routeBucket` already uses `Math.floorMod` over a SHA-256 digest. It is correct as written, and converting it to masking would change which reader owns a document. Left as is.

### Does this PR introduce a user-facing change?

No. Refactor only; routing decisions are identical for all inputs.

### How was this patch tested?

New `HashUtilsTest`, 10 tests, covering `Integer.MIN_VALUE` (the overflow case that motivated #11721), `Long.MIN_VALUE`, negative hashes across power-of-two and non-power-of-two bucket counts, `bucketCount == 1`, rejection of `bucketCount <= 0` on both overloads, the non-equivalence with `Math.floorMod`, the non-equivalence of the two overloads with each other, and exhaustive equivalence checks against the previous `(hash & Integer.MAX_VALUE) % bucketCount` and `(hash & Long.MAX_VALUE) % bucketCount` spellings over `hash` in `[-1000, 1000]`.

The two existing tests that mirrored the masking expression inline, `BigtableSourceSplitEnumeratorTest` and `JdbcSourceSplitEnumeratorTest`, were updated to call the helper so they still assert against a single source of truth.

```
HashUtilsTest ................................ Tests run: 10, Failures: 0, Errors: 0
JdbcSourceSplitEnumeratorTest ................ Tests run: 3,  Failures: 0, Errors: 0
BigtableSourceSplitEnumeratorTest ............ Tests run: 14, Failures: 0, Errors: 0
```

`spotless:check` passes on all thirteen touched modules, and all of them compile.

### Check list

* [x] Code changed are covered with tests, or it does not need tests
* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/contribution/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update change log that in connector document. For more details you can refer to [connector-v2](https://github.com/apache/seatunnel/tree/dev/docs/en/connector-v2)
  2. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  3. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
* [x] Update the [`release-note`](https://github.com/apache/seatunnel/blob/dev/release-note.md).
