### PR TITLE
[Test][E2E] Add regression coverage for task stuck in CANCELING when worker crashes mid-cancel

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterFaultToleranceIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterFaultToleranceIT.java
@@ -29,7 +29,9 @@ import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.JobConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
+import org.apache.seatunnel.engine.common.job.JobResult;
 import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
 import org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan;
@@ -54,6 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -331,6 +334,240 @@ public class SplitClusterFaultToleranceIT {
                 workerNode2.shutdown();
             }
         }
+    }
+
+    /**
+     * Regression test for the CANCELING-stuck-forever bug fixed by <a
+     * href="https://github.com/apache/seatunnel/pull/10729">#10729</a> ("[Fix][Zeta] prevent cancel
+     * stuck and downgrade tmp cleanup failure"). Before that fix, {@code
+     * PhysicalVertex#noticeTaskExecutionServiceCancel} sent a {@code CancelTaskOperation} to the
+     * worker owning the task and retried while that worker remained a cluster member, but once the
+     * worker actually left the cluster before acking the cancel, the retry loop simply exited
+     * without ever resolving the task's state: the vertex - and therefore its pipeline and job -
+     * stayed CANCELING forever, because nothing else in that method drove it to a terminal state.
+     * The fix added a fallback right after the retry loop: if the loop exits with the ack still
+     * missing and the vertex is still CANCELING, mark it CANCELED locally.
+     *
+     * <p>{@code CoordinatorService#failedTaskOnMemberRemoved} also matches CANCELING tasks when a
+     * member is lost, but it cannot be the one to save this race: {@code PhysicalVertex#cancel},
+     * {@code #updateTaskState} and {@code #stateProcess} are all {@code synchronized} on the vertex
+     * itself, and the whole call chain down into {@code noticeTaskExecutionServiceCancel} runs
+     * without releasing that lock. A competing {@code failedTaskOnMemberRemoved} call has to go
+     * through the same {@code synchronized updateTaskState}, so it can only run after the
+     * cancelling thread has already returned - by which point the fixed code has already resolved
+     * the vertex to CANCELED, and the end-state consistency check inside {@code updateTaskState}
+     * rejects any later attempt to move a terminal-state task to FAILED. So the fixed method's own
+     * fallback is the sole, deterministic mechanism that unsticks this specific race, which is why
+     * this test asserts CANCELED rather than FAILED as the outcome.
+     *
+     * <p>No existing fault-tolerance test combines "cancel requested" with "worker crashes before
+     * the cancel ack arrives": {@link #testStreamJobRunOk()} cancels a job on a fully healthy
+     * cluster, and {@link #testStreamJobRestoreInWorkerDown()} kills a worker on a job that is
+     * simply RUNNING with no cancel in flight, then cancels only after restore has completed. This
+     * test constructs the narrow race directly: it white-box polls {@code
+     * PhysicalVertex#getExecutionState()} (same in-JVM technique as {@code
+     * SplitClusterPendingJobLifecycleFailoverIT#getJobMaster}) in a tight loop right after issuing
+     * the cancel, and shuts the worker down the instant a task vertex is first observed CANCELING -
+     * landing squarely inside the RPC-in-flight window instead of guessing at timing.
+     */
+    @Test
+    public void testStreamJobCancelResolvesWhenWorkerCrashesBeforeCancelAck() throws Exception {
+        String testCaseName = "testStreamJobCancelResolvesWhenWorkerCrashesBeforeCancelAck";
+        String testClusterName = "SplitClusterFaultToleranceIT_" + testCaseName;
+        HazelcastInstanceImpl masterNode = null;
+        HazelcastInstanceImpl workerNode = null;
+        SeaTunnelClient engineClient = null;
+
+        SeaTunnelConfig seaTunnelConfig = getSeaTunnelConfig(testClusterName);
+        SeaTunnelConfig masterNodeConfig = getSeaTunnelConfig(testClusterName);
+        SeaTunnelConfig workerNodeConfig = getSeaTunnelConfig(testClusterName);
+
+        try {
+            masterNode = SeaTunnelServerStarter.createMasterHazelcastInstance(masterNodeConfig);
+
+            workerNode = SeaTunnelServerStarter.createWorkerHazelcastInstance(workerNodeConfig);
+
+            // waiting all node added to cluster
+            HazelcastInstanceImpl finalMasterNode = masterNode;
+            Awaitility.await()
+                    .atMost(10000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            2, finalMasterNode.getCluster().getMembers().size()));
+
+            Common.setDeployMode(DeployMode.CLIENT);
+            JobConfig jobConfig = new JobConfig();
+            jobConfig.setName(testCaseName);
+
+            ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            clientConfig.setClusterName(TestUtils.getClusterName(testClusterName));
+            engineClient = new SeaTunnelClient(clientConfig);
+            ClientJobExecutionEnvironment jobExecutionEnv =
+                    engineClient.createExecutionContext(
+                            TestUtils.getResource("pending_jobs_streaming_lifecycle.conf"),
+                            jobConfig,
+                            seaTunnelConfig);
+            ClientJobProxy clientJobProxy = jobExecutionEnv.execute();
+            long jobId = clientJobProxy.getJobId();
+
+            Awaitility.await()
+                    .atMost(120, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            JobStatus.RUNNING, clientJobProxy.getJobStatus()));
+            // Wait for every task vertex to actually finish deploying before cancelling, so the
+            // CANCELING transition observed below is unambiguously caused by the cancel request,
+            // not mixed up with an in-flight DEPLOYING -> RUNNING transition.
+            assertAllVerticesRunning(masterNode, jobId, 60);
+
+            // CoordinatorService#cancelJob runs JobMaster#cancelJob synchronously on its own
+            // executor, and the client's cancelJob() blocks (PassiveCompletableFuture#join) until
+            // that whole per-vertex cancel resolves. Issue it on its own thread so this thread
+            // stays free to tight-poll for CANCELING and react to it immediately.
+            CompletableFuture<Void> cancelInvocation =
+                    CompletableFuture.runAsync(clientJobProxy::cancelJob);
+
+            boolean observedCanceling =
+                    awaitAnyVertexCanceling(masterNode, jobId, 10, TimeUnit.SECONDS);
+            Assertions.assertTrue(
+                    observedCanceling,
+                    "Should have observed a task vertex enter CANCELING before its cancel ack "
+                            + "could possibly arrive; otherwise this test never exercised the "
+                            + "race it targets");
+
+            // The vertex is CANCELING and still waiting on a CancelTaskOperation ack from
+            // workerNode. Kill workerNode right now, before that ack can arrive, landing inside
+            // the exact window PR #10729 fixed: cancel requested, CANCELING set, worker gone
+            // before the terminal callback.
+            workerNode.shutdown();
+
+            CompletableFuture<JobResult> waitForCompleteFuture =
+                    CompletableFuture.supplyAsync(clientJobProxy::waitForJobCompleteV2);
+            assertEventuallyCanceled(clientJobProxy, waitForCompleteFuture);
+
+            Assertions.assertDoesNotThrow(
+                    () -> cancelInvocation.get(30, TimeUnit.SECONDS),
+                    "cancelJob() should return once the vertex resolves locally, not hang");
+        } finally {
+            if (engineClient != null) {
+                engineClient.close();
+            }
+
+            if (workerNode != null) {
+                workerNode.shutdown();
+            }
+
+            if (masterNode != null) {
+                masterNode.shutdown();
+            }
+        }
+    }
+
+    /**
+     * Waits until every coordinator and task vertex of the job's single pipeline has itself
+     * reported RUNNING, not just the top-level job status.
+     */
+    private static void assertAllVerticesRunning(
+            HazelcastInstanceImpl masterNode, long jobId, long timeoutSeconds) {
+        Awaitility.await()
+                .atMost(timeoutSeconds, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            JobMaster jobMaster = getJobMaster(masterNode, jobId);
+                            Assertions.assertNotNull(
+                                    jobMaster,
+                                    "Job master should exist before checking task vertex states");
+                            PhysicalPlan physicalPlan = jobMaster.getPhysicalPlan();
+                            Assertions.assertEquals(JobStatus.RUNNING, physicalPlan.getJobStatus());
+                            physicalPlan
+                                    .getPipelineList()
+                                    .forEach(SplitClusterFaultToleranceIT::assertRunningSubPlan);
+                        });
+    }
+
+    private static void assertRunningSubPlan(SubPlan subPlan) {
+        Assertions.assertEquals(PipelineStatus.RUNNING, subPlan.getPipelineState());
+        subPlan.getCoordinatorVertexList()
+                .forEach(SplitClusterFaultToleranceIT::assertRunningVertex);
+        subPlan.getPhysicalVertexList().forEach(SplitClusterFaultToleranceIT::assertRunningVertex);
+    }
+
+    private static void assertRunningVertex(PhysicalVertex physicalVertex) {
+        Assertions.assertEquals(ExecutionState.RUNNING, physicalVertex.getExecutionState());
+    }
+
+    /**
+     * Tight-polls (no fixed sleep) every coordinator and task vertex of the job for CANCELING,
+     * returning as soon as any one is observed. The window between a task vertex entering CANCELING
+     * and its cancel ack arriving from a healthy worker can be sub-millisecond, well under
+     * Awaitility's default ~100ms poll interval, so this deliberately busy-spins instead.
+     */
+    private static boolean awaitAnyVertexCanceling(
+            HazelcastInstanceImpl masterNode, long jobId, long timeout, TimeUnit unit) {
+        long deadline = System.nanoTime() + unit.toNanos(timeout);
+        while (System.nanoTime() < deadline) {
+            JobMaster jobMaster = getJobMaster(masterNode, jobId);
+            if (jobMaster != null) {
+                PhysicalPlan physicalPlan = jobMaster.getPhysicalPlan();
+                if (physicalPlan != null) {
+                    for (SubPlan subPlan : physicalPlan.getPipelineList()) {
+                        if (isAnyVertexCanceling(subPlan.getCoordinatorVertexList())
+                                || isAnyVertexCanceling(subPlan.getPhysicalVertexList())) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            Thread.yield();
+        }
+        return false;
+    }
+
+    private static boolean isAnyVertexCanceling(List<PhysicalVertex> vertices) {
+        for (PhysicalVertex vertex : vertices) {
+            if (ExecutionState.CANCELING.equals(vertex.getExecutionState())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Reads the current job master from the active SeaTunnel server embedded in the test cluster.
+     */
+    private static JobMaster getJobMaster(HazelcastInstanceImpl masterNode, long jobId) {
+        SeaTunnelServer server =
+                masterNode.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+        return server.getCoordinatorService().getJobMaster(jobId);
+    }
+
+    /**
+     * Waits for the job to reach a terminal state and asserts it is CANCELED, using the
+     * already-in-flight {@code waitForJobCompleteV2()} future so this assertion cannot itself hang
+     * forever if the CANCELING-stuck regression this test guards against were to reappear.
+     */
+    private static void assertEventuallyCanceled(
+            ClientJobProxy clientJobProxy, CompletableFuture<JobResult> waitForCompleteFuture) {
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(
+                        () -> {
+                            Assertions.assertTrue(
+                                    waitForCompleteFuture.isDone(),
+                                    "Job should reach a terminal state instead of staying stuck "
+                                            + "in CANCELING after its worker crashed mid-cancel");
+                            Assertions.assertEquals(
+                                    JobStatus.CANCELED, waitForCompleteFuture.get().getStatus());
+                        });
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        JobStatus.CANCELED, clientJobProxy.getJobStatus()));
     }
 
     @Test
@@ -1367,15 +1604,6 @@ public class SplitClusterFaultToleranceIT {
 
     private static void assertVertexRunning(PhysicalVertex physicalVertex) {
         Assertions.assertEquals(ExecutionState.RUNNING, physicalVertex.getExecutionState());
-    }
-
-    /**
-     * Reads the current job master from the active SeaTunnel server embedded in the test cluster.
-     */
-    private static JobMaster getJobMaster(HazelcastInstanceImpl activeMaster, long jobId) {
-        SeaTunnelServer server =
-                activeMaster.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
-        return server.getCoordinatorService().getJobMaster(jobId);
     }
 
     private static HazelcastInstanceImpl waitAndFindActiveMaster(


### PR DESCRIPTION
## Purpose

Adds multi-node E2E regression coverage for the CANCELING-stuck-forever race
fixed in #10729 ("[Fix][Zeta] prevent cancel stuck and downgrade tmp cleanup
failure", commit `2c81f7f3c31`).

Before that fix, `PhysicalVertex#noticeTaskExecutionServiceCancel` sent a
`CancelTaskOperation` to the worker owning the task and retried while that
worker remained a cluster member, but once the worker actually left the
cluster before acking the cancel, the retry loop simply exited without ever
resolving the task's state. The vertex — and therefore its pipeline and job
— stayed `CANCELING` forever, because nothing else in that method drove it
to a terminal state. The fix added a fallback right after the retry loop: if
the loop exits with the ack still missing and the vertex is still
`CANCELING`, mark it `CANCELED` locally.

The fix shipped with no dedicated regression test reproducing the original
multi-node timing/race at the engine level.

## What was still missing

`CoordinatorService#failedTaskOnMemberRemoved` also matches `CANCELING`
tasks when a member is lost (this branch predates the fix — confirmed via
`git show` against the fix commit's parent), which raises the question of
whether that path already covered the bug. It does not, reliably: it has to
go through the same `synchronized updateTaskState` as
`PhysicalVertex#cancel`/`#updateTaskState`/`#stateProcess`, all of which are
synchronized on the vertex itself, and the whole call chain from `cancel()`
down into `noticeTaskExecutionServiceCancel` runs on that lock without
releasing it. A competing `failedTaskOnMemberRemoved` call can therefore
only run *after* the cancelling thread has already returned — by which
point the fixed code has already resolved the vertex to `CANCELED`, and the
end-state consistency check inside `updateTaskState` rejects any later
attempt to move a terminal-state task to `FAILED`. So the fixed method's own
fallback is the sole, deterministic mechanism that unsticks this specific
race, which is why the new test asserts `CANCELED` (not `FAILED`) as the
outcome.

I also checked the existing fault-tolerance suite
(`ClusterFaultToleranceIT`, `SplitClusterFaultToleranceIT`,
`ClusterFailureNoRestoreIT`) for anything that already combines a cancel
request with a worker crash. It does not: existing tests either cancel a
job on a fully healthy cluster, or kill a worker on a job that is simply
`RUNNING` with no cancel in flight and cancel only after restore completes.
None land a worker crash inside the narrow window between "cancel issued,
`CANCELING` set" and "cancel ack received".

## What this test does

`SplitClusterFaultToleranceIT#testStreamJobCancelResolvesWhenWorkerCrashesBeforeCancelAck`:

1. Starts a minimal split-role cluster: 1 dedicated master + 1 dedicated
   worker.
2. Submits the same long-running streaming holder job used elsewhere in
   this suite (`pending_jobs_streaming_lifecycle.conf`) and waits for the
   top-level job status **and** every individual task vertex to report
   `RUNNING`, so the cancel below isn't confounded by an in-flight
   `DEPLOYING` transition.
3. Issues `cancelJob()` on its own thread. This is required because
   `CoordinatorService#cancelJob` runs `JobMaster#cancelJob` synchronously
   on its own executor, and the client's `cancelJob()` call blocks
   (`PassiveCompletableFuture#join`) until that whole per-vertex cancel
   resolves — so the test thread needs to stay free to react while the
   cancel is in flight on the server.
4. Tight-polls (busy-spin, not Awaitility's ~100ms default interval) every
   task vertex's `PhysicalVertex#getExecutionState()` via the same in-JVM
   white-box access as `SplitClusterPendingJobLifecycleFailoverIT#getJobMaster`,
   and the instant any vertex is first observed `CANCELING`, immediately
   shuts the worker down.
5. Asserts the job converges to `CANCELED` within a bounded time (using an
   already-in-flight `waitForJobCompleteV2()` future so the assertion
   itself cannot hang forever if the regression reappears), and that the
   original `cancelJob()` call also returns without hanging.

## Why this trigger-construction is reliable

The race window this bug depends on — between a vertex's state flipping to
`CANCELING` and the `CancelTaskOperation` ack coming back from the worker —
can be sub-millisecond on a healthy local cluster, so blind timing (sleep
then kill) would be unreliable. Instead the test uses direct white-box
polling of internal engine state (same technique already proven in this
series, e.g. #12027), reacting the instant the state transition is
observed rather than guessing a delay. Because `SubPlan#cancelPipeline`
cancels vertices sequentially on a single thread and each vertex's cancel
call blocks synchronously on `noticeTaskExecutionServiceCancel`, the
`CANCELING` state is guaranteed to be visible for at least the duration of
a real cross-process Hazelcast operation invocation (these test nodes
communicate over real loopback sockets, not an in-memory bypass) — long
enough for a tight busy-poll loop to reliably observe it before the ack
round-trip completes.

## Test plan

- New test only; no production code changed.
- `./mvnw spotless:apply` run on the affected module — no additional
  formatting changes beyond what was already applied to the new code.
- `./mvnw install -DskipTests` run on the affected module and its
  dependency chain (this repo's shaded modules need `install`, not bare
  `compile`/`test-compile`, to resolve relocated classes) — confirmed
  `BUILD SUCCESS`, and confirmed the new test class actually compiled
  (`target/test-classes` contains the compiled `.class` file for the new
  method) rather than relying on a build that skips test compilation
  entirely.
- Full test execution (real Hazelcast cluster startup, worker crash
  injection) is left to CI per this repository's E2E conventions; not run
  in this sandbox.
