### PR TITLE
[Fix][Zeta] Fix schema-first multi-table sink metrics

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycle.java
@@ -132,8 +132,8 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
 
     private final EventListener eventListener;
 
-    /** Mapping relationship between upstream TablePath and downstream TablePath. */
-    private final Map<TablePath, TablePath> tablesMaps = new HashMap<>();
+    /** Mapping relationship between upstream row table IDs and downstream table IDs. */
+    private final Map<String, String> sinkTableMappings = new HashMap<>();
 
     private final MetricsContext metricsContext;
 
@@ -196,8 +196,14 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
         List<TablePath> sinkTables = new ArrayList<>();
         boolean isMulti = sinkAction.getSink() instanceof MultiTableSink;
         if (isMulti) {
-            sinkTables = ((MultiTableSink) sinkAction.getSink()).getSinkTables();
-            tablesMaps.putAll(((MultiTableSink) sinkAction.getSink()).getSinkTableMapping());
+            MultiTableSink multiTableSink = (MultiTableSink) sinkAction.getSink();
+            sinkTables = multiTableSink.getSinkTables();
+            multiTableSink
+                    .getSinkTableMapping()
+                    .forEach(
+                            (sourceTable, sinkTable) ->
+                                    sinkTableMappings.put(
+                                            sourceTable.toString(), sinkTable.getFullName()));
         } else {
             Optional<CatalogTable> catalogTable = sinkAction.getSink().getWriteCatalogTable();
             if (catalogTable.isPresent()) {
@@ -738,8 +744,8 @@ public class SinkFlowLifeCycle<T, CommitInfoT extends Serializable, AggregatedCo
             if (row.getTableId() == null || row.getTableId().isEmpty()) {
                 return row.getTableId();
             }
-            TablePath tablePath = tablesMaps.get(TablePath.of(row.getTableId()));
-            return tablePath != null ? tablePath.getFullName() : TablePath.DEFAULT.getFullName();
+            return sinkTableMappings.getOrDefault(
+                    row.getTableId(), TablePath.DEFAULT.getFullName());
         }
         Optional<CatalogTable> writeCatalogTable = this.sinkAction.getSink().getWriteCatalogTable();
         return writeCatalogTable

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycleMetricsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/flow/SinkFlowLifeCycleMetricsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.task.flow;
+
+import org.apache.seatunnel.api.common.metrics.MetricNames;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.multitablesink.MultiTableAggregatedCommitInfo;
+import org.apache.seatunnel.api.sink.multitablesink.MultiTableCommitInfo;
+import org.apache.seatunnel.api.sink.multitablesink.MultiTableSink;
+import org.apache.seatunnel.api.sink.multitablesink.MultiTableState;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.type.Record;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.core.dag.actions.SinkAction;
+import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
+import org.apache.seatunnel.engine.server.execution.TaskLocation;
+import org.apache.seatunnel.engine.server.metrics.SeaTunnelMetricsContext;
+import org.apache.seatunnel.engine.server.task.SeaTunnelTask;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+class SinkFlowLifeCycleMetricsTest {
+
+    private static final TaskLocation TASK_LOCATION =
+            new TaskLocation(new TaskGroupLocation(1L, 1, 1L), 2L, 0);
+
+    @Test
+    void schemaFirstTableIdUsesResolvedSinkTableMetrics() throws Exception {
+        TablePath sourceTable = TablePath.of(null, "PDC_SCHEMA", "CUSTOMER");
+        TablePath sinkTable = TablePath.of("target_db", "CUSTOMER");
+        MultiTableSink sink = Mockito.mock(MultiTableSink.class);
+        Mockito.when(sink.getSinkTables()).thenReturn(Collections.singletonList(sinkTable));
+        Mockito.when(sink.getSinkTableMapping())
+                .thenReturn(Collections.singletonMap(sourceTable, sinkTable));
+        SinkAction<
+                        SeaTunnelRow,
+                        MultiTableState,
+                        MultiTableCommitInfo,
+                        MultiTableAggregatedCommitInfo>
+                action =
+                        new SinkAction<>(
+                                7L, "sink", sink, Collections.emptySet(), Collections.emptySet());
+        SeaTunnelTask task = Mockito.mock(SeaTunnelTask.class);
+        Mockito.when(task.isObservabilityEnabled()).thenReturn(true);
+        SeaTunnelMetricsContext metrics = new SeaTunnelMetricsContext();
+        SinkFlowLifeCycle<
+                        SeaTunnelRow,
+                        MultiTableCommitInfo,
+                        MultiTableAggregatedCommitInfo,
+                        MultiTableState>
+                flow =
+                        new SinkFlowLifeCycle<>(
+                                action,
+                                TASK_LOCATION,
+                                0,
+                                task,
+                                null,
+                                false,
+                                new CompletableFuture<>(),
+                                metrics);
+        setWriter(flow, Mockito.mock(SinkWriter.class));
+        SeaTunnelRow row = new SeaTunnelRow(new Object[] {1});
+        row.setTableId(sourceTable.getFullName());
+
+        flow.received(new Record<>(row));
+
+        Assertions.assertEquals(
+                1L,
+                metrics.counter(MetricNames.SINK_WRITE_COUNT + "#" + sinkTable.getFullName())
+                        .getCount());
+        Assertions.assertEquals(
+                0L,
+                metrics.counter(
+                                MetricNames.SINK_WRITE_COUNT
+                                        + "#"
+                                        + TablePath.DEFAULT.getFullName())
+                        .getCount());
+    }
+
+    private static void setWriter(SinkFlowLifeCycle<?, ?, ?, ?> flow, SinkWriter<?, ?, ?> writer)
+            throws Exception {
+        Field field = SinkFlowLifeCycle.class.getDeclaredField("writer");
+        field.setAccessible(true);
+        field.set(flow, writer);
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Closes #12000.

In schema-first JDBC dialects such as DM, a two-part upstream table path represents `schema.table`. `JdbcInputFormat` stores that path in `SeaTunnelRow.tableId` as a string, and `MultiTableSinkWriter` routes the row using the same string.

`SinkFlowLifeCycle` previously parsed the string again with the default `TablePath.of(String)` semantics, which interpret two parts as `database.table`. The reconstructed `TablePath` did not equal the schema-first key in `MultiTableSink#getSinkTableMapping()`, so successful writes were counted under `default.default.default` instead of their resolved target tables.

This patch:

- stores the source-to-target metric mapping by the same string identifier used by `MultiTableSinkWriter`;
- removes the ambiguous `TablePath` reconstruction from the per-row metric path;
- adds a regression test for a schema-first two-part source table mapped to a different sink database.

The write path, connector configuration, and `TablePath` parsing API are unchanged.

### Does this PR introduce any user-facing change?

Yes. For affected multi-table Zeta jobs, `TableSinkWriteCount` is now attributed to the resolved target table instead of `default.default.default`.

### How was this patch tested?

- Added `SinkFlowLifeCycleMetricsTest#schemaFirstTableIdUsesResolvedSinkTableMetrics`.
- `./mvnw -pl seatunnel-engine/seatunnel-engine-server spotless:apply -DskipTests` — passed.
- Functional and integration tests were not run locally; the submitted regression test and existing suite are left to CI because the local DM/StarRocks test environment is unavailable.

### Check list

- [x] No new dependencies or binary files are added.
- [x] No public API, configuration option, or default value is changed.
- [x] The change is limited to Zeta metric attribution and its regression test.
- [x] No documentation update is required because this restores the documented per-table metric behavior.