### PR TITLE
[Improve][Zeta] Return the failure message instead of a stack trace from REST errors

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/filter/ExceptionHandlingFilter.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/filter/ExceptionHandlingFilter.java
@@ -65,7 +65,9 @@ public class ExceptionHandlingFilter implements Filter {
         response.setContentType("application/json;charset=UTF-8");
 
         ErrResponse errorResponse = new ErrResponse();
-        errorResponse.setMessage(ExceptionUtils.getStackTrace(e));
+        // The type and message of the failure are what a caller can act on. The frames behind it
+        // only describe the internals of this node, and they are logged below either way.
+        errorResponse.setMessage(ExceptionUtils.getMessage(e));
         errorResponse.setStatus("fail");
 
         String jsonResponse = objectMapper.writeValueAsString(errorResponse);

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/filter/ExceptionHandlingFilterTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/rest/filter/ExceptionHandlingFilterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.filter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Covers the error payload the REST filter writes when a request fails. */
+public class ExceptionHandlingFilterTest {
+
+    @Test
+    void testErrorResponseKeepsTheMessageAndDropsTheStackFrames() throws Exception {
+        StringWriter body = new StringWriter();
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+        ExceptionHandlingFilter filter = new ExceptionHandlingFilter();
+        filter.init(null);
+        FilterChain chain =
+                (req, resp) -> {
+                    throw new IllegalArgumentException("Job id is required");
+                };
+
+        filter.doFilter(mock(ServletRequest.class), response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        String json = body.toString();
+        Assertions.assertTrue(json.contains("Job id is required"), json);
+        Assertions.assertTrue(json.contains("IllegalArgumentException"), json);
+        Assertions.assertTrue(json.contains("\"status\":\"fail\""), json);
+        Assertions.assertFalse(json.contains("at org.apache.seatunnel"), json);
+    }
+
+    @Test
+    void testUnexpectedFailureIsReportedAsAServerErrorWithoutStackFrames() throws Exception {
+        StringWriter body = new StringWriter();
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+        ExceptionHandlingFilter filter = new ExceptionHandlingFilter();
+        filter.init(null);
+        FilterChain chain =
+                (req, resp) -> {
+                    throw new IllegalStateException("cluster is not ready");
+                };
+
+        filter.doFilter(mock(ServletRequest.class), response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        String json = body.toString();
+        Assertions.assertTrue(json.contains("cluster is not ready"), json);
+        Assertions.assertFalse(json.contains("at org.apache.seatunnel"), json);
+    }
+}


### PR DESCRIPTION
Close #12066

### Purpose of this pull request

`ExceptionHandlingFilter` puts the entire Java stack trace into the `message` field of the JSON error body, so a caller who forgets `jobId` gets forty frames of Zeta internals instead of "Job id is required".

The frames are already written to the server log on the next line of the same method, so nothing is lost by leaving them there. This changes the body to carry the exception type and message only, using `ExceptionUtils.getMessage(e)` — the same call `BaseLogService` already uses in this module.

### Does this PR introduce _any_ user-facing change?

Yes, the `message` field of a v2 REST error response is shorter. HTTP status codes and the `"status": "fail"` shape are unchanged.

Before:

```json
{
  "status": "fail",
  "message": "java.lang.IllegalArgumentException: Job id is required\n\tat org.apache.seatunnel.engine.server.rest.service.JobInfoService.getJobInfo(JobInfoService.java:XX)\n\tat javax.servlet.http.HttpServlet.service(HttpServlet.java:XX)\n\t... 40 more frames ...\n"
}
```

After:

```json
{
  "status": "fail",
  "message": "IllegalArgumentException: Job id is required"
}
```

The stack trace is still logged at ERROR on the server, unchanged.

### How was this patch tested?

Added `ExceptionHandlingFilterTest`, which drives the filter with a chain that throws and asserts on the JSON it writes:

- an `IllegalArgumentException` yields `400`, keeps both the exception type and the message, keeps `"status":"fail"`, and contains no `at org.apache.seatunnel` frames
- any other exception yields `500` with the same guarantees

`RestApiSubmitJobConfigShadeDecryptTest` already asserts on this response for a bad-request case and passes unchanged, since `getMessage` still yields `IllegalArgumentException: ...`.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
