### PR TITLE
[Test][E2E] Guard terminal-zombie-job restore gate after master switch

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterPendingJobLifecycleFailoverIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterPendingJobLifecycleFailoverIT.java
@@ -19,6 +19,8 @@ package org.apache.seatunnel.engine.e2e;
 
 import org.apache.seatunnel.common.config.Common;
 import org.apache.seatunnel.common.config.DeployMode;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.common.utils.FileUtils;
 import org.apache.seatunnel.engine.client.SeaTunnelClient;
 import org.apache.seatunnel.engine.client.job.ClientJobExecutionEnvironment;
 import org.apache.seatunnel.engine.client.job.ClientJobProxy;
@@ -30,6 +32,7 @@ import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
 import org.apache.seatunnel.engine.common.job.JobResult;
 import org.apache.seatunnel.engine.common.job.JobStatus;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.CoordinatorService;
 import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
 import org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan;
@@ -42,10 +45,16 @@ import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.lang3.tuple.ImmutablePair;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -252,6 +261,234 @@ public class SplitClusterPendingJobLifecycleFailoverIT {
             }
             if (workerNode != null) {
                 workerNode.shutdown();
+            }
+        }
+    }
+
+    /**
+     * Regression test for the terminal-zombie-job restore gate fixed by <a
+     * href="https://github.com/apache/seatunnel/pull/10692">#10692</a> ("[Fix][Zeta] Prevent
+     * terminal-state zombie jobs from being restored after master switch"). Before that fix, {@code
+     * CoordinatorService#restoreAllRunningJobFromMasterNodeSwitch} funneled every entry found in
+     * {@code runningJobInfoIMap} -- including jobs that had already reached a terminal status such
+     * as FINISHED -- through the same {@code while (getResourceManager().workerCount(...) == 0)}
+     * wait loop that live jobs legitimately need, so a terminal job's IMap tombstone cleanup could
+     * be starved indefinitely by the absence of a worker it never needed in the first place. The
+     * fix added a pre-filter that resolves terminal-state entries immediately, before the
+     * worker-wait loop is ever reached.
+     *
+     * <p>This test constructs the precondition the fix targets -- a master switch where the new
+     * active master has zero registered workers, with both a terminal job and a live job present in
+     * {@code runningJobInfoIMap} at that moment -- purely by controlling node start/stop order, so
+     * the outcome does not depend on winning any timing race:
+     *
+     * <ul>
+     *   <li>A small batch job is run to completion on a temporary worker, which is only shut down
+     *       after that job's tasks have already reached a terminal execution state. Tearing a
+     *       worker down while it still hosts a DEPLOYING/RUNNING/CANCELING task would route through
+     *       the synchronous Hazelcast membership listener {@code
+     *       CoordinatorService#failedTaskOnMemberRemoved}, fail that task immediately, and (with
+     *       the default {@code job.retry.times}/{@code job.retry.interval.seconds} of 3/3) drive
+     *       the job to terminal FAILED roughly 9 seconds later -- turning the intended "live" job
+     *       terminal before the switch and collapsing this test's mixed-state precondition.
+     *       Shutting the worker down only after the batch job already finished avoids that confound
+     *       entirely: no task is left DEPLOYING/RUNNING/CANCELING on it to fail.
+     *   <li>A second job is then submitted with zero workers registered anywhere in the cluster.
+     *       {@code ScheduleStrategy#WAIT} resource pre-checks (see {@code
+     *       JobMaster#preApplyResources}) fail gracefully rather than erroring out, so this job
+     *       simply lands in PENDING -- a genuinely non-end-state job that legitimately still needs
+     *       a worker, without ever requiring a worker to be torn out from under a dispatched task.
+     *   <li>The standby master has held a live IMap backup since before either job was submitted,
+     *       so both jobs' {@code runningJobInfoIMap}/{@code runningJobStateIMap} entries are
+     *       already replicated there once the active master is shut down.
+     * </ul>
+     *
+     * <p>{@code stateCleanupDelayMillis} is set far beyond this test's lifetime so the terminal
+     * job's IMap tombstone cannot be swept by its own delayed-cleanup timer mid-test; the
+     * pre-filter path under test, not the timer, must be what the assertions below observe.
+     */
+    @Test
+    public void testTerminalJobCleanupSkipsWorkerWaitAfterMasterSwitch() throws Exception {
+        String testClusterName =
+                "SplitClusterPendingJobLifecycleFailoverIT_"
+                        + "testTerminalJobCleanupSkipsWorkerWaitAfterMasterSwitch";
+        String testCaseName = "terminalJobCleanupSkipsWorkerWaitAfterMasterSwitch";
+
+        HazelcastInstanceImpl masterNode1 = null;
+        HazelcastInstanceImpl masterNode2 = null;
+        HazelcastInstanceImpl workerNode1 = null;
+        HazelcastInstanceImpl workerNode2 = null;
+        SeaTunnelClient engineClient = null;
+
+        SeaTunnelConfig masterNode1Config = getSeaTunnelConfig(testClusterName);
+        SeaTunnelConfig masterNode2Config = getSeaTunnelConfig(testClusterName);
+        SeaTunnelConfig workerNode1Config = getSeaTunnelConfig(testClusterName);
+        SeaTunnelConfig workerNode2Config = getSeaTunnelConfig(testClusterName);
+        configurePendingLifecycleTest(masterNode1Config);
+        configurePendingLifecycleTest(masterNode2Config);
+        configurePendingLifecycleTest(workerNode1Config);
+        configurePendingLifecycleTest(workerNode2Config);
+        // Keep the terminal job's IMap tombstone alive far longer than this test can possibly
+        // run, so the pre-filter under test -- not the unrelated delayed-cleanup timer -- is what
+        // the assertions below observe.
+        long stateCleanupDelayMillis = TimeUnit.MINUTES.toMillis(10);
+        masterNode1Config.getEngineConfig().setStateCleanupDelayMillis(stateCleanupDelayMillis);
+        masterNode2Config.getEngineConfig().setStateCleanupDelayMillis(stateCleanupDelayMillis);
+
+        try {
+            masterNode1 = SeaTunnelServerStarter.createMasterHazelcastInstance(masterNode1Config);
+            masterNode2 = SeaTunnelServerStarter.createMasterHazelcastInstance(masterNode2Config);
+
+            HazelcastInstanceImpl finalMasterNode1 = masterNode1;
+            Awaitility.await()
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            2, finalMasterNode1.getCluster().getMembers().size()));
+
+            Common.setDeployMode(DeployMode.CLUSTER);
+            ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            clientConfig.setClusterName(TestUtils.getClusterName(testClusterName));
+            engineClient = new SeaTunnelClient(clientConfig);
+
+            workerNode1 = SeaTunnelServerStarter.createWorkerHazelcastInstance(workerNode1Config);
+            HazelcastInstanceImpl finalWorkerNode1 = workerNode1;
+            Awaitility.await()
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            3, finalWorkerNode1.getCluster().getMembers().size()));
+
+            HazelcastInstanceImpl activeMaster = waitAndFindActiveMaster(masterNode1, masterNode2);
+            HazelcastInstanceImpl standbyMaster =
+                    activeMaster == masterNode1 ? masterNode2 : masterNode1;
+
+            // Run a small batch job to completion so it reaches a terminal status (FINISHED) the
+            // normal way, leaving a real pendingJobCleanupIMap tombstone behind -- the realistic
+            // shape of a "zombie" job, rather than one hand-injected directly into the IMaps.
+            ImmutablePair<String, String> terminalJobResources =
+                    createTerminalJobResources(testCaseName, 5L, 1);
+            ClientJobProxy terminalJob =
+                    submitJob(
+                            engineClient,
+                            masterNode1Config,
+                            "terminal_zombie_job",
+                            terminalJobResources.getRight());
+            long terminalJobId = terminalJob.getJobId();
+            assertJobStatusWithTimeout(terminalJob, JobStatus.FINISHED, 60);
+
+            // The batch job's tasks already completed, so its slot was already released; removing
+            // its worker now cannot fail any task, since none is DEPLOYING/RUNNING/CANCELING on
+            // it anymore. See the class-level javadoc above for why this ordering matters.
+            workerNode1.shutdown();
+            Awaitility.await()
+                    .atMost(30, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            2, standbyMaster.getCluster().getMembers().size()));
+
+            // With zero workers registered anywhere in the cluster, this job can only land in
+            // PENDING (see JobMaster#preApplyResources): a genuinely live, non-end-state job that
+            // legitimately still needs a worker before it can make progress.
+            ClientJobProxy liveJob =
+                    submitJob(
+                            engineClient,
+                            masterNode1Config,
+                            "live_pending_job",
+                            TestUtils.getResource(JOB_CONFIG_FILE));
+            long liveJobId = liveJob.getJobId();
+            assertJobStatusWithTimeout(liveJob, JobStatus.PENDING, 60);
+
+            // Trigger the master switch. Both jobs' IMap entries are already replicated on
+            // standbyMaster, and the cluster has already been confirmed to have zero workers, so
+            // restoreAllRunningJobFromMasterNodeSwitch begins with exactly the precondition this
+            // test needs -- no race to win.
+            activeMaster.shutdown();
+            Awaitility.await()
+                    .atMost(30, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertTrue(
+                                        standbyMaster.getLifecycleService().isRunning());
+                                Assertions.assertTrue(
+                                        isCoordinatorActive(standbyMaster),
+                                        "Standby master should become active after failover");
+                            });
+
+            SeaTunnelServer standbyServer =
+                    standbyMaster.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+            CoordinatorService standbyCoordinatorService = standbyServer.getCoordinatorService();
+
+            Awaitility.await()
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            0,
+                                            standbyCoordinatorService
+                                                    .getResourceManager()
+                                                    .workerCount(Collections.emptyMap())));
+
+            // While the new active master still has zero registered workers: the terminal job
+            // must already be resolved (not queued behind the worker-wait loop), while the live
+            // job must still be blocked waiting for a worker. Holding both for a stability window
+            // proves they are on genuinely different code paths, not merely "both happened to
+            // finish quickly."
+            Awaitility.await()
+                    .during(10, TimeUnit.SECONDS)
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertEquals(
+                                        JobStatus.FINISHED,
+                                        standbyCoordinatorService.getJobStatus(terminalJobId),
+                                        "Terminal job must not be resurrected while restore is "
+                                                + "still waiting for a worker for the live job");
+                                Assertions.assertFalse(
+                                        standbyCoordinatorService
+                                                .getPendingJobQueue()
+                                                .contains(liveJobId),
+                                        "Live job must still be blocked behind the worker-wait "
+                                                + "loop while zero workers are registered");
+                            });
+
+            // A worker finally registers: the live job's restore, previously gated behind the
+            // worker-wait loop, now proceeds to completion; the already-resolved terminal job is
+            // unaffected by it.
+            workerNode2 = SeaTunnelServerStarter.createWorkerHazelcastInstance(workerNode2Config);
+            Awaitility.await()
+                    .atMost(60, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            2, standbyMaster.getCluster().getMembers().size()));
+
+            ClientJobProxy liveJobAfterFailover =
+                    engineClient.createJobClient().getJobProxy(liveJobId);
+            assertJobStatusWithTimeout(liveJobAfterFailover, JobStatus.RUNNING, 120);
+            Assertions.assertEquals(
+                    JobStatus.FINISHED, standbyCoordinatorService.getJobStatus(terminalJobId));
+
+            liveJobAfterFailover.cancelJob();
+            assertEventuallyCanceled(liveJobAfterFailover);
+        } finally {
+            if (engineClient != null) {
+                engineClient.close();
+            }
+            if (workerNode1 != null && workerNode1.getLifecycleService().isRunning()) {
+                workerNode1.shutdown();
+            }
+            if (workerNode2 != null) {
+                workerNode2.shutdown();
+            }
+            if (masterNode1 != null && masterNode1.getLifecycleService().isRunning()) {
+                masterNode1.shutdown();
+            }
+            if (masterNode2 != null && masterNode2.getLifecycleService().isRunning()) {
+                masterNode2.shutdown();
             }
         }
     }
