### PR TITLE
[Improve][Connector-V2] Use HashUtils.bucketIndex in AzureCosmosDB enumerator

### DIFF
--- a/seatunnel-connectors-v2/connector-azurecosmosdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/azurecosmosdb/source/AzureCosmosDBSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-azurecosmosdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/azurecosmosdb/source/AzureCosmosDBSourceSplitEnumerator.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.azurecosmosdb.source;
 
 import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.common.utils.HashUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,6 +141,6 @@ public class AzureCosmosDBSourceSplitEnumerator
     }
 
     private static int getSplitOwner(Integer splitId, int numReaders) {
-        return (splitId.hashCode() & Integer.MAX_VALUE) % numReaders;
+        return HashUtils.bucketIndex(splitId, numReaders);
     }
 }

--- a/seatunnel-connectors-v2/connector-azurecosmosdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/azurecosmosdb/source/AzureCosmosDBSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-azurecosmosdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/azurecosmosdb/source/AzureCosmosDBSourceSplitEnumeratorTest.java
@@ -72,6 +72,50 @@ public class AzureCosmosDBSourceSplitEnumeratorTest {
                 "token-1", context.assignedSplits.get(0).get(0).getContinuationToken());
     }
 
+    @Test
+    public void testSplitOwnerRoutesNonZeroSplitIdsByBucketIndex() throws Exception {
+        RecordingContext context = new RecordingContext(3, new HashSet<>(Arrays.asList(0, 1, 2)));
+        AzureCosmosDBSourceSplitEnumerator enumerator =
+                new AzureCosmosDBSourceSplitEnumerator(context, null);
+        // bucketIndex(4, 3) is 1 and bucketIndex(5, 3) is 2, so the two splits are owned by
+        // different readers even though they are handed back to the enumerator together.
+        AzureCosmosDBSourceSplit ownedByReaderOne = new AzureCosmosDBSourceSplit(4);
+        AzureCosmosDBSourceSplit ownedByReaderTwo = new AzureCosmosDBSourceSplit(5);
+
+        try {
+            enumerator.addSplitsBack(Arrays.asList(ownedByReaderOne, ownedByReaderTwo), 1);
+            enumerator.registerReader(2);
+        } finally {
+            enumerator.close();
+        }
+
+        Assertions.assertEquals(1, context.assignedSplits.get(1).size());
+        Assertions.assertEquals("4", context.assignedSplits.get(1).get(0).splitId());
+        Assertions.assertEquals(1, context.assignedSplits.get(2).size());
+        Assertions.assertEquals("5", context.assignedSplits.get(2).get(0).splitId());
+    }
+
+    @Test
+    public void testSplitOwnerKeepsIntegerMinValueSplitIdInRange() throws Exception {
+        RecordingContext context = new RecordingContext(3, new HashSet<>(Arrays.asList(0, 1, 2)));
+        AzureCosmosDBSourceSplitEnumerator enumerator =
+                new AzureCosmosDBSourceSplitEnumerator(context, null);
+        // Math.abs(Integer.MIN_VALUE) is itself negative, so a split id at the minimum value is
+        // the input that would yield a negative owner index without the masking in HashUtils.
+        AzureCosmosDBSourceSplit split = new AzureCosmosDBSourceSplit(Integer.MIN_VALUE);
+
+        try {
+            enumerator.addSplitsBack(Collections.singletonList(split), 0);
+        } finally {
+            enumerator.close();
+        }
+
+        context.assignedSplits.keySet().forEach(reader -> Assertions.assertTrue(reader >= 0));
+        Assertions.assertEquals(1, context.assignedSplits.get(0).size());
+        Assertions.assertEquals(
+                String.valueOf(Integer.MIN_VALUE), context.assignedSplits.get(0).get(0).splitId());
+    }
+
     private static class RecordingContext
             implements SourceSplitEnumerator.Context<AzureCosmosDBSourceSplit> {
 


### PR DESCRIPTION
### Purpose of this pull request

Relates to #11976. Trailing follow-up to #11987, which merged on 2026-09-01 and introduced `HashUtils.bucketIndex`.

`AzureCosmosDBSourceSplitEnumerator.getSplitOwner` still hand-rolls the masking spelling that #11987 consolidated. It was not covered there because the Azure CosmosDB source connector merged in #11167 on 2026-08-30, after #11987's diff was written, so the two crossed in flight. I committed on #11987 to filing this separately rather than amending a branch that was already approved and green.

Before:

```java
private static int getSplitOwner(Integer splitId, int numReaders) {
    return (splitId.hashCode() & Integer.MAX_VALUE) % numReaders;
}
```

After:

```java
private static int getSplitOwner(Integer splitId, int numReaders) {
    return HashUtils.bucketIndex(splitId, numReaders);
}
```

The `.hashCode()` call is dropped rather than relocated. `splitId` is the boxed `Integer` field returned by `AzureCosmosDBSourceSplit.getSplitId()`, and `Integer.hashCode()` returns the value itself, so the call was an identity no-op. The argument now autounboxes into the `bucketIndex(int, int)` overload.

With this, no hand-rolled hash-to-bucket spelling remains in main source. Swept `dev` to confirm: zero hits for `Math.abs(...) %`, zero for `0x7FFFFFFF`, and the only surviving `& Integer.MAX_VALUE) %` and `& Long.MAX_VALUE) %` occurrences are the two inside `HashUtils` itself.

Two scope notes carried over from #11976. The `int` overload is used, not the `long` one, since the two are distinct mappings and the existing site produced a 32-bit result. Masking is preserved rather than switched to `Math.floorMod`, which would silently reassign split ownership across an upgrade, as pinned by `HashUtilsTest#testNotEquivalentToFloorModForNonPowerOfTwo`.

No pom change is needed. `connector-azurecosmosdb` depends on `connector-common`, which is the same path by which `connector-paimon` already imports `HashUtils`.

### Does this PR introduce _any_ user-facing change?

No. Split-to-reader assignment is identical for every reachable input.

For all `int` values, `(hash & Integer.MAX_VALUE) % numReaders` is precisely what `bucketIndex` evaluates, so no split changes owner and no state migration is implied for a job resuming from a checkpoint.

One degenerate case does differ, and it is unreachable here. For `numReaders <= 0` the helper throws `IllegalArgumentException` naming the offending value, whereas the old expression threw `ArithmeticException: / by zero` for `0` and silently returned a meaningless index for a negative count. `numReaders` is `enumeratorContext.currentParallelism()`, which is always at least 1. This is the same behaviour the nine sites migrated in #11987 already have.

A null `splitId` still raises `NullPointerException`, previously at `.hashCode()` and now at unboxing.

### How was this patch tested?

`HashUtilsTest` in `seatunnel-common` already covers the helper, including `Integer.MIN_VALUE`, the non-power-of-two divergence from `floorMod`, and the `bucketCount <= 0` contract.

No per-site test is added, matching the precedent set by #11987, which migrated nine call sites onto that shared coverage rather than duplicating it at each enumerator. This is a two-line substitution of a provably equal expression, and a test asserting that `getSplitOwner` returns `(v & Integer.MAX_VALUE) % n` would restate the implementation rather than pin a behaviour.

Built locally against `dev` under JDK 11:

```
./mvnw spotless:apply -pl seatunnel-connectors-v2/connector-azurecosmosdb
./mvnw -pl seatunnel-connectors-v2/connector-azurecosmosdb -am -DskipTests install
```

Spotless reported no reformatting, and the reactor finished `BUILD SUCCESS`, which also confirms the cross-module import resolves without a dependency change.

### Check list

None of the checklist items apply: no new jar binary, no user-facing behaviour to document, and this is not a new connector, so `plugin-mapping.properties`, `seatunnel-dist`, `label-scope-conf.yml` and `plugin_config` are unaffected.

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated
