### PR TITLE
[Improve][Zeta] Replace local StringBuffer with StringBuilder in LogService

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseLogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/BaseLogService.java
@@ -143,7 +143,7 @@ public class BaseLogService extends BaseService {
         return "<li><a href=\"" + href + "\">" + name + "</a></li>\n";
     }
 
-    protected String buildWebSiteContent(StringBuffer logLink) {
+    protected String buildWebSiteContent(StringBuilder logLink) {
         return "<html><head><title>Seatunnel log</title></head>\n"
                 + "<body>\n"
                 + " <h2>Seatunnel log</h2>\n"

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/LogService.java
@@ -134,7 +134,7 @@ public class LogService extends BaseLogService {
     }
 
     public String allNodeLogFormatHtml(String jobId) {
-        StringBuffer logLink = new StringBuffer();
+        StringBuilder logLink = new StringBuilder();
 
         allLogNameList(jobId)
                 .forEach(tuple -> logLink.append(buildLogLink(tuple._2(), tuple._3())));
@@ -143,7 +143,7 @@ public class LogService extends BaseLogService {
 
     public String currentNodeLog() {
         List<File> logFileList = FileUtils.listFile(getLogPath());
-        StringBuffer logLink = new StringBuffer();
+        StringBuilder logLink = new StringBuilder();
         if (logFileList != null) {
             for (File file : logFileList) {
                 logLink.append(buildLogLink("log/" + file.getName(), file.getName()));


### PR DESCRIPTION
### Purpose of this pull request

The log link builder in `LogService` uses a thread-local `StringBuffer` that only ever calls `append()`. `StringBuffer` is synchronized while `StringBuilder` is not, so switching to `StringBuilder` removes unnecessary synchronization overhead in the job log REST endpoints.

This aligns the code with the common Java idiom: prefer `StringBuilder` for single-threaded string assembly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./mvnw spotless:apply -pl seatunnel-engine/seatunnel-engine-server`
- `./mvnw -pl seatunnel-engine/seatunnel-engine-server compile`