### PR TITLE
[Fix][Zeta] Propagate interrupted pending job insertion

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -1155,7 +1155,15 @@ public class CoordinatorService {
         }
 
         PendingJobInfo pendingJobInfo = new PendingJobInfo(PendingSourceState.RESTORE, jobMaster);
-        pendingJobQueue.put(pendingJobInfo);
+        try {
+            pendingJobQueue.put(pendingJobInfo);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SeaTunnelEngineException(
+                    String.format(
+                            "Job id %s restore interrupted while entering pending queue", jobId),
+                    e);
+        }
         jobMaster.getPhysicalPlan().updateJobState(JobStatus.PENDING);
         logger.info(String.format("The restore job enter pending queue, JobId: %s", jobId));
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/PeekBlockingQueue.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/utils/PeekBlockingQueue.java
@@ -17,10 +17,6 @@
 
 package org.apache.seatunnel.engine.server.utils;
 
-import org.apache.seatunnel.common.utils.ExceptionUtils;
-
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +38,6 @@ import java.util.function.Predicate;
  * 2. Check if resources are sufficient. <br>
  * 3. If resources are sufficient, take() the data; otherwise, do not take data from the queue.
  */
-@Slf4j
 public class PeekBlockingQueue<E> {
 
     private final BlockingQueue<E> queue = new LinkedBlockingQueue<>();
@@ -56,7 +51,7 @@ public class PeekBlockingQueue<E> {
         this.idExtractor = idExtractor;
     }
 
-    public void put(E element) {
+    public void put(E element) throws InterruptedException {
         lock.lock();
         try {
             queue.put(element);
@@ -64,7 +59,8 @@ public class PeekBlockingQueue<E> {
             jobIdMap.put(jobId, element);
             notEmpty.signalAll();
         } catch (InterruptedException e) {
-            log.error("Put element into queue failed. {}", ExceptionUtils.getMessage(e));
+            Thread.currentThread().interrupt();
+            throw e;
         } finally {
             lock.unlock();
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -1863,8 +1863,7 @@ public class CoordinatorServiceTest {
                     .untilAsserted(
                             () -> Assertions.assertTrue(coordinatorService.isCoordinatorActive()));
 
-            long jobId =
-                    instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+            long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
             LogicalDag logicalDag =
                     TestUtils.createTestLogicalPlan(
                             "stream_fake_to_console.conf", "interrupted_restore", jobId);
@@ -1884,9 +1883,7 @@ public class CoordinatorServiceTest {
                     instance.getMap(Constant.IMAP_RUNNING_JOB_STATE);
             runningJobStateIMap.put(jobId, JobStatus.RUNNING);
             ReflectionUtils.setField(
-                    coordinatorService,
-                    "pendingJobQueue",
-                    new AlwaysInterruptedPendingJobQueue());
+                    coordinatorService, "pendingJobQueue", new AlwaysInterruptedPendingJobQueue());
 
             InvocationTargetException invocationException =
                     Assertions.assertThrows(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -1863,7 +1863,8 @@ public class CoordinatorServiceTest {
                     .untilAsserted(
                             () -> Assertions.assertTrue(coordinatorService.isCoordinatorActive()));
 
-            long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+            long jobId =
+                    instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
             LogicalDag logicalDag =
                     TestUtils.createTestLogicalPlan(
                             "stream_fake_to_console.conf", "interrupted_restore", jobId);

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -76,6 +76,7 @@ import com.hazelcast.spi.properties.ClusterProperty;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -1848,6 +1849,60 @@ public class CoordinatorServiceTest {
     }
 
     @Test
+    void testInterruptedPendingJobInsertionDuringRestoreFailsRestore() throws Exception {
+        HazelcastInstanceImpl instance =
+                createHazelcastInstanceWithJoinPortTryCount(
+                        TestUtils.getClusterName(
+                                "CoordinatorServiceTest_testInterruptedPendingJobInsertionDuringRestore"),
+                        1);
+        try {
+            SeaTunnelServer server =
+                    instance.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+            CoordinatorService coordinatorService = server.getCoordinatorService();
+            await().atMost(60, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> Assertions.assertTrue(coordinatorService.isCoordinatorActive()));
+
+            long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+            LogicalDag logicalDag =
+                    TestUtils.createTestLogicalPlan(
+                            "stream_fake_to_console.conf", "interrupted_restore", jobId);
+            JobImmutableInformation jobImmutableInformation =
+                    new JobImmutableInformation(
+                            jobId,
+                            "Test",
+                            instance.getSerializationService(),
+                            logicalDag,
+                            Collections.emptyList(),
+                            Collections.emptyList());
+            JobInfo jobInfo =
+                    new JobInfo(
+                            100L,
+                            instance.getSerializationService().toData(jobImmutableInformation));
+            IMap<Object, Object> runningJobStateIMap =
+                    instance.getMap(Constant.IMAP_RUNNING_JOB_STATE);
+            runningJobStateIMap.put(jobId, JobStatus.RUNNING);
+            ReflectionUtils.setField(
+                    coordinatorService,
+                    "pendingJobQueue",
+                    new AlwaysInterruptedPendingJobQueue());
+
+            InvocationTargetException invocationException =
+                    Assertions.assertThrows(
+                            InvocationTargetException.class,
+                            () -> invokeRestoreJobFromMasterActiveSwitch(coordinatorService, jobId, jobInfo));
+            Assertions.assertInstanceOf(SeaTunnelEngineException.class, invocationException.getCause());
+            Assertions.assertInstanceOf(
+                    InterruptedException.class, invocationException.getCause().getCause());
+            Assertions.assertFalse(coordinatorService.getPendingJobQueue().contains(jobId));
+            Assertions.assertNotEquals(JobStatus.PENDING, runningJobStateIMap.get(jobId));
+        } finally {
+            Thread.interrupted();
+            instance.shutdown();
+        }
+    }
+
+    @Test
     @Disabled("Disabled because we can't know when the master node switches in the unit tests")
     void testJobRestoreWhenMasterNodeSwitch() {
         HazelcastInstanceImpl instance1 =
@@ -2085,6 +2140,18 @@ public class CoordinatorServiceTest {
                 Thread.currentThread().interrupt();
             }
             super.put(element);
+        }
+    }
+
+    private static class AlwaysInterruptedPendingJobQueue
+            extends PeekBlockingQueue<PendingJobInfo> {
+        private AlwaysInterruptedPendingJobQueue() {
+            super(PendingJobInfo::getJobId);
+        }
+
+        @Override
+        public void put(PendingJobInfo element) throws InterruptedException {
+            throw new InterruptedException("test interruption");
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -57,6 +57,7 @@ import org.apache.seatunnel.engine.server.operation.SubmitJobOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
 import org.apache.seatunnel.engine.server.task.operation.ReportMetricsOperation;
 import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
+import org.apache.seatunnel.engine.server.utils.PeekBlockingQueue;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -802,9 +803,14 @@ public class CoordinatorServiceTest {
                 .when(jobMaster)
                 .run();
 
-        coordinatorService
-                .getPendingJobQueue()
-                .put(new PendingJobInfo(PendingSourceState.SUBMIT, jobMaster));
+        try {
+            coordinatorService
+                    .getPendingJobQueue()
+                    .put(new PendingJobInfo(PendingSourceState.SUBMIT, jobMaster));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Failed to enqueue mock pending job", e);
+        }
         return jobMaster;
     }
 
@@ -1325,6 +1331,60 @@ public class CoordinatorServiceTest {
                                     Assertions.assertNotEquals(
                                             JobStatus.PENDING,
                                             server.getCoordinatorService().getJobStatus(jobId)));
+        } finally {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = SKIP_CHECK_JAR, value = "true")
+    void testInterruptedPendingJobInsertionFailsSubmission() throws Exception {
+        String clusterName =
+                TestUtils.getClusterName(
+                        "CoordinatorServiceTest_testInterruptedPendingJobInsertionFailsSubmission");
+        HazelcastInstanceImpl instance =
+                SeaTunnelServerStarter.createHazelcastInstance(clusterName);
+        try {
+            SeaTunnelServer server =
+                    instance.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+            CoordinatorService coordinatorService = server.getCoordinatorService();
+            InterruptiblePendingJobQueue pendingJobQueue = new InterruptiblePendingJobQueue();
+            ReflectionUtils.setField(coordinatorService, "pendingJobQueue", pendingJobQueue);
+
+            long jobId = instance.getFlakeIdGenerator(Constant.SEATUNNEL_ID_GENERATOR_NAME).newId();
+            LogicalDag logicalDag =
+                    TestUtils.createTestLogicalPlan(
+                            "batch_fake_to_console.conf",
+                            "interrupted_pending_job_insertion",
+                            jobId);
+            JobImmutableInformation jobImmutableInformation =
+                    new JobImmutableInformation(
+                            jobId,
+                            "Test",
+                            instance.getSerializationService(),
+                            logicalDag,
+                            Collections.emptyList(),
+                            Collections.emptyList());
+            Data data = instance.getSerializationService().toData(jobImmutableInformation);
+
+            PassiveCompletableFuture<Void> submitFuture =
+                    coordinatorService.submitJob(
+                            jobId, data, jobImmutableInformation.isStartWithSavePoint());
+            Assertions.assertTrue(
+                    pendingJobQueue.putStarted.await(20, TimeUnit.SECONDS),
+                    "submission did not reach pending queue insertion");
+
+            coordinatorService.clearCoordinatorService();
+
+            await().atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> Assertions.assertTrue(submitFuture.isCompletedExceptionally()));
+            Assertions.assertThrows(CompletionException.class, submitFuture::join);
+            Assertions.assertFalse(pendingJobQueue.contains(jobId));
+            Assertions.assertNotEquals(
+                    JobStatus.PENDING,
+                    instance.getMap(Constant.IMAP_RUNNING_JOB_STATE).get(jobId),
+                    "an interrupted submission must not advance the job to PENDING");
         } finally {
             instance.shutdown();
         }
@@ -2006,6 +2066,26 @@ public class CoordinatorServiceTest {
         System.out.printf("Average completion time per op: %.6f seconds%n", avgSeconds);
 
         return elapsedNs / 1_000_000_000.0;
+    }
+
+    private static class InterruptiblePendingJobQueue extends PeekBlockingQueue<PendingJobInfo> {
+        private final CountDownLatch putStarted = new CountDownLatch(1);
+        private final CountDownLatch releasePut = new CountDownLatch(1);
+
+        private InterruptiblePendingJobQueue() {
+            super(PendingJobInfo::getJobId);
+        }
+
+        @Override
+        public void put(PendingJobInfo element) throws InterruptedException {
+            putStarted.countDown();
+            try {
+                releasePut.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            super.put(element);
+        }
     }
 
     private static class JobInformation {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -1890,8 +1890,11 @@ public class CoordinatorServiceTest {
             InvocationTargetException invocationException =
                     Assertions.assertThrows(
                             InvocationTargetException.class,
-                            () -> invokeRestoreJobFromMasterActiveSwitch(coordinatorService, jobId, jobInfo));
-            Assertions.assertInstanceOf(SeaTunnelEngineException.class, invocationException.getCause());
+                            () ->
+                                    invokeRestoreJobFromMasterActiveSwitch(
+                                            coordinatorService, jobId, jobInfo));
+            Assertions.assertInstanceOf(
+                    SeaTunnelEngineException.class, invocationException.getCause());
             Assertions.assertInstanceOf(
                     InterruptedException.class, invocationException.getCause().getCause());
             Assertions.assertFalse(coordinatorService.getPendingJobQueue().contains(jobId));

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/utils/PeekBlockingQueueTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/utils/PeekBlockingQueueTest.java
@@ -115,7 +115,7 @@ public class PeekBlockingQueueTest {
     }
 
     @Test
-    public void testClear() {
+    public void testClear() throws InterruptedException {
         queue.put("1");
         queue.put("2");
         queue.put("3");


### PR DESCRIPTION
### Purpose

Fixes #12010. An interrupted pending-job insertion was previously swallowed by `PeekBlockingQueue.put`, allowing `submitJob` to complete successfully even though the job was not queued.

### Changes

- Propagate `InterruptedException` from `PeekBlockingQueue.put` and restore the interrupt flag.
- Let `CoordinatorService.submitJob` complete its future exceptionally through the existing error path and avoid advancing the physical plan to `PENDING`.
- Apply the same explicit interruption handling to the master-switch restore path.
- Add a deterministic regression test covering queue state, future completion, and job status.
- Audited `take` and `peekBlocking`; they already propagate interruption.

### Verification

- `git diff --check` passes.
- Focused Maven compile/test could not start because the configured internal repository reset the connection and the HTTP plugin mirror was blocked by Maven.