### PR TITLE
[Improve][Connector-V2] Migrate ActiveMQ validation to OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-activemq/src/main/java/org/apache/seatunnel/connectors/seatunnel/activemq/sink/ActivemqSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-activemq/src/main/java/org/apache/seatunnel/connectors/seatunnel/activemq/sink/ActivemqSinkFactory.java
@@ -25,11 +25,13 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.ALWAYS_SESSION_ASYNC;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.ALWAYS_SYNC_SEND;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.CHECK_FOR_DUPLICATE;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.CLIENT_ID;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.CLOSE_TIMEOUT;
+import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.CONSUMER_EXPIRY_CHECK_ENABLED;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.DISPATCH_ASYNC;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.NESTED_MAP_AND_LIST_ENABLED;
 import static org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions.PASSWORD;
@@ -49,14 +51,16 @@ public class ActivemqSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(QUEUE_NAME, URI)
+                .required(QUEUE_NAME, notBlank(QUEUE_NAME))
+                .required(URI, notBlank(URI))
                 .bundled(USERNAME, PASSWORD)
+                .optional(CLIENT_ID, notBlank(CLIENT_ID))
                 .optional(
-                        CLIENT_ID,
                         CHECK_FOR_DUPLICATE,
                         ALWAYS_SESSION_ASYNC,
                         ALWAYS_SYNC_SEND,
                         CLOSE_TIMEOUT,
+                        CONSUMER_EXPIRY_CHECK_ENABLED,
                         DISPATCH_ASYNC,
                         NESTED_MAP_AND_LIST_ENABLED,
                         WARN_ABOUT_UNSTARTED_CONNECTION_TIMEOUT)

--- a/seatunnel-connectors-v2/connector-activemq/src/test/java/org/apache/seatunnel/connectors/seatunnel/activemq/ActivemqFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-activemq/src/test/java/org/apache/seatunnel/connectors/seatunnel/activemq/ActivemqFactoryTest.java
@@ -17,15 +17,85 @@
 
 package org.apache.seatunnel.connectors.seatunnel.activemq;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.activemq.config.ActivemqSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.activemq.sink.ActivemqSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 class ActivemqFactoryTest {
+
+    private final OptionRule optionRule = new ActivemqSinkFactory().optionRule();
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new ActivemqSinkFactory()).optionRule());
+        Assertions.assertNotNull(optionRule);
+    }
+
+    @Test
+    void testValidRequiredOptions() {
+        Assertions.assertDoesNotThrow(() -> validate(requiredConfig()));
+    }
+
+    @Test
+    void testBlankRequiredOptionsRejected() {
+        Map<String, Object> blankUriConfig = requiredConfig();
+        blankUriConfig.put(ActivemqSinkOptions.URI.key(), " ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(blankUriConfig));
+
+        Map<String, Object> blankQueueNameConfig = requiredConfig();
+        blankQueueNameConfig.put(ActivemqSinkOptions.QUEUE_NAME.key(), "\t");
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(blankQueueNameConfig));
+    }
+
+    @Test
+    void testBlankClientIdRejected() {
+        Map<String, Object> config = requiredConfig();
+        config.put(ActivemqSinkOptions.CLIENT_ID.key(), "");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @Test
+    void testCredentialsMustBeBundled() {
+        Map<String, Object> usernameOnlyConfig = requiredConfig();
+        usernameOnlyConfig.put(ActivemqSinkOptions.USERNAME.key(), "user");
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(usernameOnlyConfig));
+
+        Map<String, Object> passwordOnlyConfig = requiredConfig();
+        passwordOnlyConfig.put(ActivemqSinkOptions.PASSWORD.key(), "password");
+        Assertions.assertThrows(
+                OptionValidationException.class, () -> validate(passwordOnlyConfig));
+    }
+
+    @Test
+    void testSupportedOptionalOptions() {
+        Map<String, Object> config = requiredConfig();
+        config.put(ActivemqSinkOptions.CLIENT_ID.key(), "client-id");
+        config.put(ActivemqSinkOptions.CLOSE_TIMEOUT.key(), 1000);
+        config.put(ActivemqSinkOptions.CONSUMER_EXPIRY_CHECK_ENABLED.key(), true);
+        config.put(ActivemqSinkOptions.WARN_ABOUT_UNSTARTED_CONNECTION_TIMEOUT.key(), -1);
+        Assertions.assertDoesNotThrow(() -> validate(config));
+    }
+
+    private void validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "ActiveMQSink");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private Map<String, Object> requiredConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ActivemqSinkOptions.URI.key(), "tcp://localhost:61616");
+        config.put(ActivemqSinkOptions.QUEUE_NAME.key(), "test-queue");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

This PR handles the `connector-activemq` portion of #11007.

It completes the ActiveMQ sink factory's declarative `OptionRule` validation by:

- rejecting blank `uri` and `queue_name` values;
- rejecting a blank supplied `client_id`;
- adding the supported `consumer_expiry_check_enabled` option to the factory rule.

The change remains limited to declarative configuration eligibility. Broker, network, and runtime checks remain imperative.

### Does this PR introduce any user-facing change?

Yes.

Invalid blank `uri`, `queue_name`, and supplied `client_id` values are now rejected during configuration validation. The supported `consumer_expiry_check_enabled` option is now accepted by unknown-key validation.

### How was this patch tested?

- Added positive and negative factory validation tests.
- `ActivemqFactoryTest`: 6 tests passed, 0 failures.
- Complete ActiveMQ module `verify`: passed.
- Repository-wide Spotless formatting: passed.

### Check list

- [x] No new binary dependency was added.
- [x] No connector registration or distribution changes are required.
- [x] No incompatible configuration name or default was introduced.