### PR TITLE
[Improve][Zeta] Bound the size of a config file uploaded to the REST server

### DIFF
--- a/docs/en/engines/zeta/rest-api-v2.md
+++ b/docs/en/engines/zeta/rest-api-v2.md
@@ -16,7 +16,7 @@ The v2 API and the Web UI are both served by the embedded Jetty server. Jetty st
 
 There are two different "default" sources that are easy to mix up:
 
-- Code defaults: `enable-http = false`, `enable-https = false`, `port = 8080`, `context-path = ""`, `enable-dynamic-port = false`, `port-range = 100`
+- Code defaults: `enable-http = false`, `enable-https = false`, `port = 8080`, `context-path = ""`, `enable-dynamic-port = false`, `port-range = 100`, `upload-max-file-size-mb = 10`, `upload-max-request-size-mb = 10`
 - The packaged `seatunnel.yaml` example: it already sets `enable-http: true` and `port: 8080`
 
 As a result, if you start SeaTunnel with the packaged configuration, the Web UI and REST API usually
@@ -58,6 +58,21 @@ seatunnel:
       enable-http: true
       port: 8080
       context-path: /seatunnel
+```
+
+The size of an uploaded config file is bounded, so a single request cannot fill the master's temp
+directory or exhaust its heap. Both limits apply to `/submit-job/upload` only, and a value of `0`
+or below means unlimited:
+
+```yaml
+
+seatunnel:
+  engine:
+    http:
+      enable-http: true
+      port: 8080
+      upload-max-file-size-mb: 10
+      upload-max-request-size-mb: 10
 ```
 
 ## Web UI and Port 8080 Troubleshooting
@@ -960,6 +975,10 @@ The name of the uploaded file key is config_file, and supports the following for
 - `.json` files: parsed in JSON format
 - `.conf` or `.config` files: parsed in HOCON format
 - `.sql` files: parsed in SQL format, supports CREATE TABLE and INSERT INTO syntax
+
+The upload is limited to `seatunnel.engine.http.upload-max-file-size-mb` (10 MB by default) per
+file and `upload-max-request-size-mb` (10 MB by default) per request. A larger upload is rejected
+before the config is parsed.
 
 curl Example :
 ```bash

--- a/docs/zh/engines/zeta/rest-api-v2.md
+++ b/docs/zh/engines/zeta/rest-api-v2.md
@@ -13,7 +13,7 @@ v2 版本的 API 和 Web UI 都由内嵌 Jetty 提供，与 v1 版本保持相�
 
 这里需要区分两个容易混淆的“默认值”来源：
 
-- 代码默认值：`enable-http = false`、`enable-https = false`、`port = 8080`、`context-path = ""`、`enable-dynamic-port = false`、`port-range = 100`
+- 代码默认值：`enable-http = false`、`enable-https = false`、`port = 8080`、`context-path = ""`、`enable-dynamic-port = false`、`port-range = 100`、`upload-max-file-size-mb = 10`、`upload-max-request-size-mb = 10`
 - 发行包自带的 `seatunnel.yaml` 示例：默认写入了 `enable-http: true` 和 `port: 8080`
 
 因此，直接使用发行包自带配置启动时，Web UI 和 REST API 通常会监听
@@ -54,6 +54,20 @@ seatunnel:
       enable-http: true
       port: 8080
       context-path: /seatunnel
+```
+
+上传的配置文件有大小上限，避免单个请求把 Master 的临时目录写满或把堆内存吃光。这两个配置只作用于
+`/submit-job/upload`，取值小于等于 `0` 表示不限制：
+
+```yaml
+
+seatunnel:
+  engine:
+    http:
+      enable-http: true
+      port: 8080
+      upload-max-file-size-mb: 10
+      upload-max-request-size-mb: 10
 ```
 
 ## Web UI 与 8080 排查
@@ -934,6 +948,9 @@ INSERT INTO console_sink SELECT * FROM fake_source;
 - `.json` 文件：按照 JSON 格式解析
 - `.conf` 或 `.config` 文件：按照 HOCON 格式解析
 - `.sql` 文件：按照 SQL 格式解析，支持 CREATE TABLE 和 INSERT INTO 语法
+
+单个文件大小受 `seatunnel.engine.http.upload-max-file-size-mb`（默认 10 MB）限制，单个请求的总大小受
+`upload-max-request-size-mb`（默认 10 MB）限制。超出上限的请求会在解析配置之前被拒绝。
 
 curl Example
 

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -658,6 +658,24 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                     .key()
                     .equals(name)) {
                 httpConfig.setBasicAuthPassword(getTextContent(node));
+            } else if (ServerConfigOptions.MasterServerConfigOptions.UPLOAD_MAX_FILE_SIZE_MB
+                    .key()
+                    .equals(name)) {
+                httpConfig.setUploadMaxFileSizeMb(
+                        getIntegerValue(
+                                ServerConfigOptions.MasterServerConfigOptions
+                                        .UPLOAD_MAX_FILE_SIZE_MB
+                                        .key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.MasterServerConfigOptions.UPLOAD_MAX_REQUEST_SIZE_MB
+                    .key()
+                    .equals(name)) {
+                httpConfig.setUploadMaxRequestSizeMb(
+                        getIntegerValue(
+                                ServerConfigOptions.MasterServerConfigOptions
+                                        .UPLOAD_MAX_REQUEST_SIZE_MB
+                                        .key(),
+                                getTextContent(node)));
             } else {
                 LOGGER.warning("Unrecognized element: " + name);
             }

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/HttpConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/HttpConfig.java
@@ -78,6 +78,14 @@ public class HttpConfig implements Serializable {
     private String basicAuthPassword =
             ServerConfigOptions.MasterServerConfigOptions.BASIC_AUTH_PASSWORD.defaultValue();
 
+    /** The maximum size in MB of a single uploaded file. A value <= 0 means unlimited. */
+    private int uploadMaxFileSizeMb =
+            ServerConfigOptions.MasterServerConfigOptions.UPLOAD_MAX_FILE_SIZE_MB.defaultValue();
+
+    /** The maximum total size in MB of a multipart request. A value <= 0 means unlimited. */
+    private int uploadMaxRequestSizeMb =
+            ServerConfigOptions.MasterServerConfigOptions.UPLOAD_MAX_REQUEST_SIZE_MB.defaultValue();
+
     public void setPort(int port) {
         checkPositive(port, ServerConfigOptions.MasterServerConfigOptions.HTTP + " must be > 0");
         this.port = port;

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -374,6 +374,20 @@ public class ServerConfigOptions {
                         .defaultValue("admin")
                         .withDescription("The password for basic authentication.");
 
+        public static final Option<Integer> UPLOAD_MAX_FILE_SIZE_MB =
+                Options.key("upload-max-file-size-mb")
+                        .intType()
+                        .defaultValue(10)
+                        .withDescription(
+                                "The maximum size in MB of a single file uploaded to the http server. A value <= 0 means unlimited.");
+
+        public static final Option<Integer> UPLOAD_MAX_REQUEST_SIZE_MB =
+                Options.key("upload-max-request-size-mb")
+                        .intType()
+                        .defaultValue(10)
+                        .withDescription(
+                                "The maximum total size in MB of a multipart request sent to the http server. A value <= 0 means unlimited.");
+
         public static final Option<HttpConfig> HTTP =
                 Options.key("http")
                         .type(new TypeReference<HttpConfig>() {})

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
@@ -158,6 +158,12 @@ public class JettyService {
         log.info("SeaTunnel REST service will start on https port {}", httpsPort);
     }
 
+    private static long toBytes(int megabytes) {
+        // Jetty reads a negative limit as unlimited, which is what this server did before the
+        // limit became configurable. Keep that available instead of scaling it into bytes.
+        return megabytes <= 0 ? -1L : megabytes * 1024L * 1024L;
+    }
+
     public void createJettyServer() {
 
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
@@ -233,7 +239,12 @@ public class JettyService {
         context.addServlet(jobInfoHolder, convertUrlToPath(REST_URL_JOB_INFO));
         context.addServlet(jobInfoHolder, convertUrlToPath(REST_URL_RUNNING_JOB));
         context.addServlet(threadDumpHolder, convertUrlToPath(REST_URL_THREAD_DUMP));
-        MultipartConfigElement multipartConfigElement = new MultipartConfigElement("");
+        // Bound the upload: the whole part is buffered by Jetty and then read into a String, so an
+        // unbounded body lets a single request fill the temp directory and exhaust the master heap.
+        long maxFileSize = toBytes(httpConfig.getUploadMaxFileSizeMb());
+        long maxRequestSize = toBytes(httpConfig.getUploadMaxRequestSizeMb());
+        MultipartConfigElement multipartConfigElement =
+                new MultipartConfigElement("", maxFileSize, maxRequestSize, 0);
         submitJobByUploadFileHolder.getRegistration().setMultipartConfig(multipartConfigElement);
         context.addServlet(
                 submitJobByUploadFileHolder, convertUrlToPath(REST_URL_SUBMIT_JOB_BY_UPLOAD_FILE));


### PR DESCRIPTION
Close #12068

### Purpose of this pull request

`/submit-job/upload` registers its multipart handling with `new MultipartConfigElement("")`. That single-argument form leaves both `maxFileSize` and `maxRequestSize` at `-1`, which Jetty reads as unlimited. The uploaded part is then buffered to the temp directory by Jetty *and* read into a `String` in full by the servlet, so one oversized body is enough to fill the master's disk and exhaust its heap — a plain `curl --form` against an endpoint that only ever receives job config files.

This adds `upload-max-file-size-mb` and `upload-max-request-size-mb` under `seatunnel.engine.http`, both defaulting to 10 MB, which is orders of magnitude above any real job config. A value of `0` or below maps to Jetty's unlimited, so anyone who relies on the current behaviour can keep it.

### Does this PR introduce _any_ user-facing change?

Yes, two ways.

1. Two new options, documented in `docs/{en,zh}/engines/zeta/rest-api-v2.md`:

```yaml
seatunnel:
  engine:
    http:
      enable-http: true
      port: 8080
      upload-max-file-size-mb: 10
      upload-max-request-size-mb: 10
