### PR TITLE
[Feature][Connector-V2] Add Amazon DocumentDB source connector

### DIFF
--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -74,6 +74,11 @@ transform-v2:
       - any-glob-to-any-file: seatunnel-transforms-v2/**
 
 # Connectors
+amazondocumentdb:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: seatunnel-connectors-v2/connector-amazondocumentdb/**
+          - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(amazondocumentdb)/**'
 amazondynamodb:
   - all:
       - changed-files:

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -20,6 +20,7 @@
 # corresponding to the module in the user Config, helping SeaTunnel to load the correct Jar package.
 # Don't modify the delimiter " -- ", just select the plugin you need
 --connectors-v2--
+connector-amazondocumentdb
 connector-amazondynamodb
 connector-azurecosmosdb
 connector-assert

--- a/docs/en/connectors/changelog/connector-amazondocumentdb.md
+++ b/docs/en/connectors/changelog/connector-amazondocumentdb.md
@@ -1,0 +1,24 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+| [Feature][Connector-V2] Add Amazon DocumentDB source connector | - | Next |
+
+</details>

--- a/docs/en/connectors/source/AmazonDocumentDB.md
+++ b/docs/en/connectors/source/AmazonDocumentDB.md
@@ -1,0 +1,228 @@
+import ChangeLog from '../changelog/connector-amazondocumentdb.md';
+
+# AmazonDocumentDB
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+> Amazon DocumentDB source connector
+
+## Support Connector Version
+
+- Amazon DocumentDB clusters compatible with the MongoDB 4.0 and 5.0 APIs
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
+
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+
+## Description
+
+Read documents from an existing Amazon DocumentDB collection with a bounded batch scan.
+
+V1 scope for this connector:
+
+- source only
+- one database and one collection per source
+- explicit schema required; schema inference is out of scope
+- optional BSON filter and projection
+- one source split; sampling and range-based parallel splitting are out of scope
+- sink, CDC/change streams, catalog discovery, and collection creation are out of scope
+
+## Supported DataSource Info
+
+The connector can be installed with `install-plugin.sh` or downloaded from Maven Central.
+
+| Datasource | Supported Versions | Dependency |
+| --- | --- | --- |
+| Amazon DocumentDB | MongoDB 4.0 and 5.0 compatibility | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-amazondocumentdb) |
+
+## Database Dependency
+
+> Install the connector plugin before running jobs:
+
+```shell
+sh bin/install-plugin.sh ${version}
+```
+
+Ensure `connector-amazondocumentdb` is included in the plugin installation. The connector uses the MongoDB Java synchronous driver 4.7.1. Amazon DocumentDB is normally reachable only from the VPC that contains the cluster, or through network connectivity to that VPC.
+
+## Data Type Mapping
+
+You must define the SeaTunnel schema explicitly. BSON values are converted according to the configured field types:
+
+| Amazon DocumentDB BSON type | SeaTunnel Data type |
+| --- | --- |
+| Boolean | BOOLEAN |
+| Int32 / Int64 / Double | TINYINT / SMALLINT / INT / BIGINT / FLOAT / DOUBLE |
+| Decimal128 | DECIMAL |
+| String / ObjectId / Document | STRING |
+| Date / Timestamp | DATE / TIME / TIMESTAMP |
+| Binary | BYTES |
+| Array | ARRAY |
+| Document | MAP / ROW |
+| Null / Undefined / Decimal128 NaN | null |
+
+## Source Options
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| uri | string | yes | - | MongoDB-compatible connection URI containing the Amazon DocumentDB endpoint and credentials |
+| database | string | yes | - | Database name |
+| collection | string | yes | - | Collection name |
+| schema | config | yes | - | Explicit data schema |
+| tls | boolean | no | true | Enable TLS for the connection |
+| tls_ca_file | string | yes when `tls=true` | - | Local path to the PEM CA bundle used to verify the cluster certificate |
+| match.query | string | no | `{}` | BSON/JSON filter document |
+| match.projection | string | no | - | BSON/JSON projection document |
+| fetch.size | int | no | 2048 | Number of documents requested from the server per batch; must be greater than zero |
+| common-options | - | no | - | Source plugin common parameters, see [Source Common Options](../common-options/source-common-options.md) |
+
+### uri [string]
+
+MongoDB-compatible connection URI. Include the username, password, cluster endpoint, and port. The connector rejects an explicit `retryWrites=true` because Amazon DocumentDB does not support retryable writes, and always applies `retryWrites=false` after parsing the URI.
+
+Example: `mongodb://reader:<password>@sample.cluster-abcdefghijkl.us-east-1.docdb.amazonaws.com:27017/?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`
+
+### database [string]
+
+Name of the existing Amazon DocumentDB database to read.
+
+### collection [string]
+
+Name of the existing collection to read.
+
+### schema [config]
+
+Explicit SeaTunnel schema. Field names are looked up in each BSON document. Missing or BSON null fields become null.
+
+```hocon
+schema = {
+  fields {
+    _id = string
+    status = string
+    amount = "decimal(18,2)"
+    created_at = timestamp
+    labels = "map<string,string>"
+  }
+}
+```
+
+### tls [boolean]
+
+Enables TLS. The default is `true`. The connector applies this option after parsing `uri`, so this option determines the final driver TLS setting.
+
+### tls_ca_file [string]
+
+Path to a readable PEM CA bundle. It is required when `tls=true`. The connector creates a connector-local `SSLContext`; it does not modify the JVM-wide `javax.net.ssl.trustStore` system property.
+
+Download the current Amazon trust store from the [AWS documentation](https://docs.aws.amazon.com/documentdb/latest/developerguide/connect_programmatically.html).
+
+### match.query [string]
+
+BSON/JSON filter passed to `find`, for example `{"status": "OPEN"}`. The default `{}` reads all documents.
+
+### match.projection [string]
+
+BSON/JSON projection passed to `find`, for example `{"_id": 1, "status": 1, "amount": 1}`.
+
+### fetch.size [int]
+
+Driver batch-size hint for the server cursor. A larger value can reduce round trips but increases the amount of data buffered by the driver.
+
+### common-options
+
+Source plugin common parameters, refer to [Source Common Options](../common-options/source-common-options.md).
+
+### Tips
+
+> 1. Use a read-only Amazon DocumentDB user and keep credentials out of checked-in job files.<br/>
+> 2. TLS is enabled by default. Use the current AWS CA bundle and rotate the local file when AWS updates its trust chain.<br/>
+> 3. V1 creates one split. Increasing source parallelism does not parallelize the collection scan.<br/>
+> 4. Split state contains the filter and projection, not cursor progress. A failed task can re-read documents after recovery.<br/>
+> 5. Push selective predicates into `match.query` and include every schema field you need in `match.projection`.
+
+## How to Create an Amazon DocumentDB Data Synchronization Job
+
+The following batch job reads an existing collection and prints rows to the local client:
+
+```bash
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://reader:<password>@sample.cluster-abcdefghijkl.us-east-1.docdb.amazonaws.com:27017/?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+    database = "app-db"
+    collection = "orders"
+    tls = true
+    tls_ca_file = "/opt/seatunnel/certs/global-bundle.pem"
+    fetch.size = 2048
+    schema = {
+      fields {
+        _id = string
+        status = string
+        amount = "decimal(18,2)"
+        created_at = timestamp
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### Filter and project documents
+
+```bash
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://reader:<password>@sample.cluster-abcdefghijkl.us-east-1.docdb.amazonaws.com:27017/?replicaSet=rs0&retryWrites=false"
+    database = "app-db"
+    collection = "orders"
+    tls_ca_file = "/opt/seatunnel/certs/global-bundle.pem"
+    match.query = '{"status": "OPEN", "amount": {"$gt": 100}}'
+    match.projection = '{"_id": 1, "status": 1, "amount": 1}'
+    fetch.size = 512
+    schema = {
+      fields {
+        _id = string
+        status = string
+        amount = "decimal(18,2)"
+      }
+    }
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/docs/en/connectors/source/AmazonDocumentDB.md
+++ b/docs/en/connectors/source/AmazonDocumentDB.md
@@ -87,6 +87,9 @@ You must define the SeaTunnel schema explicitly. BSON values are converted accor
 | Document | MAP / ROW |
 | Null / Undefined / Decimal128 NaN | null |
 
+Decimal128 values are rounded to the configured scale. If the resulting precision exceeds the
+declared DECIMAL precision, conversion fails with an error instead of silently producing `null`.
+
 ## Source Options
 
 | Name | Type | Required | Default | Description |
@@ -163,7 +166,7 @@ Source plugin common parameters, refer to [Source Common Options](../common-opti
 > 1. Use a read-only Amazon DocumentDB user and keep credentials out of checked-in job files.<br/>
 > 2. TLS is enabled by default. Use the current AWS CA bundle and rotate the local file when AWS updates its trust chain.<br/>
 > 3. V1 creates one split. Increasing source parallelism does not parallelize the collection scan.<br/>
-> 4. Split state contains the filter and projection, not cursor progress. A failed task can re-read documents after recovery.<br/>
+> 4. Split state contains the filter and projection, not cursor progress. Recovery restarts the full collection scan from the beginning—even if the failed attempt was almost complete—so downstream writes must be idempotent or use a truncate-and-reload strategy to avoid duplicates.<br/>
 > 5. Push selective predicates into `match.query` and include every schema field you need in `match.projection`.
 
 ## How to Create an Amazon DocumentDB Data Synchronization Job

--- a/docs/zh/connectors/changelog/connector-amazondocumentdb.md
+++ b/docs/zh/connectors/changelog/connector-amazondocumentdb.md
@@ -1,0 +1,24 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<details><summary> Change Log </summary>
+
+| Change | Commit | Version |
+| --- | --- | --- |
+| [Feature][Connector-V2] Add Amazon DocumentDB source connector | - | Next |
+
+</details>

--- a/docs/zh/connectors/source/AmazonDocumentDB.md
+++ b/docs/zh/connectors/source/AmazonDocumentDB.md
@@ -1,0 +1,228 @@
+import ChangeLog from '../changelog/connector-amazondocumentdb.md';
+
+# AmazonDocumentDB
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+> Amazon DocumentDB 源连接器
+
+## 连接器支持版本
+
+- 兼容 MongoDB 4.0 和 5.0 API 的 Amazon DocumentDB 集群
+
+## 支持这些引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 关键特性
+
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [ ] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行度](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持用户自定义分片](../../introduction/concepts/connector-v2-features.md)
+
+## 描述
+
+通过有界批扫描从已有 Amazon DocumentDB 集合读取文档。
+
+本连接器 V1 范围：
+
+- 仅支持 source
+- 每个 source 读取一个 database 和一个 collection
+- 必须显式配置 schema，不支持 schema 推断
+- 支持可选 BSON 过滤和投影
+- 仅使用一个 source split，不支持采样或按范围并行分片
+- sink、CDC/change stream、catalog 发现和集合创建均不在范围内
+
+## 支持的数据源信息
+
+可通过 `install-plugin.sh` 安装连接器，或从 Maven Central 下载。
+
+| 数据源 | 支持版本 | 依赖 |
+| --- | --- | --- |
+| Amazon DocumentDB | 兼容 MongoDB 4.0 和 5.0 | [Download](https://mvnrepository.com/artifact/org.apache.seatunnel/connector-amazondocumentdb) |
+
+## 数据库依赖
+
+> 运行作业前请先安装连接器插件：
+
+```shell
+sh bin/install-plugin.sh ${version}
+```
+
+请确保插件安装列表包含 `connector-amazondocumentdb`。连接器使用 MongoDB Java 同步驱动 4.7.1。Amazon DocumentDB 通常只能从集群所在 VPC 或与该 VPC 打通网络的环境访问。
+
+## 数据类型映射
+
+必须显式定义 SeaTunnel schema。连接器根据配置的字段类型转换 BSON 值：
+
+| Amazon DocumentDB BSON 类型 | SeaTunnel 数据类型 |
+| --- | --- |
+| Boolean | BOOLEAN |
+| Int32 / Int64 / Double | TINYINT / SMALLINT / INT / BIGINT / FLOAT / DOUBLE |
+| Decimal128 | DECIMAL |
+| String / ObjectId / Document | STRING |
+| Date / Timestamp | DATE / TIME / TIMESTAMP |
+| Binary | BYTES |
+| Array | ARRAY |
+| Document | MAP / ROW |
+| Null / Undefined / Decimal128 NaN | null |
+
+## 源配置项
+
+| 名称 | 类型 | 必需 | 默认值 | 描述 |
+| --- | --- | --- | --- | --- |
+| uri | string | 是 | - | 包含 Amazon DocumentDB endpoint 和凭据的 MongoDB 兼容连接 URI |
+| database | string | 是 | - | 数据库名称 |
+| collection | string | 是 | - | 集合名称 |
+| schema | config | 是 | - | 显式数据 schema |
+| tls | boolean | 否 | true | 是否启用 TLS |
+| tls_ca_file | string | `tls=true` 时是 | - | 用于验证集群证书的 PEM CA bundle 本地路径 |
+| match.query | string | 否 | `{}` | BSON/JSON 过滤文档 |
+| match.projection | string | 否 | - | BSON/JSON 投影文档 |
+| fetch.size | int | 否 | 2048 | 每批向服务端请求的文档数，必须大于零 |
+| common-options | - | 否 | - | Source 插件通用参数，详见 [Source Common Options](../common-options/source-common-options.md) |
+
+### uri [string]
+
+MongoDB 兼容连接 URI。请包含用户名、密码、集群 endpoint 和端口。Amazon DocumentDB 不支持 retryable writes，因此连接器会拒绝显式的 `retryWrites=true`，并在解析 URI 后始终应用 `retryWrites=false`。
+
+示例：`mongodb://reader:<password>@sample.cluster-abcdefghijkl.us-east-1.docdb.amazonaws.com:27017/?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`
+
+### database [string]
+
+要读取的已有 Amazon DocumentDB 数据库名称。
+
+### collection [string]
+
+要读取的已有集合名称。
+
+### schema [config]
+
+显式 SeaTunnel schema。连接器按字段名从每个 BSON 文档取值；字段缺失或 BSON null 时输出 null。
+
+```hocon
+schema = {
+  fields {
+    _id = string
+    status = string
+    amount = "decimal(18,2)"
+    created_at = timestamp
+    labels = "map<string,string>"
+  }
+}
+```
+
+### tls [boolean]
+
+是否启用 TLS，默认值为 `true`。连接器在解析 `uri` 后应用该配置，因此它决定驱动最终的 TLS 设置。
+
+### tls_ca_file [string]
+
+可读的 PEM CA bundle 路径。`tls=true` 时必须配置。连接器会构造自己专用的 `SSLContext`，不会修改 JVM 全局 `javax.net.ssl.trustStore` 系统属性。
+
+请从 [AWS 文档](https://docs.aws.amazon.com/documentdb/latest/developerguide/connect_programmatically.html)下载当前 Amazon trust store。
+
+### match.query [string]
+
+传给 `find` 的 BSON/JSON 过滤条件，例如 `{"status": "OPEN"}`。默认 `{}` 读取全部文档。
+
+### match.projection [string]
+
+传给 `find` 的 BSON/JSON 投影，例如 `{"_id": 1, "status": 1, "amount": 1}`。
+
+### fetch.size [int]
+
+服务端游标的驱动批大小提示。增大该值可减少网络往返，但会增加驱动缓冲的数据量。
+
+### common-options
+
+Source 插件通用参数，详见 [Source Common Options](../common-options/source-common-options.md)。
+
+### 提示
+
+> 1. 建议使用只读 Amazon DocumentDB 用户，并避免把凭据提交到版本库中的作业文件。<br/>
+> 2. TLS 默认启用。请使用当前 AWS CA bundle，并在 AWS 更新信任链后轮换本地文件。<br/>
+> 3. V1 只创建一个 split，提高 source 并行度不会并行扫描集合。<br/>
+> 4. Split 状态只保存过滤和投影，不保存游标进度；任务失败恢复后可能重复读取文档。<br/>
+> 5. 建议把高选择性条件放到 `match.query`，并在 `match.projection` 中包含 schema 所需的全部字段。
+
+## 如何创建 Amazon DocumentDB 数据同步作业
+
+下面的批处理作业从已有集合读取数据并打印到本地客户端：
+
+```bash
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://reader:<password>@sample.cluster-abcdefghijkl.us-east-1.docdb.amazonaws.com:27017/?replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+    database = "app-db"
+    collection = "orders"
+    tls = true
+    tls_ca_file = "/opt/seatunnel/certs/global-bundle.pem"
+    fetch.size = 2048
+    schema = {
+      fields {
+        _id = string
+        status = string
+        amount = "decimal(18,2)"
+        created_at = timestamp
+      }
+    }
+  }
+}
+
+sink {
+  Console {}
+}
+```
+
+### 过滤和投影文档
+
+```bash
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://reader:<password>@sample.cluster-abcdefghijkl.us-east-1.docdb.amazonaws.com:27017/?replicaSet=rs0&retryWrites=false"
+    database = "app-db"
+    collection = "orders"
+    tls_ca_file = "/opt/seatunnel/certs/global-bundle.pem"
+    match.query = '{"status": "OPEN", "amount": {"$gt": 100}}'
+    match.projection = '{"_id": 1, "status": 1, "amount": 1}'
+    fetch.size = 512
+    schema = {
+      fields {
+        _id = string
+        status = string
+        amount = "decimal(18,2)"
+      }
+    }
+  }
+}
+```
+
+## 变更日志
+
+<ChangeLog />

--- a/docs/zh/connectors/source/AmazonDocumentDB.md
+++ b/docs/zh/connectors/source/AmazonDocumentDB.md
@@ -87,6 +87,9 @@ sh bin/install-plugin.sh ${version}
 | Document | MAP / ROW |
 | Null / Undefined / Decimal128 NaN | null |
 
+Decimal128 值会按配置的 scale 四舍五入。如果结果精度超过声明的 DECIMAL precision，转换将报错，
+而不会静默产生 `null`。
+
 ## 源配置项
 
 | 名称 | 类型 | 必需 | 默认值 | 描述 |
@@ -163,7 +166,7 @@ Source 插件通用参数，详见 [Source Common Options](../common-options/sou
 > 1. 建议使用只读 Amazon DocumentDB 用户，并避免把凭据提交到版本库中的作业文件。<br/>
 > 2. TLS 默认启用。请使用当前 AWS CA bundle，并在 AWS 更新信任链后轮换本地文件。<br/>
 > 3. V1 只创建一个 split，提高 source 并行度不会并行扫描集合。<br/>
-> 4. Split 状态只保存过滤和投影，不保存游标进度；任务失败恢复后可能重复读取文档。<br/>
+> 4. Split 状态只保存过滤和投影，不保存游标进度。失败恢复会从集合开头重新执行完整扫描，即使上一次扫描已接近完成；因此下游写入必须具备幂等性，或采用 truncate-and-reload 策略，以避免重复数据。<br/>
 > 5. 建议把高选择性条件放到 `match.query`，并在 `match.projection` 中包含 schema 所需的全部字段。
 
 ## 如何创建 Amazon DocumentDB 数据同步作业

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -85,6 +85,7 @@ seatunnel.source.S3File = connector-file-s3
 seatunnel.sink.S3File = connector-file-s3
 seatunnel.source.AmazonDynamodb = connector-amazondynamodb
 seatunnel.sink.AmazonDynamodb = connector-amazondynamodb
+seatunnel.source.AmazonDocumentDB = connector-amazondocumentdb
 seatunnel.source.AzureCosmosDB = connector-azurecosmosdb
 seatunnel.source.Cassandra = connector-cassandra
 seatunnel.sink.Cassandra = connector-cassandra

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/pom.xml
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-amazondocumentdb</artifactId>
+    <name>SeaTunnel : Connectors V2 : Amazon DocumentDB</name>
+
+    <properties>
+        <mongo.driver.version>4.7.1</mongo.driver.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongo.driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-core</artifactId>
+            <version>${mongo.driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+            <version>${mongo.driver.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBConfig.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBConfig.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config;
+
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.util.Collection;
+
+public class AmazonDocumentDBConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String uri;
+    private final String database;
+    private final String collection;
+    private final boolean tls;
+    private final String tlsCaFile;
+    private final String matchQuery;
+    private final String projection;
+    private final int fetchSize;
+    private final Config schema;
+
+    public AmazonDocumentDBConfig(ReadonlyConfig config) {
+        this.uri = requireNonBlank(config.get(AmazonDocumentDBSourceOptions.URI), "uri");
+        this.database =
+                requireNonBlank(config.get(AmazonDocumentDBSourceOptions.DATABASE), "database");
+        this.collection =
+                requireNonBlank(config.get(AmazonDocumentDBSourceOptions.COLLECTION), "collection");
+        this.tls = config.get(AmazonDocumentDBSourceOptions.TLS);
+        this.tlsCaFile =
+                config.getOptional(AmazonDocumentDBSourceOptions.TLS_CA_FILE)
+                        .map(String::trim)
+                        .filter(value -> !value.isEmpty())
+                        .orElse(null);
+        this.matchQuery = config.get(AmazonDocumentDBSourceOptions.MATCH_QUERY);
+        this.projection =
+                config.getOptional(AmazonDocumentDBSourceOptions.PROJECTION)
+                        .map(String::trim)
+                        .filter(value -> !value.isEmpty())
+                        .orElse(null);
+        this.fetchSize = config.get(AmazonDocumentDBSourceOptions.FETCH_SIZE);
+        this.schema =
+                config.getOptional(ConnectorCommonOptions.SCHEMA)
+                        .map(ReadonlyConfig::fromMap)
+                        .map(ReadonlyConfig::toConfig)
+                        .orElse(null);
+
+        ConnectionString connectionString = parseConnectionString(uri);
+        if (connectionString.getCredential() == null) {
+            throw new IllegalArgumentException(
+                    "AmazonDocumentDB option 'uri' must include authentication credentials");
+        }
+        if (hasRetryWritesEnabled(uri)) {
+            throw new IllegalArgumentException(
+                    "AmazonDocumentDB does not support retryable writes; remove 'retryWrites=true' from option 'uri' or set it to false");
+        }
+        if (tls) {
+            validateTlsCaFile(tlsCaFile);
+        }
+        validateBsonDocument(matchQuery, "match.query");
+        if (projection != null) {
+            validateBsonDocument(projection, "match.projection");
+        }
+    }
+
+    public MongoClientSettings createMongoClientSettings() {
+        ConnectionString connectionString = parseConnectionString(uri);
+        MongoClientSettings.Builder builder =
+                MongoClientSettings.builder()
+                        .applyConnectionString(connectionString)
+                        .retryWrites(false);
+        builder.applyToSslSettings(
+                sslBuilder -> {
+                    sslBuilder.enabled(tls);
+                    if (tls) {
+                        sslBuilder.context(createSslContext(Paths.get(tlsCaFile)));
+                    }
+                });
+        return builder.build();
+    }
+
+    private static ConnectionString parseConnectionString(String uri) {
+        try {
+            return new ConnectionString(uri);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Invalid AmazonDocumentDB connection URI in option 'uri'", e);
+        }
+    }
+
+    private static boolean hasRetryWritesEnabled(String uri) {
+        int queryStart = uri.indexOf('?');
+        if (queryStart < 0 || queryStart == uri.length() - 1) {
+            return false;
+        }
+        String query = uri.substring(queryStart + 1);
+        int fragmentStart = query.indexOf('#');
+        if (fragmentStart >= 0) {
+            query = query.substring(0, fragmentStart);
+        }
+        for (String parameter : query.split("&")) {
+            int separator = parameter.indexOf('=');
+            if (separator < 0) {
+                continue;
+            }
+            String key = decodeUriParameter(parameter.substring(0, separator));
+            String value = decodeUriParameter(parameter.substring(separator + 1));
+            if ("retryWrites".equalsIgnoreCase(key) && "true".equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String decodeUriParameter(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 must be supported", e);
+        }
+    }
+
+    private static String requireNonBlank(String value, String optionName) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "AmazonDocumentDB option '" + optionName + "' must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static void validateTlsCaFile(String tlsCaFile) {
+        if (tlsCaFile == null) {
+            throw new IllegalArgumentException(
+                    "AmazonDocumentDB option 'tls_ca_file' is required when TLS is enabled");
+        }
+        Path path = Paths.get(tlsCaFile);
+        if (!Files.isRegularFile(path) || !Files.isReadable(path)) {
+            throw new IllegalArgumentException(
+                    "AmazonDocumentDB TLS CA bundle is not a readable file: " + tlsCaFile);
+        }
+    }
+
+    private static void validateBsonDocument(String value, String optionName) {
+        try {
+            BsonDocument.parse(value);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(
+                    "AmazonDocumentDB option '"
+                            + optionName
+                            + "' must be a valid BSON/JSON document",
+                    e);
+        }
+    }
+
+    private static SSLContext createSslContext(Path caBundlePath) {
+        try (InputStream inputStream = Files.newInputStream(caBundlePath)) {
+            CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+            Collection<? extends Certificate> certificates =
+                    certificateFactory.generateCertificates(inputStream);
+            if (certificates.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "AmazonDocumentDB TLS CA bundle contains no certificates: " + caBundlePath);
+            }
+
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            int certificateIndex = 0;
+            for (Certificate certificate : certificates) {
+                trustStore.setCertificateEntry(
+                        "amazondocumentdb-ca-" + certificateIndex, certificate);
+                certificateIndex++;
+            }
+
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), null);
+            return sslContext;
+        } catch (IOException | GeneralSecurityException e) {
+            throw new IllegalArgumentException(
+                    "Failed to load AmazonDocumentDB TLS CA bundle: " + caBundlePath, e);
+        }
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public boolean isTls() {
+        return tls;
+    }
+
+    public String getTlsCaFile() {
+        return tlsCaFile;
+    }
+
+    public String getMatchQuery() {
+        return matchQuery;
+    }
+
+    public String getProjection() {
+        return projection;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+
+    public Config getSchema() {
+        return schema;
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBConfig.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBConfig.java
@@ -45,6 +45,12 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.util.Collection;
 
+/**
+ * Validated runtime configuration for the Amazon DocumentDB source.
+ *
+ * <p>The configuration rejects unsupported retryable writes before a reader starts and owns all TLS
+ * trust material so one job cannot change the JVM-wide trust configuration of another job.
+ */
 public class AmazonDocumentDBConfig implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -102,6 +108,14 @@ public class AmazonDocumentDBConfig implements Serializable {
         }
     }
 
