### PR TITLE
[Feature][Connector-V2][HugeGraph] Use engine-level timer flush

### DIFF
--- a/docs/en/connectors/sink/HugeGraph.md
+++ b/docs/en/connectors/sink/HugeGraph.md
@@ -24,7 +24,7 @@ This connector supports writing data as vertices or edges, providing flexible ma
 - [x] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
 - [x] [timer flush](../../introduction/concepts/connector-v2-features.md)
 
-The connector writes rows as either vertices or edges. It supports insert, update, and delete row kinds, and it can flush buffered records by `batch_size` or `batch_interval_ms`.
+The connector writes rows as either vertices or edges. It supports insert, update, and delete row kinds, and it flushes buffered records by `batch_size`, checkpoint, or close.
 
 :::caution
 
@@ -44,7 +44,7 @@ New `mappings` configurations default to `schema_save_mode = CREATE_SCHEMA_WHEN_
 | `username`          | String  | No       | -             | The username for HugeGraph authentication.                                     |
 | `password`          | String  | No       | -             | The password for HugeGraph authentication.                                     |
 | `batch_size`        | Integer | No       | 500           | The number of records to buffer before writing to HugeGraph in a single batch. |
-| `batch_interval_ms` | Integer | No       | 5000          | The maximum time in milliseconds to wait before flushing a batch.              |
+| `batch_interval_ms` | Integer | No       | 5000          | Retained for compatibility. To schedule timer flush on Zeta, configure `sink.flush.interval` in the job `env` block. |
 | `batch_failure_fallback` | Boolean | No  | true          | When a batch insert fails, fall back to inserting the batch record by record so a single bad ("poison") record no longer fails the whole batch. Failed records are logged and skipped; the rest succeed. If every record fails (systemic error), it is surfaced. Set to `false` to fail the whole batch instead. |
 | `max_insert_errors` | Integer | No       | 500           | Maximum number of records that may be skipped by the single-record fallback (`batch_failure_fallback=true`) before the task is failed. Bounds the otherwise unlimited silent skipping of poison records. Set to `-1` for unlimited. Only applies when `batch_failure_fallback` is enabled. |
 | `failure_data_path` | String  | No       | -             | Optional local directory. When set, every record skipped by the single-record fallback is appended (mapped id, label, properties and the server error) to a per-subtask file (`hugegraph-sink-failures-subtask-N.log`) for offline investigation. In cluster mode the file is created on the worker node running the sink subtask. |
@@ -66,6 +66,18 @@ New `mappings` configurations default to `schema_save_mode = CREATE_SCHEMA_WHEN_
 | `ignored_fields`           | List    | No       | -             | Deprecated. Still honored with legacy `schema_config`; use mapping `properties` for new jobs. |
 
 If both `mappings` and `schema_config` are configured, `mappings` wins and `schema_config` is ignored with a warning.
+
+## Timer Flush
+
+Timer flush is an engine-level feature supported only by Zeta. Configure `sink.flush.interval` in the job `env` block to write pending HugeGraph records even when `batch_size` has not been reached. Spark and Flink do not inject `FlushSignal` records and therefore do not trigger this scheduled flush.
+
+```hocon
+env {
+  sink.flush.interval = 5000
+}
+```
+
+HugeGraph timer flush reuses the connector's synchronized batch flush. Failures are propagated to the engine instead of being delayed in a connector-owned background thread.
 
 ### Mapping Configuration (`mappings`)
 

--- a/docs/zh/connectors/sink/HugeGraph.md
+++ b/docs/zh/connectors/sink/HugeGraph.md
@@ -24,7 +24,7 @@ HugeGraph sink连接器允许您将数据从SeaTunnel写入Apache HugeGraph，�
 - [x] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
 - [x] [定时刷新](../../introduction/concepts/connector-v2-features.md)
 
-该连接器可以把输入行写成顶点或边，支持插入、更新、删除，并且可以按 `batch_size` 或 `batch_interval_ms` 刷新缓存数据。
+该连接器可以把输入行写成顶点或边，支持插入、更新、删除，并且会在达到 `batch_size`、checkpoint 或 close 时刷新缓存数据。
 
 :::caution
 
