### PR TITLE
[Fix][Format] Preserve Avro field case during serialization

### DIFF
--- a/seatunnel-formats/seatunnel-format-avro/src/main/java/org/apache/seatunnel/format/avro/RowToAvroConverter.java
+++ b/seatunnel-formats/seatunnel-format-avro/src/main/java/org/apache/seatunnel/format/avro/RowToAvroConverter.java
@@ -79,7 +79,7 @@ public class RowToAvroConverter implements Serializable {
         for (int i = 0; i < fieldNames.length; i++) {
             String fieldName = rowType.getFieldName(i);
             Object value = element.getField(i);
-            builder.set(fieldName.toLowerCase(), resolveObject(value, rowType.getFieldType(i)));
+            builder.set(fieldName, resolveObject(value, rowType.getFieldType(i)));
         }
         return builder.build();
     }
@@ -147,8 +147,7 @@ public class RowToAvroConverter implements Serializable {
                 GenericRecordBuilder recordBuilder = new GenericRecordBuilder(recordSchema);
                 for (int i = 0; i < fieldNames.length; i++) {
                     recordBuilder.set(
-                            fieldNames[i].toLowerCase(),
-                            resolveObject(seaTunnelRow.getField(i), fieldTypes[i]));
+                            fieldNames[i], resolveObject(seaTunnelRow.getField(i), fieldTypes[i]));
                 }
                 return recordBuilder.build();
             default:

--- a/seatunnel-formats/seatunnel-format-avro/src/test/java/org/apache/seatunnel/format/avro/AvroSerializationSchemaTest.java
+++ b/seatunnel-formats/seatunnel-format-avro/src/test/java/org/apache/seatunnel/format/avro/AvroSerializationSchemaTest.java
@@ -285,4 +285,42 @@ class AvroSerializationSchemaTest {
         Assertions.assertEquals(1769504419000L, row.getField(1));
         Assertions.assertNull(row.getField(2));
     }
+
+    @Test
+    public void testMixedCaseFieldSerialization() throws IOException {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"CustomerID", "customerid"},
+                        new SeaTunnelDataType<?>[] {BasicType.INT_TYPE, BasicType.INT_TYPE});
+        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("", "", "", "test", rowType);
+        SeaTunnelRow sourceRow = new SeaTunnelRow(2);
+        sourceRow.setField(0, 42);
+        sourceRow.setField(1, 84);
+
+        byte[] bytes = new AvroSerializationSchema(rowType).serialize(sourceRow);
+        SeaTunnelRow result = new AvroDeserializationSchema(catalogTable).deserialize(bytes);
+
+        Assertions.assertEquals(42, result.getField(0));
+        Assertions.assertEquals(84, result.getField(1));
+    }
+
+    @Test
+    public void testNestedMixedCaseFieldSerialization() throws IOException {
+        SeaTunnelRowType nestedType =
+                new SeaTunnelRowType(
+                        new String[] {"InnerID"}, new SeaTunnelDataType<?>[] {BasicType.INT_TYPE});
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"payload"}, new SeaTunnelDataType<?>[] {nestedType});
+        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("", "", "", "test", rowType);
+        SeaTunnelRow nestedRow = new SeaTunnelRow(1);
+        nestedRow.setField(0, 42);
+        SeaTunnelRow sourceRow = new SeaTunnelRow(1);
+        sourceRow.setField(0, nestedRow);
+
+        byte[] bytes = new AvroSerializationSchema(rowType).serialize(sourceRow);
+        SeaTunnelRow result = new AvroDeserializationSchema(catalogTable).deserialize(bytes);
+
+        Assertions.assertEquals(42, ((SeaTunnelRow) result.getField(0)).getField(0));
+    }
 }


### PR DESCRIPTION
### Purpose of this pull request

Fixes #12008.

`SeaTunnelRowTypeToAvroSchemaConverter` preserves field names when it builds the Avro schema, while `RowToAvroConverter` lowercased names before looking them up in that schema. Avro field lookup is case-sensitive, so mixed-case fields failed before the record could be serialized. This patch uses the schema's exact field names for both top-level and nested `ROW` values.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, a schema containing a field such as `CustomerID` or a nested field such as `InnerID` failed during Avro serialization. These fields now serialize and deserialize with their original case.

Existing lowercase schemas behave unchanged. This patch does not change public APIs, configuration, dependencies, generated schemas, or the serialized layout of schemas that already worked.

### How was this patch tested?

Added byte-level Avro serialization/deserialization regression tests for:

- case-distinct top-level fields, `CustomerID` and `customerid`
- a nested `ROW` field named `InnerID`
- existing lowercase-field behavior through the complete Avro module test suite

Verification:

- JDK 8: `./mvnw -pl seatunnel-formats/seatunnel-format-avro verify` (6 tests passed)
- JDK 11: `./mvnw -pl seatunnel-formats/seatunnel-format-avro verify` (6 tests passed)
- JDK 8 shared-consumer reactor: `./mvnw -q -DskipTests verify -pl seatunnel-formats/seatunnel-format-avro,seatunnel-connectors-v2/connector-kafka,seatunnel-connectors-v2/connector-pulsar -am` (passed)
- `git diff --check upstream/dev..HEAD` (passed)

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because this restores the existing case-preserving schema behavior; no configuration or documented format contract changes.
* [x] No incompatible change is introduced, so `incompatible-changes.md` does not need an update.
* [x] The connector checklist is not applicable because this change is limited to the shared Avro format module.