### PR TITLE
[Improve][E2E][DB2] Replace Db2CDCIT wget with DependencyJar

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-db2-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/db2/Db2CDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-db2-e2e/src/test/java/org/apache/seatunnel/e2e/connector/cdc/db2/Db2CDCIT.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.e2e.common.container.TestContainer;
 import org.apache.seatunnel.e2e.common.container.seatunnel.SeaTunnelContainer;
 import org.apache.seatunnel.e2e.common.junit.DisabledOnContainer;
 import org.apache.seatunnel.e2e.common.junit.TestContainerExtension;
+import org.apache.seatunnel.e2e.common.util.DependencyJar;
 import org.apache.seatunnel.e2e.common.util.JdbcUtil;
 
 import org.junit.jupiter.api.AfterAll;
@@ -105,25 +106,12 @@ public class Db2CDCIT extends TestSuiteBase implements TestResource {
                     .withLogConsumer(new Slf4jLogConsumer(DockerLoggerFactory.getLogger(DB2_IMAGE)))
                     .acceptLicense();
 
-    private String driverUrl() {
-        return "https://repo1.maven.org/maven2/com/ibm/db2/jcc/db2jcc/db2jcc4/db2jcc-db2jcc4.jar";
-    }
-
     @TestContainerExtension
     protected final ContainerExtendedFactory extendedFactory =
             container -> {
-                Container.ExecResult extraCommands =
-                        container.execInContainer(
-                                "bash",
-                                "-c",
-                                "mkdir -p /tmp/seatunnel/plugins/DB2-CDC/lib "
-                                        + "/tmp/seatunnel/plugins/Jdbc/lib && "
-                                        + "wget --no-check-certificate -O "
-                                        + "/tmp/seatunnel/plugins/DB2-CDC/lib/db2jcc.jar "
-                                        + driverUrl()
-                                        + " && cp /tmp/seatunnel/plugins/DB2-CDC/lib/db2jcc.jar "
-                                        + "/tmp/seatunnel/plugins/Jdbc/lib/db2jcc.jar");
-                Assertions.assertEquals(0, extraCommands.getExitCode(), extraCommands.getStderr());
+                DependencyJar driver = DependencyJar.ofClassName("com.ibm.db2.jcc.DB2Driver");
+                driver.copyTo(container, "/tmp/seatunnel/plugins/DB2-CDC/lib", "db2jcc.jar");
+                driver.copyTo(container, "/tmp/seatunnel/plugins/Jdbc/lib", "db2jcc.jar");
             };
 
     @Override


### PR DESCRIPTION
### Purpose of this pull request

Closes #12018

The DB2 CDC E2E currently downloads the DB2 JDBC Driver from Maven Central via `wget` inside the SeaTunnel container. This makes the test dependent on Maven Central being reachable at runtime and duplicates the Driver dependency already declared in the module's pom.

This PR migrates `Db2CDCIT` to the `DependencyJar` mechanism introduced in #11572, following the same pattern as #11904 (MySQL error tests).

Changes:
- Remove the hard-coded `driverUrl()` and the container-side `wget` + `cp` shell command
- Resolve the existing `com.ibm.db2.jcc:db2jcc` test dependency via `DependencyJar.ofClassName("com.ibm.db2.jcc.DB2Driver")`
- Copy the same resolved JAR into both `/tmp/seatunnel/plugins/DB2-CDC/lib` and `/tmp/seatunnel/plugins/Jdbc/lib`

The GBase 8a non-Maven fallback in `AbstractJdbcIT` is intentionally left unchanged, per the issue's scope note.

### Does this PR introduce _any_ user-facing change?

No. This is a test-infrastructure-only change; runtime behavior of the DB2 CDC connector is unaffected.

### How was this patch tested?

- Ran `./mvnw spotless:apply` — no format issues.
- Full local build succeeded: `./mvnw clean install -DskipTests -Dcheckstyle.skip -Dspotless.check.skip -Dlicense.skipAddThirdParty`.
- Relying on CI to run the DB2 CDC E2E (`connector-cdc-db2-e2e`) to verify the driver is staged correctly.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)