### PR TITLE
[Fix][Transform-V2] Make rename transform case conversion locale independent

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/FieldRenameTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/FieldRenameTransform.java
@@ -45,6 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -164,10 +165,10 @@ public class FieldRenameTransform extends AbstractCatalogSupportMapTransform {
         if (config.getConvertCase() != null) {
             switch (config.getConvertCase()) {
                 case UPPER:
-                    name = name.toUpperCase();
+                    name = name.toUpperCase(Locale.ROOT);
                     break;
                 case LOWER:
-                    name = name.toLowerCase();
+                    name = name.toLowerCase(Locale.ROOT);
                     break;
                 default:
                     throw new UnsupportedOperationException(

--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/TableRenameTransform.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/rename/TableRenameTransform.java
@@ -40,6 +40,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -150,9 +151,9 @@ public class TableRenameTransform extends AbstractCatalogSupportMapTransform {
         if (config.getConvertCase() != null) {
             switch (config.getConvertCase()) {
                 case UPPER:
-                    return name.toUpperCase();
+                    return name.toUpperCase(Locale.ROOT);
                 case LOWER:
-                    return name.toLowerCase();
+                    return name.toLowerCase(Locale.ROOT);
                 default:
                     throw new UnsupportedOperationException(
                             "Unsupported convert case: " + config.getConvertCase());

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/rename/FieldRenameTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/rename/FieldRenameTransformTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 public class FieldRenameTransformTest {
@@ -273,5 +274,24 @@ public class FieldRenameTransformTest {
         FieldRenameTransform transform = new FieldRenameTransform(config, DEFAULT_TABLE);
 
         Assertions.assertEquals("invoicenum", transform.convertName("InvoiceNum"));
+    }
+
+    @Test
+    public void testConvertCaseIsLocaleIndependent() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            FieldRenameConfig config = new FieldRenameConfig().setConvertCase(ConvertCase.UPPER);
+            FieldRenameTransform transform = new FieldRenameTransform(config, DEFAULT_TABLE);
+            Assertions.assertEquals("I", transform.convertName("i"));
+            Assertions.assertEquals("ABC", transform.convertName("abc"));
+
+            config = new FieldRenameConfig().setConvertCase(ConvertCase.LOWER);
+            transform = new FieldRenameTransform(config, DEFAULT_TABLE);
+            Assertions.assertEquals("i", transform.convertName("I"));
+            Assertions.assertEquals("abc", transform.convertName("ABC"));
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/rename/TableRenameTransformTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/rename/TableRenameTransformTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 public class TableRenameTransformTest {
 
@@ -146,5 +147,24 @@ public class TableRenameTransformTest {
                 outputCatalogTable.get(0).getTableId().toTablePath().getFullName());
         Assertions.assertEquals("Database-x.Schema-x.t2-x", outputRow.getTableId());
         Assertions.assertEquals("Database-x.Schema-x.t2-x", outputEvent.tablePath().getFullName());
+    }
+
+    @Test
+    public void testConvertCaseIsLocaleIndependent() {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            TableRenameConfig config = new TableRenameConfig().setConvertCase(ConvertCase.UPPER);
+            TableRenameTransform transform = new TableRenameTransform(config, DEFAULT_TABLE);
+            Assertions.assertEquals("I", transform.convertCase("i"));
+            Assertions.assertEquals("ABC", transform.convertCase("abc"));
+
+            config = new TableRenameConfig().setConvertCase(ConvertCase.LOWER);
+            transform = new TableRenameTransform(config, DEFAULT_TABLE);
+            Assertions.assertEquals("i", transform.convertCase("I"));
+            Assertions.assertEquals("abc", transform.convertCase("ABC"));
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

`TableRenameTransform.convertCase()` and `FieldRenameTransform.convertCase()` call `String.toUpperCase()` / `String.toLowerCase()` without an explicit locale, so `convert_case=UPPER/LOWER` depends on the default locale of the worker JVM. Under the Turkish locale, `lower("I")` returns the dotless `ı` and `upper("i")` returns `İ`, so a distributed job can produce different output depending on the host.

This is the same class of bug as the SQL `lower()`/`upper()` functions (#11949) — but those PRs only fixed `StringFunction`, leaving the rename transforms affected.

The fix passes `Locale.ROOT` so case conversion is deterministic and follows SQL semantics.

### Does this PR introduce _any_ user-facing change?

No behavioral change under non-Turkish-default locales; it only makes the result locale independent.

### How was this patch tested?

- `./mvnw spotless:apply -pl seatunnel-transforms-v2`
- `TableRenameTransformTest` (2 tests) and `FieldRenameTransformTest` (3 tests) pass, including the new `testConvertCaseIsLocaleIndependent` regression test which runs under the `tr-TR` locale.