### PR TITLE
[Improve][Zeta] Log node tag changes with their previous value

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/UpdateTagsService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/UpdateTagsService.java
@@ -23,10 +23,13 @@ import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import com.hazelcast.cluster.impl.MemberImpl;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class UpdateTagsService extends BaseService {
     public UpdateTagsService(NodeEngineImpl nodeEngine) {
         super(nodeEngine);
@@ -48,7 +51,15 @@ public class UpdateTagsService extends BaseService {
                                                 value.getValue() != null
                                                         ? value.getValue().toString()
                                                         : ""));
+        // Read before the change, because updateAttribute replaces the whole tag set: without this
+        // copy the tags a job was scheduled against are gone with no record of what they were.
+        Map<String, String> previousTags = new HashMap<>(localMember.getAttributes());
         localMember.updateAttribute(tags);
+        log.info(
+                "Node tags updated: node={}, {} -> {}",
+                localMember.getAddress(),
+                previousTags,
+                tags);
         return new JsonObject().add("status", "success").add("message", "update node tags done.");
     }
 }


### PR DESCRIPTION
Close #12067

### Purpose of this pull request

`POST /update-tags` replaces the tag set Zeta uses to decide where a job may be scheduled, and leaves no trace of having done so. Because `updateAttribute` replaces the whole map instead of merging into it, a request that omits a tag silently drops it, and afterwards there is no record anywhere of what the tags used to be — so "why did this job stop being scheduled onto that node" has no answer in the logs.

This logs the node address, the previous tag set and the new tag set at INFO. Every other mutating Zeta operation (job submit, job stop, log level change) already logs what it did.

### Does this PR introduce _any_ user-facing change?

No. One new INFO log line on the node that handled the request:

```
Node tags updated: node=[localhost]:5801, {group=platform} -> {group=platform, team=team1}
```

The response body and status are unchanged.

### How was this patch tested?

No new test. The change is a single log statement around the existing `updateAttribute` call, with no branch and no change to the returned value, so the existing `RestApiIT` coverage of `/update-tags` exercises it as-is.

To read it yourself on a running cluster, `POST /update-tags` with `{"group":"platform"}` and then with `{"team":"team1"}`; the second call now logs the drop of `group` explicitly:

```
Node tags updated: node=[localhost]:5801, {group=platform} -> {team=team1}
```

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
