### PR TITLE
[Fix][Format][Protobuf] Support empty Schema Registry payloads

### DIFF
--- a/seatunnel-formats/seatunnel-format-protobuf/src/main/java/org/apache/seatunnel/format/protobuf/SchemaRegistryAwareProtobufDeserializationSchema.java
+++ b/seatunnel-formats/seatunnel-format-protobuf/src/main/java/org/apache/seatunnel/format/protobuf/SchemaRegistryAwareProtobufDeserializationSchema.java
@@ -42,10 +42,14 @@ public class SchemaRegistryAwareProtobufDeserializationSchema
 
     private static final long serialVersionUID = -2134049729306615854L;
 
+    private static final int SCHEMA_REGISTRY_PREFIX_LENGTH = 5;
+    private static final int MAX_VARINT_BYTES = 5;
+    private static final long INVALID_VARINT = -1L;
+
     /**
-     * Maximum number of additional header bytes (beyond the 5 bytes magic + schema id) to probe
-     * when trying to locate the actual Protobuf message. This covers the variable-length "message
-     * indexes" part used by Schema Registry for Protobuf.
+     * Maximum number of offsets retained for the legacy best-effort probe. Structurally valid
+     * Confluent headers do not use this limit; it only preserves non-empty messages accepted before
+     * the header parser was introduced.
      */
     private static final int MAX_ADDITIONAL_HEADER_BYTES = 16;
 
