### PR TITLE
[Improve][Core] Warn that the base64 config shade does not encrypt anything

### DIFF
--- a/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigShadeUtils.java
+++ b/seatunnel-core/seatunnel-core-starter/src/main/java/org/apache/seatunnel/core/starter/utils/ConfigShadeUtils.java
@@ -168,6 +168,12 @@ public final class ConfigShadeUtils {
                 "Miss <Sink> config! Please check the config file.");
         try {
             ConfigShade configShade = CONFIG_SHADES.getOrDefault(identifier, DEFAULT_SHADE);
+            if (Base64ConfigShade.IDENTIFIER.equals(identifier)) {
+                log.warn(
+                        "Config shade '{}' encodes sensitive options, it does not encrypt them:"
+                                + " anyone who reads the config can decode the values.",
+                        Base64ConfigShade.IDENTIFIER);
+            }
             // call open method before the encrypt/decrypt
             configShade.open(props);
 


### PR DESCRIPTION
Close #12069

### Purpose of this pull request

`base64` is the built-in `ConfigShade` and the one most users reach for first, because it needs no setup. Its name gives no hint that the result is reversible by anyone who can read the config file, and a config that has been through `POST /encrypt-config` *looks* protected. The docs already say it is not recommended for production, but nothing says so at the point where it is actually used — so configs get committed to Git and shipped in images under the belief that the credentials in them are encrypted.

This logs a warning when a config is decrypted with the `base64` shade.

### Does this PR introduce _any_ user-facing change?

No behaviour change. One new WARN line when `shade.identifier = "base64"`:

```
Config shade 'base64' encodes sensitive options, it does not encrypt them: anyone who reads the config can decode the values.
```

Configs using any other identifier, including the default, are unaffected.

### How was this patch tested?

No new test. The change is a single log statement guarded by an equality check on the shade identifier, with no effect on the returned config, so the existing `ConfigShadeTest` coverage of the `base64` path applies unchanged.

To see it, run any job whose config sets `shade.identifier = "base64"`; the warning is emitted once as the config is decrypted. A config with no `shade.identifier` does not emit it.

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
