### PR TITLE
[Fix][Zeta] Close FileOutputStream when storing connector jar file

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/service/jar/ServerConnectorPackageClient.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/service/jar/ServerConnectorPackageClient.java
@@ -88,8 +88,9 @@ public class ServerConnectorPackageClient {
         boolean success = false;
         try {
             if (!storageFile.exists()) {
-                FileOutputStream fos = new FileOutputStream(storageFile);
-                fos.write(connectorJarByteData);
+                try (FileOutputStream fos = new FileOutputStream(storageFile)) {
+                    fos.write(connectorJarByteData);
+                }
             } else {
                 LOGGER.warning(
                         String.format(


### PR DESCRIPTION
### Purpose of this pull request

`ServerConnectorPackageClient.storageConnectorJarFile()` opens a `FileOutputStream` to persist the uploaded connector jar but never closes it on the success path, leaking a file handle on every connector jar upload (via `UploadConnectorJarOperation` / `SendConnectorJarToMemberNodeOperation`).

The sibling implementation `AbstractConnectorJarStorageStrategy` already uses `Files.write()` which closes the stream automatically. This change makes `ServerConnectorPackageClient` consistent by using try-with-resources.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./mvnw spotless:apply -pl seatunnel-engine/seatunnel-engine-server`
- `./mvnw -pl seatunnel-engine/seatunnel-engine-server compile`