### PR TITLE
[Fix][Zeta] Stabilize pending job scheduler regression test

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -623,6 +623,7 @@ public class CoordinatorServiceTest {
         EngineConfig engineConfig = new EngineConfig();
         engineConfig.setScheduleStrategy(ScheduleStrategy.REJECT);
         CoordinatorService coordinatorService = newMockCoordinatorService(server, engineConfig);
+        CountDownLatch firstScheduleStarted = new CountDownLatch(1);
         CountDownLatch allowFirstScheduleToFinish = new CountDownLatch(1);
         try {
             JobMaster blockedJobMaster =
@@ -630,6 +631,7 @@ public class CoordinatorServiceTest {
             Mockito.when(blockedJobMaster.preApplyResources())
                     .thenAnswer(
                             invocation -> {
+                                firstScheduleStarted.countDown();
                                 allowFirstScheduleToFinish.await();
                                 return true;
                             });
@@ -637,12 +639,9 @@ public class CoordinatorServiceTest {
             ReflectionUtils.setField(coordinatorService, "isActive", true);
             invokePendingJobScheduler(coordinatorService);
 
-            // Wait until the scheduler thread is parked inside preApplyResources().
-            await().atMost(5, TimeUnit.SECONDS)
-                    .untilAsserted(
-                            () ->
-                                    Mockito.verify(blockedJobMaster, Mockito.atLeastOnce())
-                                            .preApplyResources());
+            Assertions.assertTrue(
+                    firstScheduleStarted.await(30, TimeUnit.SECONDS),
+                    "Pending job scheduler did not enter preApplyResources");
 
             // Simulate a master step-down. The blocked JobMaster is interrupted; the
             // PendingJobInfo must be dropped from the queue so a later restore cannot


### PR DESCRIPTION
### Purpose of this pull request

Fixes #12012.

`CoordinatorServiceTest.testClearCoordinatorServiceDropsPendingJobsUnderRejectStrategy` waited for the pending-job scheduler by polling Mockito while `preApplyResources()` was still running on another thread. On a loaded Java 8 CI runner, that polling condition timed out even though the test was only trying to establish that the scheduler had entered the mocked method.

This PR replaces the polling synchronization with a `CountDownLatch` signalled from inside `preApplyResources()`. The test now waits for the exact scheduler-entry event with a bounded timeout before clearing the coordinator.

Only test code changes. Coordinator scheduling and cleanup behavior are unchanged.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Ran the focused regression test five consecutive times on Java 8: 5 passed.
- Ran the complete `CoordinatorServiceTest` on Java 8: 35 tests, 0 failures, 0 errors, 2 skipped.
- Ran the complete `CoordinatorServiceTest` on Java 11: 35 tests, 0 failures, 0 errors, 2 skipped.
- Ran the Java 8 reactor install for `seatunnel-engine-server` and its dependencies with tests skipped: 40 modules passed.
- Spotless and `git diff --check` passed.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because this is a test-only stabilization.
* [x] `incompatible-changes.md` is not required because runtime behavior is unchanged.
* [x] Connector checklist is not applicable because no connector code is changed.