@@ -479,5 +716,39 @@ public class SplitClusterPendingJobLifecycleFailoverIT {
                                                 .contains(expectedRemovedJobId),
                                         "Pending queue should not contain job "
                                                 + expectedRemovedJobId));
+    }
+
+    /**
+     * Renders a small, quickly-completing batch job from {@code
+     * cluster_batch_fake_to_localfile_template.conf} so it reaches FINISHED almost immediately,
+     * leaving a realistic terminal-job IMap tombstone behind for {@link
+     * #testTerminalJobCleanupSkipsWorkerWaitAfterMasterSwitch}. Mirrors {@code
+     * ClusterFaultToleranceIT#createTestResources}; kept local since it is only needed by that test
+     * in this class.
+     *
+     * @return pair of (sink output directory, generated job config file path)
+     */
+    private static ImmutablePair<String, String> createTerminalJobResources(
+            String testCaseName, long rowNumber, int parallelism) throws IOException {
+        Map<String, String> valueMap = new HashMap<>();
+        valueMap.put("dynamic_test_case_name", testCaseName);
+        valueMap.put("dynamic_job_mode", JobMode.BATCH.toString());
+        valueMap.put("dynamic_test_row_num_per_parallelism", String.valueOf(rowNumber));
+        valueMap.put("dynamic_test_parallelism", String.valueOf(parallelism));
+
+        String targetDir = ("/tmp/hive/warehouse/" + testCaseName).replace("/", File.separator);
+        FileUtils.createNewDir(targetDir);
+
+        String targetConfigFilePath =
+                File.separator
+                        + "tmp"
+                        + File.separator
+                        + "test_conf"
+                        + File.separator
+                        + testCaseName
+                        + ".conf";
+        TestUtils.createTestConfigFileFromTemplate(
+                "cluster_batch_fake_to_localfile_template.conf", valueMap, targetConfigFilePath);
+        return new ImmutablePair<>(targetDir, targetConfigFilePath);
     }
 }