+    /**
+     * Builds driver settings with DocumentDB-safe overrides.
+     *
+     * <p>The URI is applied first and {@code retryWrites(false)} second deliberately: the latter
+     * must win over both driver defaults and any URI option. TLS uses a connector-local {@link
+     * SSLContext} built from the configured CA bundle instead of mutating the JVM-global trust
+     * store, which would affect unrelated connectors running in the same process.
+     */
     public MongoClientSettings createMongoClientSettings() {
         ConnectionString connectionString = parseConnectionString(uri);
         MongoClientSettings.Builder builder =
@@ -191,6 +205,7 @@ public class AmazonDocumentDBConfig implements Serializable {
         }
     }
 
+    /** Builds an isolated trust context from every X.509 certificate in the supplied CA bundle. */
     private static SSLContext createSslContext(Path caBundlePath) {
         try (InputStream inputStream = Files.newInputStream(caBundlePath)) {
             CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBSourceOptions.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+
+import java.io.Serializable;
+
+public class AmazonDocumentDBSourceOptions extends ConnectorCommonOptions implements Serializable {
+
+    public static final Option<String> URI =
+            Options.key("uri")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Amazon DocumentDB connection URI, including endpoint and credentials");
+
+    public static final Option<String> DATABASE =
+            Options.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Amazon DocumentDB database name");
+
+    public static final Option<String> COLLECTION =
+            Options.key("collection")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Amazon DocumentDB collection name");
+
+    public static final Option<Boolean> TLS =
+            Options.key("tls")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether to enable TLS for the Amazon DocumentDB connection");
+
+    public static final Option<String> TLS_CA_FILE =
+            Options.key("tls_ca_file")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Path to a PEM CA bundle used to verify Amazon DocumentDB");
+
+    public static final Option<String> MATCH_QUERY =
+            Options.key("match.query")
+                    .stringType()
+                    .defaultValue("{}")
+                    .withDescription("BSON query document used to filter source records");
+
+    public static final Option<String> PROJECTION =
+            Options.key("match.projection")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("BSON projection document used to select source fields");
+
+    public static final Option<Integer> FETCH_SIZE =
+            Options.key("fetch.size")
+                    .intType()
+                    .defaultValue(2048)
+                    .withDescription("Number of documents requested from the server per batch");
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBSourceOptions.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 
 import java.io.Serializable;
 
+/** Option definitions shared by factory validation and the DocumentDB runtime configuration. */
 public class AmazonDocumentDBSourceOptions extends ConnectorCommonOptions implements Serializable {
 
     public static final Option<String> URI =

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/serialize/DocumentDBItemDeserializer.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/serialize/DocumentDBItemDeserializer.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.serialize;
+
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
+import org.apache.seatunnel.common.exception.CommonError;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.Decimal128;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DocumentDBItemDeserializer {
+
+    private static final String CONNECTOR_NAME = "AmazonDocumentDB";
+    private static final JsonWriterSettings RELAXED_JSON_SETTINGS =
+            JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).build();
+
+    private final SeaTunnelRowType rowType;
+
+    public DocumentDBItemDeserializer(SeaTunnelRowType rowType) {
+        this.rowType = rowType;
+    }
+
+    public SeaTunnelRow deserialize(BsonDocument document) {
+        return convertRow("root", rowType, document);
+    }
+
+    private Object convert(String field, SeaTunnelDataType<?> type, BsonValue value) {
+        if (isNull(value)) {
+            return null;
+        }
+
+        try {
+            switch (type.getSqlType()) {
+                case NULL:
+                    return null;
+                case BOOLEAN:
+                    return value.asBoolean().getValue();
+                case TINYINT:
+                    return (byte) checkedInteger(value, Byte.MIN_VALUE, Byte.MAX_VALUE);
+                case SMALLINT:
+                    return (short) checkedInteger(value, Short.MIN_VALUE, Short.MAX_VALUE);
+                case INT:
+                    return checkedInteger(value, Integer.MIN_VALUE, Integer.MAX_VALUE);
+                case BIGINT:
+                    return checkedLong(value);
+                case FLOAT:
+                    return (float) value.asNumber().doubleValue();
+                case DOUBLE:
+                    return value.asNumber().doubleValue();
+                case DECIMAL:
+                    return convertDecimal((DecimalType) type, value);
+                case STRING:
+                    return convertString(value);
+                case DATE:
+                    return convertDateTime(value).toLocalDate();
+                case TIME:
+                    return convertDateTime(value).toLocalTime();
+                case TIMESTAMP:
+                    return convertDateTime(value);
+                case BYTES:
+                    return value.asBinary().getData();
+                case ARRAY:
+                    return convertArray(field, (ArrayType<?, ?>) type, value);
+                case MAP:
+                    return convertMap(field, (MapType<?, ?>) type, value);
+                case ROW:
+                    return convertRow(field, (SeaTunnelRowType) type, value.asDocument());
+                default:
+                    throw conversionError(field, type);
+            }
+        } catch (SeaTunnelRuntimeException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw conversionError(field, type);
+        }
+    }
+
+    private static boolean isNull(BsonValue value) {
+        return value == null
+                || value.isNull()
+                || value.getBsonType() == BsonType.UNDEFINED
+                || (value.isDecimal128() && value.asDecimal128().getValue().isNaN());
+    }
+
+    private static int checkedInteger(BsonValue value, int minimum, int maximum) {
+        long number = value.asNumber().longValue();
+        if (number < minimum || number > maximum) {
+            throw new IllegalArgumentException("Integer value is out of range");
+        }
+        return (int) number;
+    }
+
+    private static long checkedLong(BsonValue value) {
+        if (value.isInt32() || value.isInt64()) {
+            return value.asNumber().longValue();
+        }
+        if (value.isDouble()) {
+            double number = value.asNumber().doubleValue();
+            if (number < Long.MIN_VALUE || number > Long.MAX_VALUE) {
+                throw new IllegalArgumentException("Long value is out of range");
+            }
+            return value.asNumber().longValue();
+        }
+        throw new IllegalArgumentException("Value is not a supported long");
+    }
+
+    private static BigDecimal convertDecimal(DecimalType type, BsonValue value) {
+        Decimal128 decimal128 = value.asDecimal128().decimal128Value();
+        if (!decimal128.isFinite()) {
+            throw new IllegalArgumentException("Infinite Decimal128 values are not supported");
+        }
+        BigDecimal decimal =
+                decimal128.bigDecimalValue().setScale(type.getScale(), RoundingMode.HALF_UP);
+        return decimal.precision() <= type.getPrecision() ? decimal : null;
+    }
+
+    private static String convertString(BsonValue value) {
+        if (value.isString()) {
+            return value.asString().getValue();
+        }
+        if (value.isObjectId()) {
+            return value.asObjectId().getValue().toHexString();
+        }
+        if (value.isDocument()) {
+            return value.asDocument().toJson(RELAXED_JSON_SETTINGS);
+        }
+        return value.toString();
+    }
+
+    private static LocalDateTime convertDateTime(BsonValue value) {
+        Instant instant;
+        if (value.isDateTime()) {
+            instant = Instant.ofEpochMilli(value.asDateTime().getValue());
+        } else if (value.isTimestamp()) {
+            instant = Instant.ofEpochSecond(value.asTimestamp().getTime());
+        } else {
+            throw new IllegalArgumentException("Value is not a BSON date or timestamp");
+        }
+        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+    }
+
+    private Object convertArray(String field, ArrayType<?, ?> type, BsonValue value) {
+        List<BsonValue> source = value.asArray();
+        Object target = Array.newInstance(type.getElementType().getTypeClass(), source.size());
+        for (int i = 0; i < source.size(); i++) {
+            Array.set(target, i, convert(field, type.getElementType(), source.get(i)));
+        }
+        return target;
+    }
+
+    private Map<String, Object> convertMap(String field, MapType<?, ?> type, BsonValue value) {
+        if (type.getKeyType().getSqlType() != SqlType.STRING) {
+            throw conversionError(field, type);
+        }
+        Map<String, Object> target = new HashMap<>();
+        BsonDocument document = value.asDocument();
+        for (String key : document.keySet()) {
+            target.put(key, convert(field, type.getValueType(), document.get(key)));
+        }
+        return target;
+    }
+
+    private SeaTunnelRow convertRow(String field, SeaTunnelRowType type, BsonDocument document) {
+        SeaTunnelRow row = new SeaTunnelRow(type.getTotalFields());
+        for (int i = 0; i < type.getTotalFields(); i++) {
+            String fieldName = type.getFieldName(i);
+            row.setField(i, convert(fieldName, type.getFieldType(i), document.get(fieldName)));
+        }
+        return row;
+    }
+
+    private static RuntimeException conversionError(String field, SeaTunnelDataType<?> type) {
+        return CommonError.convertToSeaTunnelTypeError(
+                CONNECTOR_NAME, type.getSqlType().toString(), field);
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/serialize/DocumentDBItemDeserializer.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/serialize/DocumentDBItemDeserializer.java
@@ -44,6 +44,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Converts standalone MongoDB-driver BSON values into rows described by a SeaTunnel schema.
+ *
+ * <p>This implementation intentionally lives in the Amazon DocumentDB module: compatibility with
+ * the wire protocol does not create a runtime dependency on connector-mongodb internals.
+ */
 public class DocumentDBItemDeserializer {
 
     private static final String CONNECTOR_NAME = "AmazonDocumentDB";
@@ -56,10 +62,16 @@ public class DocumentDBItemDeserializer {
         this.rowType = rowType;
     }
 
+    /**
+     * Converts a complete BSON document, leaving fields absent from the document as {@code null}.
+     */
     public SeaTunnelRow deserialize(BsonDocument document) {
         return convertRow("root", rowType, document);
     }
 
+    /**
+     * Dispatches conversion by the declared SeaTunnel type and retains low-level failure causes.
+     */
     private Object convert(String field, SeaTunnelDataType<?> type, BsonValue value) {
         if (isNull(value)) {
             return null;
@@ -107,7 +119,9 @@ public class DocumentDBItemDeserializer {
         } catch (SeaTunnelRuntimeException e) {
             throw e;
         } catch (RuntimeException e) {
-            throw conversionError(field, type);
+            SeaTunnelRuntimeException error = conversionError(field, type);
+            error.initCause(e);
+            throw error;
         }
     }
 
@@ -140,6 +154,10 @@ public class DocumentDBItemDeserializer {
         throw new IllegalArgumentException("Value is not a supported long");
     }
 
+    /**
+     * Applies the configured scale and rejects precision overflow instead of silently emitting
+     * {@code null}, which would make malformed source data indistinguishable from BSON null.
+     */
     private static BigDecimal convertDecimal(DecimalType type, BsonValue value) {
         Decimal128 decimal128 = value.asDecimal128().decimal128Value();
         if (!decimal128.isFinite()) {
@@ -147,7 +165,13 @@ public class DocumentDBItemDeserializer {
         }
         BigDecimal decimal =
                 decimal128.bigDecimalValue().setScale(type.getScale(), RoundingMode.HALF_UP);
-        return decimal.precision() <= type.getPrecision() ? decimal : null;
+        if (decimal.precision() > type.getPrecision()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Decimal precision %d exceeds configured precision %d",
+                            decimal.precision(), type.getPrecision()));
+        }
+        return decimal;
     }
 
     private static String convertString(BsonValue value) {
@@ -175,6 +199,7 @@ public class DocumentDBItemDeserializer {
         return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
     }
 
+    /** Converts array elements recursively so nested rows, maps, and arrays use the same rules. */
     private Object convertArray(String field, ArrayType<?, ?> type, BsonValue value) {
         List<BsonValue> source = value.asArray();
         Object target = Array.newInstance(type.getElementType().getTypeClass(), source.size());
@@ -184,6 +209,7 @@ public class DocumentDBItemDeserializer {
         return target;
     }
 
+    /** Converts BSON documents to maps; BSON field names require a string map key type. */
     private Map<String, Object> convertMap(String field, MapType<?, ?> type, BsonValue value) {
         if (type.getKeyType().getSqlType() != SqlType.STRING) {
             throw conversionError(field, type);
@@ -196,6 +222,7 @@ public class DocumentDBItemDeserializer {
         return target;
     }
 
+    /** Maps document fields by schema name, preserving schema order in the resulting row. */
     private SeaTunnelRow convertRow(String field, SeaTunnelRowType type, BsonDocument document) {
         SeaTunnelRow row = new SeaTunnelRow(type.getTotalFields());
         for (int i = 0; i < type.getTotalFields(); i++) {
@@ -205,7 +232,8 @@ public class DocumentDBItemDeserializer {
         return row;
     }
 
-    private static RuntimeException conversionError(String field, SeaTunnelDataType<?> type) {
+    private static SeaTunnelRuntimeException conversionError(
+            String field, SeaTunnelDataType<?> type) {
         return CommonError.convertToSeaTunnelTypeError(
                 CONNECTOR_NAME, type.getSqlType().toString(), field);
     }

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSource.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSource.java
@@ -28,6 +28,12 @@ import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonD
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Bounded Amazon DocumentDB source for a schema-driven collection scan.
+ *
+ * <p>V1 intentionally creates one split for the basic read path. Filter and projection are carried
+ * by that split, while cursor progress is not checkpointed, so recovery restarts the scan.
+ */
 public class AmazonDocumentDBSource
         implements SeaTunnelSource<
                 SeaTunnelRow, AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState> {
@@ -55,6 +61,7 @@ public class AmazonDocumentDBSource
         return Collections.singletonList(catalogTable);
     }
 
+    /** Starts a fresh single-split enumeration using the configured filter and projection. */
     @Override
     public SourceSplitEnumerator<AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState>
             createEnumerator(
@@ -63,6 +70,7 @@ public class AmazonDocumentDBSource
                 enumeratorContext, null, config.getMatchQuery(), config.getProjection());
     }
 
+    /** Restores only pending split descriptors; assigned cursor progress cannot be resumed. */
     @Override
     public SourceSplitEnumerator<AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState>
             restoreEnumerator(
@@ -72,6 +80,7 @@ public class AmazonDocumentDBSource
                 enumeratorContext, checkpointState, config.getMatchQuery(), config.getProjection());
     }
 
+    /** Creates the blocking reader that converts BSON according to the declared catalog schema. */
     @Override
     public SourceReader<SeaTunnelRow, AmazonDocumentDBSourceSplit> createReader(
             SourceReader.Context readerContext) {

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSource.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSource.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBConfig;
+
+import java.util.Collections;
+import java.util.List;
+
+public class AmazonDocumentDBSource
+        implements SeaTunnelSource<
+                SeaTunnelRow, AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState> {
+
+    private final AmazonDocumentDBConfig config;
+    private final CatalogTable catalogTable;
+
+    public AmazonDocumentDBSource(AmazonDocumentDBConfig config, CatalogTable catalogTable) {
+        this.config = config;
+        this.catalogTable = catalogTable;
+    }
+
+    @Override
+    public String getPluginName() {
+        return "AmazonDocumentDB";
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(catalogTable);
+    }
+
+    @Override
+    public SourceSplitEnumerator<AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState>
+            createEnumerator(
+                    SourceSplitEnumerator.Context<AmazonDocumentDBSourceSplit> enumeratorContext) {
+        return new AmazonDocumentDBSourceSplitEnumerator(
+                enumeratorContext, null, config.getMatchQuery(), config.getProjection());
+    }
+
+    @Override
+    public SourceSplitEnumerator<AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState>
+            restoreEnumerator(
+                    SourceSplitEnumerator.Context<AmazonDocumentDBSourceSplit> enumeratorContext,
+                    AmazonDocumentDBSourceState checkpointState) {
+        return new AmazonDocumentDBSourceSplitEnumerator(
+                enumeratorContext, checkpointState, config.getMatchQuery(), config.getProjection());
+    }
+
+    @Override
+    public SourceReader<SeaTunnelRow, AmazonDocumentDBSourceSplit> createReader(
+            SourceReader.Context readerContext) {
+        return new AmazonDocumentDBSourceReader(
+                readerContext, config, catalogTable.getSeaTunnelRowType());
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.configuration.util.Conditions;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBConfig;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+
+import static org.apache.seatunnel.api.options.ConnectorCommonOptions.SCHEMA;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.COLLECTION;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.DATABASE;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.FETCH_SIZE;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.MATCH_QUERY;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.PROJECTION;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.TLS;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.TLS_CA_FILE;
+import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.URI;
+
+@AutoService(Factory.class)
+public class AmazonDocumentDBSourceFactory implements TableSourceFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "AmazonDocumentDB";
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(URI, DATABASE, COLLECTION, SCHEMA)
+                .optional(TLS, TLS_CA_FILE, MATCH_QUERY, PROJECTION)
+                .optional(FETCH_SIZE, Conditions.greaterThan(FETCH_SIZE, 0))
+                .build();
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        return () ->
+                (SeaTunnelSource<T, SplitT, StateT>)
+                        new AmazonDocumentDBSource(
+                                new AmazonDocumentDBConfig(context.getOptions()),
+                                CatalogTableUtil.buildWithConfig(context.getOptions()));
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return AmazonDocumentDBSource.class;
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceFactory.java
@@ -42,6 +42,7 @@ import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.
 import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.TLS_CA_FILE;
 import static org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions.URI;
 
+/** Factory entry point discovered through AutoService under the {@code AmazonDocumentDB} name. */
 @AutoService(Factory.class)
 public class AmazonDocumentDBSourceFactory implements TableSourceFactory {
 

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceReader.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceReader.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBConfig;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.serialize.DocumentDBItemDeserializer;
+
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+public class AmazonDocumentDBSourceReader
+        implements SourceReader<SeaTunnelRow, AmazonDocumentDBSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AmazonDocumentDBSourceReader.class);
+
+    private final Context context;
+    private final AmazonDocumentDBConfig config;
+    private final DocumentDBItemDeserializer deserializer;
+    private final Queue<AmazonDocumentDBSourceSplit> pendingSplits = new ConcurrentLinkedDeque<>();
+
+    private MongoClient client;
+    private MongoCollection<BsonDocument> collection;
+    private MongoCursor<BsonDocument> cursor;
+    private AmazonDocumentDBSourceSplit currentSplit;
+    private volatile boolean noMoreSplits;
+    private volatile boolean finished;
+
+    public AmazonDocumentDBSourceReader(
+            Context context, AmazonDocumentDBConfig config, SeaTunnelRowType rowType) {
+        this.context = context;
+        this.config = config;
+        this.deserializer = new DocumentDBItemDeserializer(rowType);
+    }
+
+    @Override
+    public void open() {
+        try {
+            client = createMongoClient();
+            collection =
+                    client.getDatabase(config.getDatabase())
+                            .getCollection(config.getCollection(), BsonDocument.class);
+        } catch (Exception e) {
+            close();
+            throw new IllegalStateException(
+                    String.format(
+                            "Failed to open AmazonDocumentDB source reader for database [%s], collection [%s]",
+                            config.getDatabase(), config.getCollection()),
+                    e);
+        }
+    }
+
+    @Override
+    public void close() {
+        closeCursor();
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+    }
+
+    @Override
+    public void pollNext(Collector<SeaTunnelRow> output) {
+        AmazonDocumentDBSourceSplit activeSplit;
+        synchronized (output.getCheckpointLock()) {
+            if (finished) {
+                return;
+            }
+            if (currentSplit == null) {
+                currentSplit = pendingSplits.poll();
+            }
+            if (currentSplit == null) {
+                finishReaderIfNoMoreWork();
+                return;
+            }
+            activeSplit = currentSplit;
+        }
+
+        BsonDocument document = fetchNextDocument(activeSplit);
+
+        synchronized (output.getCheckpointLock()) {
+            if (finished || currentSplit != activeSplit) {
+                return;
+            }
+            if (document == null) {
+                finishCurrentSplit();
+                finishReaderIfNoMoreWork();
+                return;
+            }
+            output.collect(deserializer.deserialize(document));
+        }
+    }
+
+    @Override
+    public List<AmazonDocumentDBSourceSplit> snapshotState(long checkpointId) {
+        List<AmazonDocumentDBSourceSplit> state = new ArrayList<>();
+        pendingSplits.forEach(split -> state.add(split.copy()));
+        if (currentSplit != null) {
+            state.add(currentSplit.copy());
+        }
+        return state;
+    }
+
+    @Override
+    public void addSplits(List<AmazonDocumentDBSourceSplit> splits) {
+        pendingSplits.addAll(splits);
+    }
+
+    @Override
+    public void handleNoMoreSplits() {
+        noMoreSplits = true;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        // no-op
+    }
+
+    MongoClient createMongoClient() {
+        return MongoClients.create(config.createMongoClientSettings());
+    }
+
+    BsonDocument fetchNextDocument(AmazonDocumentDBSourceSplit split) {
+        try {
+            if (cursor == null) {
+                FindIterable<BsonDocument> findIterable =
+                        collection.find(BsonDocument.parse(split.getMatchQuery()));
+                if (split.getProjection() != null) {
+                    findIterable.projection(BsonDocument.parse(split.getProjection()));
+                }
+                cursor = findIterable.batchSize(config.getFetchSize()).iterator();
+            }
+            if (cursor.hasNext()) {
+                return cursor.next();
+            }
+            closeCursor();
+            return null;
+        } catch (Exception e) {
+            closeCursor();
+            throw new IllegalStateException(
+                    String.format(
+                            "Failed to read AmazonDocumentDB data from database [%s], collection [%s]",
+                            config.getDatabase(), config.getCollection()),
+                    e);
+        }
+    }
+
+    private void closeCursor() {
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
+        }
+    }
+
+    private void finishCurrentSplit() {
+        LOG.info("AmazonDocumentDB reader [{}] finished source scan", context.getIndexOfSubtask());
+        currentSplit = null;
+    }
+
+    private void finishReaderIfNoMoreWork() {
+        if (currentSplit == null && pendingSplits.isEmpty() && noMoreSplits) {
+            context.signalNoMoreElement();
+            finished = true;
+        }
+    }
+
+    int getFetchSize() {
+        return config.getFetchSize();
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceReader.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceReader.java
@@ -39,6 +39,13 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+/**
+ * Executes the blocking MongoDB-driver scan for the single DocumentDB source split.
+ *
+ * <p>The reader checkpoints split ownership but not server cursor position. Restoring an active
+ * split therefore starts its query again, which provides an intentionally basic at-least-once read
+ * path and requires an idempotent or truncate-and-reload downstream strategy.
+ */
 public class AmazonDocumentDBSourceReader
         implements SourceReader<SeaTunnelRow, AmazonDocumentDBSourceSplit> {
 
@@ -63,6 +70,7 @@ public class AmazonDocumentDBSourceReader
         this.deserializer = new DocumentDBItemDeserializer(rowType);
     }
 
+    /** Opens the client once per reader so its connector-local TLS context has reader scope. */
     @Override
     public void open() {
         try {
@@ -80,6 +88,7 @@ public class AmazonDocumentDBSourceReader
         }
     }
 
+    /** Closes the cursor before the client to release the server-side query promptly. */
     @Override
     public void close() {
         closeCursor();
@@ -89,6 +98,14 @@ public class AmazonDocumentDBSourceReader
         }
     }
 
+    /**
+     * Emits at most one document per call without holding the checkpoint lock during remote I/O.
+     *
+     * <p>The first lock section transfers split ownership into a stable local reference. The
+     * blocking cursor call then runs outside the lock so a MongoDB network round trip cannot delay
+     * checkpoint-barrier injection. The second section atomically publishes the row or completes
+     * the split against a concurrent snapshot.
+     */
     @Override
     public void pollNext(Collector<SeaTunnelRow> output) {
         AmazonDocumentDBSourceSplit activeSplit;
@@ -121,6 +138,7 @@ public class AmazonDocumentDBSourceReader
         }
     }
 
+    /** Snapshots pending and active split descriptors; cursor progress is deliberately excluded. */
     @Override
     public List<AmazonDocumentDBSourceSplit> snapshotState(long checkpointId) {
         List<AmazonDocumentDBSourceSplit> state = new ArrayList<>();
@@ -131,16 +149,19 @@ public class AmazonDocumentDBSourceReader
         return state;
     }
 
+    /** Queues restored or newly assigned splits for the reader thread. */
     @Override
     public void addSplits(List<AmazonDocumentDBSourceSplit> splits) {
         pendingSplits.addAll(splits);
     }
 
+    /** Records that completion may be signalled after the pending split queue is drained. */
     @Override
     public void handleNoMoreSplits() {
         noMoreSplits = true;
     }
 
+    /** No cursor position is committed because V1 recovery deliberately restarts the split. */
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
         // no-op

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplit.java
@@ -19,6 +19,12 @@ package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
 
 import org.apache.seatunnel.api.source.SourceSplit;
 
+/**
+ * Descriptor for the V1 collection scan.
+ *
+ * <p>Only the split id, filter, and projection are durable. There is no continuation token or
+ * cursor position, so restoring this split reruns its query from the beginning.
+ */
 public class AmazonDocumentDBSourceSplit implements SourceSplit {
 
     private static final long serialVersionUID = 1L;

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplit.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplit.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.source.SourceSplit;
+
+public class AmazonDocumentDBSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Integer splitId;
+    private final String matchQuery;
+    private final String projection;
+
+    public AmazonDocumentDBSourceSplit(Integer splitId, String matchQuery, String projection) {
+        this.splitId = splitId;
+        this.matchQuery = matchQuery;
+        this.projection = projection;
+    }
+
+    public Integer getSplitId() {
+        return splitId;
+    }
+
+    public String getMatchQuery() {
+        return matchQuery;
+    }
+
+    public String getProjection() {
+        return projection;
+    }
+
+    @Override
+    public String splitId() {
+        return splitId.toString();
+    }
+
+    public AmazonDocumentDBSourceSplit copy() {
+        return new AmazonDocumentDBSourceSplit(splitId, matchQuery, projection);
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumerator.java
@@ -96,7 +96,10 @@ public class AmazonDocumentDBSourceSplitEnumerator
         // no-op
     }
 
-    /** Returns failed reader work to its deterministic owner before reassignment. */
+    /**
+     * Returns failed reader work to its deterministic owner and defers reassignment until that
+     * reader is registered again.
+     */
     @Override
     public void addSplitsBack(List<AmazonDocumentDBSourceSplit> splits, int subtaskId) {
         synchronized (stateLock) {
@@ -118,7 +121,14 @@ public class AmazonDocumentDBSourceSplitEnumerator
         // The bounded source enumerates its only split eagerly.
     }
 
-    /** Assigns any pending work when its reader registers and otherwise completes that reader. */
+    /**
+     * Assigns pending work when a reader registers.
+     *
+     * <p>Zeta registers readers before invoking {@link #run()}, so an empty pending-split set here
+     * does not mean that enumeration has finished. No-more-splits is signaled only after {@link
+     * #run()} has completed enumeration; a reader registered after that point is signaled
+     * immediately.
+     */
     @Override
     public void registerReader(int subtaskId) {
         synchronized (stateLock) {
@@ -153,13 +163,20 @@ public class AmazonDocumentDBSourceSplitEnumerator
     }
 
     /**
-     * Gives the sole split to subtask 0 and sends no-more-splits to all readers.
+     * Gives the sole split to subtask 0 and, after enumeration, sends no-more-splits to all
+     * registered readers.
      *
      * <p>Assignments are removed before the callback and restored if the callback fails, keeping a
      * checkpoint from losing an unacknowledged split.
      */
     private void assignSplits(Set<Integer> readers) {
+        Set<Integer> registeredReaders = enumeratorContext.registeredReaders();
         for (int reader : readers) {
+            if (!registeredReaders.contains(reader)) {
+                LOG.warn("Reader {} is not registered. Pending splits are not assigned.", reader);
+                continue;
+            }
+
             List<AmazonDocumentDBSourceSplit> assignment = pendingSplits.remove(reader);
             if (assignment != null && !assignment.isEmpty()) {
                 LOG.info("Assign splits {} to reader {}", assignment, reader);
@@ -171,7 +188,9 @@ public class AmazonDocumentDBSourceSplitEnumerator
                     continue;
                 }
             }
-            enumeratorContext.signalNoMoreSplits(reader);
+            if (!shouldEnumerate) {
+                enumeratorContext.signalNoMoreSplits(reader);
+            }
         }
     }
 

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumerator.java
@@ -31,6 +31,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Enumerates the single split used by the Amazon DocumentDB V1 basic read path.
+ *
+ * <p>The split id hashes to subtask 0, and every other registered reader immediately receives
+ * no-more-splits. Checkpoint state retains only unassigned filter/projection descriptors; it does
+ * not capture cursor progress, so recovery of an assigned split performs a full rescan.
+ */
 public class AmazonDocumentDBSourceSplitEnumerator
         implements SourceSplitEnumerator<AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState> {
 
@@ -59,11 +66,17 @@ public class AmazonDocumentDBSourceSplitEnumerator
         }
     }
 
+    /** Defers enumeration to {@link #run()} so registered readers are visible before assignment. */
     @Override
     public void open() {
         // no-op
     }
 
+    /**
+     * Creates exactly one split on the first run and assigns it according to its fixed owner.
+     * Readers without that split are completed immediately rather than waiting for more work that
+     * V1 will never enumerate.
+     */
     @Override
     public void run() {
         synchronized (stateLock) {
@@ -77,11 +90,13 @@ public class AmazonDocumentDBSourceSplitEnumerator
         }
     }
 
+    /** Holds no external resources; readers own the MongoDB clients and cursors. */
     @Override
     public void close() throws IOException {
         // no-op
     }
 
+    /** Returns failed reader work to its deterministic owner before reassignment. */
     @Override
     public void addSplitsBack(List<AmazonDocumentDBSourceSplit> splits, int subtaskId) {
         synchronized (stateLock) {
@@ -97,11 +112,13 @@ public class AmazonDocumentDBSourceSplitEnumerator
         }
     }
 
+    /** Ignores pull requests because the bounded split is assigned eagerly in {@link #run()}. */
     @Override
     public void handleSplitRequest(int subtaskId) {
         // The bounded source enumerates its only split eagerly.
     }
 
+    /** Assigns any pending work when its reader registers and otherwise completes that reader. */
     @Override
     public void registerReader(int subtaskId) {
         synchronized (stateLock) {
@@ -109,6 +126,9 @@ public class AmazonDocumentDBSourceSplitEnumerator
         }
     }
 
+    /**
+     * Snapshots only enumeration status and unassigned split descriptors, never cursor progress.
+     */
     @Override
     public AmazonDocumentDBSourceState snapshotState(long checkpointId) {
         synchronized (stateLock) {
@@ -116,6 +136,9 @@ public class AmazonDocumentDBSourceSplitEnumerator
         }
     }
 
+    /**
+     * Has no post-checkpoint commit because enumeration state is fully represented in snapshots.
+     */
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
         // no-op
@@ -129,6 +152,12 @@ public class AmazonDocumentDBSourceSplitEnumerator
         }
     }
 
+    /**
+     * Gives the sole split to subtask 0 and sends no-more-splits to all readers.
+     *
+     * <p>Assignments are removed before the callback and restored if the callback fails, keeping a
+     * checkpoint from losing an unacknowledged split.
+     */
     private void assignSplits(Set<Integer> readers) {
         for (int reader : readers) {
             List<AmazonDocumentDBSourceSplit> assignment = pendingSplits.remove(reader);

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumerator.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AmazonDocumentDBSourceSplitEnumerator
+        implements SourceSplitEnumerator<AmazonDocumentDBSourceSplit, AmazonDocumentDBSourceState> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AmazonDocumentDBSourceSplitEnumerator.class);
+
+    private final Context<AmazonDocumentDBSourceSplit> enumeratorContext;
+    private final String matchQuery;
+    private final String projection;
+    private final Map<Integer, List<AmazonDocumentDBSourceSplit>> pendingSplits = new HashMap<>();
+    private final Object stateLock = new Object();
+
+    private boolean shouldEnumerate;
+
+    public AmazonDocumentDBSourceSplitEnumerator(
+            Context<AmazonDocumentDBSourceSplit> enumeratorContext,
+            AmazonDocumentDBSourceState sourceState,
+            String matchQuery,
+            String projection) {
+        this.enumeratorContext = enumeratorContext;
+        this.matchQuery = matchQuery;
+        this.projection = projection;
+        this.shouldEnumerate = sourceState == null || sourceState.isShouldEnumerate();
+        if (sourceState != null) {
+            this.pendingSplits.putAll(sourceState.getPendingSplits());
+        }
+    }
+
+    @Override
+    public void open() {
+        // no-op
+    }
+
+    @Override
+    public void run() {
+        synchronized (stateLock) {
+            if (shouldEnumerate) {
+                addPendingSplits(
+                        Collections.singletonList(
+                                new AmazonDocumentDBSourceSplit(0, matchQuery, projection)));
+                shouldEnumerate = false;
+            }
+            assignSplits(enumeratorContext.registeredReaders());
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // no-op
+    }
+
+    @Override
+    public void addSplitsBack(List<AmazonDocumentDBSourceSplit> splits, int subtaskId) {
+        synchronized (stateLock) {
+            addPendingSplits(splits);
+            assignSplits(Collections.singleton(subtaskId));
+        }
+    }
+
+    @Override
+    public int currentUnassignedSplitSize() {
+        synchronized (stateLock) {
+            return pendingSplits.values().stream().mapToInt(List::size).sum();
+        }
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId) {
+        // The bounded source enumerates its only split eagerly.
+    }
+
+    @Override
+    public void registerReader(int subtaskId) {
+        synchronized (stateLock) {
+            assignSplits(Collections.singleton(subtaskId));
+        }
+    }
+
+    @Override
+    public AmazonDocumentDBSourceState snapshotState(long checkpointId) {
+        synchronized (stateLock) {
+            return new AmazonDocumentDBSourceState(shouldEnumerate, pendingSplits);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        // no-op
+    }
+
+    private void addPendingSplits(Collection<AmazonDocumentDBSourceSplit> splits) {
+        int readerCount = enumeratorContext.currentParallelism();
+        for (AmazonDocumentDBSourceSplit split : splits) {
+            int ownerReader = getSplitOwner(split.getSplitId(), readerCount);
+            pendingSplits.computeIfAbsent(ownerReader, ignored -> new ArrayList<>()).add(split);
+        }
+    }
+
+    private void assignSplits(Set<Integer> readers) {
+        for (int reader : readers) {
+            List<AmazonDocumentDBSourceSplit> assignment = pendingSplits.remove(reader);
+            if (assignment != null && !assignment.isEmpty()) {
+                LOG.info("Assign splits {} to reader {}", assignment, reader);
+                try {
+                    enumeratorContext.assignSplit(reader, assignment);
+                } catch (Exception e) {
+                    LOG.error("Failed to assign splits {} to reader {}", assignment, reader, e);
+                    pendingSplits.put(reader, assignment);
+                    continue;
+                }
+            }
+            enumeratorContext.signalNoMoreSplits(reader);
+        }
+    }
+
+    private static int getSplitOwner(Integer splitId, int readerCount) {
+        return (splitId.hashCode() & Integer.MAX_VALUE) % readerCount;
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceState.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceState.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AmazonDocumentDBSourceState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean shouldEnumerate;
+    private final Map<Integer, List<AmazonDocumentDBSourceSplit>> pendingSplits;
+
+    public AmazonDocumentDBSourceState(
+            boolean shouldEnumerate,
+            Map<Integer, List<AmazonDocumentDBSourceSplit>> pendingSplits) {
+        this.shouldEnumerate = shouldEnumerate;
+        this.pendingSplits = copyPendingSplits(pendingSplits);
+    }
+
+    public boolean isShouldEnumerate() {
+        return shouldEnumerate;
+    }
+
+    public Map<Integer, List<AmazonDocumentDBSourceSplit>> getPendingSplits() {
+        return copyPendingSplits(pendingSplits);
+    }
+
+    private static Map<Integer, List<AmazonDocumentDBSourceSplit>> copyPendingSplits(
+            Map<Integer, List<AmazonDocumentDBSourceSplit>> source) {
+        Map<Integer, List<AmazonDocumentDBSourceSplit>> copy = new HashMap<>();
+        source.forEach(
+                (reader, splits) -> {
+                    List<AmazonDocumentDBSourceSplit> splitCopies = new ArrayList<>();
+                    splits.forEach(split -> splitCopies.add(split.copy()));
+                    copy.put(reader, splitCopies);
+                });
+        return copy;
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceState.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceState.java
@@ -23,6 +23,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Enumerator checkpoint for the V1 single-split contract.
+ *
+ * <p>The pending map contains copies of split id, filter, and projection only. Assigned reader
+ * state is checkpointed by the reader, and neither side stores a MongoDB cursor position; a
+ * restored active scan therefore starts again from the beginning.
+ */
 public class AmazonDocumentDBSourceState implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/AmazonDocumentDBSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/AmazonDocumentDBSourceFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source.AmazonDocumentDBSourceFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AmazonDocumentDBSourceFactoryTest {
+
+    @Test
+    public void testSourceFactoryOptions() {
+        AmazonDocumentDBSourceFactory sourceFactory = new AmazonDocumentDBSourceFactory();
+        OptionRule optionRule = sourceFactory.optionRule();
+        List<Option<?>> requiredOptions =
+                optionRule.getRequiredOptions().stream()
+                        .flatMap(requiredOption -> requiredOption.getOptions().stream())
+                        .collect(Collectors.toList());
+
+        Assertions.assertEquals("AmazonDocumentDB", sourceFactory.factoryIdentifier());
+        Assertions.assertTrue(requiredOptions.contains(AmazonDocumentDBSourceOptions.URI));
+        Assertions.assertTrue(requiredOptions.contains(AmazonDocumentDBSourceOptions.DATABASE));
+        Assertions.assertTrue(requiredOptions.contains(AmazonDocumentDBSourceOptions.COLLECTION));
+        Assertions.assertTrue(requiredOptions.contains(ConnectorCommonOptions.SCHEMA));
+        Assertions.assertTrue(
+                optionRule.getOptionalOptions().contains(AmazonDocumentDBSourceOptions.TLS));
+        Assertions.assertTrue(
+                optionRule
+                        .getOptionalOptions()
+                        .contains(AmazonDocumentDBSourceOptions.TLS_CA_FILE));
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/DocumentDBItemDeserializerTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/DocumentDBItemDeserializerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb;
+
+import org.apache.seatunnel.api.table.type.ArrayType;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.LocalTimeType;
+import org.apache.seatunnel.api.table.type.MapType;
+import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.serialize.DocumentDBItemDeserializer;
+
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonNull;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Map;
+
+public class DocumentDBItemDeserializerTest {
+
+    @Test
+    public void testDeserializeBsonDocument() {
+        SeaTunnelRowType addressType =
+                new SeaTunnelRowType(
+                        new String[] {"city"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {
+                            "id", "name", "active", "score", "amount", "created", "payload", "tags",
+                            "labels", "address", "missing"
+                        },
+                        new SeaTunnelDataType[] {
+                            BasicType.STRING_TYPE,
+                            BasicType.STRING_TYPE,
+                            BasicType.BOOLEAN_TYPE,
+                            BasicType.DOUBLE_TYPE,
+                            new DecimalType(10, 2),
+                            LocalTimeType.LOCAL_DATE_TIME_TYPE,
+                            PrimitiveByteArrayType.INSTANCE,
+                            ArrayType.of(BasicType.STRING_TYPE),
+                            new MapType<>(BasicType.STRING_TYPE, BasicType.INT_TYPE),
+                            addressType,
+                            BasicType.STRING_TYPE
+                        });
+
+        ObjectId objectId = new ObjectId("507f191e810c19729de860ea");
+        long epochMillis = 1704067200000L;
+        BsonDocument document =
+                new BsonDocument()
+                        .append("id", new BsonObjectId(objectId))
+                        .append("name", new BsonString("documentdb-user"))
+                        .append("active", BsonBoolean.TRUE)
+                        .append("score", new BsonDouble(98.5))
+                        .append("amount", new BsonDecimal128(Decimal128.parse("123.456")))
+                        .append("created", new BsonDateTime(epochMillis))
+                        .append("payload", new BsonBinary(new byte[] {1, 2, 3}))
+                        .append(
+                                "tags",
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonString("alpha"), new BsonString("beta"))))
+                        .append("labels", new BsonDocument("priority", new BsonInt32(2)))
+                        .append("address", new BsonDocument("city", new BsonString("Seattle")))
+                        .append("missing", new BsonNull());
+
+        SeaTunnelRow row = new DocumentDBItemDeserializer(rowType).deserialize(document);
+
+        Assertions.assertEquals(objectId.toHexString(), row.getField(0));
+        Assertions.assertEquals("documentdb-user", row.getField(1));
+        Assertions.assertEquals(true, row.getField(2));
+        Assertions.assertEquals(98.5d, row.getField(3));
+        Assertions.assertEquals(new BigDecimal("123.46"), row.getField(4));
+        Assertions.assertEquals(
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZoneId.systemDefault()),
+                row.getField(5));
+        Assertions.assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) row.getField(6));
+        Assertions.assertArrayEquals(new String[] {"alpha", "beta"}, (Object[]) row.getField(7));
+        Assertions.assertEquals(2, ((Map<?, ?>) row.getField(8)).get("priority"));
+        Assertions.assertEquals("Seattle", ((SeaTunnelRow) row.getField(9)).getField(0));
+        Assertions.assertNull(row.getField(10));
+    }
+
+    @Test
+    public void testRejectsIncompatibleBsonType() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"value"}, new SeaTunnelDataType[] {BasicType.INT_TYPE});
+        BsonDocument document = new BsonDocument("value", new BsonString("not-an-int"));
+
+        Assertions.assertThrows(
+                RuntimeException.class,
+                () -> new DocumentDBItemDeserializer(rowType).deserialize(document));
+    }
+
+    @Test
+    public void testNumericConversions() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"intValue", "longValue"},
+                        new SeaTunnelDataType[] {BasicType.INT_TYPE, BasicType.LONG_TYPE});
+        BsonDocument document =
+                new BsonDocument()
+                        .append("intValue", new BsonInt64(7))
+                        .append("longValue", new BsonInt32(9));
+
+        SeaTunnelRow row = new DocumentDBItemDeserializer(rowType).deserialize(document);
+
+        Assertions.assertEquals(7, row.getField(0));
+        Assertions.assertEquals(9L, row.getField(1));
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/DocumentDBItemDeserializerTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/DocumentDBItemDeserializerTest.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.table.type.PrimitiveByteArrayType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.serialize.DocumentDBItemDeserializer;
 
 import org.bson.BsonArray;
@@ -143,5 +144,38 @@ public class DocumentDBItemDeserializerTest {
 
         Assertions.assertEquals(7, row.getField(0));
         Assertions.assertEquals(9L, row.getField(1));
+    }
+
+    @Test
+    public void testPreservesNumericConversionFailureCause() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"value"}, new SeaTunnelDataType[] {BasicType.BYTE_TYPE});
+        BsonDocument document = new BsonDocument("value", new BsonInt32(128));
+
+        SeaTunnelRuntimeException exception =
+                Assertions.assertThrows(
+                        SeaTunnelRuntimeException.class,
+                        () -> new DocumentDBItemDeserializer(rowType).deserialize(document));
+
+        Assertions.assertNotNull(exception.getCause());
+        Assertions.assertTrue(exception.getCause().getMessage().contains("out of range"));
+    }
+
+    @Test
+    public void testRejectsDecimalPrecisionOverflow() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"value"}, new SeaTunnelDataType[] {new DecimalType(4, 2)});
+        BsonDocument document =
+                new BsonDocument("value", new BsonDecimal128(Decimal128.parse("123.45")));
+
+        SeaTunnelRuntimeException exception =
+                Assertions.assertThrows(
+                        SeaTunnelRuntimeException.class,
+                        () -> new DocumentDBItemDeserializer(rowType).deserialize(document));
+
+        Assertions.assertNotNull(exception.getCause());
+        Assertions.assertTrue(exception.getCause().getMessage().contains("exceeds"));
     }
 }

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBConfigTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/config/AmazonDocumentDBConfigTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.mongodb.MongoClientSettings;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AmazonDocumentDBConfigTest {
+
+    @TempDir private Path tempDirectory;
+
+    @Test
+    public void testForcesRetryWritesFalse() {
+        AmazonDocumentDBConfig config =
+                new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(baseOptions()));
+
+        MongoClientSettings settings = config.createMongoClientSettings();
+
+        Assertions.assertFalse(settings.getRetryWrites());
+        Assertions.assertFalse(settings.getSslSettings().isEnabled());
+        Assertions.assertEquals("app-db", config.getDatabase());
+        Assertions.assertEquals("orders", config.getCollection());
+    }
+
+    @Test
+    public void testRejectsRetryWritesTrue() {
+        Map<String, Object> options = baseOptions();
+        options.put(
+                "uri",
+                "mongodb://reader:secret@cluster.example.docdb.amazonaws.com:27017/?retryWrites=true");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(options)));
+
+        Assertions.assertTrue(exception.getMessage().contains("retryWrites=true"));
+        Assertions.assertTrue(exception.getMessage().contains("does not support retryable writes"));
+    }
+
+    @Test
+    public void testRequiresCredentialsInUri() {
+        Map<String, Object> options = baseOptions();
+        options.put("uri", "mongodb://cluster.example.docdb.amazonaws.com:27017/");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(options)));
+
+        Assertions.assertTrue(exception.getMessage().contains("authentication credentials"));
+    }
+
+    @Test
+    public void testTlsRequiresReadableCaBundle() throws Exception {
+        Map<String, Object> missingCaOptions = baseOptions();
+        missingCaOptions.put("tls", true);
+
+        IllegalArgumentException missingCaException =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(missingCaOptions)));
+        Assertions.assertTrue(missingCaException.getMessage().contains("tls_ca_file"));
+
+        Path invalidBundle = tempDirectory.resolve("invalid-ca.pem");
+        Files.write(invalidBundle, "not a certificate".getBytes());
+        Map<String, Object> invalidCaOptions = baseOptions();
+        invalidCaOptions.put("tls", true);
+        invalidCaOptions.put("tls_ca_file", invalidBundle.toString());
+        AmazonDocumentDBConfig config =
+                new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(invalidCaOptions));
+
+        IllegalArgumentException invalidCaException =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class, config::createMongoClientSettings);
+        Assertions.assertTrue(invalidCaException.getMessage().contains("TLS CA bundle"));
+    }
+
+    @Test
+    public void testRejectsInvalidFilter() {
+        Map<String, Object> options = baseOptions();
+        options.put("match.query", "{invalid");
+
+        IllegalArgumentException exception =
+                Assertions.assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(options)));
+
+        Assertions.assertTrue(exception.getMessage().contains("match.query"));
+    }
+
+    private static Map<String, Object> baseOptions() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", new HashMap<String, Object>());
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(
+                "uri",
+                "mongodb://reader:secret@cluster.example.docdb.amazonaws.com:27017/?retryWrites=false");
+        options.put("database", "app-db");
+        options.put("collection", "orders");
+        options.put("tls", false);
+        options.put("match.query", "{\"status\": \"OPEN\"}");
+        options.put("match.projection", "{\"_id\": 1, \"status\": 1}");
+        options.put("fetch.size", 128);
+        options.put("schema", schema);
+        return options;
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceReaderTest.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.config.AmazonDocumentDBConfig;
+
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AmazonDocumentDBSourceReaderTest {
+
+    @Test
+    public void testUsesFilterProjectionAndFetchSize() {
+        RecordingFetchReader reader = new RecordingFetchReader(createConfig(37), createRowType());
+        AmazonDocumentDBSourceSplit split =
+                new AmazonDocumentDBSourceSplit(0, "{\"status\": \"OPEN\"}", "{\"status\": 1}");
+        RecordingCollector collector = new RecordingCollector();
+
+        reader.addSplits(Collections.singletonList(split));
+        reader.pollNext(collector);
+
+        Assertions.assertEquals(37, reader.getFetchSize());
+        Assertions.assertEquals(split.getMatchQuery(), reader.seenSplit.getMatchQuery());
+        Assertions.assertEquals(split.getProjection(), reader.seenSplit.getProjection());
+        Assertions.assertTrue(reader.snapshotState(1L).isEmpty());
+    }
+
+    @Test
+    public void testSplitCopyPreservesQueryInformation() {
+        AmazonDocumentDBSourceSplit split =
+                new AmazonDocumentDBSourceSplit(0, "{\"status\": 1}", "{\"_id\": 0}");
+
+        AmazonDocumentDBSourceSplit copy = split.copy();
+
+        Assertions.assertEquals(split.getSplitId(), copy.getSplitId());
+        Assertions.assertEquals(split.getMatchQuery(), copy.getMatchQuery());
+        Assertions.assertEquals(split.getProjection(), copy.getProjection());
+    }
+
+    @Test
+    public void testCloseReleasesMongoClient() {
+        AtomicBoolean clientClosed = new AtomicBoolean();
+        MongoClient client = createMongoClientProxy(clientClosed);
+        AmazonDocumentDBSourceReader reader =
+                new AmazonDocumentDBSourceReader(
+                        new RecordingReaderContext(), createConfig(1), createRowType()) {
+                    @Override
+                    MongoClient createMongoClient() {
+                        return client;
+                    }
+                };
+
+        reader.open();
+        reader.close();
+
+        Assertions.assertTrue(clientClosed.get());
+    }
+
+    @Test
+    public void testRemoteFetchDoesNotHoldCheckpointLock() throws Exception {
+        CountDownLatch fetchStarted = new CountDownLatch(1);
+        CountDownLatch releaseFetch = new CountDownLatch(1);
+        RecordingCollector collector = new RecordingCollector();
+        BlockingFetchReader reader =
+                new BlockingFetchReader(
+                        createConfig(1), createRowType(), fetchStarted, releaseFetch);
+        AtomicReference<Throwable> pollFailure = new AtomicReference<>();
+        Thread pollThread =
+                new Thread(
+                        () -> {
+                            try {
+                                reader.pollNext(collector);
+                            } catch (Throwable throwable) {
+                                pollFailure.set(throwable);
+                            }
+                        });
+
+        reader.addSplits(Collections.singletonList(new AmazonDocumentDBSourceSplit(0, "{}", null)));
+        pollThread.start();
+        Assertions.assertTrue(fetchStarted.await(5, TimeUnit.SECONDS));
+
+        ExecutorService checkpointThread = Executors.newSingleThreadExecutor();
+        try {
+            Future<Boolean> checkpointLockAcquired =
+                    checkpointThread.submit(
+                            () -> {
+                                synchronized (collector.getCheckpointLock()) {
+                                    return true;
+                                }
+                            });
+            Assertions.assertTrue(checkpointLockAcquired.get(1, TimeUnit.SECONDS));
+        } finally {
+            releaseFetch.countDown();
+            pollThread.join(TimeUnit.SECONDS.toMillis(5));
+            checkpointThread.shutdownNow();
+            reader.close();
+        }
+
+        Assertions.assertFalse(pollThread.isAlive());
+        if (pollFailure.get() != null) {
+            Assertions.fail(pollFailure.get());
+        }
+    }
+
+    private static AmazonDocumentDBConfig createConfig(int fetchSize) {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", new HashMap<String, Object>());
+
+        Map<String, Object> options = new HashMap<>();
+        options.put(
+                "uri",
+                "mongodb://reader:secret@cluster.example.docdb.amazonaws.com:27017/?retryWrites=false");
+        options.put("database", "app-db");
+        options.put("collection", "orders");
+        options.put("tls", false);
+        options.put("match.query", "{}");
+        options.put("fetch.size", fetchSize);
+        options.put("schema", schema);
+        return new AmazonDocumentDBConfig(ReadonlyConfig.fromMap(options));
+    }
+
+    private static SeaTunnelRowType createRowType() {
+        return new SeaTunnelRowType(
+                new String[] {"id"}, new SeaTunnelDataType[] {BasicType.STRING_TYPE});
+    }
+
+    private static MongoClient createMongoClientProxy(AtomicBoolean clientClosed) {
+        MongoCollection<?> collection =
+                (MongoCollection<?>)
+                        Proxy.newProxyInstance(
+                                MongoCollection.class.getClassLoader(),
+                                new Class<?>[] {MongoCollection.class},
+                                (proxy, method, arguments) -> defaultValue(method.getReturnType()));
+        MongoDatabase database =
+                (MongoDatabase)
+                        Proxy.newProxyInstance(
+                                MongoDatabase.class.getClassLoader(),
+                                new Class<?>[] {MongoDatabase.class},
+                                (proxy, method, arguments) -> {
+                                    if ("getCollection".equals(method.getName())) {
+                                        return collection;
+                                    }
+                                    return defaultValue(method.getReturnType());
+                                });
+        return (MongoClient)
+                Proxy.newProxyInstance(
+                        MongoClient.class.getClassLoader(),
+                        new Class<?>[] {MongoClient.class},
+                        (proxy, method, arguments) -> {
+                            if ("getDatabase".equals(method.getName())) {
+                                return database;
+                            }
+                            if ("close".equals(method.getName())) {
+                                clientClosed.set(true);
+                            }
+                            return defaultValue(method.getReturnType());
+                        });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+
+    private static class RecordingFetchReader extends AmazonDocumentDBSourceReader {
+        private AmazonDocumentDBSourceSplit seenSplit;
+
+        private RecordingFetchReader(AmazonDocumentDBConfig config, SeaTunnelRowType rowType) {
+            super(new RecordingReaderContext(), config, rowType);
+        }
+
+        @Override
+        BsonDocument fetchNextDocument(AmazonDocumentDBSourceSplit split) {
+            seenSplit = split;
+            return null;
+        }
+    }
+
+    private static class BlockingFetchReader extends AmazonDocumentDBSourceReader {
+        private final CountDownLatch fetchStarted;
+        private final CountDownLatch releaseFetch;
+
+        private BlockingFetchReader(
+                AmazonDocumentDBConfig config,
+                SeaTunnelRowType rowType,
+                CountDownLatch fetchStarted,
+                CountDownLatch releaseFetch) {
+            super(new RecordingReaderContext(), config, rowType);
+            this.fetchStarted = fetchStarted;
+            this.releaseFetch = releaseFetch;
+        }
+
+        @Override
+        BsonDocument fetchNextDocument(AmazonDocumentDBSourceSplit split) {
+            fetchStarted.countDown();
+            try {
+                if (!releaseFetch.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to release fetch");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting to release fetch", e);
+            }
+            return null;
+        }
+    }
+
+    private static class RecordingCollector implements Collector<SeaTunnelRow> {
+        private final Object checkpointLock = new Object();
+
+        @Override
+        public void collect(SeaTunnelRow record) {}
+
+        @Override
+        public Object getCheckpointLock() {
+            return checkpointLock;
+        }
+    }
+
+    private static class RecordingReaderContext implements SourceReader.Context {
+        @Override
+        public int getIndexOfSubtask() {
+            return 0;
+        }
+
+        @Override
+        public Boundedness getBoundedness() {
+            return Boundedness.BOUNDED;
+        }
+
+        @Override
+        public void signalNoMoreElement() {}
+
+        @Override
+        public void sendSplitRequest() {}
+
+        @Override
+        public void sendSourceEventToEnumerator(SourceEvent sourceEvent) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumeratorTest.java
@@ -79,17 +79,59 @@ public class AmazonDocumentDBSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testReturnedSplitIsReassigned() {
+    public void testReaderRegisteredBeforeRunIsNotSignaledEarly() {
         RecordingContext context = new RecordingContext(1, Collections.singleton(0));
         AmazonDocumentDBSourceSplitEnumerator enumerator =
                 new AmazonDocumentDBSourceSplitEnumerator(context, null, "{}", null);
+
+        enumerator.registerReader(0);
+
+        Assertions.assertTrue(context.noMoreSplitReaders.isEmpty());
+        Assertions.assertTrue(context.assignedSplits.isEmpty());
+
+        enumerator.run();
+
+        Assertions.assertEquals(1, context.assignedSplits.get(0).size());
+        Assertions.assertTrue(context.noMoreSplitReaders.contains(0));
+    }
+
+    @Test
+    public void testReaderRegisteredAfterRunIsSignaledImmediately() {
+        RecordingContext context = new RecordingContext(2, Collections.singleton(0));
+        AmazonDocumentDBSourceSplitEnumerator enumerator =
+                new AmazonDocumentDBSourceSplitEnumerator(context, null, "{}", null);
+
+        enumerator.run();
+        context.registerReader(1);
+        enumerator.registerReader(1);
+
+        Assertions.assertTrue(context.noMoreSplitReaders.contains(1));
+        Assertions.assertTrue(
+                context.assignedSplits.getOrDefault(1, Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void testReturnedSplitWaitsForReaderRegistration() {
+        AmazonDocumentDBSourceState state =
+                new AmazonDocumentDBSourceState(false, Collections.emptyMap());
+        RecordingContext context = new RecordingContext(1, Collections.emptySet());
+        AmazonDocumentDBSourceSplitEnumerator enumerator =
+                new AmazonDocumentDBSourceSplitEnumerator(context, state, "{}", null);
         AmazonDocumentDBSourceSplit returnedSplit =
                 new AmazonDocumentDBSourceSplit(0, "{\"retry\": true}", null);
 
         enumerator.addSplitsBack(Collections.singletonList(returnedSplit), 0);
 
+        Assertions.assertEquals(1, enumerator.currentUnassignedSplitSize());
+        Assertions.assertTrue(context.assignedSplits.isEmpty());
+        Assertions.assertTrue(context.noMoreSplitReaders.isEmpty());
+
+        context.registerReader(0);
+        enumerator.registerReader(0);
+
         Assertions.assertEquals(
                 "{\"retry\": true}", context.assignedSplits.get(0).get(0).getMatchQuery());
+        Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
         Assertions.assertTrue(context.noMoreSplitReaders.contains(0));
     }
 
@@ -104,7 +146,11 @@ public class AmazonDocumentDBSourceSplitEnumeratorTest {
 
         private RecordingContext(int parallelism, Set<Integer> registeredReaders) {
             this.parallelism = parallelism;
-            this.registeredReaders = registeredReaders;
+            this.registeredReaders = new HashSet<>(registeredReaders);
+        }
+
+        private void registerReader(int subtaskId) {
+            registeredReaders.add(subtaskId);
         }
 
         @Override

--- a/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-amazondocumentdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazondocumentdb/source/AmazonDocumentDBSourceSplitEnumeratorTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.amazondocumentdb.source;
+
+import org.apache.seatunnel.api.common.metrics.MetricsContext;
+import org.apache.seatunnel.api.event.EventListener;
+import org.apache.seatunnel.api.source.SourceEvent;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class AmazonDocumentDBSourceSplitEnumeratorTest {
+
+    @Test
+    public void testAssignsOneSplitAndSignalsAllReaders() throws Exception {
+        Set<Integer> readers = new HashSet<>(Arrays.asList(0, 1));
+        RecordingContext context = new RecordingContext(2, readers);
+        AmazonDocumentDBSourceSplitEnumerator enumerator =
+                new AmazonDocumentDBSourceSplitEnumerator(
+                        context, null, "{\"status\": \"OPEN\"}", "{\"status\": 1}");
+
+        try {
+            enumerator.run();
+        } finally {
+            enumerator.close();
+        }
+
+        Assertions.assertEquals(1, context.assignedSplits.get(0).size());
+        Assertions.assertEquals("0", context.assignedSplits.get(0).get(0).splitId());
+        Assertions.assertEquals(
+                "{\"status\": \"OPEN\"}", context.assignedSplits.get(0).get(0).getMatchQuery());
+        Assertions.assertTrue(
+                context.assignedSplits.getOrDefault(1, Collections.emptyList()).isEmpty());
+        Assertions.assertEquals(readers, context.noMoreSplitReaders);
+    }
+
+    @Test
+    public void testRestoresWithoutCreatingAnotherSplit() {
+        Map<Integer, List<AmazonDocumentDBSourceSplit>> pendingSplits = new HashMap<>();
+        pendingSplits.put(
+                0,
+                Collections.singletonList(
+                        new AmazonDocumentDBSourceSplit(0, "{\"restored\": true}", null)));
+        AmazonDocumentDBSourceState state = new AmazonDocumentDBSourceState(false, pendingSplits);
+        RecordingContext context = new RecordingContext(1, Collections.singleton(0));
+        AmazonDocumentDBSourceSplitEnumerator enumerator =
+                new AmazonDocumentDBSourceSplitEnumerator(context, state, "{}", null);
+
+        enumerator.run();
+
+        Assertions.assertEquals(1, context.assignedSplits.get(0).size());
+        Assertions.assertEquals(
+                "{\"restored\": true}", context.assignedSplits.get(0).get(0).getMatchQuery());
+        Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
+    }
+
+    @Test
+    public void testReturnedSplitIsReassigned() {
+        RecordingContext context = new RecordingContext(1, Collections.singleton(0));
+        AmazonDocumentDBSourceSplitEnumerator enumerator =
+                new AmazonDocumentDBSourceSplitEnumerator(context, null, "{}", null);
+        AmazonDocumentDBSourceSplit returnedSplit =
+                new AmazonDocumentDBSourceSplit(0, "{\"retry\": true}", null);
+
+        enumerator.addSplitsBack(Collections.singletonList(returnedSplit), 0);
+
+        Assertions.assertEquals(
+                "{\"retry\": true}", context.assignedSplits.get(0).get(0).getMatchQuery());
+        Assertions.assertTrue(context.noMoreSplitReaders.contains(0));
+    }
+
+    private static class RecordingContext
+            implements SourceSplitEnumerator.Context<AmazonDocumentDBSourceSplit> {
+
+        private final int parallelism;
+        private final Set<Integer> registeredReaders;
+        private final Map<Integer, List<AmazonDocumentDBSourceSplit>> assignedSplits =
+                new HashMap<>();
+        private final Set<Integer> noMoreSplitReaders = new HashSet<>();
+
+        private RecordingContext(int parallelism, Set<Integer> registeredReaders) {
+            this.parallelism = parallelism;
+            this.registeredReaders = registeredReaders;
+        }
+
+        @Override
+        public int currentParallelism() {
+            return parallelism;
+        }
+
+        @Override
+        public Set<Integer> registeredReaders() {
+            return registeredReaders;
+        }
+
+        @Override
+        public void assignSplit(int subtaskId, List<AmazonDocumentDBSourceSplit> splits) {
+            assignedSplits.put(subtaskId, splits);
+        }
+
+        @Override
+        public void signalNoMoreSplits(int subtask) {
+            noMoreSplitReaders.add(subtask);
+        }
+
+        @Override
+        public void sendEventToSourceReader(int subtaskId, SourceEvent event) {}
+
+        @Override
+        public MetricsContext getMetricsContext() {
+            return null;
+        }
+
+        @Override
+        public EventListener getEventListener() {
+            return null;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -103,6 +103,7 @@
         <module>connector-lance</module>
         <module>connector-bigquery</module>
         <module>connector-edge-socket</module>
+        <module>connector-amazondocumentdb</module>
         <module>connector-azurecosmosdb</module>
         <module>connector-nats-jetstream</module>
         <module>connector-firebase</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -604,6 +604,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-amazondocumentdb</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-azurecosmosdb</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connector-v2-e2e</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-amazondocumentdb-e2e</artifactId>
+    <name>SeaTunnel : E2E : Connector V2 : Amazon DocumentDB</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-amazondocumentdb</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-assert</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-fake</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/pom.xml
@@ -42,12 +42,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
-            <artifactId>connector-fake</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.seatunnel</groupId>
             <artifactId>connector-common</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/amazondocumentdb/AmazonDocumentDBIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/amazondocumentdb/AmazonDocumentDBIT.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.amazondocumentdb;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.awaitility.Awaitility;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.DockerLoggerFactory;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+@Slf4j
+public class AmazonDocumentDBIT extends TestSuiteBase implements TestResource {
+
+    private static final String MONGO_IMAGE = "mongo:latest";
+    private static final String MONGO_HOST = "e2e_amazondocumentdb";
+    private static final int MONGO_PORT = 27017;
+    private static final String USERNAME = "seatunnel";
+    private static final String PASSWORD = "seatunnel-password";
+    private static final String DATABASE = "seatunnel_e2e";
+    private static final String COLLECTION = "source_orders";
+
+    private GenericContainer<?> mongoContainer;
+    private MongoClient mongoClient;
+
+    @BeforeAll
+    @Override
+    public void startUp() {
+        DockerImageName imageName = DockerImageName.parse(MONGO_IMAGE);
+        mongoContainer =
+                new GenericContainer<>(imageName)
+                        .withEnv("MONGO_INITDB_ROOT_USERNAME", USERNAME)
+                        .withEnv("MONGO_INITDB_ROOT_PASSWORD", PASSWORD)
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(MONGO_HOST)
+                        .withExposedPorts(MONGO_PORT)
+                        .waitingFor(
+                                Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(2)))
+                        .withLogConsumer(
+                                new Slf4jLogConsumer(DockerLoggerFactory.getLogger(MONGO_IMAGE)));
+        Startables.deepStart(Stream.of(mongoContainer)).join();
+        log.info("MongoDB compatibility container for Amazon DocumentDB started");
+
+        Awaitility.given()
+                .ignoreExceptions()
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .atMost(180, TimeUnit.SECONDS)
+                .untilAsserted(this::assertMongoAvailable);
+
+        mongoClient = MongoClients.create(hostConnectionString());
+        MongoCollection<BsonDocument> collection =
+                mongoClient.getDatabase(DATABASE).getCollection(COLLECTION, BsonDocument.class);
+        collection.insertMany(
+                Arrays.asList(
+                        order("1", "alpha", 10), order("2", "beta", 20), order("3", "gamma", 30)));
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        if (mongoContainer != null) {
+            mongoContainer.close();
+        }
+    }
+
+    @TestTemplate
+    public void testBasicRead(TestContainer container) throws IOException, InterruptedException {
+        assertJobSucceeded(container, "/amazondocumentdb_source_basic.conf");
+    }
+
+    @TestTemplate
+    public void testQueryFilter(TestContainer container) throws IOException, InterruptedException {
+        assertJobSucceeded(container, "/amazondocumentdb_source_query_filter.conf");
+    }
+
+    @TestTemplate
+    public void testProjection(TestContainer container) throws IOException, InterruptedException {
+        assertJobSucceeded(container, "/amazondocumentdb_source_projection.conf");
+    }
+
+    private void assertMongoAvailable() {
+        try (MongoClient candidate = MongoClients.create(hostConnectionString())) {
+            BsonDocument result =
+                    candidate
+                            .getDatabase("admin")
+                            .runCommand(
+                                    new BsonDocument("ping", new BsonInt32(1)), BsonDocument.class);
+            Assertions.assertEquals(1, result.get("ok").asNumber().intValue());
+        }
+    }
+
+    private String hostConnectionString() {
+        return String.format(
+                "mongodb://%s:%s@%s:%d/?authSource=admin&retryWrites=false",
+                USERNAME,
+                PASSWORD,
+                mongoContainer.getHost(),
+                mongoContainer.getMappedPort(MONGO_PORT));
+    }
+
+    private static BsonDocument order(String id, String name, int score) {
+        return new BsonDocument()
+                .append("id", new BsonString(id))
+                .append("name", new BsonString(name))
+                .append("score", new BsonInt32(score));
+    }
+
+    private static void assertJobSucceeded(TestContainer container, String configPath)
+            throws IOException, InterruptedException {
+        Container.ExecResult result = container.executeJob(configPath);
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/resources/amazondocumentdb_source_basic.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/resources/amazondocumentdb_source_basic.conf
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://seatunnel:seatunnel-password@e2e_amazondocumentdb:27017/?authSource=admin&retryWrites=false"
+    database = "seatunnel_e2e"
+    collection = "source_orders"
+    tls = false
+    schema = {
+      fields {
+        id = string
+        name = string
+        score = int
+      }
+    }
+  }
+}
+
+sink {
+  Assert {
+    rules {
+      row_rules = [
+        {rule_type = MIN_ROW, rule_value = 3},
+        {rule_type = MAX_ROW, rule_value = 3}
+      ],
+      field_rules = [
+        {
+          field_name = id
+          field_type = string
+          field_value = [{rule_type = NOT_NULL}]
+        },
+        {
+          field_name = name
+          field_type = string
+          field_value = [{rule_type = NOT_NULL}]
+        },
+        {
+          field_name = score
+          field_type = int
+          field_value = [{rule_type = MIN, rule_value = 10}]
+        }
+      ]
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/resources/amazondocumentdb_source_projection.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/resources/amazondocumentdb_source_projection.conf
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://seatunnel:seatunnel-password@e2e_amazondocumentdb:27017/?authSource=admin&retryWrites=false"
+    database = "seatunnel_e2e"
+    collection = "source_orders"
+    tls = false
+    match.projection = "{\"_id\": 0, \"id\": 1, \"name\": 1}"
+    schema = {
+      fields {
+        id = string
+        name = string
+      }
+    }
+  }
+}
+
+sink {
+  Assert {
+    rules {
+      row_rules = [
+        {rule_type = MIN_ROW, rule_value = 3},
+        {rule_type = MAX_ROW, rule_value = 3}
+      ],
+      field_rules = [
+        {
+          field_name = id
+          field_type = string
+          field_value = [{rule_type = NOT_NULL}]
+        },
+        {
+          field_name = name
+          field_type = string
+          field_value = [{rule_type = NOT_NULL}]
+        }
+      ]
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/resources/amazondocumentdb_source_query_filter.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-amazondocumentdb-e2e/src/test/resources/amazondocumentdb_source_query_filter.conf
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  AmazonDocumentDB {
+    uri = "mongodb://seatunnel:seatunnel-password@e2e_amazondocumentdb:27017/?authSource=admin&retryWrites=false"
+    database = "seatunnel_e2e"
+    collection = "source_orders"
+    tls = false
+    match.query = "{\"score\": {\"$gte\": 20}}"
+    schema = {
+      fields {
+        id = string
+        name = string
+        score = int
+      }
+    }
+  }
+}
+
+sink {
+  Assert {
+    rules {
+      row_rules = [
+        {rule_type = MIN_ROW, rule_value = 2},
+        {rule_type = MAX_ROW, rule_value = 2}
+      ],
+      field_rules = [
+        {
+          field_name = score
+          field_type = int
+          field_value = [{rule_type = MIN, rule_value = 20}]
+        }
+      ]
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
@@ -37,6 +37,7 @@
         <module>connector-starrocks-e2e</module>
         <module>connector-influxdb-e2e</module>
         <module>connector-amazondynamodb-e2e</module>
+        <module>connector-amazondocumentdb-e2e</module>
         <module>connector-azurecosmosdb-e2e</module>
         <module>connector-amazonsqs-e2e</module>
         <module>connector-file-local-e2e</module>


### PR DESCRIPTION
Part of #10443. Adds a source-only connector-amazondocumentdb.

DocumentDB is MongoDB wire-compatible but does not work with connector-mongodb out of the box: it rejects retryWrites, which the driver enables by default, and it requires TLS with the Amazon RDS CA bundle. This connector forces retryWrites=false, rejects an explicit retryWrites=true at configuration time, and builds its own SSLContext from a configured CA file rather than mutating the JVM-wide trust store.

V1 is source only, one database and collection per source, explicit schema, a single split, with optional BSON filter and projection. connector-mongodb is not modified or imported; the BSON to SeaTunnelRow conversion is implemented independently in this module.

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->


### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->


### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
