### PR TITLE
[Feature][Connector-V2] Support per-table primary key mapping via multi_table_config.primary_keys for JDBC sink

### DIFF
--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -176,6 +176,7 @@ Exactly-once delivery uses XA transactions and therefore requires XA support fro
 | tablePrefix                               | String  | No       | -                            |
 | tableSuffix                               | String  | No       | -                            |
 | primary_keys                              | Array   | No       | -                            |
+| multi-table_config                        | Object  | No       | -                            |
 | connection_check_timeout_sec              | Int     | No       | 30                           |
 | connect_timeout_ms                        | Int     | No       | 86400000                     |
 | socket_timeout_ms                         | Int     | No       | 86400000                     |
@@ -294,6 +295,61 @@ Deprecated. Use `table` with table placeholders instead. For example, use `table
 ### primary_keys [array]
 
 The target key columns used to generate database-native UPSERT, UPDATE, and DELETE statements. If omitted, SeaTunnel attempts to inherit a primary key or the first unique key from upstream catalog metadata. If no key is available, generated SQL uses plain INSERT.
+
+### multi-table_config [object]
+
+Per-table primary key mapping for multi-table generated-SQL jobs. It has higher precedence than the top-level `primary_keys` option: when an upstream table name matches one of the patterns declared under `primary_keys`, that mapping is used; otherwise SeaTunnel falls back to the existing `primary_keys` / catalog metadata logic.
+
+The value must follow this shape:
+
+```hocon
+multi-table_config {
+  primary_keys {
+    "<table-name-regex>" = ["key1", "key2"]
+  }
+}
+```
+
+- Each key is a Java regular expression matched against the upstream table name using full match semantics (`tableName.matches(pattern)`). For example, use `"^t_nova_.*$"` or `"t_nova_.*"`, not a glob such as `"t_nova_*"`.
+- Each value is a list of column names. The `${primary_key}` and `${unique_key}` placeholders are supported inside this option only, and can be mixed with static columns. `${primary_key}` expands to the upstream primary key columns, `${unique_key}` expands to the first upstream unique key columns.
+- If a table matches multiple patterns, the first pattern in declaration order wins.
+- If a matched table uses `${primary_key}` (or `${unique_key}`) but has no upstream primary key (or unique key), the job fails with a clear error.
+
+Example: use the upstream primary key plus a shared `DATA_SOURCE` column as the composite key for tables whose names start with `t_nova_`.
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:mysql://localhost:3306/test"
+    driver = "com.mysql.cj.jdbc.Driver"
+    generate_sink_sql = true
+    multi-table_config {
+      primary_keys {
+        "^t_nova_.*$" = ["${primary_key}", "DATA_SOURCE"]
+      }
+    }
+  }
+}
+```
+
+Example: mixing `multi-table_config` with the top-level `primary_keys`. Tables matched by the mapping use the mapping; unmatched tables fall back to `primary_keys = ["merchant_id"]`.
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:mysql://localhost:3306/test"
+    driver = "com.mysql.cj.jdbc.Driver"
+    generate_sink_sql = true
+    primary_keys = ["merchant_id"]
+    multi-table_config {
+      primary_keys {
+        "t_tyuen_txn_ext.*"          = ["id_txn_ctrl", "DATA_SOURCE"]
+        "t_nova_merge_settle_serial" = ["${primary_key}", "DATA_SOURCE"]
+      }
+    }
+  }
+}
+```
 
 ### connection_check_timeout_sec [int]
 

--- a/docs/en/connectors/sink/Jdbc.md
+++ b/docs/en/connectors/sink/Jdbc.md
@@ -176,7 +176,7 @@ Exactly-once delivery uses XA transactions and therefore requires XA support fro
 | tablePrefix                               | String  | No       | -                            |
 | tableSuffix                               | String  | No       | -                            |
 | primary_keys                              | Array   | No       | -                            |
-| multi-table_config                        | Object  | No       | -                            |
+| multi_table_config                        | Object  | No       | -                            |
 | connection_check_timeout_sec              | Int     | No       | 30                           |
 | connect_timeout_ms                        | Int     | No       | 86400000                     |
 | socket_timeout_ms                         | Int     | No       | 86400000                     |
@@ -296,14 +296,14 @@ Deprecated. Use `table` with table placeholders instead. For example, use `table
 
 The target key columns used to generate database-native UPSERT, UPDATE, and DELETE statements. If omitted, SeaTunnel attempts to inherit a primary key or the first unique key from upstream catalog metadata. If no key is available, generated SQL uses plain INSERT.
 
-### multi-table_config [object]
+### multi_table_config [object]
 
 Per-table primary key mapping for multi-table generated-SQL jobs. It has higher precedence than the top-level `primary_keys` option: when an upstream table name matches one of the patterns declared under `primary_keys`, that mapping is used; otherwise SeaTunnel falls back to the existing `primary_keys` / catalog metadata logic.
 
 The value must follow this shape:
 
 ```hocon
-multi-table_config {
+multi_table_config {
   primary_keys {
     "<table-name-regex>" = ["key1", "key2"]
   }
@@ -323,7 +323,7 @@ sink {
     url = "jdbc:mysql://localhost:3306/test"
     driver = "com.mysql.cj.jdbc.Driver"
     generate_sink_sql = true
-    multi-table_config {
+    multi_table_config {
       primary_keys {
         "^t_nova_.*$" = ["${primary_key}", "DATA_SOURCE"]
       }
@@ -332,7 +332,7 @@ sink {
 }
 ```
 
-Example: mixing `multi-table_config` with the top-level `primary_keys`. Tables matched by the mapping use the mapping; unmatched tables fall back to `primary_keys = ["merchant_id"]`.
+Example: mixing `multi_table_config` with the top-level `primary_keys`. Tables matched by the mapping use the mapping; unmatched tables fall back to `primary_keys = ["merchant_id"]`.
 
 ```hocon
 sink {
@@ -341,7 +341,7 @@ sink {
     driver = "com.mysql.cj.jdbc.Driver"
     generate_sink_sql = true
     primary_keys = ["merchant_id"]
-    multi-table_config {
+    multi_table_config {
       primary_keys {
         "t_tyuen_txn_ext.*"          = ["id_txn_ctrl", "DATA_SOURCE"]
         "t_nova_merge_settle_serial" = ["${primary_key}", "DATA_SOURCE"]

--- a/docs/en/introduction/configuration/sink-options-placeholders.md
+++ b/docs/en/introduction/configuration/sink-options-placeholders.md
@@ -138,6 +138,10 @@ primary_keys = ["${primary_key}", "tenant_id"]
 
 The placeholder replacement for list values is only applied when `${primary_key}` is the only element in the list.
 
+The restriction above applies to the top-level `primary_keys` option. The JDBC sink additionally supports
+mixing `${primary_key}` (and `${unique_key}`) with static column names inside
+`multi-table_config.primary_keys`; see the JDBC sink documentation for details.
+
 The behavior is the same for both single-table and multi-table jobs.
 
 We will complete the placeholder replacement before the connector is started, ensuring that the sink options is ready before use.

--- a/docs/en/introduction/configuration/sink-options-placeholders.md
+++ b/docs/en/introduction/configuration/sink-options-placeholders.md
@@ -140,7 +140,7 @@ The placeholder replacement for list values is only applied when `${primary_key}
 
 The restriction above applies to the top-level `primary_keys` option. The JDBC sink additionally supports
 mixing `${primary_key}` (and `${unique_key}`) with static column names inside
-`multi-table_config.primary_keys`; see the JDBC sink documentation for details.
+`multi_table_config.primary_keys`; see the JDBC sink documentation for details.
 
 The behavior is the same for both single-table and multi-table jobs.
 

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -175,6 +175,7 @@ Exactly-once 依赖 XA 事务，因此数据库和 JDBC 驱动都必须支持 XA
 | tablePrefix                               | String  | 否    | -                            |
 | tableSuffix                               | String  | 否    | -                            |
 | primary_keys                              | Array   | 否    | -                            |
+| multi-table_config                        | Object  | 否    | -                            |
 | connection_check_timeout_sec              | Int     | 否    | 30                           |
 | connect_timeout_ms                        | Int     | 否    | 86400000                     |
 | socket_timeout_ms                         | Int     | 否    | 86400000                     |
@@ -294,6 +295,61 @@ Tip: 如果目标数据库有 SCHEMA 的概念，则表参数必须写成 `xxx.x
 ### primary_keys [array]
 
 生成数据库原生 UPSERT、UPDATE 和 DELETE 语句时使用的目标键列。未配置时，SeaTunnel 会尝试从上游 catalog 元数据继承主键或第一组唯一键；仍无可用键时，自动生成的 SQL 退回普通 INSERT。
+
+### multi-table_config [object]
+
+用于多表自动生成 SQL 场景的按表主键映射，优先级高于顶层 `primary_keys` 选项：当上游表名匹配到 `primary_keys` 下声明的某个模式时，使用该映射；否则回退到现有 `primary_keys` / catalog 元数据逻辑。
+
+配置结构如下：
+
+```hocon
+multi-table_config {
+  primary_keys {
+    "<表名正则>" = ["key1", "key2"]
+  }
+}
+```
+
+- 每个 key 是匹配上游表名的 Java 正则表达式，使用全匹配语义（`tableName.matches(pattern)`）。例如使用 `"^t_nova_.*$"` 或 `"t_nova_.*"`，不要使用 `"t_nova_*"` 这类 glob 写法。
+- 每个 value 是列名列表。仅在该选项内支持 `${primary_key}` 和 `${unique_key}` 占位符，且可与静态列混用。`${primary_key}` 展开为上游主键列，`${unique_key}` 展开为上游第一组唯一键列。
+- 若一张表同时匹配多个模式，按声明顺序取第一个匹配。
+- 若命中的表使用了 `${primary_key}`（或 `${unique_key}`）但上游没有主键（或唯一键），任务会以清晰错误信息失败。
+
+示例：为表名以 `t_nova_` 开头的表，使用上游主键加上共享的 `DATA_SOURCE` 列作为复合主键。
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:mysql://localhost:3306/test"
+    driver = "com.mysql.cj.jdbc.Driver"
+    generate_sink_sql = true
+    multi-table_config {
+      primary_keys {
+        "^t_nova_.*$" = ["${primary_key}", "DATA_SOURCE"]
+      }
+    }
+  }
+}
+```
+
+示例：`multi-table_config` 与顶层 `primary_keys` 混用。被映射命中的表使用映射值，未命中的表回退到 `primary_keys = ["merchant_id"]`。
+
+```hocon
+sink {
+  jdbc {
+    url = "jdbc:mysql://localhost:3306/test"
+    driver = "com.mysql.cj.jdbc.Driver"
+    generate_sink_sql = true
+    primary_keys = ["merchant_id"]
+    multi-table_config {
+      primary_keys {
+        "t_tyuen_txn_ext.*"          = ["id_txn_ctrl", "DATA_SOURCE"]
+        "t_nova_merge_settle_serial" = ["${primary_key}", "DATA_SOURCE"]
+      }
+    }
+  }
+}
+```
 
 ### connection_check_timeout_sec [int]
 

--- a/docs/zh/connectors/sink/Jdbc.md
+++ b/docs/zh/connectors/sink/Jdbc.md
@@ -175,7 +175,7 @@ Exactly-once 依赖 XA 事务，因此数据库和 JDBC 驱动都必须支持 XA
 | tablePrefix                               | String  | 否    | -                            |
 | tableSuffix                               | String  | 否    | -                            |
 | primary_keys                              | Array   | 否    | -                            |
-| multi-table_config                        | Object  | 否    | -                            |
+| multi_table_config                        | Object  | 否    | -                            |
 | connection_check_timeout_sec              | Int     | 否    | 30                           |
 | connect_timeout_ms                        | Int     | 否    | 86400000                     |
 | socket_timeout_ms                         | Int     | 否    | 86400000                     |
