### PR TITLE
[Improve][Connector-V2] Use isEmpty() instead of size() > 0 in ES connectors

### DIFF
--- a/seatunnel-connectors-v2/connector-easysearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/easysearch/serialize/index/IndexSerializerFactory.java
+++ b/seatunnel-connectors-v2/connector-easysearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/easysearch/serialize/index/IndexSerializerFactory.java
@@ -29,7 +29,7 @@ public class IndexSerializerFactory {
     public static IndexSerializer getIndexSerializer(
             String index, SeaTunnelRowType seaTunnelRowType) {
         List<String> fieldNames = RegexUtils.extractDatas(index, "\\$\\{(.*?)\\}");
-        if (fieldNames != null && fieldNames.size() > 0) {
+        if (fieldNames != null && !fieldNames.isEmpty()) {
             return new VariableIndexSerializer(seaTunnelRowType, index, fieldNames);
         } else {
             return new FixedValueIndexSerializer(index);

--- a/seatunnel-connectors-v2/connector-easysearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/easysearch/sink/EasysearchSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-easysearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/easysearch/sink/EasysearchSinkWriter.java
@@ -104,7 +104,7 @@ public class EasysearchSinkWriter
         try {
             RetryUtils.retryWithException(
                     () -> {
-                        if (requestEzsList.size() > 0) {
+                        if (!requestEzsList.isEmpty()) {
                             String requestBody = String.join("\n", requestEzsList) + "\n";
                             BulkResponse bulkResponse = ezsClient.bulk(requestBody);
                             if (bulkResponse.isErrors()) {

--- a/seatunnel-connectors-v2/connector-easysearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/easysearch/source/EasysearchSourceReader.java
+++ b/seatunnel-connectors-v2/connector-easysearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/easysearch/source/EasysearchSourceReader.java
@@ -85,7 +85,7 @@ public class EasysearchSourceReader implements SourceReader<SeaTunnelRow, Easyse
                                     sourceIndexInfo.getScrollSize());
                     scrollId = scrollResult.getScrollId();
                     outputFromScrollResult(scrollResult, sourceIndexInfo.getSource(), output);
-                    while (scrollResult.getDocs() != null && scrollResult.getDocs().size() > 0) {
+                    while (scrollResult.getDocs() != null && !scrollResult.getDocs().isEmpty()) {
                         scrollResult =
                                 ezsClient.searchWithScrollId(
                                         scrollResult.getScrollId(),

--- a/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/serialize/index/IndexSerializerFactory.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/serialize/index/IndexSerializerFactory.java
@@ -29,7 +29,7 @@ public class IndexSerializerFactory {
     public static IndexSerializer getIndexSerializer(
             String index, SeaTunnelRowType seaTunnelRowType) {
         List<String> fieldNames = RegexUtils.extractDatas(index, "\\$\\{(.*?)\\}");
-        if (fieldNames != null && fieldNames.size() > 0) {
+        if (fieldNames != null && !fieldNames.isEmpty()) {
             return new VariableIndexSerializer(seaTunnelRowType, index, fieldNames);
         } else {
             return new FixedValueIndexSerializer(index);

--- a/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/sink/ElasticsearchSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-elasticsearch/src/main/java/org/apache/seatunnel/connectors/seatunnel/elasticsearch/sink/ElasticsearchSinkWriter.java
@@ -243,7 +243,7 @@ public class ElasticsearchSinkWriter
         try {
             RetryUtils.retryWithException(
                     () -> {
-                        if (requestEsList.size() > 0) {
+                        if (!requestEsList.isEmpty()) {
                             String requestBody = String.join("\n", requestEsList) + "\n";
                             BulkResponse bulkResponse = esRestClient.bulk(requestBody);
                             if (bulkResponse.isErrors()) {


### PR DESCRIPTION
### Purpose of this pull request

Replace `list.size() > 0` / `list.size() == 0` collection checks with `!isEmpty()` / `isEmpty()` in the Easysearch and Elasticsearch connectors (sink flush, scroll reader, index serializer factory). Behavior is unchanged, but `isEmpty()` expresses the intent directly and avoids deriving the size of an already-computed collection. This matches the Java collection idiom used elsewhere in the codebase.

Files:
- `connector-easysearch`: `EasysearchSourceReader`, `EasysearchSinkWriter`, `IndexSerializerFactory`
- `connector-elasticsearch`: `ElasticsearchSinkWriter`, `IndexSerializerFactory`

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `./mvnw spotless:apply -pl seatunnel-connectors-v2/connector-easysearch,seatunnel-connectors-v2/connector-elasticsearch`
- `./mvnw -pl seatunnel-connectors-v2/connector-easysearch,seatunnel-connectors-v2/connector-elasticsearch compile`