### PR TITLE
[Fix][Zeta] Avoid metrics failures during coordinator startup

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/AbstractCollector.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/AbstractCollector.java
@@ -19,7 +19,7 @@ package org.apache.seatunnel.engine.server.telemetry.metrics;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
-import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineRetryableException;
+import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 
@@ -70,11 +70,20 @@ public abstract class AbstractCollector extends Collector {
         return getServer().getCoordinatorService();
     }
 
+    /**
+     * Gets the coordinator after a readiness check without failing a metrics scrape during a master
+     * transition.
+     *
+     * @return the active coordinator, or {@code null} when the coordinator is unavailable
+     */
     protected CoordinatorService getReadyCoordinatorService() {
         try {
             return getCoordinatorService();
-        } catch (SeaTunnelEngineRetryableException ignored) {
-            // The coordinator can become inactive after the readiness check succeeds.
+        } catch (SeaTunnelEngineException e) {
+            getLogger(getClass())
+                    .fine(
+                            "Coordinator service is unavailable while collecting metrics; skipping this scrape",
+                            e);
             return null;
         }
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/AbstractCollector.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/AbstractCollector.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.engine.server.telemetry.metrics;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
+import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineRetryableException;
 import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 
@@ -67,6 +68,15 @@ public abstract class AbstractCollector extends Collector {
 
     protected CoordinatorService getCoordinatorService() {
         return getServer().getCoordinatorService();
+    }
+
+    protected CoordinatorService getReadyCoordinatorService() {
+        try {
+            return getCoordinatorService();
+        } catch (SeaTunnelEngineRetryableException ignored) {
+            // The coordinator can become inactive after the readiness check succeeds.
+            return null;
+        }
     }
 
     // Non-blocking coordinator readiness check; call before getCoordinatorService() in collect().

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/JobMetricExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/JobMetricExports.java
@@ -38,7 +38,10 @@ public class JobMetricExports extends AbstractCollector {
         List<MetricFamilySamples> mfs = new ArrayList();
         // Report metrics only when the local node is ACTIVE and the master is available.
         if (isMaster() && isCoordinatorReady()) {
-            CoordinatorService coordinatorService = getCoordinatorService();
+            CoordinatorService coordinatorService = getReadyCoordinatorService();
+            if (coordinatorService == null) {
+                return mfs;
+            }
             JobCounter jobCountMetrics = coordinatorService.getJobCountMetrics();
 
             GaugeMetricFamily metricFamily =

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/RequestSlotOperationExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/RequestSlotOperationExports.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.telemetry.metrics.exports;
 
+import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.resourcemanager.ResourceManager;
 import org.apache.seatunnel.engine.server.telemetry.metrics.AbstractCollector;
 import org.apache.seatunnel.engine.server.telemetry.metrics.entity.RequestSlotOperationStats;
@@ -41,7 +42,12 @@ public class RequestSlotOperationExports extends AbstractCollector {
             return mfs;
         }
 
-        ResourceManager resourceManager = getCoordinatorService().getInitializedResourceManager();
+        CoordinatorService coordinatorService = getReadyCoordinatorService();
+        if (coordinatorService == null) {
+            return mfs;
+        }
+
+        ResourceManager resourceManager = coordinatorService.getInitializedResourceManager();
         if (resourceManager == null) {
             return mfs;
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/TelemetryCollectorCoordinatorGuardTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/TelemetryCollectorCoordinatorGuardTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.telemetry.metrics;
 
+import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineRetryableException;
 import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
@@ -134,6 +135,21 @@ public class TelemetryCollectorCoordinatorGuardTest {
         Assertions.assertTrue(
                 result.isEmpty(),
                 "collect() must not fail a metrics scrape when the coordinator changes state");
+    }
+
+    @Test
+    void testJobMetricExportsReturnsEmptyWhenNodeLosesMasterRole() {
+        Mockito.when(mockNode.isMaster()).thenReturn(true);
+        Mockito.when(mockServer.isCoordinatorActive()).thenReturn(true);
+        Mockito.when(mockServer.getCoordinatorService())
+                .thenThrow(new SeaTunnelEngineException("This is not a master node now."));
+
+        JobMetricExports exports = new JobMetricExports(mockNode);
+        List<Collector.MetricFamilySamples> result = exports.collect();
+
+        Assertions.assertTrue(
+                result.isEmpty(),
+                "collect() must not fail a metrics scrape when the master changes");
     }
 
     @Test
@@ -312,6 +328,21 @@ public class TelemetryCollectorCoordinatorGuardTest {
         Assertions.assertTrue(
                 result.isEmpty(),
                 "collect() must not fail a metrics scrape when the coordinator changes state");
+    }
+
+    @Test
+    void testRequestSlotOperationExportsReturnsEmptyWhenNodeLosesMasterRole() {
+        Mockito.when(mockNode.isMaster()).thenReturn(true);
+        Mockito.when(mockServer.isCoordinatorActive()).thenReturn(true);
+        Mockito.when(mockServer.getCoordinatorService())
+                .thenThrow(new SeaTunnelEngineException("This is not a master node now."));
+
+        RequestSlotOperationExports exports = new RequestSlotOperationExports(mockNode);
+        List<Collector.MetricFamilySamples> result = exports.collect();
+
+        Assertions.assertTrue(
+                result.isEmpty(),
+                "collect() must not fail a metrics scrape when the master changes");
     }
 
     @Test

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/TelemetryCollectorCoordinatorGuardTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/telemetry/metrics/TelemetryCollectorCoordinatorGuardTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.engine.server.telemetry.metrics;
 
+import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineRetryableException;
 import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.TaskExecutionService;
@@ -118,6 +119,21 @@ public class TelemetryCollectorCoordinatorGuardTest {
                 "collect() must return empty when coordinator is not ready"
                         + " to avoid blocking Hazelcast operation threads");
         Mockito.verify(mockServer, Mockito.never()).getCoordinatorService();
+    }
+
+    @Test
+    void testJobMetricExportsReturnsEmptyWhenCoordinatorBecomesUnavailable() {
+        Mockito.when(mockNode.isMaster()).thenReturn(true);
+        Mockito.when(mockServer.isCoordinatorActive()).thenReturn(true);
+        Mockito.when(mockServer.getCoordinatorService())
+                .thenThrow(new SeaTunnelEngineRetryableException("coordinator is starting"));
+
+        JobMetricExports exports = new JobMetricExports(mockNode);
+        List<Collector.MetricFamilySamples> result = exports.collect();
+
+        Assertions.assertTrue(
+                result.isEmpty(),
+                "collect() must not fail a metrics scrape when the coordinator changes state");
     }
 
     @Test
@@ -281,6 +297,21 @@ public class TelemetryCollectorCoordinatorGuardTest {
                 "collect() must return empty when coordinator is not ready"
                         + " to avoid initializing resource manager from scrape path");
         Mockito.verify(mockServer, Mockito.never()).getCoordinatorService();
+    }
+
+    @Test
+    void testRequestSlotOperationExportsReturnsEmptyWhenCoordinatorBecomesUnavailable() {
+        Mockito.when(mockNode.isMaster()).thenReturn(true);
+        Mockito.when(mockServer.isCoordinatorActive()).thenReturn(true);
+        Mockito.when(mockServer.getCoordinatorService())
+                .thenThrow(new SeaTunnelEngineRetryableException("coordinator is starting"));
+
+        RequestSlotOperationExports exports = new RequestSlotOperationExports(mockNode);
+        List<Collector.MetricFamilySamples> result = exports.collect();
+
+        Assertions.assertTrue(
+                result.isEmpty(),
+                "collect() must not fail a metrics scrape when the coordinator changes state");
     }
 
     @Test


### PR DESCRIPTION
### Purpose of this pull request

Avoid a `/metrics` scrape returning HTTP 500 when the coordinator becomes unavailable between the existing readiness check and a collector lookup during startup or re-election. The affected collectors now skip that scrape only for `SeaTunnelEngineRetryableException`; unexpected failures still propagate.

### Does this PR introduce _any_ user-facing change?

Yes. During the short coordinator startup/re-election window, job and request-slot metric families may be absent from a scrape instead of causing the entire `/metrics` endpoint to return 500.

### How was this patch tested?

- Added readiness-race regression coverage for `JobMetricExports` and `RequestSlotOperationExports`.
- `TelemetryCollectorCoordinatorGuardTest`: 17 tests passed, including both new race cases.
- Verified the affected engine common/core/server module chain with Maven `verify -DskipTests`.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not needed for this internal readiness-race fix.
* [x] No incompatible change is introduced.
* [x] This change does not modify connector code.