### PR TITLE
[Improve][Connector-V2] Migrate HugeGraph sink validation to OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/main/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkFactory.java
@@ -29,6 +29,11 @@ import org.apache.seatunnel.connectors.seatunnel.hugegraph.config.HugeGraphSinkO
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.greaterOrEqual;
+import static org.apache.seatunnel.api.configuration.util.Conditions.lessOrEqual;
+import static org.apache.seatunnel.api.configuration.util.Conditions.matches;
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+
 @AutoService(Factory.class)
 public class HugeGraphSinkFactory implements TableSinkFactory {
 
@@ -47,11 +52,16 @@ public class HugeGraphSinkFactory implements TableSinkFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 // connection config
-                .required(HugeGraphOptions.HOST, HugeGraphOptions.PORT, HugeGraphOptions.GRAPH_NAME)
+                .required(HugeGraphOptions.HOST, notBlank(HugeGraphOptions.HOST))
+                .required(
+                        HugeGraphOptions.PORT,
+                        greaterOrEqual(HugeGraphOptions.PORT, 1),
+                        lessOrEqual(HugeGraphOptions.PORT, 65535))
+                .required(HugeGraphOptions.GRAPH_NAME, notBlank(HugeGraphOptions.GRAPH_NAME))
+                .bundled(HugeGraphOptions.USERNAME, HugeGraphOptions.PASSWORD)
                 .optional(
-                        HugeGraphOptions.PROTOCOL,
-                        HugeGraphOptions.USERNAME,
-                        HugeGraphOptions.PASSWORD,
+                        HugeGraphOptions.PROTOCOL, matches(HugeGraphOptions.PROTOCOL, "(?i)https?"))
+                .optional(
                         // Optional connection setting passed through to select the HugeGraph graph
                         // space (defaults to "DEFAULT").
                         HugeGraphOptions.GRAPH_SPACE)
@@ -79,8 +89,13 @@ public class HugeGraphSinkFactory implements TableSinkFactory {
                 // retry config
                 .optional(
                         HugeGraphOptions.MAX_RETRIES,
+                        greaterOrEqual(HugeGraphOptions.MAX_RETRIES, 0))
+                .optional(
                         HugeGraphOptions.RETRY_BACKOFF_MS,
-                        HugeGraphOptions.RETRY_BACKOFF_MAX_MS)
+                        greaterOrEqual(HugeGraphOptions.RETRY_BACKOFF_MS, 0))
+                .optional(
+                        HugeGraphOptions.RETRY_BACKOFF_MAX_MS,
+                        greaterOrEqual(HugeGraphOptions.RETRY_BACKOFF_MAX_MS, 0))
                 // deprecated field selection
                 .optional(HugeGraphSinkOptions.SELECTED_FIELDS, HugeGraphSinkOptions.IGNORED_FIELDS)
                 .build();

--- a/seatunnel-connectors-v2/connector-hugegraph/src/test/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-hugegraph/src/test/java/org/apache/seatunnel/connectors/seatunnel/hugegraph/sink/HugeGraphSinkFactoryTest.java
@@ -18,16 +18,26 @@
 package org.apache.seatunnel.connectors.seatunnel.hugegraph.sink;
 
 import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.seatunnel.hugegraph.config.HugeGraphOptions;
 import org.apache.seatunnel.connectors.seatunnel.hugegraph.config.HugeGraphSinkOptions;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HugeGraphSinkFactoryTest {
+
+    private final OptionRule optionRule = new HugeGraphSinkFactory().optionRule();
 
     /**
      * Every option the sink actually reads must be declared in {@code optionRule()}; otherwise
@@ -36,7 +46,7 @@ class HugeGraphSinkFactoryTest {
      */
     @Test
     void optionRuleDeclaresAllReadOptions() {
-        List<Option<?>> optional = new HugeGraphSinkFactory().optionRule().getOptionalOptions();
+        List<Option<?>> optional = optionRule.getOptionalOptions();
         assertTrue(
                 optional.contains(HugeGraphSinkOptions.DATA_SAVE_MODE), "data_save_mode missing");
         assertTrue(optional.contains(HugeGraphOptions.CHECK_VERTEX), "check_vertex missing");
@@ -50,5 +60,88 @@ class HugeGraphSinkFactoryTest {
         assertTrue(
                 optional.contains(HugeGraphOptions.RETRY_BACKOFF_MAX_MS),
                 "retry_backoff_max_ms missing");
+    }
+
+    @Test
+    void acceptsValidConnectionOptions() {
+        assertDoesNotThrow(() -> validate(requiredConfig()));
+
+        Map<String, Object> config = requiredConfig();
+        config.put(HugeGraphOptions.PROTOCOL.key(), "HTTPS");
+        config.put(HugeGraphOptions.USERNAME.key(), "user");
+        config.put(HugeGraphOptions.PASSWORD.key(), "password");
+        config.put(HugeGraphOptions.MAX_RETRIES.key(), 0);
+        config.put(HugeGraphOptions.RETRY_BACKOFF_MS.key(), 0);
+        config.put(HugeGraphOptions.RETRY_BACKOFF_MAX_MS.key(), 0);
+
+        assertDoesNotThrow(() -> validate(config));
+    }
+
+    @Test
+    void rejectsBlankRequiredConnectionOptions() {
+        Map<String, Object> blankHost = requiredConfig();
+        blankHost.put(HugeGraphOptions.HOST.key(), " ");
+        assertThrows(OptionValidationException.class, () -> validate(blankHost));
+
+        Map<String, Object> blankGraphName = requiredConfig();
+        blankGraphName.put(HugeGraphOptions.GRAPH_NAME.key(), "\t");
+        assertThrows(OptionValidationException.class, () -> validate(blankGraphName));
+    }
+
+    @Test
+    void rejectsPortOutsideValidRange() {
+        Map<String, Object> portTooLow = requiredConfig();
+        portTooLow.put(HugeGraphOptions.PORT.key(), 0);
+        assertThrows(OptionValidationException.class, () -> validate(portTooLow));
+
+        Map<String, Object> portTooHigh = requiredConfig();
+        portTooHigh.put(HugeGraphOptions.PORT.key(), 65536);
+        assertThrows(OptionValidationException.class, () -> validate(portTooHigh));
+    }
+
+    @Test
+    void rejectsUnsupportedProtocol() {
+        Map<String, Object> config = requiredConfig();
+        config.put(HugeGraphOptions.PROTOCOL.key(), "ftp");
+
+        assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @Test
+    void requiresCredentialsToBeConfiguredTogether() {
+        Map<String, Object> usernameOnly = requiredConfig();
+        usernameOnly.put(HugeGraphOptions.USERNAME.key(), "user");
+        assertThrows(OptionValidationException.class, () -> validate(usernameOnly));
+
+        Map<String, Object> passwordOnly = requiredConfig();
+        passwordOnly.put(HugeGraphOptions.PASSWORD.key(), "password");
+        assertThrows(OptionValidationException.class, () -> validate(passwordOnly));
+    }
+
+    @Test
+    void rejectsNegativeRetryOptions() {
+        assertNegativeOptionRejected(HugeGraphOptions.MAX_RETRIES);
+        assertNegativeOptionRejected(HugeGraphOptions.RETRY_BACKOFF_MS);
+        assertNegativeOptionRejected(HugeGraphOptions.RETRY_BACKOFF_MAX_MS);
+    }
+
+    private void assertNegativeOptionRejected(Option<Integer> option) {
+        Map<String, Object> config = requiredConfig();
+        config.put(option.key(), -1);
+        assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    private void validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "HugeGraphSink");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private static Map<String, Object> requiredConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(HugeGraphOptions.HOST.key(), "127.0.0.1");
+        config.put(HugeGraphOptions.PORT.key(), 8080);
+        config.put(HugeGraphOptions.GRAPH_NAME.key(), "hugegraph");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Related to #11007.

This PR migrates deterministic HugeGraph sink connection validation into `HugeGraphSinkFactory.optionRule()` so invalid configuration is rejected during factory validation.

The declarative rules now validate:

- nonblank `host` and `graph_name` values;
- `port` in the range `[1, 65535]`;
- `protocol` as `http` or `https` (case-insensitive);
- `username` and `password` as bundled options; and
- nonnegative retry count and retry backoff values.

Server, network, schema-dependent, mapping, and record-dependent checks remain in their existing runtime paths. No dependencies, configuration options, or defaults are changed.

Focused factory tests cover valid defaults and explicit values, blank required strings, port boundaries, unsupported protocols, incomplete credential pairs, and negative retry settings.

### Does this PR introduce _any_ user-facing change?

Yes. Invalid HugeGraph sink connection settings are now rejected earlier by factory configuration validation with the relevant option constraint. Valid configurations and all option defaults are unchanged.

### How was this patch tested?

```shell
./mvnw -pl seatunnel-connectors-v2/connector-hugegraph spotless:apply
./mvnw -pl seatunnel-connectors-v2/connector-hugegraph test
./mvnw -q -pl seatunnel-connectors-v2/connector-hugegraph -DskipTests verify
```

The complete HugeGraph connector unit-test suite passes: 188 tests, 0 failures, 0 errors, 0 skipped.

### Check list

* [x] No new Jar binary package is added.
* [x] No documentation update is required because no option, default, or valid behavior changes.
* [x] No incompatible-changes entry is required.
* [x] Existing connector packaging, mapping, CI labels, and E2E coverage are unchanged; this PR only updates factory validation and focused unit tests.