@@ -44,7 +44,7 @@ HugeGraph sink连接器允许您将数据从SeaTunnel写入Apache HugeGraph，�
 | `username`          | String  | 否       | -      | 用于HugeGraph身份验证的用户名。                                        |
 | `password`          | String  | 否       | -      | 用于HugeGraph身份验证的密码。                                          |
 | `batch_size`        | Integer | 否       | 500    | 在单批次写入HugeGraph之前缓冲的记录数。                                |
-| `batch_interval_ms` | Integer | 否       | 5000   | 刷新批次前等待的最大时间（毫秒）。                                     |
+| `batch_interval_ms` | Integer | 否       | 5000   | 为兼容性保留。在 Zeta 上需要定时刷新时，请在作业 `env` 中配置 `sink.flush.interval`。 |
 | `batch_failure_fallback` | Boolean | 否   | true   | 批量写入失败时，降级为逐条写入，使单条“毒药”记录不再拖垮整批。失败记录会记录日志并跳过，其余成功；若整批全部失败（系统性错误）则抛出。设为 `false` 则整批失败。 |
 | `max_insert_errors` | Integer | 否       | 500    | 逐条降级（`batch_failure_fallback=true`）累计跳过的失败记录达到该数量后使任务失败，用于约束原本无上限的“毒药”记录静默跳过。设为 `-1` 表示不限。仅在开启 `batch_failure_fallback` 时生效。 |
 | `failure_data_path` | String  | 否       | -      | 可选本地目录。设置后，逐条降级跳过的每条记录（映射后的 id、label、属性及服务端错误）会追加写入按子任务区分的文件（`hugegraph-sink-failures-subtask-N.log`）以便离线排查。集群模式下文件写在运行该 sink 子任务的 worker 节点上。 |
@@ -66,6 +66,18 @@ HugeGraph sink连接器允许您将数据从SeaTunnel写入Apache HugeGraph，�
 | `ignored_fields`           | List    | 否       | -      | 已废弃。Legacy `schema_config` 仍会应用；新任务请使用 mapping 内的 `properties`。 |
 
 如果同时配置 `mappings` 和 `schema_config`，connector 会使用 `mappings`，并输出警告说明 `schema_config` 被忽略。
+
+## 定时刷新
+
+定时刷新是仅由 Zeta 支持的引擎级能力。在作业的 `env` 中配置 `sink.flush.interval` 后，即使尚未达到 `batch_size`，HugeGraph Sink 也会写出待处理的记录。Spark 和 Flink 不会注入 `FlushSignal`，因此不会触发这种定时刷新。
+
+```hocon
+env {
+  sink.flush.interval = 5000
+}
+```
+
+HugeGraph 定时刷新复用连接器现有的同步批量刷新。失败会直接传递给引擎，而不会被连接器自建后台线程延迟暴露。
 
 ### 映射配置 (`mappings`)
 

--- a/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/buffer/BatchBuffer.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/buffer/BatchBuffer.java
@@ -39,16 +39,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
  * Dual-bucket batch buffer that independently accumulates and flushes vertices and edges. Each
- * bucket triggers flush when reaching batch_size; both buckets are flushed on timer, prepareCommit,
- * or close.
+ * bucket triggers flush when reaching batch_size; both buckets are flushed by the engine timer,
+ * prepareCommit, or close.
  *
  * <p>Vertex-before-edge ordering is enforced only when {@code check_vertex} is true — the server
  * then rejects edges whose endpoint vertices do not yet exist, so a filling edge bucket first
