### PR TITLE
[Feature][Connector-V2] Add Azure Queue Storage source

### DIFF
--- a/docs/en/connectors/changelog/connector-azure-queue-storage.md
+++ b/docs/en/connectors/changelog/connector-azure-queue-storage.md
@@ -2,6 +2,7 @@
 
 | Change | Commit | Version |
 | --- | --- | --- |
+|[Feature][Connector-V2] Add Azure Queue Storage source connector|-|Next|
 |[Feature][Connector-V2] Add Azure Queue Storage sink connector|-|Next|
 
 </details>

--- a/docs/en/connectors/source/AzureQueueStorage.md
+++ b/docs/en/connectors/source/AzureQueueStorage.md
@@ -1,0 +1,164 @@
+import ChangeLog from '../changelog/connector-azure-queue-storage.md';
+
+# AzureQueueStorage
+
+> Azure Queue Storage source connector
+
+## Description
+
+Reads messages from one Azure Storage queue and converts each payload to a SeaTunnel row.
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
+
+- [ ] [batch](../../introduction/concepts/connector-v2-features.md)
+- [x] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
+
+## Options
+
+| name | type | required | default value |
+| --- | --- | --- | --- |
+| queue_name | string | yes | - |
+| authentication_type | enum | yes | - |
+| connection_string | string | conditional | - |
+| endpoint | string | conditional | - |
+| account_name | string | conditional | - |
+| account_key | string | conditional | - |
+| sas_token | string | conditional | - |
+| format | enum | no | json |
+| field_delimiter | string | no | , |
+| message_encoding | enum | no | none |
+| batch_size | int | no | 32 |
+| visibility_timeout_seconds | int | no | 300 |
+| poll_interval_ms | long | no | 1000 |
+| max_in_flight_messages | int | no | 1000 |
+| operation_timeout_ms | long | no | 60000 |
+| schema | config | yes | - |
+| common-options | | no | - |
+
+### queue_name [string]
+
+Source Azure Storage queue. The queue must exist before the job starts. Queue names must contain 3-63 lowercase letters, numbers or single hyphens.
+
+### authentication_type [enum]
+
+Selects one explicit authentication path:
+
+- `connection_string`: requires `connection_string`.
+- `shared_key`: requires `endpoint`, `account_name` and `account_key`.
+- `sas_token`: requires `endpoint` and `sas_token`.
+
+Credentials from different authentication modes cannot be mixed. The connector does not log credential values.
+
+### connection_string [string]
+
+Azure Storage connection string. This mode also supports Azurite connection strings with a custom `QueueEndpoint`.
+
+### endpoint [string]
+
+Azure Queue service endpoint, for example `https://myaccount.queue.core.windows.net`.
+
+### account_name [string]
+
+Azure Storage account name used by shared-key authentication.
+
+### account_key [string]
+
+Azure Storage account key used by shared-key authentication.
+
+### sas_token [string]
+
+Azure Storage SAS token. A leading `?` is accepted and removed before the client is created.
+
+### format [enum]
+
+Message payload format:
+
+- `json`: reads the payload as a JSON object.
+- `text`: splits the payload fields with `field_delimiter`.
+
+### field_delimiter [string]
+
+Field delimiter used when `format = text`.
+
+### message_encoding [enum]
+
+Controls Azure SDK message decoding:
+
+- `none`: reads the UTF-8 payload verbatim.
+- `base64`: Base64-decodes the queue message before deserialization.
+
+Use the same value that the queue producer uses when publishing messages.
+
+### batch_size [int]
+
+Maximum messages requested in one Azure Queue receive call. Azure accepts values from 1 to 32.
+
+### visibility_timeout_seconds [int]
+
+How long a received message is hidden from other consumers. The connector renews this visibility period while the message waits for a completed checkpoint. Azure accepts values from 1 to 604800 seconds.
+
+### poll_interval_ms [long]
+
+Delay before polling again when the queue is empty or `max_in_flight_messages` has been reached.
+
+### max_in_flight_messages [int]
+
+Maximum messages retained by the source until checkpoint completion. It must be at least `batch_size` and bounds source memory usage when checkpoints are slow.
+
+### operation_timeout_ms [long]
+
+Maximum duration of each receive, visibility update or delete request. It must be less than half of `visibility_timeout_seconds` so a renewal request has time to finish before the current lease expires.
+
+### schema [config]
+
+Schema used to deserialize each message payload.
+
+### common options
+
+Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
+
+## Delivery Semantics
+
+The source supports streaming jobs with checkpointing. It does not delete a received message until a checkpoint containing that row completes. An aborted checkpoint keeps the message pending for a later checkpoint, and visibility renewal prevents it from becoming available to another consumer while it is pending.
+
+Delivery is at-least-once. A task failure, visibility lease loss or partial delete failure can cause Azure Queue Storage to deliver a message again, so downstream processing should tolerate duplicates. A payload that cannot be deserialized is released back to the queue and fails the source task.
+
+One queue is represented by one SeaTunnel source split. Increasing job parallelism does not create additional Azure Queue consumers for this source.
+
+## Task Example
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 10000
+}
+
+source {
+  AzureQueueStorage {
+    queue_name = "events"
+    authentication_type = connection_string
+    connection_string = "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=...;EndpointSuffix=core.windows.net"
+    format = json
+    schema = {
+      fields {
+        event_id = string
+        event_type = string
+      }
+    }
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-azure-queue-storage.md
+++ b/docs/zh/connectors/changelog/connector-azure-queue-storage.md
@@ -2,6 +2,7 @@
 
 | Change | Commit | Version |
 | --- | --- | --- |
+|[Feature][Connector-V2] Add Azure Queue Storage source connector|-|Next|
 |[Feature][Connector-V2] Add Azure Queue Storage sink connector|-|Next|
 
 </details>

--- a/docs/zh/connectors/source/AzureQueueStorage.md
+++ b/docs/zh/connectors/source/AzureQueueStorage.md
@@ -1,0 +1,164 @@
+import ChangeLog from '../changelog/connector-azure-queue-storage.md';
+
+# AzureQueueStorage
+
+> Azure Queue Storage source connector
+
+## 描述
+
+从一个 Azure Storage 队列读取消息，并将每个消息负载转换为 SeaTunnel 行。
+
+## 支持的引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 主要特性
+
+- [ ] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [x] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [CDC](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
+
+## 选项
+
+| 名称 | 类型 | 是否必填 | 默认值 |
+| --- | --- | --- | --- |
+| queue_name | string | 是 | - |
+| authentication_type | enum | 是 | - |
+| connection_string | string | 条件必填 | - |
+| endpoint | string | 条件必填 | - |
+| account_name | string | 条件必填 | - |
+| account_key | string | 条件必填 | - |
+| sas_token | string | 条件必填 | - |
+| format | enum | 否 | json |
+| field_delimiter | string | 否 | , |
+| message_encoding | enum | 否 | none |
+| batch_size | int | 否 | 32 |
+| visibility_timeout_seconds | int | 否 | 300 |
+| poll_interval_ms | long | 否 | 1000 |
+| max_in_flight_messages | int | 否 | 1000 |
+| operation_timeout_ms | long | 否 | 60000 |
+| schema | config | 是 | - |
+| common-options | | 否 | - |
+
+### queue_name [string]
+
+源 Azure Storage 队列。作业启动前队列必须已经存在。队列名称必须包含 3-63 个小写字母、数字或单个连字符。
+
+### authentication_type [enum]
+
+选择一种认证方式：
+
+- `connection_string`：需要 `connection_string`。
+- `shared_key`：需要 `endpoint`、`account_name` 和 `account_key`。
+- `sas_token`：需要 `endpoint` 和 `sas_token`。
+
+不能混用不同认证方式的凭据。连接器不会记录凭据值。
+
+### connection_string [string]
+
+Azure Storage 连接字符串。该方式也支持包含自定义 `QueueEndpoint` 的 Azurite 连接字符串。
+
+### endpoint [string]
+
+Azure Queue 服务端点，例如 `https://myaccount.queue.core.windows.net`。
+
+### account_name [string]
+
+共享密钥认证使用的 Azure Storage 账户名。
+
+### account_key [string]
+
+共享密钥认证使用的 Azure Storage 账户密钥。
+
+### sas_token [string]
+
+Azure Storage SAS 令牌。创建客户端前会移除开头的 `?`。
+
+### format [enum]
+
+消息负载格式：
+
+- `json`：将负载读取为 JSON 对象。
+- `text`：使用 `field_delimiter` 拆分负载字段。
+
+### field_delimiter [string]
+
+`format = text` 时使用的字段分隔符。
+
+### message_encoding [enum]
+
+控制 Azure SDK 的消息解码：
+
+- `none`：直接读取 UTF-8 负载。
+- `base64`：反序列化前对队列消息执行 Base64 解码。
+
+该值应与消息生产者发布时使用的编码一致。
+
+### batch_size [int]
+
+每次 Azure Queue 接收请求的最大消息数。Azure 接受 1 到 32 的值。
+
+### visibility_timeout_seconds [int]
+
+已接收消息对其他消费者保持隐藏的时间。消息等待检查点完成时，连接器会续期该可见性期限。Azure 接受 1 到 604800 秒的值。
+
+### poll_interval_ms [long]
+
+队列为空或达到 `max_in_flight_messages` 后再次轮询的等待时间。
+
+### max_in_flight_messages [int]
+
+源在检查点完成前保留的最大消息数。该值必须不小于 `batch_size`，并在检查点较慢时限制源的内存使用。
+
+### operation_timeout_ms [long]
+
+每次接收、可见性更新或删除请求的最长时间。该值必须小于 `visibility_timeout_seconds` 的一半，以便续期请求能在当前租约到期前完成。
+
+### schema [config]
+
+用于反序列化每个消息负载的 schema。
+
+### 通用选项
+
+源插件通用参数请参考 [Source 通用选项](../common-options/source-common-options.md)。
+
+## 投递语义
+
+源支持启用检查点的流作业。只有包含该行的检查点完成后，源才删除对应消息。中止的检查点会让消息保留到后续检查点，可见性续期可防止等待期间消息再次提供给其他消费者。
+
+投递语义为至少一次。任务失败、可见性租约丢失或部分删除失败可能使 Azure Queue Storage 再次投递消息，因此下游处理应能容忍重复。无法反序列化的负载会被重新释放到队列，并使源任务失败。
+
+一个队列对应一个 SeaTunnel 源分片。提高作业并行度不会为此源创建更多 Azure Queue 消费者。
+
+## 作业示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 10000
+}
+
+source {
+  AzureQueueStorage {
+    queue_name = "events"
+    authentication_type = connection_string
+    connection_string = "DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=...;EndpointSuffix=core.windows.net"
+    format = json
+    schema = {
+      fields {
+        event_id = string
+        event_type = string
+      }
+    }
+  }
+}
+```
+
+## 变更日志
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -93,6 +93,7 @@ seatunnel.source.GoogleSheets = connector-google-sheets
 seatunnel.sink.GoogleFirestore = connector-google-firestore
 seatunnel.sink.GooglePubSub = connector-google-pubsub
 seatunnel.source.GooglePubSub = connector-google-pubsub
+seatunnel.source.AzureQueueStorage = connector-azure-queue-storage
 seatunnel.sink.AzureQueueStorage = connector-azure-queue-storage
 seatunnel.source.GoogleBigtable = connector-google-bigtable
 seatunnel.sink.GoogleBigtable = connector-google-bigtable

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/client/AzureQueueClientFactory.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/client/AzureQueueClientFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.client;
+
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AuthenticationType;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueClientConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageEncoding;
+
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.queue.QueueClientBuilder;
+import com.azure.storage.queue.QueueMessageEncoding;
+
+/** Builds Azure Queue clients with the connector's shared authentication contract. */
+public final class AzureQueueClientFactory {
+
+    private AzureQueueClientFactory() {}
+
+    public static QueueClientBuilder builder(AzureQueueClientConfig config) {
+        QueueClientBuilder builder =
+                new QueueClientBuilder()
+                        .queueName(config.getQueueName())
+                        .messageEncoding(toAzureEncoding(config.getMessageEncoding()));
+
+        AuthenticationType authenticationType = config.getAuthenticationType();
+        switch (authenticationType) {
+            case CONNECTION_STRING:
+                return builder.connectionString(config.getConnectionString());
+            case SHARED_KEY:
+                return builder.endpoint(config.getEndpoint())
+                        .credential(
+                                new StorageSharedKeyCredential(
+                                        config.getAccountName(), config.getAccountKey()));
+            case SAS_TOKEN:
+                return builder.endpoint(config.getEndpoint())
+                        .sasToken(normalizeSasToken(config.getSasToken()));
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported authentication type: " + authenticationType);
+        }
+    }
+
+    private static QueueMessageEncoding toAzureEncoding(MessageEncoding messageEncoding) {
+        return messageEncoding == MessageEncoding.BASE64
+                ? QueueMessageEncoding.BASE64
+                : QueueMessageEncoding.NONE;
+    }
+
+    private static String normalizeSasToken(String sasToken) {
+        return sasToken.startsWith("?") ? sasToken.substring(1) : sasToken;
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueClientConfig.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueClientConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.config;
+
+import java.io.Serializable;
+
+/** Common connection settings used by Azure Queue Storage sources and sinks. */
+public interface AzureQueueClientConfig extends Serializable {
+
+    String getQueueName();
+
+    AuthenticationType getAuthenticationType();
+
+    String getConnectionString();
+
+    String getEndpoint();
+
+    String getAccountName();
+
+    String getAccountKey();
+
+    String getSasToken();
+
+    MessageEncoding getMessageEncoding();
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueConfigValidator.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueConfigValidator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.config;
+
+import java.util.regex.Pattern;
+
+final class AzureQueueConfigValidator {
+
+    private static final Pattern QUEUE_NAME_PATTERN =
+            Pattern.compile("[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?");
+
+    private AzureQueueConfigValidator() {}
+
+    static void validateClient(AzureQueueClientConfig config) {
+        requireNonBlank(config.getQueueName(), "queue_name");
+        if (config.getQueueName().length() < 3
+                || config.getQueueName().length() > 63
+                || !QUEUE_NAME_PATTERN.matcher(config.getQueueName()).matches()
+                || config.getQueueName().contains("--")) {
+            throw new IllegalArgumentException(
+                    "Option 'queue_name' must contain 3-63 lowercase letters, numbers or single hyphens");
+        }
+        if (config.getAuthenticationType() == null) {
+            throw new IllegalArgumentException("Option 'authentication_type' is required");
+        }
+
+        switch (config.getAuthenticationType()) {
+            case CONNECTION_STRING:
+                requireNonBlank(config.getConnectionString(), "connection_string");
+                rejectPresent(
+                        config.getEndpoint(),
+                        "endpoint",
+                        config.getAccountName(),
+                        "account_name",
+                        config.getAccountKey(),
+                        "account_key",
+                        config.getSasToken(),
+                        "sas_token");
+                break;
+            case SHARED_KEY:
+                requireNonBlank(config.getEndpoint(), "endpoint");
+                requireNonBlank(config.getAccountName(), "account_name");
+                requireNonBlank(config.getAccountKey(), "account_key");
+                rejectPresent(
+                        config.getConnectionString(),
+                        "connection_string",
+                        config.getSasToken(),
+                        "sas_token");
+                break;
+            case SAS_TOKEN:
+                requireNonBlank(config.getEndpoint(), "endpoint");
+                requireNonBlank(config.getSasToken(), "sas_token");
+                rejectPresent(
+                        config.getConnectionString(),
+                        "connection_string",
+                        config.getAccountName(),
+                        "account_name",
+                        config.getAccountKey(),
+                        "account_key");
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported authentication_type: " + config.getAuthenticationType());
+        }
+    }
+
+    static void requireNonBlank(String value, String option) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("Option '" + option + "' cannot be blank");
+        }
+    }
+
+    private static void rejectPresent(Object... valuesAndOptions) {
+        for (int index = 0; index < valuesAndOptions.length; index += 2) {
+            if (valuesAndOptions[index] != null) {
+                throw new IllegalArgumentException(
+                        "Option '"
+                                + valuesAndOptions[index + 1]
+                                + "' is not valid for the selected authentication_type");
+            }
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueSinkConfig.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueSinkConfig.java
@@ -23,14 +23,10 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.io.Serializable;
-import java.util.regex.Pattern;
 
 @Getter
 @Builder(toBuilder = true)
-public class AzureQueueSinkConfig implements Serializable {
-
-    private static final Pattern QUEUE_NAME_PATTERN =
-            Pattern.compile("[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?");
+public class AzureQueueSinkConfig implements AzureQueueClientConfig, Serializable {
 
     private final String queueName;
     private final AuthenticationType authenticationType;
@@ -69,57 +65,7 @@ public class AzureQueueSinkConfig implements Serializable {
     }
 
     private void validate() {
-        requireNonBlank(queueName, AzureQueueStorageSinkOptions.QUEUE_NAME.key());
-        if (queueName.length() < 3
-                || queueName.length() > 63
-                || !QUEUE_NAME_PATTERN.matcher(queueName).matches()
-                || queueName.contains("--")) {
-            throw new IllegalArgumentException(
-                    "Option 'queue_name' must contain 3-63 lowercase letters, numbers or single hyphens");
-        }
-        if (authenticationType == null) {
-            throw new IllegalArgumentException("Option 'authentication_type' is required");
-        }
-
-        switch (authenticationType) {
-            case CONNECTION_STRING:
-                requireNonBlank(
-                        connectionString, AzureQueueStorageSinkOptions.CONNECTION_STRING.key());
-                rejectPresent(
-                        endpoint,
-                        AzureQueueStorageSinkOptions.ENDPOINT.key(),
-                        accountName,
-                        AzureQueueStorageSinkOptions.ACCOUNT_NAME.key(),
-                        accountKey,
-                        AzureQueueStorageSinkOptions.ACCOUNT_KEY.key(),
-                        sasToken,
-                        AzureQueueStorageSinkOptions.SAS_TOKEN.key());
-                break;
-            case SHARED_KEY:
-                requireNonBlank(endpoint, AzureQueueStorageSinkOptions.ENDPOINT.key());
-                requireNonBlank(accountName, AzureQueueStorageSinkOptions.ACCOUNT_NAME.key());
-                requireNonBlank(accountKey, AzureQueueStorageSinkOptions.ACCOUNT_KEY.key());
-                rejectPresent(
-                        connectionString,
-                        AzureQueueStorageSinkOptions.CONNECTION_STRING.key(),
-                        sasToken,
-                        AzureQueueStorageSinkOptions.SAS_TOKEN.key());
-                break;
-            case SAS_TOKEN:
-                requireNonBlank(endpoint, AzureQueueStorageSinkOptions.ENDPOINT.key());
-                requireNonBlank(sasToken, AzureQueueStorageSinkOptions.SAS_TOKEN.key());
-                rejectPresent(
-                        connectionString,
-                        AzureQueueStorageSinkOptions.CONNECTION_STRING.key(),
-                        accountName,
-                        AzureQueueStorageSinkOptions.ACCOUNT_NAME.key(),
-                        accountKey,
-                        AzureQueueStorageSinkOptions.ACCOUNT_KEY.key());
-                break;
-            default:
-                throw new IllegalArgumentException(
-                        "Unsupported authentication_type: " + authenticationType);
-        }
+        AzureQueueConfigValidator.validateClient(this);
 
         if (format == MessageFormat.TEXT && fieldDelimiter.isEmpty()) {
             throw new IllegalArgumentException("Option 'field_delimiter' cannot be empty");
@@ -130,24 +76,6 @@ public class AzureQueueSinkConfig implements Serializable {
         if (operationTimeoutMillis <= 0) {
             throw new IllegalArgumentException(
                     "Option 'operation_timeout_ms' must be greater than zero");
-        }
-    }
-
-    private static void requireNonBlank(String value, String option) {
-        if (value == null || value.trim().isEmpty()) {
-            throw new IllegalArgumentException("Option '" + option + "' cannot be blank");
-        }
-    }
-
-    private static void rejectPresent(Object... valuesAndOptions) {
-        for (int index = 0; index < valuesAndOptions.length; index += 2) {
-            Object value = valuesAndOptions[index];
-            if (value != null) {
-                throw new IllegalArgumentException(
-                        "Option '"
-                                + valuesAndOptions[index + 1]
-                                + "' is not valid for the selected authentication_type");
-            }
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueSourceConfig.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueSourceConfig.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+/** Immutable runtime configuration for the Azure Queue Storage source. */
+@Getter
+@Builder
+public class AzureQueueSourceConfig implements AzureQueueClientConfig, Serializable {
+
+    static final int MAX_BATCH_SIZE = 32;
+    static final int MAX_VISIBILITY_TIMEOUT_SECONDS = 7 * 24 * 60 * 60;
+
+    private final String queueName;
+    private final AuthenticationType authenticationType;
+    private final String connectionString;
+    private final String endpoint;
+    private final String accountName;
+    private final String accountKey;
+    private final String sasToken;
+    private final MessageFormat format;
+    private final String fieldDelimiter;
+    private final MessageEncoding messageEncoding;
+    private final int batchSize;
+    private final int visibilityTimeoutSeconds;
+    private final long pollIntervalMillis;
+    private final int maxInFlightMessages;
+    private final long operationTimeoutMillis;
+
+    public static AzureQueueSourceConfig from(ReadonlyConfig config) {
+        AzureQueueSourceConfig sourceConfig =
+                AzureQueueSourceConfig.builder()
+                        .queueName(config.get(AzureQueueStorageSourceOptions.QUEUE_NAME))
+                        .authenticationType(
+                                config.get(AzureQueueStorageSourceOptions.AUTHENTICATION_TYPE))
+                        .connectionString(
+                                config.get(AzureQueueStorageSourceOptions.CONNECTION_STRING))
+                        .endpoint(config.get(AzureQueueStorageSourceOptions.ENDPOINT))
+                        .accountName(config.get(AzureQueueStorageSourceOptions.ACCOUNT_NAME))
+                        .accountKey(config.get(AzureQueueStorageSourceOptions.ACCOUNT_KEY))
+                        .sasToken(config.get(AzureQueueStorageSourceOptions.SAS_TOKEN))
+                        .format(config.get(AzureQueueStorageSourceOptions.FORMAT))
+                        .fieldDelimiter(config.get(AzureQueueStorageSourceOptions.FIELD_DELIMITER))
+                        .messageEncoding(
+                                config.get(AzureQueueStorageSourceOptions.MESSAGE_ENCODING))
+                        .batchSize(config.get(AzureQueueStorageSourceOptions.BATCH_SIZE))
+                        .visibilityTimeoutSeconds(
+                                config.get(
+                                        AzureQueueStorageSourceOptions.VISIBILITY_TIMEOUT_SECONDS))
+                        .pollIntervalMillis(
+                                config.get(AzureQueueStorageSourceOptions.POLL_INTERVAL_MS))
+                        .maxInFlightMessages(
+                                config.get(AzureQueueStorageSourceOptions.MAX_IN_FLIGHT_MESSAGES))
+                        .operationTimeoutMillis(
+                                config.get(AzureQueueStorageSourceOptions.OPERATION_TIMEOUT_MS))
+                        .build();
+        sourceConfig.validate();
+        return sourceConfig;
+    }
+
+    private void validate() {
+        AzureQueueConfigValidator.validateClient(this);
+        if (format == MessageFormat.TEXT && fieldDelimiter.isEmpty()) {
+            throw new IllegalArgumentException("Option 'field_delimiter' cannot be empty");
+        }
+        if (batchSize < 1 || batchSize > MAX_BATCH_SIZE) {
+            throw new IllegalArgumentException("Option 'batch_size' must be between 1 and 32");
+        }
+        if (visibilityTimeoutSeconds < 1
+                || visibilityTimeoutSeconds > MAX_VISIBILITY_TIMEOUT_SECONDS) {
+            throw new IllegalArgumentException(
+                    "Option 'visibility_timeout_seconds' must be between 1 and 604800");
+        }
+        if (pollIntervalMillis <= 0) {
+            throw new IllegalArgumentException(
+                    "Option 'poll_interval_ms' must be greater than zero");
+        }
+        if (maxInFlightMessages < batchSize) {
+            throw new IllegalArgumentException(
+                    "Option 'max_in_flight_messages' must be greater than or equal to batch_size");
+        }
+        if (operationTimeoutMillis <= 0) {
+            throw new IllegalArgumentException(
+                    "Option 'operation_timeout_ms' must be greater than zero");
+        }
+        long visibilityTimeoutMillis = visibilityTimeoutSeconds * 1_000L;
+        if (operationTimeoutMillis >= visibilityTimeoutMillis / 2) {
+            throw new IllegalArgumentException(
+                    "Option 'operation_timeout_ms' must be less than half of visibility_timeout_seconds");
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueStorageSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueStorageSourceOptions.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+
+public class AzureQueueStorageSourceOptions extends ConnectorCommonOptions {
+
+    public static final Option<String> QUEUE_NAME = AzureQueueStorageSinkOptions.QUEUE_NAME;
+    public static final Option<AuthenticationType> AUTHENTICATION_TYPE =
+            AzureQueueStorageSinkOptions.AUTHENTICATION_TYPE;
+    public static final Option<String> CONNECTION_STRING =
+            AzureQueueStorageSinkOptions.CONNECTION_STRING;
+    public static final Option<String> ENDPOINT = AzureQueueStorageSinkOptions.ENDPOINT;
+    public static final Option<String> ACCOUNT_NAME = AzureQueueStorageSinkOptions.ACCOUNT_NAME;
+    public static final Option<String> ACCOUNT_KEY = AzureQueueStorageSinkOptions.ACCOUNT_KEY;
+    public static final Option<String> SAS_TOKEN = AzureQueueStorageSinkOptions.SAS_TOKEN;
+    public static final Option<MessageFormat> FORMAT = AzureQueueStorageSinkOptions.FORMAT;
+    public static final Option<String> FIELD_DELIMITER =
+            AzureQueueStorageSinkOptions.FIELD_DELIMITER;
+    public static final Option<MessageEncoding> MESSAGE_ENCODING =
+            AzureQueueStorageSinkOptions.MESSAGE_ENCODING;
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("batch_size")
+                    .intType()
+                    .defaultValue(32)
+                    .withDescription("Maximum number of messages requested in each receive call.");
+
+    public static final Option<Integer> VISIBILITY_TIMEOUT_SECONDS =
+            Options.key("visibility_timeout_seconds")
+                    .intType()
+                    .defaultValue(300)
+                    .withDescription(
+                            "Initial message invisibility period in seconds. The connector renews it until checkpoint acknowledgement.");
+
+    public static final Option<Long> POLL_INTERVAL_MS =
+            Options.key("poll_interval_ms")
+                    .longType()
+                    .defaultValue(1_000L)
+                    .withDescription("Delay in milliseconds before polling an empty queue again.");
+
+    public static final Option<Integer> MAX_IN_FLIGHT_MESSAGES =
+            Options.key("max_in_flight_messages")
+                    .intType()
+                    .defaultValue(1_000)
+                    .withDescription(
+                            "Maximum number of received messages retained until a checkpoint completes.");
+
+    public static final Option<Long> OPERATION_TIMEOUT_MS =
+            Options.key("operation_timeout_ms")
+                    .longType()
+                    .defaultValue(60_000L)
+                    .withDescription(
+                            "Maximum time in milliseconds for an Azure Queue receive, visibility update or delete request.");
+
+    private AzureQueueStorageSourceOptions() {}
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/exception/AzureQueueConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/exception/AzureQueueConnectorErrorCode.java
@@ -23,7 +23,12 @@ public enum AzureQueueConnectorErrorCode implements SeaTunnelErrorCode {
     CONNECTION_FAILED("AzureQueueStorage-01", "Create Azure Queue Storage client failed"),
     WRITE_FAILED("AzureQueueStorage-02", "Send Azure Queue Storage message failed"),
     MESSAGE_TOO_LARGE("AzureQueueStorage-03", "Azure Queue Storage message is too large"),
-    CLOSE_FAILED("AzureQueueStorage-04", "Close Azure Queue Storage sender failed");
+    CLOSE_FAILED("AzureQueueStorage-04", "Close Azure Queue Storage sender failed"),
+    READ_FAILED("AzureQueueStorage-05", "Read Azure Queue Storage message failed"),
+    ACKNOWLEDGE_FAILED("AzureQueueStorage-06", "Delete Azure Queue Storage message failed"),
+    VISIBILITY_RENEWAL_FAILED(
+            "AzureQueueStorage-07", "Renew Azure Queue Storage message visibility failed"),
+    CONFIGURATION_FAILED("AzureQueueStorage-08", "Azure Queue Storage configuration is invalid");
 
     private final String code;
     private final String description;

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/sink/AzureQueueStorageSender.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/sink/AzureQueueStorageSender.java
@@ -17,16 +17,12 @@
 
 package org.apache.seatunnel.connectors.seatunnel.azure.queue.sink;
 
-import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AuthenticationType;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.client.AzureQueueClientFactory;
 import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSinkConfig;
-import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageEncoding;
 import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorException;
 
-import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.queue.QueueAsyncClient;
-import com.azure.storage.queue.QueueClientBuilder;
-import com.azure.storage.queue.QueueMessageEncoding;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -40,31 +36,8 @@ class AzureQueueStorageSender implements AzureQueueSender {
 
     static AzureQueueSender create(AzureQueueSinkConfig config) {
         try {
-            QueueClientBuilder builder =
-                    new QueueClientBuilder()
-                            .queueName(config.getQueueName())
-                            .messageEncoding(toAzureEncoding(config.getMessageEncoding()));
-
-            AuthenticationType authenticationType = config.getAuthenticationType();
-            switch (authenticationType) {
-                case CONNECTION_STRING:
-                    builder.connectionString(config.getConnectionString());
-                    break;
-                case SHARED_KEY:
-                    builder.endpoint(config.getEndpoint())
-                            .credential(
-                                    new StorageSharedKeyCredential(
-                                            config.getAccountName(), config.getAccountKey()));
-                    break;
-                case SAS_TOKEN:
-                    builder.endpoint(config.getEndpoint())
-                            .sasToken(normalizeSasToken(config.getSasToken()));
-                    break;
-                default:
-                    throw new IllegalArgumentException(
-                            "Unsupported authentication type: " + authenticationType);
-            }
-            return new AzureQueueStorageSender(builder.buildAsyncClient());
+            return new AzureQueueStorageSender(
+                    AzureQueueClientFactory.builder(config).buildAsyncClient());
         } catch (Exception e) {
             throw new AzureQueueConnectorException(
                     AzureQueueConnectorErrorCode.CONNECTION_FAILED,
@@ -82,15 +55,5 @@ class AzureQueueStorageSender implements AzureQueueSender {
     @Override
     public void close() {
         // QueueAsyncClient has no close contract; its Reactor resources are process-wide.
-    }
-
-    private static QueueMessageEncoding toAzureEncoding(MessageEncoding messageEncoding) {
-        return messageEncoding == MessageEncoding.BASE64
-                ? QueueMessageEncoding.BASE64
-                : QueueMessageEncoding.NONE;
-    }
-
-    private static String normalizeSasToken(String sasToken) {
-        return sasToken.startsWith("?") ? sasToken.substring(1) : sasToken;
     }
 }

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueMessage.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueMessage.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+/** A received queue message and the mutable pop receipt needed to manage its lease. */
+@Getter
+final class AzureQueueMessage {
+
+    private final String messageId;
+    private final String messageText;
+    private final byte[] body;
+    private String popReceipt;
+    private boolean deleted;
+
+    AzureQueueMessage(String messageId, String popReceipt, String messageText, byte[] body) {
+        this.messageId = messageId;
+        this.popReceipt = popReceipt;
+        this.messageText = messageText;
+        this.body = Arrays.copyOf(body, body.length);
+    }
+
+    void updatePopReceipt(String popReceipt) {
+        this.popReceipt = popReceipt;
+    }
+
+    void markDeleted() {
+        this.deleted = true;
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueReceiver.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueReceiver.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import java.util.List;
+
+interface AzureQueueReceiver extends AutoCloseable {
+
+    List<AzureQueueMessage> receive(int maxMessages);
+
+    void renewVisibility(AzureQueueMessage message);
+
+    void delete(AzureQueueMessage message);
+
+    void release(AzureQueueMessage message);
+
+    @Override
+    default void close() {
+        // Azure Queue clients have no close contract.
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageReceiver.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageReceiver.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.client.AzureQueueClientFactory;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorException;
+
+import com.azure.core.util.Context;
+import com.azure.storage.queue.QueueClient;
+import com.azure.storage.queue.models.QueueMessageItem;
+import com.azure.storage.queue.models.UpdateMessageResult;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+final class AzureQueueStorageReceiver implements AzureQueueReceiver {
+
+    private final QueueClient queueClient;
+    private final Duration visibilityTimeout;
+    private final Duration operationTimeout;
+
+    private AzureQueueStorageReceiver(
+            QueueClient queueClient, Duration visibilityTimeout, Duration operationTimeout) {
+        this.queueClient = queueClient;
+        this.visibilityTimeout = visibilityTimeout;
+        this.operationTimeout = operationTimeout;
+    }
+
+    static AzureQueueReceiver create(AzureQueueSourceConfig config) {
+        try {
+            return new AzureQueueStorageReceiver(
+                    AzureQueueClientFactory.builder(config).buildClient(),
+                    Duration.ofSeconds(config.getVisibilityTimeoutSeconds()),
+                    Duration.ofMillis(config.getOperationTimeoutMillis()));
+        } catch (Exception e) {
+            throw new AzureQueueConnectorException(
+                    AzureQueueConnectorErrorCode.CONNECTION_FAILED,
+                    "Failed to create Azure Queue Storage client for queue "
+                            + config.getQueueName(),
+                    e);
+        }
+    }
+
+    @Override
+    public List<AzureQueueMessage> receive(int maxMessages) {
+        List<AzureQueueMessage> messages = new ArrayList<>(maxMessages);
+        for (QueueMessageItem message :
+                queueClient.receiveMessages(
+                        maxMessages, visibilityTimeout, operationTimeout, Context.NONE)) {
+            messages.add(
+                    new AzureQueueMessage(
+                            message.getMessageId(),
+                            message.getPopReceipt(),
+                            message.getBody().toString(),
+                            message.getBody().toBytes()));
+        }
+        return messages;
+    }
+
+    @Override
+    public void renewVisibility(AzureQueueMessage message) {
+        UpdateMessageResult result =
+                queueClient
+                        .updateMessageWithResponse(
+                                message.getMessageId(),
+                                message.getPopReceipt(),
+                                message.getMessageText(),
+                                visibilityTimeout,
+                                operationTimeout,
+                                Context.NONE)
+                        .getValue();
+        message.updatePopReceipt(result.getPopReceipt());
+    }
+
+    @Override
+    public void delete(AzureQueueMessage message) {
+        queueClient.deleteMessageWithResponse(
+                message.getMessageId(), message.getPopReceipt(), operationTimeout, Context.NONE);
+        message.markDeleted();
+    }
+
+    @Override
+    public void release(AzureQueueMessage message) {
+        UpdateMessageResult result =
+                queueClient
+                        .updateMessageWithResponse(
+                                message.getMessageId(),
+                                message.getPopReceipt(),
+                                message.getMessageText(),
+                                Duration.ZERO,
+                                operationTimeout,
+                                Context.NONE)
+                        .getValue();
+        message.updatePopReceipt(result.getPopReceipt());
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSource.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSource.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplit;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitEnumerator;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitEnumeratorState;
+
+import java.util.Collections;
+import java.util.List;
+
+/** Unbounded source for one Azure Storage queue. */
+public class AzureQueueStorageSource
+        implements SeaTunnelSource<SeaTunnelRow, SingleSplit, SingleSplitEnumeratorState> {
+
+    public static final String PLUGIN_NAME = "AzureQueueStorage";
+
+    private final AzureQueueSourceConfig config;
+    private final CatalogTable catalogTable;
+    private final DeserializationSchema<SeaTunnelRow> deserializationSchema;
+    private JobContext jobContext;
+
+    public AzureQueueStorageSource(
+            AzureQueueSourceConfig config,
+            CatalogTable catalogTable,
+            DeserializationSchema<SeaTunnelRow> deserializationSchema) {
+        this.config = config;
+        this.catalogTable = catalogTable;
+        this.deserializationSchema = deserializationSchema;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        if (jobContext != null) {
+            if (!JobMode.STREAMING.equals(jobContext.getJobMode())) {
+                throw new AzureQueueConnectorException(
+                        AzureQueueConnectorErrorCode.CONFIGURATION_FAILED,
+                        "Azure Queue Storage source supports streaming jobs only");
+            }
+            if (!jobContext.isEnableCheckpoint()) {
+                throw new AzureQueueConnectorException(
+                        AzureQueueConnectorErrorCode.CONFIGURATION_FAILED,
+                        "Azure Queue Storage source requires checkpointing to delete messages");
+            }
+        }
+        return Boundedness.UNBOUNDED;
+    }
+
+    @Override
+    public String getPluginName() {
+        return PLUGIN_NAME;
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(catalogTable);
+    }
+
+    @Override
+    public SourceReader<SeaTunnelRow, SingleSplit> createReader(
+            SourceReader.Context readerContext) {
+        return new AzureQueueStorageSourceReader(config, deserializationSchema);
+    }
+
+    @Override
+    public SourceSplitEnumerator<SingleSplit, SingleSplitEnumeratorState> createEnumerator(
+            SourceSplitEnumerator.Context<SingleSplit> enumeratorContext) {
+        return new SingleSplitEnumerator(enumeratorContext);
+    }
+
+    @Override
+    public SourceSplitEnumerator<SingleSplit, SingleSplitEnumeratorState> restoreEnumerator(
+            SourceSplitEnumerator.Context<SingleSplit> enumeratorContext,
+            SingleSplitEnumeratorState checkpointState) {
+        return new SingleSplitEnumerator(enumeratorContext);
+    }
+
+    @Override
+    public void setJobContext(JobContext jobContext) {
+        this.jobContext = jobContext;
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceFactory.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.apache.seatunnel.api.configuration.util.Conditions;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AuthenticationType;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueStorageSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageFormat;
+import org.apache.seatunnel.format.json.JsonDeserializationSchema;
+import org.apache.seatunnel.format.text.TextDeserializationSchema;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+
+import static org.apache.seatunnel.api.options.ConnectorCommonOptions.SCHEMA;
+
+@AutoService(Factory.class)
+public class AzureQueueStorageSourceFactory implements TableSourceFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return AzureQueueStorageSource.PLUGIN_NAME;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        AzureQueueStorageSourceOptions.QUEUE_NAME,
+                        AzureQueueStorageSourceOptions.AUTHENTICATION_TYPE,
+                        SCHEMA)
+                .conditional(
+                        AzureQueueStorageSourceOptions.AUTHENTICATION_TYPE,
+                        AuthenticationType.CONNECTION_STRING,
+                        AzureQueueStorageSourceOptions.CONNECTION_STRING)
+                .conditional(
+                        AzureQueueStorageSourceOptions.AUTHENTICATION_TYPE,
+                        AuthenticationType.SHARED_KEY,
+                        AzureQueueStorageSourceOptions.ENDPOINT,
+                        AzureQueueStorageSourceOptions.ACCOUNT_NAME,
+                        AzureQueueStorageSourceOptions.ACCOUNT_KEY)
+                .conditional(
+                        AzureQueueStorageSourceOptions.AUTHENTICATION_TYPE,
+                        AuthenticationType.SAS_TOKEN,
+                        AzureQueueStorageSourceOptions.ENDPOINT,
+                        AzureQueueStorageSourceOptions.SAS_TOKEN)
+                .optional(
+                        AzureQueueStorageSourceOptions.FORMAT,
+                        AzureQueueStorageSourceOptions.FIELD_DELIMITER,
+                        AzureQueueStorageSourceOptions.MESSAGE_ENCODING)
+                .optional(
+                        AzureQueueStorageSourceOptions.BATCH_SIZE,
+                        Conditions.greaterOrEqual(AzureQueueStorageSourceOptions.BATCH_SIZE, 1)
+                                .and(
+                                        Conditions.lessOrEqual(
+                                                AzureQueueStorageSourceOptions.BATCH_SIZE, 32)))
+                .optional(
+                        AzureQueueStorageSourceOptions.VISIBILITY_TIMEOUT_SECONDS,
+                        Conditions.greaterOrEqual(
+                                        AzureQueueStorageSourceOptions.VISIBILITY_TIMEOUT_SECONDS,
+                                        1)
+                                .and(
+                                        Conditions.lessOrEqual(
+                                                AzureQueueStorageSourceOptions
+                                                        .VISIBILITY_TIMEOUT_SECONDS,
+                                                604_800)))
+                .optional(
+                        AzureQueueStorageSourceOptions.POLL_INTERVAL_MS,
+                        Conditions.greaterThan(AzureQueueStorageSourceOptions.POLL_INTERVAL_MS, 0L))
+                .optional(
+                        AzureQueueStorageSourceOptions.MAX_IN_FLIGHT_MESSAGES,
+                        Conditions.greaterThan(
+                                AzureQueueStorageSourceOptions.MAX_IN_FLIGHT_MESSAGES, 0))
+                .optional(
+                        AzureQueueStorageSourceOptions.OPERATION_TIMEOUT_MS,
+                        Conditions.greaterThan(
+                                AzureQueueStorageSourceOptions.OPERATION_TIMEOUT_MS, 0L))
+                .build();
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        AzureQueueSourceConfig config = AzureQueueSourceConfig.from(context.getOptions());
+        CatalogTable catalogTable = CatalogTableUtil.buildWithConfig(context.getOptions());
+        DeserializationSchema<SeaTunnelRow> deserializationSchema =
+                createDeserializationSchema(catalogTable, config);
+
+        return () ->
+                (SeaTunnelSource<T, SplitT, StateT>)
+                        new AzureQueueStorageSource(config, catalogTable, deserializationSchema);
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return AzureQueueStorageSource.class;
+    }
+
+    private DeserializationSchema<SeaTunnelRow> createDeserializationSchema(
+            CatalogTable catalogTable, AzureQueueSourceConfig config) {
+        if (config.getFormat() == MessageFormat.JSON) {
+            return new JsonDeserializationSchema(catalogTable, false, false);
+        }
+        return TextDeserializationSchema.builder()
+                .seaTunnelRowType(catalogTable.getSeaTunnelRowType())
+                .delimiter(config.getFieldDelimiter())
+                .build();
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReader.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReader.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplit;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Reads Azure Queue messages and deletes them only after their checkpoint completes. */
+@Slf4j
+public class AzureQueueStorageSourceReader implements SourceReader<SeaTunnelRow, SingleSplit> {
+
+    private final AzureQueueSourceConfig config;
+    private final DeserializationSchema<SeaTunnelRow> deserializationSchema;
+    private final ReceiverFactory receiverFactory;
+    private final Object acknowledgementLock = new Object();
+    private final Set<AzureQueueMessage> leasedMessages = new LinkedHashSet<>();
+    private final Set<AzureQueueMessage> unacknowledgedMessages = new LinkedHashSet<>();
+    private final NavigableMap<Long, List<AzureQueueMessage>> pendingAcknowledgements =
+            new TreeMap<>();
+    private final AtomicReference<Throwable> visibilityRenewalFailure = new AtomicReference<>();
+
+    private AzureQueueReceiver receiver;
+    private ScheduledExecutorService visibilityRenewalExecutor;
+    private boolean splitAssigned;
+
+    public AzureQueueStorageSourceReader(
+            AzureQueueSourceConfig config,
+            DeserializationSchema<SeaTunnelRow> deserializationSchema) {
+        this(config, deserializationSchema, () -> AzureQueueStorageReceiver.create(config));
+    }
+
+    AzureQueueStorageSourceReader(
+            AzureQueueSourceConfig config,
+            DeserializationSchema<SeaTunnelRow> deserializationSchema,
+            ReceiverFactory receiverFactory) {
+        this.config = config;
+        this.deserializationSchema = deserializationSchema;
+        this.receiverFactory = receiverFactory;
+    }
+
+    @Override
+    public void open() {
+        // The client starts after the source split has been assigned.
+    }
+
+    @Override
+    public void pollNext(Collector<SeaTunnelRow> output) {
+        checkVisibilityRenewalFailure();
+        int availableCapacity;
+        synchronized (acknowledgementLock) {
+            availableCapacity = config.getMaxInFlightMessages() - leasedMessages.size();
+        }
+        if (availableCapacity <= 0) {
+            sleepBeforeNextPoll();
+            return;
+        }
+
+        List<AzureQueueMessage> messages;
+        try {
+            messages = receiver.receive(Math.min(config.getBatchSize(), availableCapacity));
+        } catch (Exception e) {
+            throw readFailure("Failed to receive Azure Queue Storage messages", e);
+        }
+        if (messages.isEmpty()) {
+            sleepBeforeNextPoll();
+            return;
+        }
+
+        synchronized (acknowledgementLock) {
+            leasedMessages.addAll(messages);
+        }
+        for (int index = 0; index < messages.size(); index++) {
+            AzureQueueMessage message = messages.get(index);
+            try {
+                synchronized (output.getCheckpointLock()) {
+                    deserializationSchema.deserialize(message.getBody(), output);
+                    synchronized (acknowledgementLock) {
+                        unacknowledgedMessages.add(message);
+                    }
+                }
+            } catch (Exception e) {
+                releaseMessages(messages, index, e);
+                throw readFailure(
+                        "Failed to process Azure Queue Storage message " + message.getMessageId(),
+                        e);
+            }
+        }
+        checkVisibilityRenewalFailure();
+    }
+
+    @Override
+    public List<SingleSplit> snapshotState(long checkpointId) {
+        synchronized (acknowledgementLock) {
+            pendingAcknowledgements.put(checkpointId, new ArrayList<>(unacknowledgedMessages));
+        }
+        return Collections.singletonList(new SingleSplit(null));
+    }
+
+    @Override
+    public void addSplits(List<SingleSplit> splits) {
+        if (splits.size() != 1) {
+            throw new IllegalArgumentException(
+                    "Azure Queue Storage source expects exactly one source split");
+        }
+        if (splitAssigned) {
+            return;
+        }
+
+        receiver = receiverFactory.create();
+        visibilityRenewalExecutor =
+                Executors.newSingleThreadScheduledExecutor(
+                        runnable -> {
+                            Thread thread = new Thread(runnable, "azure-queue-visibility-renewal");
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+        long renewalIntervalSeconds = Math.max(1L, config.getVisibilityTimeoutSeconds() / 3L);
+        visibilityRenewalExecutor.scheduleWithFixedDelay(
+                this::renewVisibilitySafely,
+                renewalIntervalSeconds,
+                renewalIntervalSeconds,
+                TimeUnit.SECONDS);
+        splitAssigned = true;
+    }
+
+    @Override
+    public void handleNoMoreSplits() {
+        // The queue split remains active for the lifetime of the streaming job.
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        List<AzureQueueMessage> messages;
+        synchronized (acknowledgementLock) {
+            Map.Entry<Long, List<AzureQueueMessage>> checkpoint =
+                    pendingAcknowledgements.floorEntry(checkpointId);
+            if (checkpoint == null) {
+                return;
+            }
+            messages = new ArrayList<>(checkpoint.getValue());
+        }
+
+        for (AzureQueueMessage message : messages) {
+            try {
+                synchronized (message) {
+                    if (!message.isDeleted()) {
+                        receiver.delete(message);
+                    }
+                }
+            } catch (Exception e) {
+                throw new AzureQueueConnectorException(
+                        AzureQueueConnectorErrorCode.ACKNOWLEDGE_FAILED,
+                        "Failed to delete Azure Queue Storage messages for checkpoint "
+                                + checkpointId,
+                        e);
+            }
+        }
+
+        synchronized (acknowledgementLock) {
+            leasedMessages.removeAll(messages);
+            unacknowledgedMessages.removeAll(messages);
+            pendingAcknowledgements.headMap(checkpointId, true).clear();
+            for (List<AzureQueueMessage> pending : pendingAcknowledgements.values()) {
+                pending.removeAll(messages);
+            }
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        synchronized (acknowledgementLock) {
+            pendingAcknowledgements.remove(checkpointId);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (visibilityRenewalExecutor != null) {
+            visibilityRenewalExecutor.shutdownNow();
+        }
+
+        IOException closeFailure = null;
+        List<AzureQueueMessage> messages;
+        synchronized (acknowledgementLock) {
+            messages = new ArrayList<>(leasedMessages);
+        }
+        for (AzureQueueMessage message : messages) {
+            try {
+                release(message);
+            } catch (Exception e) {
+                if (closeFailure == null) {
+                    closeFailure = new IOException("Failed to release Azure Queue message", e);
+                } else {
+                    closeFailure.addSuppressed(e);
+                }
+            }
+        }
+        synchronized (acknowledgementLock) {
+            leasedMessages.clear();
+            unacknowledgedMessages.clear();
+            pendingAcknowledgements.clear();
+        }
+        if (receiver != null) {
+            receiver.close();
+        }
+        if (closeFailure != null) {
+            throw closeFailure;
+        }
+    }
+
+    void renewVisibilityNow() {
+        List<AzureQueueMessage> messages;
+        synchronized (acknowledgementLock) {
+            messages = new ArrayList<>(leasedMessages);
+        }
+        for (AzureQueueMessage message : messages) {
+            synchronized (message) {
+                if (!message.isDeleted()) {
+                    receiver.renewVisibility(message);
+                }
+            }
+        }
+    }
+
+    void renewVisibilitySafely() {
+        try {
+            renewVisibilityNow();
+        } catch (Throwable failure) {
+            visibilityRenewalFailure.compareAndSet(null, failure);
+            log.error("Failed to renew Azure Queue Storage message visibility", failure);
+        }
+    }
+
+    private void releaseMessages(
+            List<AzureQueueMessage> messages, int firstMessage, Exception primaryFailure) {
+        for (int index = firstMessage; index < messages.size(); index++) {
+            try {
+                release(messages.get(index));
+            } catch (Exception releaseFailure) {
+                primaryFailure.addSuppressed(releaseFailure);
+            }
+        }
+    }
+
+    private void release(AzureQueueMessage message) {
+        synchronized (message) {
+            if (!message.isDeleted()) {
+                receiver.release(message);
+            }
+        }
+        synchronized (acknowledgementLock) {
+            leasedMessages.remove(message);
+            unacknowledgedMessages.remove(message);
+            for (List<AzureQueueMessage> pending : pendingAcknowledgements.values()) {
+                pending.remove(message);
+            }
+        }
+    }
+
+    private void sleepBeforeNextPoll() {
+        try {
+            Thread.sleep(config.getPollIntervalMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw readFailure("Interrupted while polling Azure Queue Storage", e);
+        }
+    }
+
+    private void checkVisibilityRenewalFailure() {
+        Throwable failure = visibilityRenewalFailure.get();
+        if (failure != null) {
+            throw new AzureQueueConnectorException(
+                    AzureQueueConnectorErrorCode.VISIBILITY_RENEWAL_FAILED,
+                    "Azure Queue Storage message visibility renewal failed",
+                    failure);
+        }
+    }
+
+    private AzureQueueConnectorException readFailure(String message, Throwable cause) {
+        return new AzureQueueConnectorException(
+                AzureQueueConnectorErrorCode.READ_FAILED, message, cause);
+    }
+
+    @FunctionalInterface
+    interface ReceiverFactory {
+        AzureQueueReceiver create();
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReader.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/main/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReader.java
@@ -58,7 +58,7 @@ public class AzureQueueStorageSourceReader implements SourceReader<SeaTunnelRow,
 
     private AzureQueueReceiver receiver;
     private ScheduledExecutorService visibilityRenewalExecutor;
-    private boolean splitAssigned;
+    private volatile boolean splitAssigned;
 
     public AzureQueueStorageSourceReader(
             AzureQueueSourceConfig config,
@@ -82,6 +82,9 @@ public class AzureQueueStorageSourceReader implements SourceReader<SeaTunnelRow,
 
     @Override
     public void pollNext(Collector<SeaTunnelRow> output) {
+        if (!splitAssigned) {
+            return;
+        }
         checkVisibilityRenewalFailure();
         int availableCapacity;
         synchronized (acknowledgementLock) {

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueSourceConfigTest.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/config/AzureQueueSourceConfigTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class AzureQueueSourceConfigTest {
+
+    @Test
+    void shouldCreateConnectionStringConfiguration() {
+        AzureQueueSourceConfig config = config(validOptions());
+
+        Assertions.assertEquals("events", config.getQueueName());
+        Assertions.assertEquals(
+                AuthenticationType.CONNECTION_STRING, config.getAuthenticationType());
+        Assertions.assertEquals(32, config.getBatchSize());
+        Assertions.assertEquals(300, config.getVisibilityTimeoutSeconds());
+    }
+
+    @Test
+    void shouldRejectBatchOutsideAzureLimit() {
+        Map<String, Object> options = validOptions();
+        options.put("batch_size", 33);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> config(options));
+        Assertions.assertTrue(exception.getMessage().contains("between 1 and 32"));
+    }
+
+    @Test
+    void shouldRequireEnoughInFlightCapacityForOneBatch() {
+        Map<String, Object> options = validOptions();
+        options.put("batch_size", 10);
+        options.put("max_in_flight_messages", 9);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> config(options));
+        Assertions.assertTrue(exception.getMessage().contains("greater than or equal"));
+    }
+
+    @Test
+    void shouldKeepOperationTimeoutBelowVisibilityRenewalWindow() {
+        Map<String, Object> options = validOptions();
+        options.put("visibility_timeout_seconds", 60);
+        options.put("operation_timeout_ms", 30_000L);
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> config(options));
+        Assertions.assertTrue(exception.getMessage().contains("less than half"));
+    }
+
+    @Test
+    void shouldReuseStrictAuthenticationValidation() {
+        Map<String, Object> options = validOptions();
+        options.put("endpoint", "https://account.queue.core.windows.net");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(IllegalArgumentException.class, () -> config(options));
+        Assertions.assertTrue(exception.getMessage().contains("not valid"));
+    }
+
+    private AzureQueueSourceConfig config(Map<String, Object> options) {
+        return AzureQueueSourceConfig.from(ReadonlyConfig.fromMap(options));
+    }
+
+    private Map<String, Object> validOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("queue_name", "events");
+        options.put("authentication_type", "connection_string");
+        options.put("connection_string", "UseDevelopmentStorage=true");
+        return options;
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceFactoryTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AzureQueueStorageSourceFactoryTest {
+
+    @Test
+    void shouldExposeAzureQueueStorageIdentifierAndOptions() {
+        AzureQueueStorageSourceFactory factory = new AzureQueueStorageSourceFactory();
+
+        Assertions.assertEquals("AzureQueueStorage", factory.factoryIdentifier());
+        Assertions.assertNotNull(factory.optionRule());
+        Assertions.assertEquals(AzureQueueStorageSource.class, factory.getSourceClass());
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReaderTest.java
@@ -46,6 +46,21 @@ import java.util.concurrent.atomic.AtomicInteger;
 class AzureQueueStorageSourceReaderTest {
 
     @Test
+    void shouldWaitForSplitBeforePolling() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        reader.pollNext(new TestCollector());
+        Assertions.assertEquals(0, receiver.receiveCount.get());
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        Assertions.assertEquals(1, receiver.receiveCount.get());
+        reader.close();
+    }
+
+    @Test
     void shouldDeleteOnlyAfterCheckpointCompletes() throws Exception {
         TestReceiver receiver = new TestReceiver();
         AzureQueueMessage message = receiver.enqueue("first");

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceReaderTest.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AuthenticationType;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageEncoding;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class AzureQueueStorageSourceReaderTest {
+
+    @Test
+    void shouldDeleteOnlyAfterCheckpointCompletes() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage message = receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.snapshotState(1L);
+
+        Assertions.assertTrue(receiver.deleted.isEmpty());
+        reader.notifyCheckpointComplete(1L);
+        Assertions.assertEquals(Collections.singletonList(message), receiver.deleted);
+        reader.close();
+    }
+
+    @Test
+    void shouldRetainMessageAfterCheckpointIsAborted() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage message = receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.snapshotState(1L);
+        reader.notifyCheckpointAborted(1L);
+        reader.snapshotState(2L);
+        reader.notifyCheckpointComplete(2L);
+
+        Assertions.assertEquals(Collections.singletonList(message), receiver.deleted);
+        reader.close();
+    }
+
+    @Test
+    void shouldDeleteMessagesFromOverlappingCheckpointsOnce() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage first = receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.snapshotState(1L);
+
+        AzureQueueMessage second = receiver.enqueue("second");
+        reader.pollNext(new TestCollector());
+        reader.snapshotState(2L);
+        reader.notifyCheckpointComplete(2L);
+        reader.notifyCheckpointComplete(1L);
+
+        Assertions.assertEquals(Arrays.asList(first, second), receiver.deleted);
+        reader.close();
+    }
+
+    @Test
+    void shouldRetryOnlyMessagesNotDeletedByPartialCheckpointFailure() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage first = receiver.enqueue("first");
+        AzureQueueMessage second = receiver.enqueue("second");
+        receiver.failDeleteFor = second;
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.snapshotState(1L);
+
+        Assertions.assertThrows(
+                AzureQueueConnectorException.class, () -> reader.notifyCheckpointComplete(1L));
+        Assertions.assertTrue(first.isDeleted());
+        Assertions.assertFalse(second.isDeleted());
+
+        receiver.failDeleteFor = null;
+        reader.notifyCheckpointComplete(1L);
+        Assertions.assertEquals(Arrays.asList(first, second), receiver.deleted);
+        reader.close();
+    }
+
+    @Test
+    void shouldUseRenewedPopReceiptForCheckpointDelete() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage message = receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.renewVisibilityNow();
+        reader.snapshotState(1L);
+        reader.notifyCheckpointComplete(1L);
+
+        Assertions.assertEquals(1, receiver.renewCount.get());
+        Assertions.assertEquals("renewed-receipt", receiver.receiptUsedForDelete);
+        Assertions.assertTrue(message.isDeleted());
+        reader.close();
+    }
+
+    @Test
+    void shouldSurfaceBackgroundVisibilityRenewalFailure() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        receiver.failRenewal = true;
+        reader.renewVisibilitySafely();
+
+        AzureQueueConnectorException exception =
+                Assertions.assertThrows(
+                        AzureQueueConnectorException.class,
+                        () -> reader.pollNext(new TestCollector()));
+        Assertions.assertTrue(exception.getMessage().contains("visibility renewal failed"));
+        reader.close();
+    }
+
+    @Test
+    void shouldReleaseMalformedMessageAndRestOfReceivedBatch() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage first = receiver.enqueue("invalid");
+        AzureQueueMessage second = receiver.enqueue("not-processed");
+        AzureQueueStorageSourceReader reader =
+                createReader(receiver, new FailingDeserializationSchema());
+
+        assignSplit(reader);
+        Assertions.assertThrows(
+                AzureQueueConnectorException.class, () -> reader.pollNext(new TestCollector()));
+
+        Assertions.assertEquals(Arrays.asList(first, second), receiver.released);
+        reader.close();
+    }
+
+    @Test
+    void shouldUseCollectorBasedDeserialization() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage message = receiver.enqueue("first");
+        CollectorDeserializationSchema schema = new CollectorDeserializationSchema();
+        AzureQueueStorageSourceReader reader = createReader(receiver, schema);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.snapshotState(1L);
+        reader.notifyCheckpointComplete(1L);
+
+        Assertions.assertTrue(schema.collectorMethodCalled);
+        Assertions.assertEquals(Collections.singletonList(message), receiver.deleted);
+        reader.close();
+    }
+
+    @Test
+    void shouldBoundReceivedMessagesUntilCheckpointCompletes() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        receiver.enqueue("first");
+        receiver.enqueue("second");
+        AzureQueueStorageSourceReader reader = createReader(receiver, schema(), config(1, 1));
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        Assertions.assertEquals(1, receiver.receiveCount.get());
+
+        reader.pollNext(new TestCollector());
+        Assertions.assertEquals(1, receiver.receiveCount.get());
+
+        reader.snapshotState(1L);
+        reader.notifyCheckpointComplete(1L);
+        reader.pollNext(new TestCollector());
+        Assertions.assertEquals(2, receiver.receiveCount.get());
+        reader.close();
+    }
+
+    @Test
+    void shouldReleaseOutstandingMessagesWhenReaderCloses() throws Exception {
+        TestReceiver receiver = new TestReceiver();
+        AzureQueueMessage message = receiver.enqueue("first");
+        AzureQueueStorageSourceReader reader = createReader(receiver);
+
+        assignSplit(reader);
+        reader.pollNext(new TestCollector());
+        reader.close();
+
+        Assertions.assertEquals(Collections.singletonList(message), receiver.released);
+    }
+
+    private AzureQueueStorageSourceReader createReader(TestReceiver receiver) {
+        return createReader(receiver, schema(), config(32, 1_000));
+    }
+
+    private AzureQueueStorageSourceReader createReader(
+            TestReceiver receiver, DeserializationSchema<SeaTunnelRow> schema) {
+        return createReader(receiver, schema, config(32, 1_000));
+    }
+
+    private AzureQueueStorageSourceReader createReader(
+            TestReceiver receiver,
+            DeserializationSchema<SeaTunnelRow> schema,
+            AzureQueueSourceConfig config) {
+        return new AzureQueueStorageSourceReader(config, schema, () -> receiver);
+    }
+
+    private AzureQueueSourceConfig config(int batchSize, int maxInFlightMessages) {
+        return AzureQueueSourceConfig.builder()
+                .queueName("events")
+                .authenticationType(AuthenticationType.CONNECTION_STRING)
+                .connectionString("UseDevelopmentStorage=true")
+                .format(MessageFormat.JSON)
+                .fieldDelimiter(",")
+                .messageEncoding(MessageEncoding.NONE)
+                .batchSize(batchSize)
+                .visibilityTimeoutSeconds(300)
+                .pollIntervalMillis(1)
+                .maxInFlightMessages(maxInFlightMessages)
+                .operationTimeoutMillis(60_000)
+                .build();
+    }
+
+    private DeserializationSchema<SeaTunnelRow> schema() {
+        return new TestDeserializationSchema();
+    }
+
+    private void assignSplit(AzureQueueStorageSourceReader reader) {
+        reader.addSplits(Collections.singletonList(new SingleSplit(null)));
+    }
+
+    private static class TestReceiver implements AzureQueueReceiver {
+        private final Deque<AzureQueueMessage> messages = new ArrayDeque<>();
+        private final List<AzureQueueMessage> deleted = new ArrayList<>();
+        private final List<AzureQueueMessage> released = new ArrayList<>();
+        private final AtomicInteger receiveCount = new AtomicInteger();
+        private final AtomicInteger renewCount = new AtomicInteger();
+        private AzureQueueMessage failDeleteFor;
+        private boolean failRenewal;
+        private String receiptUsedForDelete;
+
+        AzureQueueMessage enqueue(String value) {
+            byte[] body = value.getBytes(StandardCharsets.UTF_8);
+            AzureQueueMessage message =
+                    new AzureQueueMessage(
+                            "message-" + messages.size(), "initial-receipt", value, body);
+            messages.add(message);
+            return message;
+        }
+
+        @Override
+        public List<AzureQueueMessage> receive(int maxMessages) {
+            receiveCount.incrementAndGet();
+            List<AzureQueueMessage> result = new ArrayList<>();
+            while (result.size() < maxMessages && !messages.isEmpty()) {
+                result.add(messages.removeFirst());
+            }
+            return result;
+        }
+
+        @Override
+        public void renewVisibility(AzureQueueMessage message) {
+            if (failRenewal) {
+                throw new IllegalStateException("renewal failed");
+            }
+            renewCount.incrementAndGet();
+            message.updatePopReceipt("renewed-receipt");
+        }
+
+        @Override
+        public void delete(AzureQueueMessage message) {
+            if (message == failDeleteFor) {
+                throw new IllegalStateException("delete failed");
+            }
+            receiptUsedForDelete = message.getPopReceipt();
+            message.markDeleted();
+            deleted.add(message);
+        }
+
+        @Override
+        public void release(AzureQueueMessage message) {
+            released.add(message);
+        }
+    }
+
+    private static class TestDeserializationSchema implements DeserializationSchema<SeaTunnelRow> {
+        private static final SeaTunnelRowType ROW_TYPE =
+                new SeaTunnelRowType(
+                        new String[] {"value"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+
+        @Override
+        public SeaTunnelRow deserialize(byte[] message) throws IOException {
+            return new SeaTunnelRow(new Object[] {new String(message, StandardCharsets.UTF_8)});
+        }
+
+        @Override
+        public SeaTunnelDataType<SeaTunnelRow> getProducedType() {
+            return ROW_TYPE;
+        }
+    }
+
+    private static final class FailingDeserializationSchema extends TestDeserializationSchema {
+        @Override
+        public SeaTunnelRow deserialize(byte[] message) throws IOException {
+            throw new IOException("invalid payload");
+        }
+    }
+
+    private static final class CollectorDeserializationSchema extends TestDeserializationSchema {
+        private boolean collectorMethodCalled;
+
+        @Override
+        public SeaTunnelRow deserialize(byte[] message) {
+            throw new AssertionError("Single-row deserialization must not be used");
+        }
+
+        @Override
+        public void deserialize(byte[] message, Collector<SeaTunnelRow> output) {
+            collectorMethodCalled = true;
+            output.collect(
+                    new SeaTunnelRow(new Object[] {new String(message, StandardCharsets.UTF_8)}));
+        }
+    }
+
+    private static final class TestCollector implements Collector<SeaTunnelRow> {
+        private final Object checkpointLock = new Object();
+
+        @Override
+        public void collect(SeaTunnelRow record) {}
+
+        @Override
+        public Object getCheckpointLock() {
+            return checkpointLock;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceTest.java
+++ b/seatunnel-connectors-v2/connector-azure-queue-storage/src/test/java/org/apache/seatunnel/connectors/seatunnel/azure/queue/source/AzureQueueStorageSourceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.azure.queue.source;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.serialization.DeserializationSchema;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AuthenticationType;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.AzureQueueSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageEncoding;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.config.MessageFormat;
+import org.apache.seatunnel.connectors.seatunnel.azure.queue.exception.AzureQueueConnectorException;
+import org.apache.seatunnel.format.json.JsonDeserializationSchema;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AzureQueueStorageSourceTest {
+
+    @Test
+    void shouldRequireStreamingModeWithCheckpointing() {
+        AzureQueueStorageSource source = createSource();
+
+        source.setJobContext(
+                new JobContext().setJobMode(JobMode.STREAMING).setEnableCheckpoint(true));
+        Assertions.assertEquals(Boundedness.UNBOUNDED, source.getBoundedness());
+
+        source.setJobContext(
+                new JobContext().setJobMode(JobMode.STREAMING).setEnableCheckpoint(false));
+        AzureQueueConnectorException checkpointException =
+                Assertions.assertThrows(AzureQueueConnectorException.class, source::getBoundedness);
+        Assertions.assertTrue(checkpointException.getMessage().contains("requires checkpointing"));
+
+        source.setJobContext(new JobContext().setJobMode(JobMode.BATCH).setEnableCheckpoint(true));
+        AzureQueueConnectorException batchException =
+                Assertions.assertThrows(AzureQueueConnectorException.class, source::getBoundedness);
+        Assertions.assertTrue(batchException.getMessage().contains("streaming jobs only"));
+    }
+
+    private AzureQueueStorageSource createSource() {
+        CatalogTable catalogTable = CatalogTableUtil.buildSimpleTextTable();
+        DeserializationSchema<SeaTunnelRow> deserializationSchema =
+                new JsonDeserializationSchema(catalogTable, false, false);
+        AzureQueueSourceConfig config =
+                AzureQueueSourceConfig.builder()
+                        .queueName("events")
+                        .authenticationType(AuthenticationType.CONNECTION_STRING)
+                        .connectionString("UseDevelopmentStorage=true")
+                        .format(MessageFormat.JSON)
+                        .fieldDelimiter(",")
+                        .messageEncoding(MessageEncoding.NONE)
+                        .batchSize(32)
+                        .visibilityTimeoutSeconds(300)
+                        .pollIntervalMillis(1_000)
+                        .maxInFlightMessages(1_000)
+                        .operationTimeoutMillis(60_000)
+                        .build();
+        return new AzureQueueStorageSource(config, catalogTable, deserializationSchema);
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-azure-queue-storage-e2e/src/test/java/org/apache/seatunnel/e2e/connector/azure/queue/AzureQueueStorageIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-azure-queue-storage-e2e/src/test/java/org/apache/seatunnel/e2e/connector/azure/queue/AzureQueueStorageIT.java
@@ -19,8 +19,11 @@ package org.apache.seatunnel.e2e.connector.azure.queue;
 
 import org.apache.seatunnel.e2e.common.TestResource;
 import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.EngineType;
 import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.container.seatunnel.SeaTunnelContainer;
+import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
+import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +42,7 @@ import com.azure.storage.queue.models.QueueMessageItem;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -53,13 +57,19 @@ public class AzureQueueStorageIT extends TestSuiteBase implements TestResource {
     private static final String ACCOUNT_KEY =
             "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
     private static final String QUEUE_NAME = "events";
+    private static final String SOURCE_QUEUE_NAME = "source-events";
     private static final int QUEUE_PORT = 10001;
     private static final String NETWORK_ALIAS = "azure-queue";
     private static final String JOB_CONFIG = "/azurequeue/fake_to_azure_queue.conf";
+    private static final String SOURCE_JOB_CONFIG = "/azurequeue/azure_queue_to_console.conf";
     private static final String EXPECTED_MESSAGE = "{\"name\":\"alice\",\"age\":30}";
+    private static final String EXPECTED_SOURCE_EVENT_ID = "azure-queue-source-checkpoint-event";
+    private static final String SOURCE_MESSAGE =
+            "{\"event_id\":\"" + EXPECTED_SOURCE_EVENT_ID + "\",\"event_type\":\"created\"}";
 
     private GenericContainer<?> azurite;
     private QueueClient queueClient;
+    private QueueClient sourceQueueClient;
 
     @BeforeAll
     @Override
@@ -90,6 +100,12 @@ public class AzureQueueStorageIT extends TestSuiteBase implements TestResource {
                         .queueName(QUEUE_NAME)
                         .buildClient();
         queueClient.createIfNotExists();
+        sourceQueueClient =
+                new QueueClientBuilder()
+                        .connectionString(hostConnectionString())
+                        .queueName(SOURCE_QUEUE_NAME)
+                        .buildClient();
+        sourceQueueClient.createIfNotExists();
         SeaTunnelContainer.enableAzureQueueReactorThreadExemption();
     }
 
@@ -127,6 +143,81 @@ public class AzureQueueStorageIT extends TestSuiteBase implements TestResource {
         Assertions.assertEquals(EXPECTED_MESSAGE, receivedMessage.get().getBody().toString());
         queueClient.deleteMessage(
                 receivedMessage.get().getMessageId(), receivedMessage.get().getPopReceipt());
+    }
+
+    @TestTemplate
+    @DisabledOnContainer(
+            value = {},
+            type = {EngineType.FLINK, EngineType.SPARK},
+            disabledReason =
+                    "The source checkpoint assertion uses the Zeta REST job status and server logs")
+    public void testAzureQueueStorageSourceDeletesAfterCheckpoint(TestContainer container)
+            throws Exception {
+        sourceQueueClient.clearMessages();
+        String jobId = String.valueOf(JobIdGenerator.newJobId());
+        CompletableFuture<Container.ExecResult> jobFuture =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return container.executeJob(SOURCE_JOB_CONFIG, jobId);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        try {
+            await().atMost(60, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                assertJobStillRunning(jobFuture);
+                                Assertions.assertEquals("RUNNING", container.getJobStatus(jobId));
+                            });
+
+            long checkpointCount = container.getCompletedCheckpointCount(jobId);
+            sourceQueueClient.sendMessage(SOURCE_MESSAGE);
+
+            await().atMost(60, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                assertJobStillRunning(jobFuture);
+                                Assertions.assertTrue(
+                                        container
+                                                .getServerLogs()
+                                                .contains(EXPECTED_SOURCE_EVENT_ID),
+                                        "Azure Queue message was not emitted by the source");
+                            });
+            await().atMost(60, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                assertJobStillRunning(jobFuture);
+                                Assertions.assertTrue(
+                                        container.getCompletedCheckpointCount(jobId)
+                                                > checkpointCount,
+                                        "No checkpoint completed after the Azure Queue message was emitted");
+                                Assertions.assertNull(
+                                        sourceQueueClient.peekMessage(),
+                                        "Azure Queue message was not deleted after checkpoint completion");
+                            });
+        } finally {
+            if (!jobFuture.isDone()) {
+                Container.ExecResult cancelResult = container.cancelJob(jobId);
+                Assertions.assertEquals(0, cancelResult.getExitCode(), cancelResult.getStderr());
+            }
+        }
+
+        Container.ExecResult jobResult = jobFuture.get(120, TimeUnit.SECONDS);
+        Assertions.assertEquals(0, jobResult.getExitCode(), jobResult.getStderr());
+    }
+
+    private void assertJobStillRunning(CompletableFuture<Container.ExecResult> jobFuture)
+            throws Exception {
+        if (jobFuture.isDone()) {
+            Container.ExecResult result = jobFuture.get();
+            Assertions.fail("Streaming source job terminated early:\n" + result.getStderr());
+        }
     }
 
     private String hostConnectionString() {

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-azure-queue-storage-e2e/src/test/resources/azurequeue/azure_queue_to_console.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-azure-queue-storage-e2e/src/test/resources/azurequeue/azure_queue_to_console.conf
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 1000
+}
+
+source {
+  AzureQueueStorage {
+    queue_name = "source-events"
+    authentication_type = connection_string
+    connection_string = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://azure-queue:10001/devstoreaccount1;"
+    format = json
+    visibility_timeout_seconds = 120
+    operation_timeout_ms = 10000
+    schema = {
+      fields {
+        event_id = string
+        event_type = string
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
+}


### PR DESCRIPTION
### Purpose of this pull request

Related to #10753.

This PR adds an Azure Queue Storage source to the existing `connector-azure-queue-storage` module.

The source:

- reads messages from one Azure Storage queue in bounded batches
- supports connection string, shared key, and SAS token authentication
- supports JSON and delimited text payloads
- supports plain and Base64 message encoding
- renews message visibility while messages wait for checkpoint completion
- deletes messages only after the checkpoint containing them completes
- retains messages after aborted checkpoints for a later checkpoint
- bounds retained messages through `max_in_flight_messages`
- releases malformed and unprocessed messages back to the queue
- reports receive, delete, and visibility-renewal failures to the source task
- provides at-least-once delivery semantics

The Azure client construction and authentication validation are shared with the existing sink. Existing sink behavior is unchanged.

This PR also adds source registration, English and Chinese documentation, configuration examples, unit tests, and Azurite E2E coverage.

### Does this PR introduce _any_ user-facing change?

Yes.

Users can now configure `AzureQueueStorage` as a streaming source.

The source requires checkpointing because messages are deleted from Azure Queue Storage only after checkpoint completion. Until then, their visibility timeout is renewed. A task failure or lease loss can cause redelivery, so the source provides at-least-once delivery.

One Azure queue is represented by one source split in this first implementation. Increasing job parallelism does not create additional consumers for the same queue.

The existing Azure Queue Storage sink configuration and behavior are unchanged.

### How was this patch tested?

Added unit coverage for:

- source configuration and authentication validation
- streaming and checkpoint requirements
- source factory creation
- checkpoint-complete deletion
- aborted and overlapping checkpoints
- partial delete failure and retry
- visibility renewal and renewed pop-receipt usage
- asynchronous visibility-renewal failure propagation
- bounded in-flight message handling
- malformed payload release
- collector-based deserialization
- reader shutdown and outstanding-message release
- existing sink behavior after sharing client construction

Verified the connector module with JDK 8 and JDK 11:

```shell
./mvnw -pl seatunnel-connectors-v2/connector-azure-queue-storage test
```

Result: 36 tests passed with no failures or errors.

Verified the connector package with JDK 11:

```shell
./mvnw -pl seatunnel-connectors-v2/connector-azure-queue-storage package
```

Verified E2E test compilation:

```shell
./mvnw -pl seatunnel-e2e/seatunnel-connector-v2-e2e/connector-azure-queue-storage-e2e -DskipTests test-compile
```

The existing Azurite E2E suite now includes a source case that emits a message, waits for a completed checkpoint, and verifies that the message is deleted afterward.

### Check list

* [x] No new Jar binary package is added, so no License Notice update is required.
* [x] English and Chinese source documentation and changelog entries are added.
* [x] No incompatible change is introduced, so `incompatible-changes.md` does not require an update.
* [x] Connector integration files were checked:
  1. `plugin-mapping.properties` includes the Azure Queue Storage source.
  2. `seatunnel-dist` already includes the connector module for the existing sink.
  3. The existing CI label scope already covers the connector module.
  4. The existing Azure Queue Storage E2E module now covers the source.
  5. `config/plugin_config` already includes the shared connector module.