### PR DESCRIPTION
## What this guards

Two related fixes both concern job restore getting stuck after a Zeta master switch:

- **#10692** ("[Fix][Zeta] Prevent terminal-state zombie jobs from being restored after master switch"): before this fix, `CoordinatorService#restoreAllRunningJobFromMasterNodeSwitch` funneled *every* entry found in `runningJobInfoIMap` — including jobs that had already reached a terminal status such as FINISHED/CANCELED — through the same `while (getResourceManager().workerCount(...) == 0)` wait loop that live (still-running) jobs legitimately need. A terminal job's IMap tombstone cleanup does not need a worker at all, so it could be starved indefinitely behind that loop. The fix added a pre-filter that resolves terminal-state entries immediately, before the worker-wait loop is ever reached, so only genuinely live jobs are subject to it.
- **#10562** and **#10842**: a related pair of fixes in the same restore path — `RetryableHazelcastException` (thrown when an IMap partition is still loading, e.g. during a master switch) wasn't classified as retryable, so restore could fail outright instead of retrying; and a call site re-read `runningJobInfoIMap.get(jobId)` redundantly instead of reusing the already-available `jobInfo` parameter.

I traced current `dev` HEAD (`CoordinatorService.restoreAllRunningJobFromMasterNodeSwitch`, `restoreJobFromMasterActiveSwitch`) to confirm what's still in place before writing this test:

- The **terminal-job pre-filter from #10692 is present and unchanged in shape**: it iterates the restore candidates, and for any whose last known `JobStatus.isEndState() == true`, calls `restoreJobFromMasterActiveSwitch` immediately and removes it from the list — *before* the `while (getResourceManager().workerCount(Collections.emptyMap()) == 0)` loop that only the remaining (live) jobs fall through to.
- The **`RetryUtils.retryWithException(...)` wrapping from #10562/#10842 around the IMap reads is present** in both `restoreAllRunningJobFromMasterNodeSwitch` (fetching the candidate list) and `restoreJobFromMasterActiveSwitch` (fetching job state), and `restoreJobFromMasterActiveSwitch` correctly reuses the `jobInfo` parameter rather than re-reading the IMap.
- The **worker-wait loop itself is still unbounded** — no timeout, no max iteration count:
  ```java
  // waiting have worker registered
  while (getResourceManager().workerCount(Collections.emptyMap()) == 0) {
      try {
          logger.info("Waiting for worker registered");
          Thread.sleep(1000);
      } catch (InterruptedException e) { ... }
  }
  ```
  This is a **related but distinct, still-open architectural gap**: if no worker ever registers after a master switch, restore of every remaining *live* job blocks forever (not just the terminal ones #10692 already excludes). This PR is test-only and does not fix that gap — it only proves that live jobs correctly wait (and successfully proceed once a worker appears), while terminal jobs correctly do *not* wait at all. Flagging it here per the task brief as a separate, out-of-scope observation.

Existing coverage for #10692 was `CoordinatorServiceTest#testTerminalZombieJobShouldNotRestartAfterMasterSwitch`, a single-job scenario that hand-injects stale terminal IMap entries via direct `IMap.put(...)` calls and reflection into a 2-node unit-test-style cluster. It does not exercise a **mix** of terminal and live jobs restoring together, and does not construct the "zero workers registered at switch time" precondition explicitly. This PR adds a real multi-node E2E path for that gap.

## What the new test does

`SplitClusterPendingJobLifecycleFailoverIT#testTerminalJobCleanupSkipsWorkerWaitAfterMasterSwitch`:

1. Starts two master-eligible nodes plus one temporary worker; runs a small batch job (`cluster_batch_fake_to_localfile_template.conf`) to completion on that worker, so it reaches FINISHED the normal way (leaving a real `pendingJobCleanupIMap` tombstone behind, not a hand-injected one).
2. Shuts the worker down — **only after** that batch job's tasks already reached a terminal execution state — then confirms (via cluster membership size) that zero workers remain anywhere in the cluster.
3. Submits a second job with zero workers registered. `ScheduleStrategy#WAIT` resource pre-checks fail gracefully rather than erroring out (see `JobMaster#preApplyResources`), so this job lands in PENDING: a genuinely live, non-end-state job that legitimately still needs a worker.
4. Shuts down the active master, confirming the standby (which has held a live IMap backup since before either job was submitted) becomes the new active coordinator with zero registered workers.
5. Asserts, for a 10-second stability window while zero workers remain registered: the terminal job's status stays FINISHED (never re-queued), while the live job is **not yet** in the new master's pending-job queue — proving they take genuinely different code paths, not just "both happened to resolve quickly."
6. Starts a fresh worker; asserts the live job's restore now proceeds and reaches RUNNING, and re-confirms the terminal job's status is unaffected.

## Why the trigger construction is reliable

The precondition ("terminal job present, live job present, and the *new* active master has zero registered workers") is built purely by controlling node start/stop **order**, not by racing or sleeping past a hoped-for window:

- Both master nodes are started before either job is submitted, so the IMap backup that survives the switch is already live.
- The temporary worker is torn down **only after** the batch job's tasks have already completed — not while any task is still DEPLOYING/RUNNING/CANCELING on it. This matters because `CoordinatorService#failedTaskOnMemberRemoved` is a *synchronous* Hazelcast membership listener: killing a worker out from under an in-flight task fails that task immediately (not after a delay), and with the default `job.retry.times`/`job.retry.interval.seconds` (3/3) a job that loses its only worker mid-flight would flip to terminal FAILED roughly 9 seconds later. That would have silently collapsed this test's mixed-state precondition (both "jobs" ending up terminal) — I verified this failure path directly in `CoordinatorService` and had it independently confirmed by another investigation before choosing this construction.
- The "live" job is therefore built as a genuinely non-end-state PENDING job submitted *after* the sole worker is already gone, rather than a RUNNING job whose worker is killed later — this exercises the exact same `isEndState() == false` branch in `restoreAllRunningJobFromMasterNodeSwitch` (the fix in #10692 doesn't distinguish RUNNING from PENDING; it only checks end-state-ness), without any dependency on winning a race against `failedTaskOnMemberRemoved`.
- No sleeps are used to "hope" the precondition holds; every gating condition (cluster member counts, job statuses) is asserted via `Awaitility` before the next step proceeds.

## Why scenario 2 (transient IMap-loading exception classification) is not covered here

I considered also covering the #10562/#10842 retry-on-`RetryableHazelcastException` behavior, but this test module's Hazelcast IMaps have no `MapStore` configured (no external/S3-backed loading, confirmed by inspecting the test `hazelcast.yaml`/`seatunnel.yaml` resources), so there is no honest, black-box way to make a real IMap partition report "still loading" during a master switch in this environment. The only existing coverage of that exact mechanism (`CoordinatorServiceTest#testRestoreUsesProvidedJobInfoInitializationTimestamp`) already does this correctly via a Mockito spy that throws `RetryableHazelcastException` from an IMap `get(...)` call — that is an appropriate way to test an internal exception-handling contract, but not something a black-box multi-node E2E test can reproduce honestly without equivalent internal instrumentation. Per the task guidance, I focused this PR on the scenario I could construct reliably (terminal-vs-live job restore gating) rather than force a weaker or flaky simulation of the IMap-loading race.

## Test plan

- `./mvnw spotless:apply -pl seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base -am -nsu` — BUILD SUCCESS, no formatting changes needed beyond what's in this diff.
- `./mvnw install -pl 'seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base,!seatunnel-engine/seatunnel-engine-ui' -am -nsu -Dmaven.gitcommitid.skip=true -DskipTests -Dspotless.check.skip=true -T 3C` — BUILD SUCCESS; directly confirmed (via `javap`) that the new test method and its helper compiled into `SplitClusterPendingJobLifecycleFailoverIT.class`, since `-DskipTests` alone (Surefire-only) still compiles test sources, unlike `-Dmaven.test.skip=true` which would have skipped compilation entirely.
- Actual test execution is left to CI, consistent with this repository's local-verification policy for the main Apache SeaTunnel repo.