```

2. A previously-accepted upload larger than 10 MB is now rejected by Jetty before the config is parsed. This is a behaviour change relative to dev and to released versions, which is why the default is set well above any plausible config file and why `0` restores the old behaviour.

### How was this patch tested?

No new test. Asserting on the limit means standing up Jetty and pushing a >10 MB body through it — `MultipartConfigElement` exposes no state on the `ServletHolder` registration to check otherwise — and an IT of that weight is not worth it for a two-field constructor change. The existing `/submit-job/upload` coverage exercises the normal path, since a real config file is far below the default.

To reproduce the behaviour change on a running cluster:

```bash
dd if=/dev/zero of=/tmp/big.conf bs=1M count=64
# before: the master's temp dir grows by 64 MB, then OOM in IOUtils.toString
# after:  Jetty rejects the request before the config is parsed
curl --location 'http://127.0.0.1:8080/submit-job/upload' --form 'config_file=@"/tmp/big.conf"'
# a normal config upload is unaffected
curl --location 'http://127.0.0.1:8080/submit-job/upload' --form 'config_file=@"/tmp/fake_to_console.conf"'
```

Both keys are wired through `YamlSeaTunnelDomConfigProcessor.parseHttpConfig`, so they are parsed rather than falling through to `Unrecognized element` — worth reviewing, since a missing branch there fails silently.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