@@ -296,14 +296,14 @@ Tip: 如果目标数据库有 SCHEMA 的概念，则表参数必须写成 `xxx.x
 
 生成数据库原生 UPSERT、UPDATE 和 DELETE 语句时使用的目标键列。未配置时，SeaTunnel 会尝试从上游 catalog 元数据继承主键或第一组唯一键；仍无可用键时，自动生成的 SQL 退回普通 INSERT。
 
-### multi-table_config [object]
+### multi_table_config [object]
 
 用于多表自动生成 SQL 场景的按表主键映射，优先级高于顶层 `primary_keys` 选项：当上游表名匹配到 `primary_keys` 下声明的某个模式时，使用该映射；否则回退到现有 `primary_keys` / catalog 元数据逻辑。
 
 配置结构如下：
 
 ```hocon
-multi-table_config {
+multi_table_config {
   primary_keys {
     "<表名正则>" = ["key1", "key2"]
   }
@@ -323,7 +323,7 @@ sink {
     url = "jdbc:mysql://localhost:3306/test"
     driver = "com.mysql.cj.jdbc.Driver"
     generate_sink_sql = true
-    multi-table_config {
+    multi_table_config {
       primary_keys {
         "^t_nova_.*$" = ["${primary_key}", "DATA_SOURCE"]
       }
@@ -332,7 +332,7 @@ sink {
 }
 ```
 
-示例：`multi-table_config` 与顶层 `primary_keys` 混用。被映射命中的表使用映射值，未命中的表回退到 `primary_keys = ["merchant_id"]`。
+示例：`multi_table_config` 与顶层 `primary_keys` 混用。被映射命中的表使用映射值，未命中的表回退到 `primary_keys = ["merchant_id"]`。
 
 ```hocon
 sink {
@@ -341,7 +341,7 @@ sink {
     driver = "com.mysql.cj.jdbc.Driver"
     generate_sink_sql = true
     primary_keys = ["merchant_id"]
-    multi-table_config {
+    multi_table_config {
       primary_keys {
         "t_tyuen_txn_ext.*"          = ["id_txn_ctrl", "DATA_SOURCE"]
         "t_nova_merge_settle_serial" = ["${primary_key}", "DATA_SOURCE"]

--- a/docs/zh/introduction/configuration/sink-options-placeholders.md
+++ b/docs/zh/introduction/configuration/sink-options-placeholders.md
@@ -139,6 +139,10 @@ primary_keys = ["${primary_key}", "tenant_id"]
 
 只有当 `${primary_key}` 是列表中的唯一元素时，才会执行列表占位符替换。
 
+上述限制仅针对顶层 `primary_keys` 选项。JDBC Sink 额外支持在
+`multi-table_config.primary_keys` 中将 `${primary_key}`（以及 `${unique_key}`）与静态列名混用，
+详见 JDBC Sink 文档。
+
 单表任务和多表任务中的行为保持一致。
 
 占位符的替换将在连接器启动之前完成，确保 Sink 参数在使用前已准备就绪。

--- a/docs/zh/introduction/configuration/sink-options-placeholders.md
+++ b/docs/zh/introduction/configuration/sink-options-placeholders.md
@@ -140,7 +140,7 @@ primary_keys = ["${primary_key}", "tenant_id"]
 只有当 `${primary_key}` 是列表中的唯一元素时，才会执行列表占位符替换。
 
 上述限制仅针对顶层 `primary_keys` 选项。JDBC Sink 额外支持在
-`multi-table_config.primary_keys` 中将 `${primary_key}`（以及 `${unique_key}`）与静态列名混用，
+`multi_table_config.primary_keys` 中将 `${primary_key}`（以及 `${unique_key}`）与静态列名混用，
 详见 JDBC Sink 文档。
 
 单表任务和多表任务中的行为保持一致。

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/multitable/MultiTableFailureHelper.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/common/multitable/MultiTableFailureHelper.java
@@ -59,7 +59,10 @@ public final class MultiTableFailureHelper {
         if (fallback == null) {
             return primary;
         }
-        return ReadonlyConfig.fromConfig(primary.toConfig().withFallback(fallback.toConfig()));
+        Map<String, Object> merged = new HashMap<>();
+        merged.putAll(fallback.getSourceMap());
+        merged.putAll(primary.getSourceMap());
+        return ReadonlyConfig.fromMap(merged);
     }
 
     public static ReadonlyConfig withMultiTableFailurePolicy(

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/ReadonlyConfig.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/ReadonlyConfig.java
@@ -22,7 +22,9 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigParseOptions;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigRenderOptions;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigSyntax;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,7 +76,13 @@ public class ReadonlyConfig implements Serializable {
      */
     @Deprecated
     public Config toConfig() {
-        return ConfigFactory.parseMap(confData);
+        try {
+            return ConfigFactory.parseString(
+                    JACKSON_MAPPER.writeValueAsString(confData),
+                    ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON));
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Json parsing exception.", e);
+        }
     }
 
     public Map<String, String> toMap() {

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/ReadonlyConfig.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/configuration/ReadonlyConfig.java
@@ -22,9 +22,7 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
-import org.apache.seatunnel.shade.com.typesafe.config.ConfigParseOptions;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigRenderOptions;
-import org.apache.seatunnel.shade.com.typesafe.config.ConfigSyntax;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -76,13 +74,7 @@ public class ReadonlyConfig implements Serializable {
      */
     @Deprecated
     public Config toConfig() {
-        try {
-            return ConfigFactory.parseString(
-                    JACKSON_MAPPER.writeValueAsString(confData),
-                    ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON));
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Json parsing exception.", e);
-        }
+        return ConfigFactory.parseMap(confData);
     }
 
     public Map<String, String> toMap() {

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/common/multitable/MultiTableFailureHelperTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/common/multitable/MultiTableFailureHelperTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.api.common.multitable;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+class MultiTableFailureHelperTest {
+
+    @Test
+    void testMergeOptionsPreservesSpecialCharacterKeys() {
+        Map<String, Object> primaryKeys = new HashMap<>();
+        primaryKeys.put("^t_nova_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
+
+        Map<String, Object> multiTableConfig = new HashMap<>();
+        multiTableConfig.put("primary_keys", primaryKeys);
+
+        Map<String, Object> primaryMap = new HashMap<>();
+        primaryMap.put("multi-table_config", multiTableConfig);
+        primaryMap.put("url", "jdbc:mysql://localhost:3306/primary");
+
+        Map<String, Object> fallbackMap = new HashMap<>();
+        fallbackMap.put("url", "jdbc:mysql://localhost:3306/fallback");
+        fallbackMap.put("username", "u");
+
+        ReadonlyConfig merged =
+                MultiTableFailureHelper.mergeOptions(
+                        ReadonlyConfig.fromMap(primaryMap), ReadonlyConfig.fromMap(fallbackMap));
+
+        Map<String, Object> mergedMap = merged.getSourceMap();
+        Assertions.assertEquals("jdbc:mysql://localhost:3306/primary", mergedMap.get("url"));
+        Assertions.assertEquals("u", mergedMap.get("username"));
+
+        Map<String, Object> mergedMultiTableConfig =
+                (Map<String, Object>) mergedMap.get("multi-table_config");
+        Assertions.assertNotNull(mergedMultiTableConfig);
+        Map<String, Object> mergedPrimaryKeys =
+                (Map<String, Object>) mergedMultiTableConfig.get("primary_keys");
+        Assertions.assertNotNull(mergedPrimaryKeys);
+        Assertions.assertTrue(mergedPrimaryKeys.containsKey("^t_nova_.*$"));
+        Assertions.assertEquals(
+                Arrays.asList("${primary_key}", "DATA_SOURCE"),
+                mergedPrimaryKeys.get("^t_nova_.*$"));
+    }
+}

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/common/multitable/MultiTableFailureHelperTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/common/multitable/MultiTableFailureHelperTest.java
@@ -37,7 +37,7 @@ class MultiTableFailureHelperTest {
         multiTableConfig.put("primary_keys", primaryKeys);
 
         Map<String, Object> primaryMap = new HashMap<>();
-        primaryMap.put("multi-table_config", multiTableConfig);
+        primaryMap.put("multi_table_config", multiTableConfig);
         primaryMap.put("url", "jdbc:mysql://localhost:3306/primary");
 
         Map<String, Object> fallbackMap = new HashMap<>();
@@ -53,7 +53,7 @@ class MultiTableFailureHelperTest {
         Assertions.assertEquals("u", mergedMap.get("username"));
 
         Map<String, Object> mergedMultiTableConfig =
-                (Map<String, Object>) mergedMap.get("multi-table_config");
+                (Map<String, Object>) mergedMap.get("multi_table_config");
         Assertions.assertNotNull(mergedMultiTableConfig);
         Map<String, Object> mergedPrimaryKeys =
                 (Map<String, Object>) mergedMultiTableConfig.get("primary_keys");

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/ReadableConfigTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/ReadableConfigTest.java
@@ -31,7 +31,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -378,27 +377,5 @@ public class ReadableConfigTest {
         map.put("user", null);
         ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
         Assertions.assertNull(readonlyConfig.toMap().get("user"));
-    }
-
-    @Test
-    public void testToConfigPreservesSpecialCharacterKeys() {
-        Map<String, Object> primaryKeys = new HashMap<>();
-        primaryKeys.put("^t_nova_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
-
-        Map<String, Object> multiTableConfig = new HashMap<>();
-        multiTableConfig.put("primary_keys", primaryKeys);
-
-        Map<String, Object> map = new HashMap<>();
-        map.put("multi-table_config", multiTableConfig);
-
-        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
-        Config config = readonlyConfig.toConfig();
-
-        Map<String, Object> result =
-                config.getConfig("multi-table_config").getConfig("primary_keys").root().unwrapped();
-
-        Assertions.assertTrue(result.containsKey("^t_nova_.*$"));
-        Assertions.assertEquals(
-                Arrays.asList("${primary_key}", "DATA_SOURCE"), result.get("^t_nova_.*$"));
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/ReadableConfigTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/ReadableConfigTest.java
@@ -31,6 +31,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -377,5 +378,27 @@ public class ReadableConfigTest {
         map.put("user", null);
         ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
         Assertions.assertNull(readonlyConfig.toMap().get("user"));
+    }
+
+    @Test
+    public void testToConfigPreservesSpecialCharacterKeys() {
+        Map<String, Object> primaryKeys = new HashMap<>();
+        primaryKeys.put("^t_nova_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
+
+        Map<String, Object> multiTableConfig = new HashMap<>();
+        multiTableConfig.put("primary_keys", primaryKeys);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("multi-table_config", multiTableConfig);
+
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
+        Config config = readonlyConfig.toConfig();
+
+        Map<String, Object> result =
+                config.getConfig("multi-table_config").getConfig("primary_keys").root().unwrapped();
+
+        Assertions.assertTrue(result.containsKey("^t_nova_.*$"));
+        Assertions.assertEquals(
+                Arrays.asList("${primary_key}", "DATA_SOURCE"), result.get("^t_nova_.*$"));
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/ReadableConfigTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/configuration/ReadableConfigTest.java
@@ -378,4 +378,15 @@ public class ReadableConfigTest {
         ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
         Assertions.assertNull(readonlyConfig.toMap().get("user"));
     }
+
+    @Test
+    public void testToConfigPreservesDottedKeyExpansion() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("a.b", 1);
+
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(map);
+        Config config = readonlyConfig.toConfig();
+
+        Assertions.assertEquals(1, config.getInt("a.b"));
+    }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkOptions.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.sink.SchemaSaveMode;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.internal.dialect.dialectenum.FieldIdeEnum;
 
 import java.util.List;
+import java.util.Map;
 
 public class JdbcSinkOptions extends JdbcCommonOptions {
 
@@ -107,6 +108,17 @@ public class JdbcSinkOptions extends JdbcCommonOptions {
 
     public static final Option<List<String>> PRIMARY_KEYS =
             Options.key("primary_keys").listType().noDefaultValue().withDescription("primary keys");
+
+    public static final Option<Map<String, Object>> MULTI_TABLE_CONFIG =
+            Options.key("multi-table_config")
+                    .mapObjectType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Per-table primary key mapping for multi-table generated-SQL sinks. "
+                                    + "When a table matches one of the patterns under primary_keys, "
+                                    + "that mapping takes precedence over the top-level `primary_keys` "
+                                    + "option. Value shape: { primary_keys = { \"<regex>\" = "
+                                    + "[\"col1\", \"${primary_key}\"] } }.");
 
     public static final Option<Boolean> IS_PRIMARY_KEY_UPDATED =
             Options.key("is_primary_key_updated")

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/config/JdbcSinkOptions.java
@@ -110,7 +110,7 @@ public class JdbcSinkOptions extends JdbcCommonOptions {
             Options.key("primary_keys").listType().noDefaultValue().withDescription("primary keys");
 
     public static final Option<Map<String, Object>> MULTI_TABLE_CONFIG =
-            Options.key("multi-table_config")
+            Options.key("multi_table_config")
                     .mapObjectType()
                     .noDefaultValue()
                     .withDescription(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/exception/JdbcConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/exception/JdbcConnectorErrorCode.java
@@ -33,7 +33,8 @@ public enum JdbcConnectorErrorCode implements SeaTunnelErrorCode {
     NO_SUPPORT_OPERATION_FAILED("JDBC-09", "The jdbc driver not support operation."),
     DATA_TYPE_CAST_FAILED("JDBC-10", "Data type cast failed"),
     REFRESH_PHYSICAL_TABLESCHEMA_BY_SCHEMA_CHANGE_EVENT(
-            "JDBC-11", "Refresh the table with schema change failed");
+            "JDBC-11", "Refresh the table with schema change failed"),
+    INVALID_MULTI_TABLE_CONFIG("JDBC-12", "Invalid multi-table_config primary key mapping");
 
     private final String code;
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/exception/JdbcConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/exception/JdbcConnectorErrorCode.java
@@ -34,7 +34,7 @@ public enum JdbcConnectorErrorCode implements SeaTunnelErrorCode {
     DATA_TYPE_CAST_FAILED("JDBC-10", "Data type cast failed"),
     REFRESH_PHYSICAL_TABLESCHEMA_BY_SCHEMA_CHANGE_EVENT(
             "JDBC-11", "Refresh the table with schema change failed"),
-    INVALID_MULTI_TABLE_CONFIG("JDBC-12", "Invalid multi-table_config primary key mapping");
+    INVALID_MULTI_TABLE_CONFIG("JDBC-12", "Invalid multi_table_config primary key mapping");
 
     private final String code;
 

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -125,68 +125,9 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         Optional<List<String>> multiTablePrimaryKeys =
                 resolveMultiTablePrimaryKeys(config, catalogTable);
         if (multiTablePrimaryKeys.isPresent()) {
-            List<String> primaryKeys = multiTablePrimaryKeys.get();
-            PrimaryKey configPk =
-                    PrimaryKey.of(
-                            catalogTable.getTablePath().getTableName() + "_config_pk", primaryKeys);
-            map.put(JdbcSinkOptions.PRIMARY_KEYS.key(), String.join(",", primaryKeys));
-            TableSchema tableSchema = catalogTable.getTableSchema();
-            catalogTable =
-                    CatalogTable.of(
-                            catalogTable.getTableId(),
-                            TableSchema.builder()
-                                    .primaryKey(configPk)
-                                    .constraintKey(tableSchema.getConstraintKeys())
-                                    .columns(tableSchema.getColumns())
-                                    .build(),
-                            catalogTable.getOptions(),
-                            catalogTable.getPartitionKeys(),
-                            catalogTable.getComment(),
-                            catalogTable.getCatalogName());
+            catalogTable = applyPrimaryKeys(map, catalogTable, multiTablePrimaryKeys.get());
         } else {
-            PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
-            if (CollectionUtils.isEmpty(config.get(JdbcSinkOptions.PRIMARY_KEYS))) {
-                if (primaryKey != null && !CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
-                    map.put(
-                            JdbcSinkOptions.PRIMARY_KEYS.key(),
-                            String.join(",", primaryKey.getColumnNames()));
-                } else {
-                    Optional<ConstraintKey> keyOptional =
-                            catalogTable.getTableSchema().getConstraintKeys().stream()
-                                    .filter(
-                                            key ->
-                                                    ConstraintKey.ConstraintType.UNIQUE_KEY.equals(
-                                                            key.getConstraintType()))
-                                    .findFirst();
-                    keyOptional.ifPresent(
-                            constraintKey ->
-                                    map.put(
-                                            JdbcSinkOptions.PRIMARY_KEYS.key(),
-                                            constraintKey.getColumnNames().stream()
-                                                    .map(
-                                                            ConstraintKey.ConstraintKeyColumn
-                                                                    ::getColumnName)
-                                                    .collect(Collectors.joining(","))));
-                }
-            } else {
-                PrimaryKey configPk =
-                        PrimaryKey.of(
-                                catalogTable.getTablePath().getTableName() + "_config_pk",
-                                config.get(JdbcSinkOptions.PRIMARY_KEYS));
-                TableSchema tableSchema = catalogTable.getTableSchema();
-                catalogTable =
-                        CatalogTable.of(
-                                catalogTable.getTableId(),
-                                TableSchema.builder()
-                                        .primaryKey(configPk)
-                                        .constraintKey(tableSchema.getConstraintKeys())
-                                        .columns(tableSchema.getColumns())
-                                        .build(),
-                                catalogTable.getOptions(),
-                                catalogTable.getPartitionKeys(),
-                                catalogTable.getComment(),
-                                catalogTable.getCatalogName());
-            }
+            catalogTable = applyFallbackPrimaryKeys(config, map, catalogTable);
         }
         config = ReadonlyConfig.fromMap(new HashMap<>(map));
         final ReadonlyConfig options = config;
@@ -219,6 +160,89 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                         finalCatalogTable);
     }
 
+    /**
+     * Writes the resolved primary key columns into the sink config map and rebuilds the catalog
+     * table so that auto-created tables and generated upsert/update/delete statements use the given
+     * key columns.
+     *
+     * @param map the sink config map that is later turned back into a {@link ReadonlyConfig}
+     * @param catalogTable the table being processed
+     * @param primaryKeys the resolved key columns
+     * @return a new catalog table whose primary key is replaced with the resolved columns
+     */
+    private CatalogTable applyPrimaryKeys(
+            Map<String, String> map, CatalogTable catalogTable, List<String> primaryKeys) {
+        map.put(JdbcSinkOptions.PRIMARY_KEYS.key(), String.join(",", primaryKeys));
+        PrimaryKey configPk =
+                PrimaryKey.of(
+                        catalogTable.getTablePath().getTableName() + "_config_pk", primaryKeys);
+        TableSchema tableSchema = catalogTable.getTableSchema();
+        return CatalogTable.of(
+                catalogTable.getTableId(),
+                TableSchema.builder()
+                        .primaryKey(configPk)
+                        .constraintKey(tableSchema.getConstraintKeys())
+                        .columns(tableSchema.getColumns())
+                        .build(),
+                catalogTable.getOptions(),
+                catalogTable.getPartitionKeys(),
+                catalogTable.getComment(),
+                catalogTable.getCatalogName());
+    }
+
+    /**
+     * Resolves the primary key columns using the pre-existing fallback logic when no multi-table
+     * mapping matches: explicit top-level {@code primary_keys}, otherwise the catalog primary key,
+     * otherwise the first unique key. When no key can be determined, the config map is left
+     * unchanged and the sink falls back to plain INSERT.
+     *
+     * @param config the sink config
+     * @param map the sink config map that is later turned back into a {@link ReadonlyConfig}
+     * @param catalogTable the table being processed
+     * @return the (possibly rebuilt) catalog table
+     */
+    private CatalogTable applyFallbackPrimaryKeys(
+            ReadonlyConfig config, Map<String, String> map, CatalogTable catalogTable) {
+        PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
+        if (CollectionUtils.isEmpty(config.get(JdbcSinkOptions.PRIMARY_KEYS))) {
+            if (primaryKey != null && !CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
+                map.put(
+                        JdbcSinkOptions.PRIMARY_KEYS.key(),
+                        String.join(",", primaryKey.getColumnNames()));
+            } else {
+                Optional<ConstraintKey> keyOptional =
+                        catalogTable.getTableSchema().getConstraintKeys().stream()
+                                .filter(
+                                        key ->
+                                                ConstraintKey.ConstraintType.UNIQUE_KEY.equals(
+                                                        key.getConstraintType()))
+                                .findFirst();
+                keyOptional.ifPresent(
+                        constraintKey ->
+                                map.put(
+                                        JdbcSinkOptions.PRIMARY_KEYS.key(),
+                                        constraintKey.getColumnNames().stream()
+                                                .map(
+                                                        ConstraintKey.ConstraintKeyColumn
+                                                                ::getColumnName)
+                                                .collect(Collectors.joining(","))));
+            }
+            return catalogTable;
+        }
+        return applyPrimaryKeys(map, catalogTable, config.get(JdbcSinkOptions.PRIMARY_KEYS));
+    }
+
+    /**
+     * Resolves the per-table primary key mapping from {@code multi-table_config.primary_keys}.
+     *
+     * <p>Each key is a Java regular expression matched against the upstream table name using full
+     * match semantics; the first matching pattern in declaration order wins. An unmatched table
+     * returns {@link Optional#empty()}, leaving the fallback logic to run.
+     *
+     * @param config the sink config
+     * @param catalogTable the table being processed
+     * @return the resolved key columns, or {@link Optional#empty()} when no pattern matches
+     */
     Optional<List<String>> resolveMultiTablePrimaryKeys(
             ReadonlyConfig config, CatalogTable catalogTable) {
         Map<String, Object> multiTableConfig = config.get(JdbcSinkOptions.MULTI_TABLE_CONFIG);
@@ -242,6 +266,11 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         return Optional.empty();
     }
 
+    /**
+     * Matches a table name against a regular expression using full-match semantics.
+     *
+     * @throws JdbcConnectorException when the pattern is not a valid regular expression
+     */
     private boolean matchesPattern(String tableName, String pattern) {
         try {
             return tableName.matches(pattern);
@@ -255,6 +284,12 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         }
     }
 
+    /**
+     * Converts a configured primary key value into a list of column names. A list value is used
+     * as-is; a string value is split by comma.
+     *
+     * @throws JdbcConnectorException when the value is neither a list nor a string
+     */
     private List<String> toPrimaryKeyList(Object value) {
         if (value instanceof List) {
             List<String> keys = new ArrayList<>();
@@ -277,6 +312,14 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                 "multi-table_config.primary_keys values must be a string or a list of strings.");
     }
 
+    /**
+     * Expands {@code ${primary_key}} and {@code ${unique_key}} placeholders in a key-column list.
+     * Each placeholder must be a whole element and is replaced by the corresponding upstream key
+     * columns.
+     *
+     * @throws JdbcConnectorException when a placeholder is used but the upstream table has no
+     *     matching key
+     */
     private List<String> expandPrimaryKeyPlaceholder(
             List<String> keys, CatalogTable catalogTable, String pattern) {
         String primaryKeyPlaceholder =
@@ -314,6 +357,9 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         return resolved;
     }
 
+    /**
+     * Returns the upstream primary key column names, or an empty list when there is no primary key.
+     */
     private List<String> getPrimaryKeyColumns(CatalogTable catalogTable) {
         PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
         if (primaryKey == null || CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
@@ -322,6 +368,10 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         return new ArrayList<>(primaryKey.getColumnNames());
     }
 
+    /**
+     * Returns the first upstream unique key column names, or an empty list when there is no unique
+     * key.
+     */
     private List<String> getUniqueKeyColumns(CatalogTable catalogTable) {
         Optional<ConstraintKey> keyOptional =
                 catalogTable.getTableSchema().getConstraintKeys().stream()

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -28,6 +28,7 @@ import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.sink.DataSaveMode;
 import org.apache.seatunnel.api.sink.SchemaSaveMode;
+import org.apache.seatunnel.api.sink.TablePlaceholder;
 import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.Column;
@@ -55,6 +56,9 @@ import org.apache.commons.collections4.CollectionUtils;
 import com.google.auto.service.AutoService;
 
 import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -118,35 +122,14 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
             map.put(JdbcSinkOptions.TABLE.key(), catalogTable.getTableId().getTableName());
         }
         map.put(JdbcSinkOptions.DATABASE.key(), catalogTable.getTableId().getDatabaseName());
-        PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
-        if (CollectionUtils.isEmpty(config.get(JdbcSinkOptions.PRIMARY_KEYS))) {
-            if (primaryKey != null && !CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
-                map.put(
-                        JdbcSinkOptions.PRIMARY_KEYS.key(),
-                        String.join(",", primaryKey.getColumnNames()));
-            } else {
-                Optional<ConstraintKey> keyOptional =
-                        catalogTable.getTableSchema().getConstraintKeys().stream()
-                                .filter(
-                                        key ->
-                                                ConstraintKey.ConstraintType.UNIQUE_KEY.equals(
-                                                        key.getConstraintType()))
-                                .findFirst();
-                keyOptional.ifPresent(
-                        constraintKey ->
-                                map.put(
-                                        JdbcSinkOptions.PRIMARY_KEYS.key(),
-                                        constraintKey.getColumnNames().stream()
-                                                .map(
-                                                        ConstraintKey.ConstraintKeyColumn
-                                                                ::getColumnName)
-                                                .collect(Collectors.joining(","))));
-            }
-        } else {
+        Optional<List<String>> multiTablePrimaryKeys =
+                resolveMultiTablePrimaryKeys(config, catalogTable);
+        if (multiTablePrimaryKeys.isPresent()) {
+            List<String> primaryKeys = multiTablePrimaryKeys.get();
             PrimaryKey configPk =
                     PrimaryKey.of(
-                            catalogTable.getTablePath().getTableName() + "_config_pk",
-                            config.get(JdbcSinkOptions.PRIMARY_KEYS));
+                            catalogTable.getTablePath().getTableName() + "_config_pk", primaryKeys);
+            map.put(JdbcSinkOptions.PRIMARY_KEYS.key(), String.join(",", primaryKeys));
             TableSchema tableSchema = catalogTable.getTableSchema();
             catalogTable =
                     CatalogTable.of(
@@ -160,6 +143,50 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                             catalogTable.getPartitionKeys(),
                             catalogTable.getComment(),
                             catalogTable.getCatalogName());
+        } else {
+            PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
+            if (CollectionUtils.isEmpty(config.get(JdbcSinkOptions.PRIMARY_KEYS))) {
+                if (primaryKey != null && !CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
+                    map.put(
+                            JdbcSinkOptions.PRIMARY_KEYS.key(),
+                            String.join(",", primaryKey.getColumnNames()));
+                } else {
+                    Optional<ConstraintKey> keyOptional =
+                            catalogTable.getTableSchema().getConstraintKeys().stream()
+                                    .filter(
+                                            key ->
+                                                    ConstraintKey.ConstraintType.UNIQUE_KEY.equals(
+                                                            key.getConstraintType()))
+                                    .findFirst();
+                    keyOptional.ifPresent(
+                            constraintKey ->
+                                    map.put(
+                                            JdbcSinkOptions.PRIMARY_KEYS.key(),
+                                            constraintKey.getColumnNames().stream()
+                                                    .map(
+                                                            ConstraintKey.ConstraintKeyColumn
+                                                                    ::getColumnName)
+                                                    .collect(Collectors.joining(","))));
+                }
+            } else {
+                PrimaryKey configPk =
+                        PrimaryKey.of(
+                                catalogTable.getTablePath().getTableName() + "_config_pk",
+                                config.get(JdbcSinkOptions.PRIMARY_KEYS));
+                TableSchema tableSchema = catalogTable.getTableSchema();
+                catalogTable =
+                        CatalogTable.of(
+                                catalogTable.getTableId(),
+                                TableSchema.builder()
+                                        .primaryKey(configPk)
+                                        .constraintKey(tableSchema.getConstraintKeys())
+                                        .columns(tableSchema.getColumns())
+                                        .build(),
+                                catalogTable.getOptions(),
+                                catalogTable.getPartitionKeys(),
+                                catalogTable.getComment(),
+                                catalogTable.getCatalogName());
+            }
         }
         config = ReadonlyConfig.fromMap(new HashMap<>(map));
         final ReadonlyConfig options = config;
@@ -192,6 +219,126 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                         finalCatalogTable);
     }
 
+    Optional<List<String>> resolveMultiTablePrimaryKeys(
+            ReadonlyConfig config, CatalogTable catalogTable) {
+        Map<String, Object> multiTableConfig = config.get(JdbcSinkOptions.MULTI_TABLE_CONFIG);
+        if (multiTableConfig == null || multiTableConfig.isEmpty()) {
+            return Optional.empty();
+        }
+        Object primaryKeysObj = multiTableConfig.get("primary_keys");
+        if (!(primaryKeysObj instanceof Map)) {
+            return Optional.empty();
+        }
+        String tableName = catalogTable.getTableId().getTableName();
+        Map<?, ?> primaryKeyMap = (Map<?, ?>) primaryKeysObj;
+        for (Map.Entry<?, ?> entry : primaryKeyMap.entrySet()) {
+            String pattern = String.valueOf(entry.getKey());
+            if (matchesPattern(tableName, pattern)) {
+                return Optional.of(
+                        expandPrimaryKeyPlaceholder(
+                                toPrimaryKeyList(entry.getValue()), catalogTable, pattern));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean matchesPattern(String tableName, String pattern) {
+        try {
+            return tableName.matches(pattern);
+        } catch (java.util.regex.PatternSyntaxException e) {
+            throw new JdbcConnectorException(
+                    JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
+                    String.format(
+                            "Invalid regular expression '%s' in multi-table_config.primary_keys.",
+                            pattern),
+                    e);
+        }
+    }
+
+    private List<String> toPrimaryKeyList(Object value) {
+        if (value instanceof List) {
+            List<String> keys = new ArrayList<>();
+            for (Object element : (List<?>) value) {
+                keys.add(String.valueOf(element));
+            }
+            return keys;
+        }
+        if (value instanceof String) {
+            String stringValue = (String) value;
+            if (StringUtils.isBlank(stringValue)) {
+                return Collections.emptyList();
+            }
+            return Arrays.stream(stringValue.split(","))
+                    .map(String::trim)
+                    .collect(Collectors.toList());
+        }
+        throw new JdbcConnectorException(
+                JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
+                "multi-table_config.primary_keys values must be a string or a list of strings.");
+    }
+
+    private List<String> expandPrimaryKeyPlaceholder(
+            List<String> keys, CatalogTable catalogTable, String pattern) {
+        String primaryKeyPlaceholder =
+                "${" + TablePlaceholder.REPLACE_PRIMARY_KEY.getPlaceholder() + "}";
+        String uniqueKeyPlaceholder =
+                "${" + TablePlaceholder.REPLACE_UNIQUE_KEY.getPlaceholder() + "}";
+        List<String> primaryKeyColumns = getPrimaryKeyColumns(catalogTable);
+        List<String> uniqueKeyColumns = getUniqueKeyColumns(catalogTable);
+        List<String> resolved = new ArrayList<>();
+        for (String key : keys) {
+            if (primaryKeyPlaceholder.equals(key)) {
+                if (primaryKeyColumns.isEmpty()) {
+                    throw new JdbcConnectorException(
+                            JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
+                            String.format(
+                                    "Table '%s' matched pattern '%s' in multi-table_config.primary_keys "
+                                            + "which uses '${primary_key}', but the upstream table has no primary key.",
+                                    catalogTable.getTableId().getTableName(), pattern));
+                }
+                resolved.addAll(primaryKeyColumns);
+            } else if (uniqueKeyPlaceholder.equals(key)) {
+                if (uniqueKeyColumns.isEmpty()) {
+                    throw new JdbcConnectorException(
+                            JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
+                            String.format(
+                                    "Table '%s' matched pattern '%s' in multi-table_config.primary_keys "
+                                            + "which uses '${unique_key}', but the upstream table has no unique key.",
+                                    catalogTable.getTableId().getTableName(), pattern));
+                }
+                resolved.addAll(uniqueKeyColumns);
+            } else {
+                resolved.add(key);
+            }
+        }
+        return resolved;
+    }
+
+    private List<String> getPrimaryKeyColumns(CatalogTable catalogTable) {
+        PrimaryKey primaryKey = catalogTable.getTableSchema().getPrimaryKey();
+        if (primaryKey == null || CollectionUtils.isEmpty(primaryKey.getColumnNames())) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(primaryKey.getColumnNames());
+    }
+
+    private List<String> getUniqueKeyColumns(CatalogTable catalogTable) {
+        Optional<ConstraintKey> keyOptional =
+                catalogTable.getTableSchema().getConstraintKeys().stream()
+                        .filter(
+                                key ->
+                                        ConstraintKey.ConstraintType.UNIQUE_KEY.equals(
+                                                key.getConstraintType()))
+                        .findFirst();
+        return keyOptional
+                .map(
+                        constraintKey ->
+                                constraintKey.getColumnNames().stream()
+                                        .map(ConstraintKey.ConstraintKeyColumn::getColumnName)
+                                        .collect(Collectors.toList()))
+                .orElseGet(Collections::emptyList);
+    }
+
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
@@ -220,6 +367,7 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                         JdbcSinkOptions.GENERATE_SINK_SQL,
                         JdbcSinkOptions.AUTO_COMMIT,
                         JdbcSinkOptions.PRIMARY_KEYS,
+                        JdbcSinkOptions.MULTI_TABLE_CONFIG,
                         JdbcSinkOptions.IS_PRIMARY_KEY_UPDATED,
                         JdbcSinkOptions.SUPPORT_UPSERT_BY_INSERT_ONLY,
                         JdbcSinkOptions.USE_COPY_STATEMENT,

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -66,13 +66,23 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @AutoService(Factory.class)
 public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValidation {
-    private static final Map<String, Pattern> COMPILED_PATTERN_CACHE = new ConcurrentHashMap<>();
+    private static final int MAX_CACHED_PATTERNS = 256;
+
+    // Shared across all jobs in this JVM; bounded LRU so dynamically-generated regex patterns
+    // cannot grow this cache without limit over the life of the process.
+    private static final Map<String, Pattern> COMPILED_PATTERN_CACHE =
+            Collections.synchronizedMap(
+                    new LinkedHashMap<String, Pattern>(16, 0.75f, true) {
+                        @Override
+                        protected boolean removeEldestEntry(Map.Entry<String, Pattern> eldest) {
+                            return size() > MAX_CACHED_PATTERNS;
+                        }
+                    });
 
     @Override
     public String factoryIdentifier() {

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -60,11 +60,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @AutoService(Factory.class)
@@ -172,6 +174,7 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
      */
     private CatalogTable applyPrimaryKeys(
             Map<String, String> map, CatalogTable catalogTable, List<String> primaryKeys) {
+        validatePrimaryKeyColumns(primaryKeys, catalogTable.getTablePath().getTableName());
         map.put(JdbcSinkOptions.PRIMARY_KEYS.key(), String.join(",", primaryKeys));
         PrimaryKey configPk =
                 PrimaryKey.of(
@@ -233,11 +236,40 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
     }
 
     /**
-     * Resolves the per-table primary key mapping from {@code multi-table_config.primary_keys}.
+     * Validates that each resolved primary key column is a non-empty plain identifier that does not
+     * contain a comma, so it can be safely comma-joined into {@code PRIMARY_KEYS} and used in
+     * generated SQL.
+     *
+     * @param primaryKeys the resolved key columns
+     * @param tableName the table being processed, used in the error message
+     * @throws JdbcConnectorException when a column name is blank or contains a comma
+     */
+    private void validatePrimaryKeyColumns(List<String> primaryKeys, String tableName) {
+        for (String key : primaryKeys) {
+            if (StringUtils.isBlank(key)) {
+                throw new JdbcConnectorException(
+                        JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
+                        String.format(
+                                "Resolved primary key column for table '%s' is empty.", tableName));
+            }
+            if (key.contains(",")) {
+                throw new JdbcConnectorException(
+                        JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
+                        String.format(
+                                "Resolved primary key column '%s' for table '%s' must not contain a comma.",
+                                key, tableName));
+            }
+        }
+    }
+
+    /**
+     * Resolves the per-table primary key mapping from {@code multi_table_config.primary_keys}.
      *
      * <p>Each key is a Java regular expression matched against the upstream table name using full
-     * match semantics; the first matching pattern in declaration order wins. An unmatched table
-     * returns {@link Optional#empty()}, leaving the fallback logic to run.
+     * match semantics; the first matching pattern in declaration order wins. Every pattern is
+     * compiled eagerly so an invalid expression fails fast with {@code JDBC-12} instead of
+     * surfacing lazily once a matching table is processed. An unmatched table returns {@link
+     * Optional#empty()}, leaving the fallback logic to run.
      *
      * @param config the sink config
      * @param catalogTable the table being processed
@@ -253,32 +285,50 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         if (!(primaryKeysObj instanceof Map)) {
             return Optional.empty();
         }
+        LinkedHashMap<Pattern, List<String>> primaryKeyMap =
+                toCompiledPatternMap((Map<?, ?>) primaryKeysObj);
         String tableName = catalogTable.getTableId().getTableName();
-        Map<?, ?> primaryKeyMap = (Map<?, ?>) primaryKeysObj;
-        for (Map.Entry<?, ?> entry : primaryKeyMap.entrySet()) {
-            String pattern = String.valueOf(entry.getKey());
-            if (matchesPattern(tableName, pattern)) {
+        for (Map.Entry<Pattern, List<String>> entry : primaryKeyMap.entrySet()) {
+            if (entry.getKey().matcher(tableName).matches()) {
                 return Optional.of(
                         expandPrimaryKeyPlaceholder(
-                                toPrimaryKeyList(entry.getValue()), catalogTable, pattern));
+                                entry.getValue(), catalogTable, entry.getKey().pattern()));
             }
         }
         return Optional.empty();
     }
 
     /**
-     * Matches a table name against a regular expression using full-match semantics.
+     * Converts the configured {@code primary_keys} map into an ordered map of compiled patterns to
+     * key-column lists. A {@link LinkedHashMap} is used so the first matching pattern in
+     * declaration order wins.
+     *
+     * @throws JdbcConnectorException when a pattern is not a valid regular expression
+     */
+    private LinkedHashMap<Pattern, List<String>> toCompiledPatternMap(Map<?, ?> primaryKeyMap) {
+        LinkedHashMap<Pattern, List<String>> ordered = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : primaryKeyMap.entrySet()) {
+            ordered.put(
+                    compilePattern(String.valueOf(entry.getKey())),
+                    toPrimaryKeyList(entry.getValue()));
+        }
+        return ordered;
+    }
+
+    /**
+     * Compiles a user-supplied regular expression and raises {@code JDBC-12} up front when it is
+     * invalid.
      *
      * @throws JdbcConnectorException when the pattern is not a valid regular expression
      */
-    private boolean matchesPattern(String tableName, String pattern) {
+    private Pattern compilePattern(String pattern) {
         try {
-            return tableName.matches(pattern);
+            return Pattern.compile(pattern);
         } catch (java.util.regex.PatternSyntaxException e) {
             throw new JdbcConnectorException(
                     JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
                     String.format(
-                            "Invalid regular expression '%s' in multi-table_config.primary_keys.",
+                            "Invalid regular expression '%s' in multi_table_config.primary_keys.",
                             pattern),
                     e);
         }
@@ -309,7 +359,7 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
         }
         throw new JdbcConnectorException(
                 JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
-                "multi-table_config.primary_keys values must be a string or a list of strings.");
+                "multi_table_config.primary_keys values must be a string or a list of strings.");
     }
 
     /**
@@ -335,7 +385,7 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                     throw new JdbcConnectorException(
                             JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
                             String.format(
-                                    "Table '%s' matched pattern '%s' in multi-table_config.primary_keys "
+                                    "Table '%s' matched pattern '%s' in multi_table_config.primary_keys "
                                             + "which uses '${primary_key}', but the upstream table has no primary key.",
                                     catalogTable.getTableId().getTableName(), pattern));
                 }
@@ -345,7 +395,7 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                     throw new JdbcConnectorException(
                             JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
                             String.format(
-                                    "Table '%s' matched pattern '%s' in multi-table_config.primary_keys "
+                                    "Table '%s' matched pattern '%s' in multi_table_config.primary_keys "
                                             + "which uses '${unique_key}', but the upstream table has no unique key.",
                                     catalogTable.getTableId().getTableName(), pattern));
                 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactory.java
@@ -66,11 +66,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @AutoService(Factory.class)
 public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValidation {
+    private static final Map<String, Pattern> COMPILED_PATTERN_CACHE = new ConcurrentHashMap<>();
+
     @Override
     public String factoryIdentifier() {
         return "Jdbc";
@@ -316,14 +319,19 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
     }
 
     /**
-     * Compiles a user-supplied regular expression and raises {@code JDBC-12} up front when it is
-     * invalid.
+     * Compiles a user-supplied regular expression, memoizing the result so each distinct pattern is
+     * compiled only once and reused across tables. Raises {@code JDBC-12} up front when the pattern
+     * is invalid.
      *
      * @throws JdbcConnectorException when the pattern is not a valid regular expression
      */
-    private Pattern compilePattern(String pattern) {
+    Pattern compilePattern(String pattern) {
+        Pattern compiled = COMPILED_PATTERN_CACHE.get(pattern);
+        if (compiled != null) {
+            return compiled;
+        }
         try {
-            return Pattern.compile(pattern);
+            compiled = Pattern.compile(pattern);
         } catch (java.util.regex.PatternSyntaxException e) {
             throw new JdbcConnectorException(
                     JdbcConnectorErrorCode.INVALID_MULTI_TABLE_CONFIG,
@@ -332,6 +340,8 @@ public class JdbcSinkFactory implements TableSinkFactory, SupportSinkDryRunValid
                             pattern),
                     e);
         }
+        COMPILED_PATTERN_CACHE.put(pattern, compiled);
+        return compiled;
     }
 
     /**

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
@@ -29,14 +29,19 @@ import org.apache.seatunnel.api.table.catalog.TableSchema;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.exception.JdbcConnectorException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 class JdbcSinkFactoryTest {
 
@@ -75,6 +80,41 @@ class JdbcSinkFactoryTest {
                 new ArrayList<>(),
                 null,
                 "catalog");
+    }
+
+    private CatalogTable createCatalogTable(String tableName, List<String> primaryKeyColumns) {
+        TableSchema.Builder schemaBuilder =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 22, false, null, "id"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "name", BasicType.STRING_TYPE, 128, false, null, "name"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "DATA_SOURCE",
+                                        BasicType.STRING_TYPE,
+                                        32,
+                                        false,
+                                        null,
+                                        "DATA_SOURCE"));
+        if (primaryKeyColumns != null && !primaryKeyColumns.isEmpty()) {
+            schemaBuilder.primaryKey(PrimaryKey.of("pk_id", primaryKeyColumns));
+        }
+        return CatalogTable.of(
+                TableIdentifier.of("catalog", "ORCL", null, tableName),
+                schemaBuilder.build(),
+                new HashMap<>(),
+                new ArrayList<>(),
+                null,
+                "catalog");
+    }
+
+    private ReadonlyConfig multiTableReadonlyConfig(Map<String, Object> primaryKeys) {
+        Map<String, Object> cfg = baseConfig();
+        Map<String, Object> multiTableConfig = new LinkedHashMap<>();
+        multiTableConfig.put("primary_keys", primaryKeys);
+        cfg.put("multi-table_config", multiTableConfig);
+        return ReadonlyConfig.fromMap(cfg);
     }
 
     /**
@@ -241,5 +281,77 @@ class JdbcSinkFactoryTest {
                 "Factory-level validation and createSink should succeed even when "
                         + "CatalogTable has primary keys; the PK + APPEND_VALUES conflict "
                         + "is guarded at runtime by JdbcOutputFormatBuilder.validateOracleInsertMode");
+    }
+
+    @Test
+    void testResolveMultiTablePrimaryKeysMapped() {
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^TEST_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
+        ReadonlyConfig config = multiTableReadonlyConfig(primaryKeys);
+        CatalogTable table = createCatalogTable("TEST_TABLE", Collections.singletonList("id"));
+
+        Optional<List<String>> resolved = factory.resolveMultiTablePrimaryKeys(config, table);
+
+        Assertions.assertTrue(resolved.isPresent());
+        Assertions.assertEquals(Arrays.asList("id", "DATA_SOURCE"), resolved.get());
+    }
+
+    @Test
+    void testResolveMultiTablePrimaryKeysUnmatched() {
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^OTHER_.*$", Arrays.asList("id_txn_ctrl"));
+        ReadonlyConfig config = multiTableReadonlyConfig(primaryKeys);
+        CatalogTable table = createCatalogTable("TEST_TABLE", Collections.singletonList("id"));
+
+        Assertions.assertFalse(factory.resolveMultiTablePrimaryKeys(config, table).isPresent());
+    }
+
+    @Test
+    void testResolveMultiTablePrimaryKeysMissingPrimaryKeyFails() {
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^TEST_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
+        ReadonlyConfig config = multiTableReadonlyConfig(primaryKeys);
+        CatalogTable table = createCatalogTable("TEST_TABLE", Collections.emptyList());
+
+        Assertions.assertThrows(
+                JdbcConnectorException.class,
+                () -> factory.resolveMultiTablePrimaryKeys(config, table));
+    }
+
+    @Test
+    void testResolveMultiTablePrimaryKeysFirstMatchWins() {
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^TEST_.*$", Arrays.asList("id"));
+        primaryKeys.put("^T.*$", Arrays.asList("other"));
+        ReadonlyConfig config = multiTableReadonlyConfig(primaryKeys);
+        CatalogTable table = createCatalogTable("TEST_TABLE", Collections.singletonList("id"));
+
+        Assertions.assertEquals(
+                Collections.singletonList("id"),
+                factory.resolveMultiTablePrimaryKeys(config, table).get());
+    }
+
+    @Test
+    void testResolveMultiTablePrimaryKeysStringValue() {
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^TEST_.*$", "id, DATA_SOURCE");
+        ReadonlyConfig config = multiTableReadonlyConfig(primaryKeys);
+        CatalogTable table = createCatalogTable("TEST_TABLE", Collections.singletonList("id"));
+
+        Assertions.assertEquals(
+                Arrays.asList("id", "DATA_SOURCE"),
+                factory.resolveMultiTablePrimaryKeys(config, table).get());
+    }
+
+    @Test
+    void testFactoryContextWithMultiTableConfigValid() {
+        Map<String, Object> cfg = baseConfig();
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^TEST_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
+        Map<String, Object> multiTableConfig = new LinkedHashMap<>();
+        multiTableConfig.put("primary_keys", primaryKeys);
+        cfg.put("multi-table_config", multiTableConfig);
+
+        Assertions.assertDoesNotThrow(() -> createSinkViaFactoryContext(cfg, true));
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 class JdbcSinkFactoryTest {
 
@@ -353,6 +354,20 @@ class JdbcSinkFactoryTest {
         Assertions.assertThrows(
                 JdbcConnectorException.class,
                 () -> factory.resolveMultiTablePrimaryKeys(config, table));
+    }
+
+    @Test
+    void testCompilePatternCachesCompiledPattern() {
+        Pattern first = factory.compilePattern("^TEST_.*$");
+        Pattern second = factory.compilePattern("^TEST_.*$");
+
+        Assertions.assertSame(first, second);
+    }
+
+    @Test
+    void testCompilePatternInvalidFails() {
+        Assertions.assertThrows(
+                JdbcConnectorException.class, () -> factory.compilePattern("^[unclosed"));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/sink/JdbcSinkFactoryTest.java
@@ -113,7 +113,7 @@ class JdbcSinkFactoryTest {
         Map<String, Object> cfg = baseConfig();
         Map<String, Object> multiTableConfig = new LinkedHashMap<>();
         multiTableConfig.put("primary_keys", primaryKeys);
-        cfg.put("multi-table_config", multiTableConfig);
+        cfg.put("multi_table_config", multiTableConfig);
         return ReadonlyConfig.fromMap(cfg);
     }
 
@@ -344,13 +344,38 @@ class JdbcSinkFactoryTest {
     }
 
     @Test
+    void testResolveMultiTablePrimaryKeysInvalidRegexFails() {
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^[unclosed", Arrays.asList("id"));
+        ReadonlyConfig config = multiTableReadonlyConfig(primaryKeys);
+        CatalogTable table = createCatalogTable("TEST_TABLE", Collections.singletonList("id"));
+
+        Assertions.assertThrows(
+                JdbcConnectorException.class,
+                () -> factory.resolveMultiTablePrimaryKeys(config, table));
+    }
+
+    @Test
+    void testFactoryContextWithMultiTableConfigInvalidColumnFails() {
+        Map<String, Object> cfg = baseConfig();
+        Map<String, Object> primaryKeys = new LinkedHashMap<>();
+        primaryKeys.put("^TEST_.*$", Arrays.asList("id", ""));
+        Map<String, Object> multiTableConfig = new LinkedHashMap<>();
+        multiTableConfig.put("primary_keys", primaryKeys);
+        cfg.put("multi_table_config", multiTableConfig);
+
+        Assertions.assertThrows(
+                JdbcConnectorException.class, () -> createSinkViaFactoryContext(cfg, true));
+    }
+
+    @Test
     void testFactoryContextWithMultiTableConfigValid() {
         Map<String, Object> cfg = baseConfig();
         Map<String, Object> primaryKeys = new LinkedHashMap<>();
         primaryKeys.put("^TEST_.*$", Arrays.asList("${primary_key}", "DATA_SOURCE"));
         Map<String, Object> multiTableConfig = new LinkedHashMap<>();
         multiTableConfig.put("primary_keys", primaryKeys);
-        cfg.put("multi-table_config", multiTableConfig);
+        cfg.put("multi_table_config", multiTableConfig);
 
         Assertions.assertDoesNotThrow(() -> createSinkViaFactoryContext(cfg, true));
     }

--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigShadeUtils.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigShadeUtils.java
@@ -21,7 +21,9 @@ import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.seatunnel.shade.com.google.common.base.Preconditions;
 import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigParseOptions;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigRenderOptions;
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigSyntax;
 
 import org.apache.seatunnel.api.configuration.ConfigShade;
 import org.apache.seatunnel.common.Constants;
@@ -210,7 +212,9 @@ public final class ConfigShadeUtils {
             configMap.put(Constants.SOURCE, sources);
             configMap.put(Constants.SINK, sinks);
             configMap.put(Constants.TRANSFORM, transforms);
-            return ConfigFactory.parseMap(configMap);
+            return ConfigFactory.parseString(
+                    JsonUtils.toJsonString(configMap),
+                    ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON));
         } catch (Exception e) {
             // Log desensitized error information
             log.error(

--- a/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/utils/ConfigShadeTest.java
+++ b/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/utils/ConfigShadeTest.java
@@ -403,6 +403,37 @@ public class ConfigShadeTest {
                 token, encryptedConfig.getConfigList("sink").get(0).getString("token"));
     }
 
+    @Test
+    public void testDecryptPreservesSpecialCharacterKeys() {
+        Config input =
+                ConfigFactory.parseString(
+                        "source { FakeSource { plugin_output = \"fake\" } }\n"
+                                + "sink { Jdbc { url = \"jdbc:mysql://localhost:3306/db\" "
+                                + "username = \"u\" password = \"p\" "
+                                + "multi-table_config { primary_keys { "
+                                + "\"^t_nova_.*$\" = [\"${primary_key}\", \"DATA_SOURCE\"] "
+                                + "\"^t_tyuen_txn_.*$\" = [\"id_txn_ctrl\", \"DATA_SOURCE\"] "
+                                + "} } } }");
+
+        Config decrypted = ConfigShadeUtils.decryptConfig(input);
+
+        Map<String, Object> primaryKeys =
+                decrypted
+                        .getConfigList("sink")
+                        .get(0)
+                        .getConfig("multi-table_config")
+                        .getConfig("primary_keys")
+                        .root()
+                        .unwrapped();
+
+        Assertions.assertTrue(primaryKeys.containsKey("^t_nova_.*$"));
+        Assertions.assertTrue(primaryKeys.containsKey("^t_tyuen_txn_.*$"));
+        Assertions.assertEquals(
+                Arrays.asList("${primary_key}", "DATA_SOURCE"), primaryKeys.get("^t_nova_.*$"));
+        Assertions.assertEquals(
+                Arrays.asList("id_txn_ctrl", "DATA_SOURCE"), primaryKeys.get("^t_tyuen_txn_.*$"));
+    }
+
     public static class ConfigShadeWithProps implements ConfigShade {
 
         private String suffix;

--- a/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/utils/ConfigShadeTest.java
+++ b/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/utils/ConfigShadeTest.java
@@ -408,10 +408,10 @@ public class ConfigShadeTest {
         Config input =
                 ConfigFactory.parseString(
                         "source { FakeSource { plugin_output = \"fake\" } }\n"
-                                + "sink { Jdbc { url = \"jdbc:mysql://localhost:3306/db\" "
-                                + "username = \"u\" password = \"p\" "
+                                + "sink { Jdbc { url = \"jdbc:mysql://localhost:3306/db\", "
+                                + "username = \"u\", password = \"p\", "
                                 + "multi-table_config { primary_keys { "
-                                + "\"^t_nova_.*$\" = [\"${primary_key}\", \"DATA_SOURCE\"] "
+                                + "\"^t_nova_.*$\" = [\"${primary_key}\", \"DATA_SOURCE\"], "
                                 + "\"^t_tyuen_txn_.*$\" = [\"id_txn_ctrl\", \"DATA_SOURCE\"] "
                                 + "} } } }");
 


### PR DESCRIPTION
### Purpose of this pull request

Close #11878.

Add a new JDBC sink option `multi_table_config.primary_keys` to support per-table
primary key mapping in multi-table generated-SQL scenarios.

When the upstream table name matches one of the configured patterns, the mapped key
columns are used; otherwise it falls back to the existing `primary_keys` / catalog
metadata logic. Inside this new option, `${primary_key}` / `${unique_key}` can be
mixed with static columns. The legacy top-level `primary_keys` contract is kept
unchanged.

This PR also fixes the config-parsing issue that blocked the feature. SeaTunnel rebuilds
configs with `ConfigFactory.parseMap(...)`, which treats map keys as Typesafe Config path
expressions; regex keys such as `^t_nova_.*$` contain `.` and `$`, so they failed with
`ConfigException$BadPath`. The rebuild in `ConfigShadeUtils.processConfig` therefore now uses a
JSON round-trip (`ConfigFactory.parseString(..., ConfigSyntax.JSON)`), which keeps plugin option
keys literal.

The fix is deliberately scoped to avoid a cross-cutting API change: `ReadonlyConfig#toConfig()`
is left byte-for-byte identical to `dev`, so dotted-key semantics are unchanged for all existing
callers. The only shared code touched is `MultiTableFailureHelper#mergeOptions()`, which now
merges the two option maps directly instead of round-tripping through HOCON `withFallback`, with
a Javadoc note stating that the merge is shallow/top-level.

### Review status (F1-F8)

F1 (ReadonlyConfig#toConfig dotted-key round-trip):
Done. `ReadonlyConfig#toConfig()` is unchanged and identical to `dev`, so dotted-key path
semantics for existing callers are untouched. The parsing fix is scoped to
`ConfigShadeUtils.processConfig()` (JSON round-trip, so regex option keys such as `^t_nova_.*$`
are not read as HOCON paths) and to `MultiTableFailureHelper#mergeOptions()` (direct shallow map
merge instead of `Config#withFallback`, with the merge contract documented on the method).
Regression test: `ReadableConfigTest#testToConfigPreservesDottedKeyExpansion`;
`MultiTableFailureHelperTest#testMergeOptionsPreservesSpecialCharacterKeys` covers the merge.
Neither parsing change is specific to the new option, and both are documented as such:
`ConfigShadeUtils.processConfig` runs for every job (it is the shade rebuild); the change only makes
the rebuild keep keys literal instead of interpreting them as HOCON paths. `ConfigFactory.parseMap`
stores dotted keys literally as well (an `env` map with `"job.mode"` keeps a literal key in both
cases), so the shape of every other option is unchanged and only inputs that previously failed with
`ConfigException.BadPath` behave differently. `MultiTableFailureHelper#mergeOptions` is shared too:
its merge changed from a HOCON deep merge to a shallow top-level merge, where the primary side's
value replaces the fallback side's on a key collision. All of its callers - `MultipleTableJobConfigParser`,
`AbstractSinkExecuteProcessor` and its Flink 1.13 variant, the Spark 2 / Spark common
`SinkExecuteProcessor`s (five production call sites), plus the two helpers in the same class - merge
sink plugin options against job-env options (disjoint namespaces) or a single-key internal map, so no
caller can hit a nested-object collision; the new contract is documented on the method.
One entry point is still open and is out of scope here: when a job is submitted through the REST
submit-job API with the (default) JSON body, the body is turned into a map and parsed by
`ConfigBuilder.of(Map)` before the shade rebuild, so `ConfigFactory.parseMap(...)` still rejects
regex keys such as `^t_nova_.*$` with `ConfigException.BadPath`. This is documented as a known
limitation in `docs/en|zh/connectors/sink/Jdbc.md` (config files and the HOCON REST body work) and
will be fixed separately; see the Follow-up section.

F2 / F5 (declaration-order semantics):
Done. `JdbcSinkFactory#toCompiledPatternMap` copies the configured patterns into an explicit
`LinkedHashMap<Pattern, List<String>>`, so "the first pattern in declaration order wins" is
guaranteed by the code instead of relying on the map implementation that Jackson happens to
produce. `JdbcSinkFactoryTest#testResolveMultiTablePrimaryKeysFromHoconFirstMatchWins` declares
overlapping patterns in a real HOCON string in non-alphabetical order (`^table2$`, `^table1$`,
then a catch-all `^table.*$`) and asserts that the first declared match wins. That test does not use
a hand-built map: it parses the HOCON string with `ConfigFactory.parseString`, wraps the `sink` block
with `ReadonlyConfig.fromConfig(...)` and calls `JdbcSinkFactory#resolveMultiTablePrimaryKeys`, which
reads the option and builds the ordered map in `toCompiledPatternMap` - the same `HOCON string ->
ReadonlyConfig -> option -> toCompiledPatternMap` chain the runtime uses (the E2E below covers the
remaining engine-level steps: shade rebuild, placeholder pass, `createSink`). The English and Chinese
`connectors/sink/Jdbc.md` docs state the same rule.

F3 (identifier validation for the resolved key columns):
Done. `JdbcSinkFactory#validatePrimaryKeyColumns` rejects blank names and names containing a
comma before they are joined into `PRIMARY_KEYS`, raising `JDBC-12`
(`INVALID_MULTI_TABLE_CONFIG`). Those are the only unsafe inputs, because the resolved names are
interpolated through the dialect's `quoteIdentifier` when SQL is generated
(`JdbcDialect#getDeleteStatement`, `MysqlDialect#quoteIdentifier`,
`MysqlCreateTableSqlBuilder#buildPrimaryKeySql`); a comma would collide with the delimiter of the
comma-joined `primary_keys` value and a blank name would produce an empty list element. Test:
`JdbcSinkFactoryTest#testFactoryContextWithMultiTableConfigInvalidColumnFails`.
Embedded quote characters are deliberately not rejected: the dialect quoting only wraps the name
(`MysqlDialect#quoteIdentifier` returns a backtick-wrapped name without escaping, and
`CatalogUtils#quoteIdentifier` behaves the same), so a name containing the dialect quote character
would already be unusable in the generated SQL. Such a name cannot come from the `${primary_key}` /
`${unique_key}` expansion (those are upstream catalog column names) and would have to be typed by the
user, so it surfaces as a database error rather than as a silently wrong key. A dialect-specific
quote-character rule is left as a deliberate follow-up instead of half-implementing it here.

F4 (connector-level `${primary_key}` / `${unique_key}` vs engine-level TablePlaceholder):
The engine pass runs first (`TableSinkFactoryContext#replacePlaceholderAndCreate` ->
`TablePlaceholderProcessor#replaceTablePlaceholder`), but it only rewrites top-level `String`
values and single-element `String` lists and never descends into nested objects, so the
`multi_table_config` map reaches the connector untouched. The connector then expands
`${primary_key}` / `${unique_key}` per matched table in
`JdbcSinkFactory#expandPrimaryKeyPlaceholder`. When a matched table uses such a placeholder but
the upstream catalog table has no primary key (or no unique key), the job fails fast with
`JDBC-12`; it does not silently fall back and does not leave the literal placeholder in
`PRIMARY_KEYS`. Documented in `docs/{en,zh}/introduction/configuration/sink-options-placeholders.md`
and pinned by `JdbcSinkFactoryTest#testPlaceholderOrderBetweenEngineAndConnectorPasses`, which
asserts that the engine pass expands a top-level `primary_keys = ["${primary_key}"]`, leaves the
nested `multi_table_config.primary_keys` map untouched, and that the connector expands it
afterwards. The fail-fast path is covered by
`JdbcSinkFactoryTest#testResolveMultiTablePrimaryKeysMissingPrimaryKeyFails`.

F5: see F2.

F6 (regex validation -> JDBC-12):
Done. Every configured pattern is compiled up front in `toCompiledPatternMap` ->
`compilePattern`, which maps `PatternSyntaxException` to `JdbcConnectorException` carrying
`JDBC-12`. Tests: `JdbcSinkFactoryTest#testResolveMultiTablePrimaryKeysInvalidRegexFails` and
`JdbcSinkFactoryTest#testCompilePatternInvalidFails`. Compiled patterns are memoized in a
bounded, access-ordered LRU cache (`MAX_CACHED_PATTERNS = 256`, wrapped in
`Collections.synchronizedMap`), so each distinct pattern is compiled once per JVM. 256 sits
comfortably above the number of distinct patterns a busy deployment configures (a handful to a
few dozen), and exceeding it only evicts an older entry that is recompiled on next use.

F7 (tests):
Done, no longer deferred. Both halves are in this PR.

The `toConfig()` regression test already exists and is part of this PR's diff:
`ReadableConfigTest#testToConfigPreservesDottedKeyExpansion` (`seatunnel-api`, line 383) asserts
that a dotted map key such as `a.b` still expands through the dotted path.

The engine-level E2E for the new option is
`JdbcMysqlMultipleTablesIT#testMysqlJdbcMultipleTableE2e`. It uses two dedicated source tables
(`source.mtc_table1` / `source.mtc_table2`) whose key columns are `NOT NULL`, points
`jdbc_mysql_source_and_sink_with_multi_table_config.conf` at them, and lets the sink create the
target tables (`schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"`). It then asserts the resolved
primary keys read from `information_schema.STATISTICS` (`sink.mtc_table1` -> `c_int, c_integer`;
`sink.mtc_table2` -> `c_mediumint`) plus the table row counts. It runs on the Zeta, Flink and
Spark containers in CI.

The dedicated fixture (rather than the shared `source.table1` / `source.table2`, which the other
test methods depend on) is required because of the pre-existing MySQL DDL gap described in the
Follow-up section: a column that is explicitly declared `NULL` cannot be part of a `PRIMARY KEY`.

F8 (option key naming):
Done. The key is fully snake_case - `multi_table_config` - in `JdbcSinkOptions`, the English and
Chinese docs, the E2E config and all tests; no mixed `multi-table_config` spelling remains in the
PR.

Additional fix from the previous review round (not part of F1-F8):
The patterns were previously matched against the resolved sink table name, so combining
`multi_table_config.primary_keys` with `table` / `tablePrefix` / `tableSuffix` silently defeated
the mapping and the sink fell back to catalog metadata. `JdbcSinkFactory#createSink` now keeps the
upstream `CatalogTable` and matches on that, which is what the docs already described. Regression
test: `JdbcSinkFactoryTest#testFactoryContextWithMultiTableConfigMatchesUpstreamTableName`.

### Does this PR introduce _any_ user-facing change?

Yes. Adds a new optional JDBC sink option `multi_table_config`.

Semantics:

- Each key is a Java regular expression matched against the upstream table name with
  full-match semantics (`tableName.matches(pattern)`).
- Each value is a list of key columns. `${primary_key}` and `${unique_key}` are
  supported only inside this option and can be mixed with static columns.
- Precedence: matched mapping wins; otherwise falls back to the existing logic
  (top-level `primary_keys` -> catalog primary key -> first unique key -> plain INSERT).
- If a table matches multiple patterns, the first pattern in declaration order wins.
- If a matched table uses `${primary_key}` / `${unique_key}` but the upstream table has
  no primary/unique key, the job fails with a clear error.

No existing option is renamed, removed, or changed in default behavior.

### Example configurations

#### Example 1

```hocon
env {
  job.mode = "STREAMING"
  parallelism = 1
  checkpoint.interval = 10000
}

source {
  MySQL-CDC {
    plugin_output = "sharding00_source"
    url = "jdbc:mysql://<host>:3306/st_source"
    username = "<username>"
    password = "<password>"
    database-names = ["st_source"]
    table-pattern = "st_source\\.t_(nova_(fo_serial|order)_(000|048)|tyuen_txn_(cp|qr)_(000|048))"
    startup.mode = "initial"
    server-id = "5400-5408"
  }
}

transform {
  Sql {
    plugin_input = "sharding00_source"
    plugin_output = "sharding00_transform"
    query = "SELECT *, 'idc' AS DATA_SOURCE FROM dual"
  }

  DefineSinkType {
    plugin_input = "sharding00_transform"
    plugin_output = "sharding00_typed"
    columns = [
      { column = "DATA_SOURCE", type = "VARCHAR(32)" }
    ]
  }
}

sink {
  Jdbc {
    plugin_input = "sharding00_typed"
    url = "jdbc:mysql://<host>:3306/st_target?rewriteBatchedStatements=true&autoReconnect=true"
    driver = "com.mysql.cj.jdbc.Driver"
    username = "<username>"
    password = "<password>"
    generate_sink_sql = true
    database = "st_target"

    multi_table_config {
      primary_keys {
        "^t_nova_.*$"      = ["${primary_key}", "DATA_SOURCE"]
        "^t_tyuen_txn_.*$" = ["id_txn_ctrl", "DATA_SOURCE"]
      }
    }

    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
    data_save_mode = "APPEND_DATA"
  }
}
```

#### Example 2

```hocon
env {
  job.mode = "STREAMING"
  parallelism = 1
  checkpoint.interval = 10000
}

source {
  MySQL-CDC {
    plugin_output = "gote_source"
    url = "jdbc:mysql://<host>:3306/st_source"
    username = "<username>"
    password = "<password>"
    database-names = ["st_source"]
    table-pattern = "st_source\\.t_(nova_merchant_info|tyuen_txn_ext|nova_merge_settle_serial)"
    startup.mode = "initial"
    server-id = "5500-5508"
  }
}

transform {
  Sql {
    plugin_input = "gote_source"
    plugin_output = "gote_transform"
    query = "SELECT *, 'idc' AS DATA_SOURCE FROM dual"

    table_transform = [
      {
        table_path = "st_source.t_nova_merchant_info"
        query = "SELECT * FROM dual"
      }
    ]
  }

  DefineSinkType {
    plugin_input = "gote_transform"
    plugin_output = "gote_typed"
    columns = [
      { column = "DATA_SOURCE", type = "VARCHAR(32)" }
    ]
    table_match_regex = "st_source\\.t_(tyuen_txn_ext|nova_merge_settle_serial)"
  }
}

sink {
  Jdbc {
    plugin_input = "gote_typed"
    url = "jdbc:mysql://<host>:3306/st_target?rewriteBatchedStatements=true&autoReconnect=true"
    driver = "com.mysql.cj.jdbc.Driver"
    username = "<username>"
    password = "<password>"
    generate_sink_sql = true
    database = "st_target"

    primary_keys = ["merchant_id"]

    multi_table_config {
      primary_keys {
        "t_tyuen_txn_ext.*"          = ["id_txn_ctrl", "DATA_SOURCE"]
        "t_nova_merge_settle_serial" = ["${primary_key}", "DATA_SOURCE"]
      }
    }

    schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
    data_save_mode = "APPEND_DATA"
  }
}
```

### Table DDL

The source tables are created manually on the upstream side; the target tables are created by
`generate_sink_sql = true`. `multi_table_config.primary_keys` decides which key columns are used
when writing to the target tables, which shows up as the key columns of the generated
upsert / delete statements.

To keep the transform-derived `DATA_SOURCE` column (a length-less STRING) from being created as
`LONGTEXT` by the MySQL dialect - which cannot be part of a primary key - the example
configurations use `DefineSinkType` to declare it as `VARCHAR(32)`. The source table DDL is listed
below, followed by the target table DDL as created by the sink.

#### Demo 1 source tables

```sql
CREATE TABLE t_nova_fo_serial_000 (
  serial_id   BIGINT       NOT NULL,
  order_no    VARCHAR(64),
  amount      DECIMAL(18,2),
  status      VARCHAR(16),
  created_at  DATETIME,
  PRIMARY KEY (serial_id)
);

CREATE TABLE t_nova_order_000 (
  id          BIGINT       NOT NULL,
  order_no    VARCHAR(64),
  amount      DECIMAL(18,2),
  created_at  DATETIME,
  PRIMARY KEY (id)
);

CREATE TABLE t_tyuen_txn_cp_000 (
  id          BIGINT       NOT NULL,
  id_txn_ctrl VARCHAR(64)  NOT NULL,
  amount      DECIMAL(18,2),
  channel     VARCHAR(16),
  created_at  DATETIME,
  PRIMARY KEY (id),
  UNIQUE KEY uk_id_txn_ctrl (id_txn_ctrl)
);

CREATE TABLE t_tyuen_txn_qr_000 (
  id          BIGINT       NOT NULL,
  id_txn_ctrl VARCHAR(64)  NOT NULL,
  qr_code     VARCHAR(128),
  amount      DECIMAL(18,2),
  created_at  DATETIME,
  PRIMARY KEY (id),
  UNIQUE KEY uk_id_txn_ctrl (id_txn_ctrl)
);
```

#### Demo 1 target tables (created by the sink)

```sql
CREATE TABLE t_nova_fo_serial_000 (
  serial_id   BIGINT       NOT NULL,
  DATA_SOURCE VARCHAR(32)  NOT NULL,
  order_no    VARCHAR(64),
  amount      DECIMAL(18,2),
  status      VARCHAR(16),
  created_at  DATETIME,
  PRIMARY KEY (serial_id, DATA_SOURCE)
);

CREATE TABLE t_nova_order_000 (
  id          BIGINT       NOT NULL,
  DATA_SOURCE VARCHAR(32)  NOT NULL,
  order_no    VARCHAR(64),
  amount      DECIMAL(18,2),
  created_at  DATETIME,
  PRIMARY KEY (id, DATA_SOURCE)
);

CREATE TABLE t_tyuen_txn_cp_000 (
  id          BIGINT       NOT NULL,
  id_txn_ctrl VARCHAR(64)  NOT NULL,
  DATA_SOURCE VARCHAR(32)  NOT NULL,
  amount      DECIMAL(18,2),
  channel     VARCHAR(16),
  created_at  DATETIME,
  PRIMARY KEY (id_txn_ctrl, DATA_SOURCE)
);

CREATE TABLE t_tyuen_txn_qr_000 (
  id          BIGINT       NOT NULL,
  id_txn_ctrl VARCHAR(64)  NOT NULL,
  DATA_SOURCE VARCHAR(32)  NOT NULL,
  qr_code     VARCHAR(128),
  amount      DECIMAL(18,2),
  created_at  DATETIME,
  PRIMARY KEY (id_txn_ctrl, DATA_SOURCE)
);
```

#### Demo 2 source tables

```sql
CREATE TABLE t_nova_merchant_info (
  id            BIGINT       NOT NULL,
  merchant_id   VARCHAR(64)  NOT NULL,
  merchant_name VARCHAR(128),
  mcc           VARCHAR(16),
  created_at    DATETIME,
  PRIMARY KEY (id),
  UNIQUE KEY uk_merchant_id (merchant_id)
);

CREATE TABLE t_tyuen_txn_ext (
  id          BIGINT       NOT NULL,
  id_txn_ctrl VARCHAR(64)  NOT NULL,
  txn_amount  DECIMAL(18,2),
  ext_info    VARCHAR(255),
  created_at  DATETIME,
  PRIMARY KEY (id),
  UNIQUE KEY uk_id_txn_ctrl (id_txn_ctrl)
);

CREATE TABLE t_nova_merge_settle_serial (
  id          BIGINT       NOT NULL,
  settle_no   VARCHAR(64),
  amount      DECIMAL(18,2),
  settle_date DATE,
  created_at  DATETIME,
  PRIMARY KEY (id)
);
```

#### Demo 2 target tables (created by the sink)

```sql
CREATE TABLE t_nova_merchant_info (
  id            BIGINT       NOT NULL,
  merchant_id   VARCHAR(64)  NOT NULL,
  merchant_name VARCHAR(128),
  mcc           VARCHAR(16),
  created_at    DATETIME,
  PRIMARY KEY (merchant_id)
);

CREATE TABLE t_tyuen_txn_ext (
  id          BIGINT       NOT NULL,
  id_txn_ctrl VARCHAR(64)  NOT NULL,
  DATA_SOURCE VARCHAR(32)  NOT NULL,
  txn_amount  DECIMAL(18,2),
  ext_info    VARCHAR(255),
  created_at  DATETIME,
  PRIMARY KEY (id_txn_ctrl, DATA_SOURCE)
);

CREATE TABLE t_nova_merge_settle_serial (
  id          BIGINT       NOT NULL,
  DATA_SOURCE VARCHAR(32)  NOT NULL,
  settle_no   VARCHAR(64),
  amount      DECIMAL(18,2),
  settle_date DATE,
  created_at  DATETIME,
  PRIMARY KEY (id, DATA_SOURCE)
);
```

### Generated SQL

Below are the upsert / delete statements that the MySQL JDBC sink actually generated after
running the two demos above. Each target table uses the different key columns assigned to it by
`multi_table_config.primary_keys`.

```text
-- Example 1
INSERT INTO `st_target`.`t_nova_fo_serial_000`
  (`serial_id`, `order_no`, `amount`, `status`, `created_at`, `DATA_SOURCE`)
VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE ...;
DELETE FROM `st_target`.`t_nova_fo_serial_000`
  WHERE `serial_id` = ? AND `DATA_SOURCE` = ?;

INSERT INTO `st_target`.`t_tyuen_txn_cp_000`
  (`id`, `id_txn_ctrl`, `amount`, `channel`, `created_at`, `DATA_SOURCE`)
VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE ...;
DELETE FROM `st_target`.`t_tyuen_txn_cp_000`
  WHERE `id_txn_ctrl` = ? AND `DATA_SOURCE` = ?;

-- Example 2
INSERT INTO `st_target`.`t_nova_merchant_info`
  (`id`, `merchant_id`, `merchant_name`, `mcc`, `created_at`)
VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE ...;
DELETE FROM `st_target`.`t_nova_merchant_info`
  WHERE `merchant_id` = ?;

INSERT INTO `st_target`.`t_tyuen_txn_ext`
  (`id`, `id_txn_ctrl`, `txn_amount`, `ext_info`, `created_at`, `DATA_SOURCE`)
VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE ...;
DELETE FROM `st_target`.`t_tyuen_txn_ext`
  WHERE `id_txn_ctrl` = ? AND `DATA_SOURCE` = ?;

INSERT INTO `st_target`.`t_nova_merge_settle_serial`
  (`id`, `settle_no`, `amount`, `settle_date`, `created_at`, `DATA_SOURCE`)
VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE ...;
DELETE FROM `st_target`.`t_nova_merge_settle_serial`
  WHERE `id` = ? AND `DATA_SOURCE` = ?;
```

### How was this patch tested?

Added unit tests:

- `JdbcSinkFactoryTest`: mapping hit, fallback to legacy `primary_keys`, missing upstream
  primary key error, first-match-wins, string value handling, invalid regex, blank/comma column
  rejection, compiled-pattern caching, matching against the upstream table name when the sink
  table name is remapped, and the full factory-context path.
- `JdbcSinkFactoryTest#testResolveMultiTablePrimaryKeysFromHoconFirstMatchWins`: parses a real
  HOCON config string whose patterns overlap in non-alphabetical declaration order (`^table2$`,
  `^table1$`, then a catch-all `^table.*$`) and asserts that the first declared match wins.
- `JdbcSinkFactoryTest#testFactoryContextWithMultiTableConfigMatchesUpstreamTableName`: runs the
  whole `createSink` path with a static `table` remap and asserts the pattern still resolves
  against the upstream table name.
- `JdbcSinkFactoryTest#testPlaceholderOrderBetweenEngineAndConnectorPasses`: pins the order
  between the engine-level TablePlaceholder pass and the connector-level expansion (the nested
  `multi_table_config.primary_keys` map reaches the sink untouched and is expanded there).
- `ConfigShadeTest#testDecryptPreservesSpecialCharacterKeys`: special-character config keys are
  preserved after `decryptConfig`.
- `ReadableConfigTest#testToConfigPreservesDottedKeyExpansion`: dotted-key expansion is preserved
  for existing `ReadonlyConfig#toConfig` callers.
- `MultiTableFailureHelperTest#testMergeOptionsPreservesSpecialCharacterKeys`: overlapping scalar
  option keys keep the primary-side value under the direct map merge.
- `ConfigShadeTest#testDecryptPreservesOrdinaryConfigShapes`: an unquoted dotted key, a quoted
  dotted key inside a nested map and numeric values come back unchanged from `decryptConfig`.
- `JdbcSinkFactoryTest#testLegacyPrimaryKeysStillRebuildCatalogPrimaryKey`: the legacy top-level
  `primary_keys` branch still rebuilds the catalog primary key after the refactor.

Engine-level E2E coverage (exercised by CI on the Zeta, Flink and Spark containers):

- `JdbcMysqlMultipleTablesIT#testMysqlJdbcMultipleTableE2e` drops the dedicated target tables and
  runs
  `seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-1/src/test/resources/jdbc_mysql_source_and_sink_with_multi_table_config.conf`.
  The job reads two dedicated source tables (`source.mtc_table1` / `source.mtc_table2`) whose key
  columns are `NOT NULL`, so the sink can create the target tables itself
  (`schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"`) and the resolved key columns end up in the
  generated create-table DDL. The `NOT NULL` key columns are required because of the pre-existing
  MySQL DDL gap described in the Follow-up section, and the shared
  `source.table1` / `source.table2` fixture used by the other test methods is left untouched.
- The test then asserts the primary keys read back from `information_schema.STATISTICS`
  (`sink.mtc_table1` -> `c_int, c_integer`, `sink.mtc_table2` -> `c_mediumint`) plus the table row
  counts, which fails if the per-table mapping or the declaration order is lost.
- The same config also pins precedence: the fallback `primary_keys = ["id"]` must not be used, and
  a catch-all pattern declared last must not win.

Manually verified with MySQL-CDC -> JDBC using the two demo configurations above
(`generate_sink_sql = true`), and confirmed the auto-created target tables (with
`DefineSinkType` setting `DATA_SOURCE` to `VARCHAR(32)`) together with the generated
upsert / delete statements match the expected per-table primary key mapping.

Also run `./mvnw spotless:apply` and
`./mvnw -pl :connector-jdbc-e2e-part-1 -am -DskipTests -Dskip.ui=true package` to compile the
E2E module locally.

### Follow-up

- Pre-existing MySQL DDL gap found while writing the E2E: `MysqlCreateTableSqlBuilder` (and the
  OceanBase MySQL-mode twin) emit an explicit `NULL` for nullable columns even when those columns
  are part of a `PRIMARY KEY`, which MySQL rejects with `ER_PRIMARY_CANT_HAVE_NULL` (1171,
  `All parts of a PRIMARY KEY must be NOT NULL`). It affects the existing top-level `primary_keys`
  option as well, so it is not specific to `multi_table_config`. Tracked in
  apache/seatunnel#12415 and deliberately left out of this PR to keep the diff scoped; a follow-up
  PR will emit `NOT NULL` for key columns plus a unit test in `MysqlCreateTableSqlBuilderTest`.
- Optional follow-up: fail fast with `JDBC-12` when a static primary key column does not exist in
  the upstream schema. Not done here because the check has to account for `field_ide` case
  conversion, so it deserves its own change.
- REST JSON submission path: `ConfigBuilder.of(Map)` (used by `RestUtil.buildConfig` /
  `RestUtil.buildConfigList`) still parses the JSON body with `ConfigFactory.parseMap(...)`, which
  rejects regex keys such as `^t_nova_.*$` with `ConfigException.BadPath`. Documented as a known
  limitation in the JDBC sink docs; the fix (rebuild the map with literal keys when a key is not a
  valid path) will be tracked in a separate issue so this PR stays scoped.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. [x] Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