@@ -71,19 +75,30 @@ public class SchemaRegistryAwareProtobufDeserializationSchema
         // Confluent Schema Registry Protobuf wire format:
         // 1 byte magic (0), 4 bytes schema id, N bytes message indexes (varints), then protobuf.
         if (length >= 6 && message[0] == 0) {
+            int payloadOffset = findPayloadOffset(message);
+            if (payloadOffset >= 0) {
+                SeaTunnelRow result = tryDeserialize(message, payloadOffset, length, true);
+                if (result != null) {
+                    return result;
+                }
+            }
+
+            // Preserve compatibility with messages accepted by the previous best-effort probe.
             // Try candidateStart = 6 first (common case: single message index)
-            SeaTunnelRow result = tryDeserialize(message, 6, length);
-            if (result != null) {
-                return result;
+            if (payloadOffset != 6) {
+                SeaTunnelRow result = tryDeserialize(message, 6, length, false);
+                if (result != null) {
+                    return result;
+                }
             }
 
             // Probe other offsets (5 to 5 + MAX_ADDITIONAL_HEADER_BYTES)
             int maxProbeStart = Math.min(5 + MAX_ADDITIONAL_HEADER_BYTES, length - 1);
             for (int start = 5; start <= maxProbeStart; start++) {
-                if (start == 6) {
+                if (start == 6 || start == payloadOffset) {
                     continue; // Already tried
                 }
-                result = tryDeserialize(message, start, length);
+                SeaTunnelRow result = tryDeserialize(message, start, length, false);
                 if (result != null) {
                     return result;
                 }
@@ -94,6 +109,62 @@ public class SchemaRegistryAwareProtobufDeserializationSchema
         return inner.deserialize(message);
     }
 
+    /** Returns the payload offset for a structurally valid Confluent Protobuf header. */
+    private static int findPayloadOffset(byte[] message) {
+        long lengthVarInt = readUnsignedVarInt(message, SCHEMA_REGISTRY_PREFIX_LENGTH);
+        if (lengthVarInt == INVALID_VARINT) {
+            return -1;
+        }
+
+        int offset = (int) (lengthVarInt >>> 32);
+        long encodedLength = lengthVarInt & 0xFFFFFFFFL;
+        if (encodedLength == 0) {
+            // Confluent encodes the common message-index path [0] as a single zero byte.
+            return offset;
+        }
+
+        int indexCount = decodeZigZagInt(encodedLength);
+        if (indexCount <= 0 || indexCount > message.length - offset) {
+            return -1;
+        }
+
+        for (int index = 0; index < indexCount; index++) {
+            long indexVarInt = readUnsignedVarInt(message, offset);
+            if (indexVarInt == INVALID_VARINT || decodeZigZagInt(indexVarInt & 0xFFFFFFFFL) < 0) {
+                return -1;
+            }
+            offset = (int) (indexVarInt >>> 32);
+        }
+        return offset;
+    }
+
+    /**
+     * Reads one unsigned 32-bit varint without allocating a holder object. The upper 32 bits
+     * contain the next offset and the lower 32 bits contain the decoded value.
+     */
+    private static long readUnsignedVarInt(byte[] message, int offset) {
+        int value = 0;
+        for (int byteIndex = 0; byteIndex < MAX_VARINT_BYTES; byteIndex++) {
+            if (offset >= message.length) {
+                return INVALID_VARINT;
+            }
+
+            int current = message[offset++] & 0xFF;
+            if (byteIndex == MAX_VARINT_BYTES - 1 && (current & 0xF0) != 0) {
+                return INVALID_VARINT;
+            }
+            value |= (current & 0x7F) << (byteIndex * 7);
+            if ((current & 0x80) == 0) {
+                return ((long) offset << 32) | (value & 0xFFFFFFFFL);
+            }
+        }
+        return INVALID_VARINT;
+    }
+
+    private static int decodeZigZagInt(long value) {
+        return (int) ((value >>> 1) ^ -(value & 1L));
+    }
+
     /**
      * Try to deserialize message starting from the given offset. Uses ByteArrayInputStream to avoid
      * copying the byte array.
@@ -101,12 +172,13 @@ public class SchemaRegistryAwareProtobufDeserializationSchema
      * @param message the original message byte array
      * @param offset the starting offset in the array
      * @param length the total length of the array
+     * @param allowEmptyPayload whether a structurally validated header may have a zero-byte payload
      * @return deserialized SeaTunnelRow, or null if parsing fails
      */
-    private SeaTunnelRow tryDeserialize(byte[] message, int offset, int length) {
+    private SeaTunnelRow tryDeserialize(
+            byte[] message, int offset, int length, boolean allowEmptyPayload) {
         int remaining = length - offset;
-        // A valid protobuf message must have at least 2 bytes (tag + value for a small field)
-        if (remaining < 2) {
+        if (remaining < (allowEmptyPayload ? 0 : 2)) {
             return null;
         }
 

--- a/seatunnel-formats/seatunnel-format-protobuf/src/test/java/org/apache/seatunnel/format/protobuf/SchemaRegistryAwareProtobufDeserializationSchemaTest.java
+++ b/seatunnel-formats/seatunnel-format-protobuf/src/test/java/org/apache/seatunnel/format/protobuf/SchemaRegistryAwareProtobufDeserializationSchemaTest.java
@@ -23,7 +23,9 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import com.google.protobuf.Descriptors;
 
@@ -31,6 +33,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SchemaRegistryAwareProtobufDeserializationSchemaTest {
 
     private static final String PROTO_CONTENT =
@@ -46,6 +49,26 @@ public class SchemaRegistryAwareProtobufDeserializationSchemaTest {
                     + "}";
 
     private static final String MESSAGE_NAME = "TestMessage";
+
+    private static final String EMPTY_PROTO_CONTENT =
+            "syntax = \"proto3\";\n"
+                    + "package org.apache.seatunnel.format.protobuf;\n"
+                    + "message EmptyMessage {}";
+
+    private static final String EMPTY_MESSAGE_NAME = "EmptyMessage";
+
+    private static final byte[] OPTIMIZED_FIRST_MESSAGE_INDEX = {0};
+
+    private SchemaRegistryAwareProtobufDeserializationSchema schema;
+    private SchemaRegistryAwareProtobufDeserializationSchema emptyMessageSchema;
+
+    @BeforeAll
+    void setUpSchemas() {
+        schema = new SchemaRegistryAwareProtobufDeserializationSchema(createCatalogTable());
+        emptyMessageSchema =
+                new SchemaRegistryAwareProtobufDeserializationSchema(
+                        createEmptyMessageCatalogTable());
+    }
 
     private CatalogTable createCatalogTable() {
         Map<String, String> options = new HashMap<>();
@@ -65,7 +88,22 @@ public class SchemaRegistryAwareProtobufDeserializationSchemaTest {
         return catalogTable;
     }
 
+    private CatalogTable createEmptyMessageCatalogTable() {
+        Map<String, String> options = new HashMap<>();
+        options.put("protobuf_schema", EMPTY_PROTO_CONTENT);
+        options.put("protobuf_message_name", EMPTY_MESSAGE_NAME);
+
+        SeaTunnelRowType rowType = new SeaTunnelRowType(new String[0], new SeaTunnelDataType<?>[0]);
+        CatalogTable catalogTable = CatalogTableUtil.getCatalogTable("empty_table", rowType);
+        catalogTable.getOptions().putAll(options);
+        return catalogTable;
+    }
+
     private byte[] createPlainProtobufMessage() throws Exception {
+        return createPlainProtobufMessage(123, "test");
+    }
+
+    private byte[] createPlainProtobufMessage(int id, String name) throws Exception {
         Descriptors.Descriptor descriptor =
                 CompileDescriptor.compileDescriptorTempFile(PROTO_CONTENT, MESSAGE_NAME);
 
@@ -80,65 +118,57 @@ public class SchemaRegistryAwareProtobufDeserializationSchemaTest {
         RowToProtobufConverter converter = new RowToProtobufConverter(rowType, descriptor);
 
         SeaTunnelRow row = new SeaTunnelRow(2);
-        row.setField(0, 123);
-        row.setField(1, "test");
+        row.setField(0, id);
+        row.setField(1, name);
 
         return converter.convertRowToGenericRecord(row);
     }
 
     private byte[] createSchemaRegistryMessage(byte[] plainMessage) {
-        byte[] srMessage = new byte[6 + plainMessage.length];
+        return createSchemaRegistryMessage(OPTIMIZED_FIRST_MESSAGE_INDEX, plainMessage);
+    }
+
+    private byte[] createSchemaRegistryMessage(byte[] messageIndexes, byte[] plainMessage) {
+        byte[] srMessage = new byte[5 + messageIndexes.length + plainMessage.length];
         srMessage[0] = 0;
         srMessage[1] = 0;
         srMessage[2] = 0;
         srMessage[3] = 0;
         srMessage[4] = 1;
-        srMessage[5] = 0;
-        System.arraycopy(plainMessage, 0, srMessage, 6, plainMessage.length);
+        System.arraycopy(messageIndexes, 0, srMessage, 5, messageIndexes.length);
+        System.arraycopy(
+                plainMessage, 0, srMessage, 5 + messageIndexes.length, plainMessage.length);
         return srMessage;
     }
 
-    @Test
-    void testDeserializeNullMessage() {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
+    private void assertInvalidPayload(byte[] message) {
+        IOException exception =
+                Assertions.assertThrows(IOException.class, () -> schema.deserialize(message));
 
+        Assertions.assertTrue(exception.getMessage().contains("invalid tag"));
+    }
+
+    @Test
+    void throwsWhenMessageIsNull() {
         Assertions.assertThrows(NullPointerException.class, () -> schema.deserialize(null));
     }
 
     @Test
-    void testDeserializeEmptyMessage() throws IOException {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
-
-        // Empty message may return a row with default values
+    void shouldDeserializePlainEmptyPayloadWithDefaultValues() throws IOException {
         SeaTunnelRow result = schema.deserialize(new byte[0]);
-        // After fallback tries, the inner schema returns a row with default values
+
         Assertions.assertNotNull(result);
         Assertions.assertEquals(0, result.getField(0));
         Assertions.assertEquals("", result.getField(1));
     }
 
     @Test
-    void testDeserializeInvalidMessage() throws IOException {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
-
-        // Invalid protobuf message without magic byte - should throw exception
-        byte[] invalidMessage = new byte[] {0, 1, 2, 3, 4};
-
-        Assertions.assertThrows(IOException.class, () -> schema.deserialize(invalidMessage));
+    void shouldRejectInvalidPlainPayload() {
+        assertInvalidPayload(new byte[] {0, 1, 2, 3, 4});
     }
 
     @Test
-    void testDeserializePlainProtobufMessage() throws Exception {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
-
+    void shouldDeserializePlainProtobufMessage() throws Exception {
         byte[] plainMessage = createPlainProtobufMessage();
         SeaTunnelRow result = schema.deserialize(plainMessage);
 
@@ -148,11 +178,7 @@ public class SchemaRegistryAwareProtobufDeserializationSchemaTest {
     }
 
     @Test
-    void testDeserializeSchemaRegistryMessage() throws Exception {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
-
+    void shouldDeserializeSchemaRegistryMessage() throws Exception {
         byte[] plainMessage = createPlainProtobufMessage();
         byte[] srMessage = createSchemaRegistryMessage(plainMessage);
 
@@ -164,29 +190,111 @@ public class SchemaRegistryAwareProtobufDeserializationSchemaTest {
     }
 
     @Test
-    void testDeserializeMessageWithMagicByteOnly() throws IOException {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
+    void shouldDeserializeSchemaRegistryMessageWithDefaultValuedPayload() throws Exception {
+        byte[] defaultValuedMessage = createPlainProtobufMessage(0, "");
 
-        // Message with magic byte but invalid protobuf content
-        byte[] message = new byte[] {0, 1, 2, 3, 4, 5};
+        Assertions.assertEquals(0, defaultValuedMessage.length);
+        SeaTunnelRow result = schema.deserialize(createSchemaRegistryMessage(defaultValuedMessage));
 
-        // Should try to strip header, fail on all offsets, then fallback to original
-        // Original message is also invalid, so throws exception
-        Assertions.assertThrows(IOException.class, () -> schema.deserialize(message));
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.getField(0));
+        Assertions.assertEquals("", result.getField(1));
     }
 
     @Test
-    void testDeserializeMessageWithoutMagicByte() throws Exception {
-        CatalogTable catalogTable = createCatalogTable();
-        SchemaRegistryAwareProtobufDeserializationSchema schema =
-                new SchemaRegistryAwareProtobufDeserializationSchema(catalogTable);
+    void shouldDeserializeSchemaRegistryEmptyMessage() throws IOException {
+        SeaTunnelRow result =
+                emptyMessageSchema.deserialize(createSchemaRegistryMessage(new byte[0]));
 
-        byte[] plainMessage = createPlainProtobufMessage();
-        SeaTunnelRow result = schema.deserialize(plainMessage);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.getArity());
+    }
+
+    @Test
+    void shouldDeserializeEmptyPayloadWithExplicitSingleIndex() throws IOException {
+        SeaTunnelRow result =
+                schema.deserialize(createSchemaRegistryMessage(new byte[] {2, 0}, new byte[0]));
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.getField(0));
+        Assertions.assertEquals("", result.getField(1));
+    }
+
+    @Test
+    void shouldDeserializeNestedMessageIndexPayload() throws Exception {
+        byte[] nestedMessageIndexes = {6, 0, 4, 2};
+
+        SeaTunnelRow result =
+                schema.deserialize(
+                        createSchemaRegistryMessage(
+                                nestedMessageIndexes, createPlainProtobufMessage()));
 
         Assertions.assertNotNull(result);
         Assertions.assertEquals(123, result.getField(0));
+        Assertions.assertEquals("test", result.getField(1));
+    }
+
+    @Test
+    void shouldPreserveLegacyNonEmptyHeaderCompatibility() throws Exception {
+        SeaTunnelRow result =
+                schema.deserialize(
+                        createSchemaRegistryMessage(new byte[] {1}, createPlainProtobufMessage()));
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(123, result.getField(0));
+        Assertions.assertEquals("test", result.getField(1));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMessageIndexLengthIsTruncated() {
+        assertInvalidPayload(createSchemaRegistryMessage(new byte[] {(byte) 0x80}, new byte[0]));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMessageIndexLengthIsNegative() {
+        assertInvalidPayload(createSchemaRegistryMessage(new byte[] {1}, new byte[0]));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMessageIndexVectorIsTruncated() {
+        assertInvalidPayload(createSchemaRegistryMessage(new byte[] {4, 0}, new byte[0]));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMessageIndexIsNegative() {
+        assertInvalidPayload(createSchemaRegistryMessage(new byte[] {2, 1}, new byte[0]));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMessageIndexLengthVarIntIsOversized() {
+        assertInvalidPayload(
+                createSchemaRegistryMessage(
+                        new byte[] {
+                            (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x10
+                        },
+                        new byte[0]));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMessageIndexVarIntIsOversized() {
+        assertInvalidPayload(
+                createSchemaRegistryMessage(
+                        new byte[] {
+                            2, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x10
+                        },
+                        new byte[0]));
+    }
+
+    @Test
+    void shouldRejectEmptyPayloadWhenMagicByteIsInvalid() {
+        byte[] message = createSchemaRegistryMessage(new byte[0]);
+        message[0] = 1;
+
+        assertInvalidPayload(message);
+    }
+
+    @Test
+    void shouldRejectMalformedSchemaRegistryHeader() {
+        assertInvalidPayload(new byte[] {0, 1, 2, 3, 4, 5});
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Closes #12037.

Confluent-framed Protobuf records can have a zero-byte data section when the message is empty or all proto3 implicit-presence fields contain default values. The existing Schema Registry-aware deserializer rejected every payload smaller than two bytes and then retried the complete frame as plain Protobuf, causing valid empty messages to fail with an invalid-tag error.

This change structurally decodes the Confluent zigzag-varint message-index vector and permits an empty data section only after the complete header is valid. It preserves plain-Protobuf fallback and retains the previous bounded probe for non-empty compatibility.

No dependency, public API, configuration, or default is changed.

Regression coverage includes:

- Optimized `[0]` and explicit single-index framing.
- Empty messages and all-default proto3 messages.
- Non-empty and nested/multi-index payloads.
- Plain Protobuf fallback.
- Legacy non-empty framing.
- Truncated, negative, oversized, malformed, and invalid-magic headers.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, a Kafka source configured with `format = protobuf` and `strip_schema_registry_header = true` failed to deserialize a valid Schema Registry record when its Protobuf data section contained zero bytes.

After this change, the record is deserialized into the schema's default-valued row when the Confluent header is structurally valid. Existing non-empty Schema Registry records and plain Protobuf records retain their previous behavior.

### How was this patch tested?

The complete Protobuf format module was tested on both Java versions using:

- `./mvnw -pl seatunnel-formats/seatunnel-format-protobuf test`
- `./mvnw -pl seatunnel-formats/seatunnel-format-protobuf -DskipTests verify`
- `./mvnw -pl seatunnel-formats/seatunnel-format-protobuf spotless:apply`

Results:

- Oracle Java 8: 19 tests, 0 failures, 0 errors.
- Eclipse Temurin Java 11: 19 tests, 0 failures, 0 errors.
- `git diff --check`: passed.

A repository-wide Java 11 `./mvnw -q -DskipTests verify` reached the unrelated `seatunnel-engine-ui` module and stopped because its npm process-tree helper could not spawn a child process (`spawn EPERM`). This PR does not change UI files.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation does not require an update because the existing Kafka documentation already defines Schema Registry header stripping; this patch corrects that documented behavior.
* [x] `incompatible-changes.md` does not require an update because this is backward-compatible.
* [x] The connector contribution checklist is not applicable because this is a focused fix to an existing shared format implementation and adds no connector or plugin.
