### PR TITLE
[Fix][Zeta] Preserve idle reader state after master switch

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertex.java
@@ -39,6 +39,7 @@ import org.apache.seatunnel.engine.server.execution.TaskGroupDefaultImpl;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
+import org.apache.seatunnel.engine.server.task.SourceSeaTunnelTask;
 import org.apache.seatunnel.engine.server.task.TaskGroupImmutableInformation;
 import org.apache.seatunnel.engine.server.task.operation.CancelTaskOperation;
 import org.apache.seatunnel.engine.server.task.operation.CheckTaskGroupIsExecutingOperation;
@@ -346,6 +347,24 @@ public class PhysicalVertex {
     @VisibleForTesting
     public TaskGroup getTaskGroup() {
         return taskGroup;
+    }
+
+    /**
+     * Identifies a source task group that was intentionally closed after an unbounded source reader
+     * became idle. Such a group is terminal during a running-pipeline master restore, but it must
+     * not cause the checkpoint coordinator to restart as if the pipeline were not ready.
+     */
+    @VisibleForTesting
+    boolean isRecoverableFinishedStateForRunningPipelineRestore() {
+        if (!ExecutionState.FINISHED.equals(getExecutionState())) {
+            return false;
+        }
+        return !taskGroup.getTasks().isEmpty()
+                && taskGroup.getTasks().stream().anyMatch(SourceSeaTunnelTask.class::isInstance)
+                && taskGroup.getTasks().stream()
+                        .filter(SourceSeaTunnelTask.class::isInstance)
+                        .map(SourceSeaTunnelTask.class::cast)
+                        .allMatch(SourceSeaTunnelTask::isUnboundedSourceTask);
     }
 
     public synchronized void updateTaskState(@NonNull ExecutionState targetState) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/SubPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/SubPlan.java
@@ -17,6 +17,8 @@
 
 package org.apache.seatunnel.engine.server.dag.physical;
 
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
 import org.apache.seatunnel.api.common.multitable.MultiTableFailureHelper;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
 import org.apache.seatunnel.common.utils.ExceptionUtils;
@@ -579,31 +581,50 @@ public class SubPlan {
         if (getPipelineState().ordinal() < PipelineStatus.RUNNING.ordinal()) {
             updatePipelineState(PipelineStatus.CANCELING);
         } else if (PipelineStatus.RUNNING.equals(getPipelineState())) {
-            AtomicBoolean allTaskRunning = new AtomicBoolean(true);
-            getCoordinatorVertexList()
-                    .forEach(
-                            task -> {
-                                if (!task.getExecutionState().equals(ExecutionState.RUNNING)) {
-                                    allTaskRunning.set(false);
-                                    return;
-                                }
-                            });
-
-            getPhysicalVertexList()
-                    .forEach(
-                            task -> {
-                                if (!task.getExecutionState().equals(ExecutionState.RUNNING)) {
-                                    allTaskRunning.set(false);
-                                    return;
-                                }
-                            });
-
             jobMaster
                     .getCheckpointManager()
                     .reportedPipelineRunning(
-                            this.getPipelineLocation().getPipelineId(), allTaskRunning.get());
+                            this.getPipelineLocation().getPipelineId(),
+                            isCheckpointCoordinatorAlreadyStarted());
         }
         startSubPlanStateProcess();
+    }
+
+    /**
+     * Determines whether the checkpoint coordinator was already running before a master switch. An
+     * unbounded source task group can be FINISHED because the coordinator closed an idle reader,
+     * while the remaining reader task groups keep the pipeline running.
+     */
+    @VisibleForTesting
+    boolean isCheckpointCoordinatorAlreadyStarted() {
+        AtomicBoolean allTaskRunning = new AtomicBoolean(true);
+        getCoordinatorVertexList()
+                .forEach(
+                        task -> {
+                            if (!ExecutionState.RUNNING.equals(task.getExecutionState())) {
+                                allTaskRunning.set(false);
+                            }
+                        });
+
+        getPhysicalVertexList()
+                .forEach(
+                        task -> {
+                            if (!isRecoverableRunningState(task)) {
+                                allTaskRunning.set(false);
+                            }
+                        });
+        return allTaskRunning.get();
+    }
+
+    /**
+     * Keeps only intentionally closed unbounded source groups in the running-restore path; all
+     * other terminal and failed physical vertices still reset the checkpoint coordinator.
+     */
+    @VisibleForTesting
+    static boolean isRecoverableRunningState(PhysicalVertex physicalVertex) {
+        ExecutionState executionState = physicalVertex.getExecutionState();
+        return ExecutionState.RUNNING.equals(executionState)
+                || physicalVertex.isRecoverableFinishedStateForRunningPipelineRestore();
     }
 
     public List<PhysicalVertex> getPhysicalVertexList() {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSeaTunnelTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SourceSeaTunnelTask.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.server.task;
 import org.apache.seatunnel.api.common.metrics.MetricsContext;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.serialization.Serializer;
+import org.apache.seatunnel.api.source.Boundedness;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
@@ -160,6 +161,15 @@ public class SourceSeaTunnelTask<T, SplitT extends SourceSplit> extends SeaTunne
 
     public void receivedSourceSplit(List<SplitT> splits) {
         ((SourceFlowLifeCycle<T, SplitT>) startFlowLifeCycle).receivedSplits(splits);
+    }
+
+    /**
+     * Returns whether this task belongs to an unbounded source. Idle reader closure is only valid
+     * for unbounded sources, so master-switch restore uses this distinction to preserve the
+     * checkpoint coordinator state.
+     */
+    public boolean isUnboundedSourceTask() {
+        return Boundedness.UNBOUNDED.equals(sourceFlow.getAction().getSource().getBoundedness());
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertexTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalVertexTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.dag.physical;
+
+import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.execution.ExecutionState;
+import org.apache.seatunnel.engine.server.execution.Task;
+import org.apache.seatunnel.engine.server.execution.TaskGroupDefaultImpl;
+import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
+import org.apache.seatunnel.engine.server.task.SourceSeaTunnelTask;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.map.IMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that only intentionally closed unbounded source task groups are recoverable during a
+ * running-pipeline master restore.
+ */
+class PhysicalVertexTest extends AbstractSeaTunnelServerTest<PhysicalVertexTest> {
+
+    @Test
+    void shouldTreatFinishedUnboundedSourceTaskGroupAsRecoverable() {
+        SourceSeaTunnelTask<?, ?> sourceTask = mock(SourceSeaTunnelTask.class);
+        when(sourceTask.getTaskID()).thenReturn(11L);
+        when(sourceTask.isUnboundedSourceTask()).thenReturn(true);
+        Task transformTask = mock(Task.class);
+        when(transformTask.getTaskID()).thenReturn(12L);
+
+        PhysicalVertex physicalVertex =
+                newPhysicalVertex(
+                        ExecutionState.FINISHED, "idle-source", sourceTask, transformTask);
+
+        Assertions.assertTrue(physicalVertex.isRecoverableFinishedStateForRunningPipelineRestore());
+    }
+
+    @Test
+    void shouldRejectFinishedBoundedSourceTaskGroupAsRecoverable() {
+        SourceSeaTunnelTask<?, ?> sourceTask = mock(SourceSeaTunnelTask.class);
+        when(sourceTask.getTaskID()).thenReturn(21L);
+        when(sourceTask.isUnboundedSourceTask()).thenReturn(false);
+
+        PhysicalVertex physicalVertex =
+                newPhysicalVertex(ExecutionState.FINISHED, "bounded-source", sourceTask);
+
+        Assertions.assertFalse(
+                physicalVertex.isRecoverableFinishedStateForRunningPipelineRestore());
+    }
+
+    @Test
+    void shouldRejectFinishedNonSourceTaskGroupAsRecoverable() {
+        Task transformTask = mock(Task.class);
+        when(transformTask.getTaskID()).thenReturn(31L);
+
+        PhysicalVertex physicalVertex =
+                newPhysicalVertex(ExecutionState.FINISHED, "transform", transformTask);
+
+        Assertions.assertFalse(
+                physicalVertex.isRecoverableFinishedStateForRunningPipelineRestore());
+    }
+
+    @Test
+    void shouldRejectRunningSourceTaskGroupAsRecoverable() {
+        SourceSeaTunnelTask<?, ?> sourceTask = mock(SourceSeaTunnelTask.class);
+        when(sourceTask.getTaskID()).thenReturn(41L);
+        when(sourceTask.isUnboundedSourceTask()).thenReturn(true);
+
+        PhysicalVertex physicalVertex =
+                newPhysicalVertex(ExecutionState.RUNNING, "running-source", sourceTask);
+
+        Assertions.assertFalse(
+                physicalVertex.isRecoverableFinishedStateForRunningPipelineRestore());
+    }
+
+    private PhysicalVertex newPhysicalVertex(
+            ExecutionState executionState, String taskGroupName, Task... tasks) {
+        TaskGroupLocation taskGroupLocation =
+                new TaskGroupLocation(1L, 1, taskGroupName.hashCode() & Integer.MAX_VALUE);
+        TaskGroupDefaultImpl taskGroup =
+                new TaskGroupDefaultImpl(taskGroupLocation, taskGroupName, Arrays.asList(tasks));
+
+        IMap<Object, Object> runningJobStateIMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap("physical-vertex-test-running-state-" + UUID.randomUUID());
+        IMap<Object, Long[]> runningJobStateTimestampsIMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap("physical-vertex-test-state-timestamps-" + UUID.randomUUID());
+        runningJobStateIMap.put(taskGroupLocation, executionState);
+
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setName("test");
+        JobImmutableInformation jobImmutableInformation = mock(JobImmutableInformation.class);
+        when(jobImmutableInformation.getJobId()).thenReturn(1L);
+        when(jobImmutableInformation.getJobConfig()).thenReturn(jobConfig);
+
+        FlakeIdGenerator flakeIdGenerator =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getFlakeIdGenerator("physical-vertex-test-" + UUID.randomUUID());
+
+        return new PhysicalVertex(
+                0,
+                1,
+                taskGroup,
+                flakeIdGenerator,
+                1,
+                1,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                jobImmutableInformation,
+                System.currentTimeMillis(),
+                nodeEngine,
+                runningJobStateIMap,
+                runningJobStateTimestampsIMap);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/dag/physical/SubPlanTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/dag/physical/SubPlanTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.dag.physical;
+
+import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
+import org.apache.seatunnel.engine.server.checkpoint.CheckpointManager;
+import org.apache.seatunnel.engine.server.execution.ExecutionState;
+import org.apache.seatunnel.engine.server.master.JobMaster;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.map.IMap;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers checkpoint coordinator restore decisions for running pipelines with an intentionally
+ * closed idle source reader.
+ */
+class SubPlanTest extends AbstractSeaTunnelServerTest<SubPlanTest> {
+
+    @Test
+    void shouldKeepCheckpointCoordinatorStartedWithFinishedIdlePhysicalTask() {
+        CheckpointManager checkpointManager = mock(CheckpointManager.class);
+        JobMaster jobMaster = mock(JobMaster.class);
+        when(jobMaster.getCheckpointManager()).thenReturn(checkpointManager);
+
+        PhysicalVertex coordinator = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex incrementalReader = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex idleReader = mockPhysicalVertex(ExecutionState.FINISHED);
+        when(idleReader.isRecoverableFinishedStateForRunningPipelineRestore()).thenReturn(true);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            SubPlan subPlan =
+                    newSubPlan(
+                            executorService,
+                            Arrays.asList(incrementalReader, idleReader),
+                            Collections.singletonList(coordinator));
+
+            subPlan.setJobMaster(jobMaster);
+            subPlan.setCurrPipelineStatus(PipelineStatus.RUNNING);
+            subPlan.restorePipelineState();
+
+            verify(checkpointManager).reportedPipelineRunning(1, true);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldResetCheckpointCoordinatorWithFinishedNonIdlePhysicalTask() {
+        CheckpointManager checkpointManager = mock(CheckpointManager.class);
+        JobMaster jobMaster = mock(JobMaster.class);
+        when(jobMaster.getCheckpointManager()).thenReturn(checkpointManager);
+
+        PhysicalVertex coordinator = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex incrementalReader = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex finishedTransform = mockPhysicalVertex(ExecutionState.FINISHED);
+        when(finishedTransform.isRecoverableFinishedStateForRunningPipelineRestore())
+                .thenReturn(false);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            SubPlan subPlan =
+                    newSubPlan(
+                            executorService,
+                            Arrays.asList(incrementalReader, finishedTransform),
+                            Collections.singletonList(coordinator));
+
+            subPlan.setJobMaster(jobMaster);
+            subPlan.setCurrPipelineStatus(PipelineStatus.RUNNING);
+            subPlan.restorePipelineState();
+
+            verify(checkpointManager).reportedPipelineRunning(1, false);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldRejectFailedPhysicalTaskDuringRunningRestore() {
+        CheckpointManager checkpointManager = mock(CheckpointManager.class);
+        JobMaster jobMaster = mock(JobMaster.class);
+        when(jobMaster.getCheckpointManager()).thenReturn(checkpointManager);
+
+        PhysicalVertex coordinator = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex incrementalReader = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex failedReader = mockPhysicalVertex(ExecutionState.FAILED);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            SubPlan subPlan =
+                    newSubPlan(
+                            executorService,
+                            Arrays.asList(incrementalReader, failedReader),
+                            Collections.singletonList(coordinator));
+
+            subPlan.setJobMaster(jobMaster);
+            subPlan.setCurrPipelineStatus(PipelineStatus.RUNNING);
+            subPlan.restorePipelineState();
+
+            verify(checkpointManager).reportedPipelineRunning(1, false);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldTreatUnknownCoordinatorStateAsNotStarted() {
+        PhysicalVertex coordinator = mockPhysicalVertex(null);
+        PhysicalVertex runningReader = mockPhysicalVertex(ExecutionState.RUNNING);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            SubPlan subPlan =
+                    newSubPlan(
+                            executorService,
+                            Collections.singletonList(runningReader),
+                            Collections.singletonList(coordinator));
+
+            Assertions.assertFalse(subPlan.isCheckpointCoordinatorAlreadyStarted());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void shouldOnlyTreatRunningOrRecoverableFinishedPhysicalVertexAsReady() {
+        PhysicalVertex runningReader = mockPhysicalVertex(ExecutionState.RUNNING);
+        PhysicalVertex idleReader = mockPhysicalVertex(ExecutionState.FINISHED);
+        when(idleReader.isRecoverableFinishedStateForRunningPipelineRestore()).thenReturn(true);
+        PhysicalVertex finishedTransform = mockPhysicalVertex(ExecutionState.FINISHED);
+        when(finishedTransform.isRecoverableFinishedStateForRunningPipelineRestore())
+                .thenReturn(false);
+        PhysicalVertex failedReader = mockPhysicalVertex(ExecutionState.FAILED);
+
+        Assertions.assertTrue(SubPlan.isRecoverableRunningState(runningReader));
+        Assertions.assertTrue(SubPlan.isRecoverableRunningState(idleReader));
+        Assertions.assertFalse(SubPlan.isRecoverableRunningState(finishedTransform));
+        Assertions.assertFalse(SubPlan.isRecoverableRunningState(failedReader));
+    }
+
+    private SubPlan newSubPlan(
+            ExecutorService executorService,
+            List<PhysicalVertex> physicalVertexList,
+            List<PhysicalVertex> coordinatorVertexList) {
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setName("test");
+
+        JobImmutableInformation jobImmutableInformation = mock(JobImmutableInformation.class);
+        when(jobImmutableInformation.getJobId()).thenReturn(1L);
+        when(jobImmutableInformation.getJobConfig()).thenReturn(jobConfig);
+
+        IMap<Object, Object> runningJobStateIMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap("sub-plan-test-running-state-" + UUID.randomUUID());
+        IMap<Object, Long[]> runningJobStateTimestampsIMap =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getMap("sub-plan-test-state-timestamps-" + UUID.randomUUID());
+
+        return new SubPlan(
+                1,
+                1,
+                System.currentTimeMillis(),
+                physicalVertexList,
+                coordinatorVertexList,
+                jobImmutableInformation,
+                executorService,
+                runningJobStateIMap,
+                runningJobStateTimestampsIMap,
+                Collections.emptyMap());
+    }
+
+    private PhysicalVertex mockPhysicalVertex(ExecutionState executionState) {
+        PhysicalVertex physicalVertex = mock(PhysicalVertex.class);
+        when(physicalVertex.getExecutionState()).thenReturn(executionState);
+        return physicalVertex;
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes Zeta running-pipeline restore after a master switch when an unbounded source has intentionally closed an idle reader. A `FINISHED` physical vertex is treated as already ready only when its task group contains source tasks and every source task is unbounded; failed, bounded, and non-source task groups remain not ready.

### Does this PR introduce _any_ user-facing change?

Yes. For streaming and CDC jobs whose unbounded source readers are closed as idle, a master switch now keeps the checkpoint coordinator on its already-started restore path so checkpointing can continue.

### How was this patch tested?

- Added `PhysicalVertexTest` and `SubPlanTest` for recoverable idle readers, bounded sources, non-source task groups, failed task groups, and unknown execution states.
- `./mvnw spotless:apply -pl seatunnel-engine/seatunnel-engine-server -am -nsu -Dmaven.gitcommitid.skip=true`
- `./mvnw spotless:check -pl seatunnel-engine/seatunnel-engine-server -am -nsu -Dmaven.gitcommitid.skip=true`
- GitHub CI is pending for this PR and is the validation path for compilation and unit tests.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)