@@ -63,11 +59,7 @@ public class BatchBuffer implements AutoCloseable {
     private final List<GraphElementEnvelope> vertexBuffer = new ArrayList<>();
     private final List<GraphElementEnvelope> edgeBuffer = new ArrayList<>();
     private final int batchSize;
-    private final ScheduledExecutorService scheduler;
-    private final ScheduledFuture<?> scheduledFuture;
-
     private volatile boolean closed = false;
-    private volatile Exception flushException;
     private final HugeGraphClient client;
     private final boolean batchFailureFallback;
     private final boolean checkVertex;
@@ -116,6 +108,8 @@ public class BatchBuffer implements AutoCloseable {
             int maxInsertErrors,
             String failureDataPath,
             int subtaskIndex) {
+        // batchIntervalMs remains in the public signature for source compatibility. Timer flush is
+        // registered by HugeGraphSinkWriter with the engine instead of creating a connector thread.
         this.batchSize = batchSize;
         this.client = client;
         this.batchFailureFallback = batchFailureFallback;
@@ -124,35 +118,9 @@ public class BatchBuffer implements AutoCloseable {
         this.failureDataPath = failureDataPath;
         this.subtaskIndex = subtaskIndex;
         this.insertFailureCount = 0;
-
-        if (batchIntervalMs > 0) {
-            this.scheduler =
-                    Executors.newSingleThreadScheduledExecutor(
-                            runnable -> {
-                                Thread thread = new Thread(runnable, "hugegraph-sink-flusher");
-                                thread.setDaemon(true);
-                                return thread;
-                            });
-            this.scheduledFuture =
-                    this.scheduler.scheduleAtFixedRate(
-                            () -> {
-                                try {
-                                    flush();
-                                } catch (Exception e) {
-                                    flushException = e;
-                                }
-                            },
-                            batchIntervalMs,
-                            batchIntervalMs,
-                            TimeUnit.MILLISECONDS);
-        } else {
-            this.scheduler = null;
-            this.scheduledFuture = null;
-        }
     }
 
     public synchronized void add(GraphElementEnvelope envelope) throws IOException {
-        checkFlushException();
         if (closed) {
             throw new HugeGraphConnectorException(
                     HugeGraphConnectorErrorCode.BUFFER_ADD_FAILED,
@@ -199,7 +167,6 @@ public class BatchBuffer implements AutoCloseable {
     }
 
     public synchronized void flush() throws IOException {
-        checkFlushException();
         if (closed && vertexBuffer.isEmpty() && edgeBuffer.isEmpty()) {
             return;
         }
@@ -456,24 +423,9 @@ public class BatchBuffer implements AutoCloseable {
             closed = true;
         }
 
-        if (scheduledFuture != null) {
-            scheduledFuture.cancel(false);
-        }
-        if (scheduler != null) {
-            scheduler.shutdown();
-            try {
-                if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
-                    scheduler.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                scheduler.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
-        }
         LOG.info("Closing BatchBuffer, performing final flush...");
         try {
             flush();
-            checkFlushException();
         } finally {
             closeFailureWriter();
         }
@@ -489,13 +441,6 @@ public class BatchBuffer implements AutoCloseable {
             } finally {
                 failureWriter = null;
             }
-        }
-    }
-
-    private void checkFlushException() {
-        if (flushException != null) {
-            throw new HugeGraphConnectorException(
-                    HugeGraphConnectorErrorCode.ASYNCHRONOUS_FLUSH_FAILED, flushException);
         }
     }
 }

--- a/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/config/HugeGraphOptions.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/config/HugeGraphOptions.java
@@ -71,7 +71,9 @@ public class HugeGraphOptions {
             Options.key("batch_interval_ms")
                     .intType()
                     .defaultValue(5000)
-                    .withDescription("The batch flash period");
+                    .withDescription(
+                            "Retained for compatibility. Configure sink.flush.interval in the "
+                                    + "job env block for Zeta timer flush.");
 
     public static final Option<Boolean> CHECK_VERTEX =
             Options.key("check_vertex")

--- a/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSink.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSink.java
@@ -68,7 +68,7 @@ public class HugeGraphSink extends AbstractSimpleSink<SeaTunnelRow, Void>
 
     @Override
     public HugeGraphSinkWriter createWriter(SinkWriter.Context context) throws IOException {
-        return new HugeGraphSinkWriter(config, rowType, tablePath, context.getIndexOfSubtask());
+        return new HugeGraphSinkWriter(config, rowType, tablePath, context);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkWriter.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.hugegraph.sink;
 
+import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
@@ -69,30 +70,48 @@ public class HugeGraphSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
     private SeaTunnelRow pendingUpdateBefore;
 
     public HugeGraphSinkWriter(HugeGraphSinkConfig sinkConfig, SeaTunnelRowType rowType) {
-        this(sinkConfig, rowType, "", 0);
+        this(sinkConfig, rowType, "", (SinkWriter.Context) null, 0);
     }
 
     public HugeGraphSinkWriter(
             HugeGraphSinkConfig sinkConfig, SeaTunnelRowType rowType, int subtaskIndex) {
-        this(sinkConfig, rowType, "", subtaskIndex);
+        this(sinkConfig, rowType, "", (SinkWriter.Context) null, subtaskIndex);
     }
 
     public HugeGraphSinkWriter(
             HugeGraphSinkConfig sinkConfig,
             SeaTunnelRowType rowType,
             String tablePath,
+            int subtaskIndex) {
+        this(sinkConfig, rowType, tablePath, (SinkWriter.Context) null, subtaskIndex);
+    }
+
+    public HugeGraphSinkWriter(
+            HugeGraphSinkConfig sinkConfig,
+            SeaTunnelRowType rowType,
+            String tablePath,
+            SinkWriter.Context context) {
+        this(sinkConfig, rowType, tablePath, context, context.getIndexOfSubtask());
+    }
+
+    private HugeGraphSinkWriter(
+            HugeGraphSinkConfig sinkConfig,
+            SeaTunnelRowType rowType,
+            String tablePath,
+            SinkWriter.Context context,
             int subtaskIndex) {
         this(
                 sinkConfig,
                 rowType,
                 tablePath,
                 new HugeGraphClient(sinkConfig.getConnectionConfig()),
+                context,
                 subtaskIndex);
     }
 
     HugeGraphSinkWriter(
             HugeGraphSinkConfig sinkConfig, SeaTunnelRowType rowType, HugeGraphClient client) {
-        this(sinkConfig, rowType, "", client, 0);
+        this(sinkConfig, rowType, "", client, null, 0);
     }
 
     HugeGraphSinkWriter(
@@ -100,7 +119,16 @@ public class HugeGraphSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
             SeaTunnelRowType rowType,
             HugeGraphClient client,
             int subtaskIndex) {
-        this(sinkConfig, rowType, "", client, subtaskIndex);
+        this(sinkConfig, rowType, "", client, null, subtaskIndex);
+    }
+
+    HugeGraphSinkWriter(
+            HugeGraphSinkConfig sinkConfig,
+            SeaTunnelRowType rowType,
+            HugeGraphClient client,
+            SinkWriter.Context context,
+            int subtaskIndex) {
+        this(sinkConfig, rowType, "", client, context, subtaskIndex);
     }
 
     HugeGraphSinkWriter(
@@ -108,6 +136,16 @@ public class HugeGraphSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
             SeaTunnelRowType rowType,
             String tablePath,
             HugeGraphClient client,
+            int subtaskIndex) {
+        this(sinkConfig, rowType, tablePath, client, null, subtaskIndex);
+    }
+
+    HugeGraphSinkWriter(
+            HugeGraphSinkConfig sinkConfig,
+            SeaTunnelRowType rowType,
+            String tablePath,
+            HugeGraphClient client,
+            SinkWriter.Context context,
             int subtaskIndex) {
         this.sinkConfig = sinkConfig;
         this.tablePath = tablePath;
@@ -135,6 +173,9 @@ public class HugeGraphSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
                         sinkConfig.getMaxInsertErrors(),
                         sinkConfig.getFailureDataPath(),
                         subtaskIndex);
+        if (context != null) {
+            context.registerFlushAction(buffer::flush);
+        }
     }
 
     private List<MappingEntry> buildMappingEntries(SeaTunnelRowType rowType) {

--- a/seatunnel-connectors-v2/connector-hugegraph/src/test/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkWriterUpdateTest.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/test/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkWriterUpdateTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.seatunnel.connectors.seatunnel.hugegraph.sink;
 
+import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.RowKind;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.utils.function.RunnableWithException;
 import org.apache.seatunnel.connectors.seatunnel.hugegraph.client.HugeGraphClient;
 import org.apache.seatunnel.connectors.seatunnel.hugegraph.config.HugeGraphSinkConfig;
 import org.apache.seatunnel.connectors.seatunnel.hugegraph.config.MappingConfig;
@@ -37,6 +39,7 @@ import org.apache.hugegraph.structure.graph.Vertex;
 import org.apache.hugegraph.structure.schema.PropertyKey;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -46,8 +49,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -394,6 +401,49 @@ class HugeGraphSinkWriterUpdateTest {
         // After UPDATE_AFTER, pendingUpdateBefore is null. prepareCommit() should flush and
         // succeed (buffer.flush() calls the mock client, which is stubbed for writes).
         writer.prepareCommit();
+    }
+
+    @Test
+    void timerFlushActionFlushesBufferedRows() throws Exception {
+        HugeGraphSinkConfig config = singleMappingConfig();
+        HugeGraphClient client = stubbedClient();
+        SinkWriter.Context context = mock(SinkWriter.Context.class);
+        ArgumentCaptor<RunnableWithException> actionCaptor =
+                ArgumentCaptor.forClass(RunnableWithException.class);
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"name"}, new SeaTunnelDataType<?>[] {BasicType.STRING_TYPE});
+
+        HugeGraphSinkWriter writer = new HugeGraphSinkWriter(config, rowType, client, context, 0);
+        writer.write(row("Ada"));
+
+        verify(context).registerFlushAction(actionCaptor.capture());
+        verify(client, never()).batchWriteVertices(anyList());
+
+        actionCaptor.getValue().run();
+
+        verify(client).batchWriteVertices(anyList());
+    }
+
+    @Test
+    void timerFlushActionPropagatesBatchWriteFailure() throws Exception {
+        HugeGraphSinkConfig config = singleMappingConfig();
+        HugeGraphClient client = stubbedClient();
+        SinkWriter.Context context = mock(SinkWriter.Context.class);
+        ArgumentCaptor<RunnableWithException> actionCaptor =
+                ArgumentCaptor.forClass(RunnableWithException.class);
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"name"}, new SeaTunnelDataType<?>[] {BasicType.STRING_TYPE});
+        doThrow(new RuntimeException("HugeGraph unavailable"))
+                .when(client)
+                .batchWriteVertices(anyList());
+
+        HugeGraphSinkWriter writer = new HugeGraphSinkWriter(config, rowType, client, context, 0);
+        writer.write(row("Ada"));
+        verify(context).registerFlushAction(actionCaptor.capture());
+
+        assertThrows(HugeGraphConnectorException.class, () -> actionCaptor.getValue().run());
     }
 
     // --- Helpers ---


### PR DESCRIPTION
Fixes #12017

## What does this PR change?

- Register HugeGraph buffer flushes with `SinkWriter.Context`, so Zeta invokes them on its engine-owned timer path.
- Remove the connector-owned scheduled executor and delayed async-exception cache. Flush failures now propagate directly to the engine.
- Preserve `batch_interval_ms` parsing for compatibility and document the migration to `env.sink.flush.interval`.
- Add English and Chinese timer-flush documentation.

## Tests

- `./mvnw -pl seatunnel-connectors-v2/connector-hugegraph test`
- `./mvnw -q -pl seatunnel-connectors-v2/connector-hugegraph -DskipTests verify`
- `./mvnw -pl seatunnel-connectors-v2/connector-hugegraph spotless:check`

The new writer regression tests cover both engine-triggered buffer flush and direct propagation of a batch-write failure.