### PR TITLE
[Fix][Connector-V2] Remove fixed sleep in AssertSinkWriter close and assert own table only

### DIFF
--- a/seatunnel-connectors-v2/connector-assert/src/main/java/org/apache/seatunnel/connectors/seatunnel/assertion/sink/AssertSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-assert/src/main/java/org/apache/seatunnel/connectors/seatunnel/assertion/sink/AssertSinkWriter.java
@@ -49,7 +49,6 @@ public class AssertSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
     private static final Map<String, LongAccumulator> LONG_ACCUMULATOR = new ConcurrentHashMap<>();
     private static final Set<String> TABLE_NAMES = new CopyOnWriteArraySet<>();
     private final String catalogTableName;
-    private final long WAIT_SINK_WRITER_COMPLETE_TIME = 1000L;
 
     public AssertSinkWriter(
             SeaTunnelRowType seaTunnelRowType,
@@ -103,16 +102,14 @@ public class AssertSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
 
     @Override
     public void close() {
-        try {
-            // When there are multiple AssertSinkWriters, some Sinks will run first, so let it wait
-            // for other Sinks, otherwise it will make incorrect judgments
-            Thread.sleep(WAIT_SINK_WRITER_COMPLETE_TIME);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         if (!assertRowRules.isEmpty()) {
             assertRowRules.entrySet().stream()
-                    .filter(entry -> !entry.getValue().isEmpty())
+                    .filter(
+                            entry ->
+                                    !entry.getValue().isEmpty()
+                                            && (assertRowRules.size() == 1
+                                                    || entry.getKey()
+                                                            .equals(this.catalogTableName)))
                     .forEach(
                             entry -> {
                                 List<AssertFieldRule.AssertRule> assertRules = entry.getValue();

--- a/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/connectors/seatunnel/assertion/sink/AssertSinkWriterCloseTest.java
+++ b/seatunnel-connectors-v2/connector-assert/src/test/java/org/apache/seatunnel/connectors/seatunnel/assertion/sink/AssertSinkWriterCloseTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.assertion.sink;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.assertion.exception.AssertConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.assertion.rule.AssertFieldRule;
+import org.apache.seatunnel.connectors.seatunnel.assertion.rule.AssertTableRule;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AssertSinkWriterCloseTest {
+
+    private static final SeaTunnelRowType ROW_TYPE =
+            new SeaTunnelRowType(new String[] {"id"}, new BasicType[] {BasicType.INT_TYPE});
+
+    private static AssertFieldRule.AssertRule minRowRule(int minRows) {
+        AssertFieldRule.AssertRule rule = new AssertFieldRule.AssertRule();
+        rule.setRuleType(AssertFieldRule.AssertRuleType.MIN_ROW);
+        rule.setRuleValue((double) minRows);
+        return rule;
+    }
+
+    @Test
+    public void testCloseOnlyAssertsOwnTableWhenMultipleTables() {
+        // Writer A receives one row; table B never receives any row. The old implementation
+        // slept 1s and asserted every table's rules in close(), so B's MIN_ROW=1 (0 rows
+        // written) made the writer for table A fail. The fixed close() only asserts the
+        // table this writer is responsible for, so it must succeed without depending on
+        // other writers' progress.
+        Map<String, List<AssertFieldRule.AssertRule>> assertRowRules = new HashMap<>();
+        assertRowRules.put("tableA_mult", Collections.singletonList(minRowRule(1)));
+        assertRowRules.put("tableB_other", Collections.singletonList(minRowRule(1)));
+
+        AssertSinkWriter writerA =
+                new AssertSinkWriter(
+                        ROW_TYPE,
+                        Collections.emptyMap(),
+                        assertRowRules,
+                        new AssertTableRule(Collections.emptyList()),
+                        "tableA_mult");
+        writerA.write(new SeaTunnelRow(new Object[] {1}));
+        Assertions.assertDoesNotThrow(writerA::close);
+    }
+
+    @Test
+    public void testCloseThrowsWhenOwnTableRuleNotMet() {
+        // MIN_ROW=2 for the writer's own table but only 1 row was written: close() must
+        // still validate the writer's own table and fail.
+        Map<String, List<AssertFieldRule.AssertRule>> assertRowRules = new HashMap<>();
+        assertRowRules.put("tableA_fail", Collections.singletonList(minRowRule(2)));
+        assertRowRules.put("tableB_other", Collections.singletonList(minRowRule(0)));
+
+        AssertSinkWriter writerA =
+                new AssertSinkWriter(
+                        ROW_TYPE,
+                        Collections.emptyMap(),
+                        assertRowRules,
+                        new AssertTableRule(Collections.emptyList()),
+                        "tableA_fail");
+        writerA.write(new SeaTunnelRow(new Object[] {1}));
+        Assertions.assertThrows(AssertConnectorException.class, writerA::close);
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

`AssertSinkWriter.close()` sleeps 1000ms to wait for other sink writers to finish, assuming a multi-writer job. This heuristic both slows down every job completion (even single-table jobs pay 1s) and is unreliable under load.

The writer already routes each row to the shared `LONG_ACCUMULATOR` keyed by table name in `write()` (its own table when `assertRowRules` contains multiple tables, the unique key otherwise). `close()` should validate only the rules of the table this writer is responsible for — using the same table-selection decision as `write()` — instead of waiting for unrelated writers.

Changes:
- remove `WAIT_SINK_WRITER_COMPLETE_TIME` and the `Thread.sleep`
- filter `assertRowRules` in `close()` by the writer's own `catalogTableName` when multiple tables are configured
- add `AssertSinkWriterCloseTest` covering the multi-table close behavior and the MIN_ROW validation on the writer's own table

### Does this PR introduce _any_ user-facing change?

No; assertion semantics are unchanged for single-table jobs, and multi-table jobs now fail fast with accurate per-table counts instead of relying on a fixed delay.

### Known limitation

For a single table with `parallelism > 1`, each parallel subtask owns its own `AssertSinkWriter` and `close()` is invoked per subtask without a barrier across siblings. In that case `assertRowRules.size() == 1` bypasses the per-table filter (same as before), and the shared `LONG_ACCUMULATOR` for the table can still be written concurrently by sibling instances when one closes — the removed sleep had provided only a weak, unreliable buffer for this window. This PR does not regress that path relative to the previous behavior (the sleep never bounded sibling completion time), and all existing Assert E2E configs use `parallelism = 1`, so it is out of scope here; a barrier-based fix would be a separate follow-up.

### How was this patch tested?

- `./mvnw spotless:apply -pl seatunnel-connectors-v2/connector-assert`
- `AssertSinkWriterCloseTest` (2 tests) passes with the fix, and the regression test fails against the previous implementation (table B's unfulfilled MIN_ROW rule is no longer asserted by table A's writer).