### PR TITLE
[Fix][Connector-V2] Fix file content comparison across read boundaries

### DIFF
--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/AbstractReadStrategy.java
@@ -50,6 +50,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipParameters;
 import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.hadoop.fs.FileChecksum;
@@ -1010,24 +1011,7 @@ public abstract class AbstractReadStrategy implements ReadStrategy {
             throws IOException {
         try (InputStream sourceIn = hadoopFileSystemProxy.getInputStream(sourceFilePath);
                 InputStream targetIn = targetHadoopFileSystemProxy.getInputStream(targetFilePath)) {
-            byte[] sourceBuffer = new byte[8 * 1024];
-            byte[] targetBuffer = new byte[8 * 1024];
-
-            while (true) {
-                int sourceRead = sourceIn.read(sourceBuffer);
-                int targetRead = targetIn.read(targetBuffer);
-                if (sourceRead != targetRead) {
-                    return false;
-                }
-                if (sourceRead == -1) {
-                    return true;
-                }
-                for (int i = 0; i < sourceRead; i++) {
-                    if (sourceBuffer[i] != targetBuffer[i]) {
-                        return false;
-                    }
-                }
-            }
+            return IOUtils.contentEquals(sourceIn, targetIn);
         }
     }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/split/ContinuousMultipleTableFileSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/main/java/org/apache/seatunnel/connectors/seatunnel/file/source/split/ContinuousMultipleTableFileSourceSplitEnumerator.java
@@ -43,6 +43,7 @@ import org.apache.seatunnel.connectors.seatunnel.file.source.event.FileSplitFini
 import org.apache.seatunnel.connectors.seatunnel.file.source.state.FileSourceOperationState;
 import org.apache.seatunnel.connectors.seatunnel.file.source.state.FileSourceState;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -1942,24 +1943,7 @@ public class ContinuousMultipleTableFileSourceSplitEnumerator
                 throws IOException {
             try (InputStream sourceIn = sourceFs.getInputStream(sourceFilePath);
                     InputStream targetIn = targetFs.getInputStream(targetFilePath)) {
-                byte[] sourceBuffer = new byte[8 * 1024];
-                byte[] targetBuffer = new byte[8 * 1024];
-
-                while (true) {
-                    int sourceRead = sourceIn.read(sourceBuffer);
-                    int targetRead = targetIn.read(targetBuffer);
-                    if (sourceRead != targetRead) {
-                        return false;
-                    }
-                    if (sourceRead == -1) {
-                        return true;
-                    }
-                    for (int i = 0; i < sourceRead; i++) {
-                        if (sourceBuffer[i] != targetBuffer[i]) {
-                            return false;
-                        }
-                    }
-                }
+                return IOUtils.contentEquals(sourceIn, targetIn);
             }
         }
 

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/ChunkedInputHadoopFileSystemProxy.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/hadoop/ChunkedInputHadoopFileSystemProxy.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.file.hadoop;
+
+import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSInputStream;
+import org.apache.hadoop.fs.FileChecksum;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/** A test filesystem proxy that exposes configured content using bounded read chunk sizes. */
+public final class ChunkedInputHadoopFileSystemProxy extends HadoopFileSystemProxy {
+    private final Path sourceFile;
+    private final byte[] sourceContent;
+    private final int sourceChunkSize;
+    private final Path targetFile;
+    private final byte[] targetContent;
+    private final int targetChunkSize;
+
+    public ChunkedInputHadoopFileSystemProxy(
+            HadoopConf hadoopConf,
+            Path sourceFile,
+            byte[] sourceContent,
+            int sourceChunkSize,
+            Path targetFile,
+            byte[] targetContent,
+            int targetChunkSize) {
+        super(hadoopConf);
+        this.sourceFile = sourceFile;
+        this.sourceContent = sourceContent;
+        this.sourceChunkSize = sourceChunkSize;
+        this.targetFile = targetFile;
+        this.targetContent = targetContent;
+        this.targetChunkSize = targetChunkSize;
+    }
+
+    @Override
+    public FileChecksum getFileChecksum(String filePath) {
+        return null;
+    }
+
+    @Override
+    public FSDataInputStream getInputStream(String filePath) throws IOException {
+        String normalizedPath = new org.apache.hadoop.fs.Path(filePath).toUri().getPath();
+        if (normalizedPath.equals(sourceFile.toString())) {
+            return chunkedInputStream(sourceContent, sourceChunkSize);
+        }
+        if (normalizedPath.equals(targetFile.toString())) {
+            return chunkedInputStream(targetContent, targetChunkSize);
+        }
+        return super.getInputStream(filePath);
+    }
+
+    private static FSDataInputStream chunkedInputStream(byte[] content, int chunkSize) {
+        return new FSDataInputStream(new ChunkedFSInputStream(content, chunkSize));
+    }
+
+    private static final class ChunkedFSInputStream extends FSInputStream {
+        private final byte[] content;
+        private final int chunkSize;
+        private int position;
+
+        private ChunkedFSInputStream(byte[] content, int chunkSize) {
+            this.content = content;
+            this.chunkSize = chunkSize;
+        }
+
+        @Override
+        public int read() {
+            if (position >= content.length) {
+                return -1;
+            }
+            return content[position++] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) {
+            if (position >= content.length) {
+                return -1;
+            }
+            int bytesToRead = Math.min(Math.min(length, chunkSize), content.length - position);
+            System.arraycopy(content, position, buffer, offset, bytesToRead);
+            position += bytesToRead;
+            return bytesToRead;
+        }
+
+        @Override
+        public void seek(long newPosition) {
+            position = (int) newPosition;
+        }
+
+        @Override
+        public long getPos() {
+            return position;
+        }
+
+        @Override
+        public boolean seekToNewSource(long targetPosition) {
+            return false;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/UpdateSyncModeTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/reader/UpdateSyncModeTest.java
@@ -21,6 +21,8 @@ import org.apache.seatunnel.shade.com.typesafe.config.Config;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.file.hadoop.ChunkedInputHadoopFileSystemProxy;
+import org.apache.seatunnel.connectors.seatunnel.file.hadoop.HadoopFileSystemProxy;
 import org.apache.seatunnel.connectors.seatunnel.file.util.LocalFileSystemConf;
 
 import org.junit.jupiter.api.Assertions;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -204,6 +207,41 @@ class UpdateSyncModeTest {
     }
 
     @Test
+    void testStrictChecksumFallbackSkipsEqualContentWithDifferentReadChunkSizes() throws Exception {
+        assertStrictChecksumFallback(
+                "identical-content".getBytes(StandardCharsets.UTF_8),
+                3,
+                "identical-content".getBytes(StandardCharsets.UTF_8),
+                5,
+                false);
+    }
+
+    @Test
+    void testStrictChecksumFallbackCopiesDifferentContent() throws Exception {
+        assertStrictChecksumFallback(
+                "same-length-a".getBytes(StandardCharsets.UTF_8),
+                3,
+                "same-length-b".getBytes(StandardCharsets.UTF_8),
+                5,
+                true);
+    }
+
+    @Test
+    void testStrictChecksumCopiesDifferentLength() throws Exception {
+        assertStrictChecksumFallback(
+                "short".getBytes(StandardCharsets.UTF_8),
+                3,
+                "longer".getBytes(StandardCharsets.UTF_8),
+                5,
+                true);
+    }
+
+    @Test
+    void testStrictChecksumFallbackSkipsEmptyContent() throws Exception {
+        assertStrictChecksumFallback(new byte[0], 3, new byte[0], 5, false);
+    }
+
+    @Test
     void testUpdateModeNonRecursiveScanOnlyComparesTopLevelFiles() throws Exception {
         Path sourceDir = tempDir.resolve("src");
         Path targetDir = tempDir.resolve("dst");
@@ -277,6 +315,47 @@ class UpdateSyncModeTest {
 
     private static void setMtime(Path path, long millis) throws IOException {
         Files.setLastModifiedTime(path, FileTime.fromMillis(millis));
+    }
+
+    private void assertStrictChecksumFallback(
+            byte[] sourceContent,
+            int sourceChunkSize,
+            byte[] targetContent,
+            int targetChunkSize,
+            boolean expectedCopy)
+            throws Exception {
+        Path sourceDir = tempDir.resolve("fallback-src-" + sourceChunkSize);
+        Path targetDir = tempDir.resolve("fallback-dst-" + targetChunkSize);
+        Path sourceFile = sourceDir.resolve("test.bin");
+        Path targetFile = targetDir.resolve("test.bin");
+        writeFile(sourceFile, sourceContent);
+        writeFile(targetFile, targetContent);
+
+        try (BinaryReadStrategy strategy = new BinaryReadStrategy()) {
+            strategy.setPluginConfig(
+                    updateConfig(
+                            sourceDir.toUri().toString(),
+                            targetDir.toUri().toString(),
+                            "strict",
+                            "checksum"));
+            strategy.init(new LocalFileSystemConf.LocalConf(FS_DEFAULT_NAME_DEFAULT));
+
+            strategy.hadoopFileSystemProxy.close();
+            HadoopFileSystemProxy fileSystem =
+                    new ChunkedInputHadoopFileSystemProxy(
+                            new LocalFileSystemConf.LocalConf(FS_DEFAULT_NAME_DEFAULT),
+                            sourceFile,
+                            sourceContent,
+                            sourceChunkSize,
+                            targetFile,
+                            targetContent,
+                            targetChunkSize);
+            strategy.hadoopFileSystemProxy = fileSystem;
+            strategy.targetHadoopFileSystemProxy = fileSystem;
+
+            List<String> files = strategy.getFileNamesByPath(sourceDir.toUri().toString());
+            Assertions.assertEquals(expectedCopy ? 1 : 0, files.size());
+        }
     }
 
     private static Config updateConfig(

--- a/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/split/ContinuousMultipleTableFileSourceSplitEnumeratorTest.java
+++ b/seatunnel-connectors-v2/connector-file/connector-file-base/src/test/java/org/apache/seatunnel/connectors/seatunnel/file/source/split/ContinuousMultipleTableFileSourceSplitEnumeratorTest.java
@@ -27,6 +27,7 @@ import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptio
 import org.apache.seatunnel.connectors.seatunnel.file.config.FilePostSyncAction;
 import org.apache.seatunnel.connectors.seatunnel.file.config.HadoopConf;
 import org.apache.seatunnel.connectors.seatunnel.file.exception.FileConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.file.hadoop.ChunkedInputHadoopFileSystemProxy;
 import org.apache.seatunnel.connectors.seatunnel.file.hadoop.HadoopFileSystemProxy;
 import org.apache.seatunnel.connectors.seatunnel.file.source.event.FileSplitFinishedEvent;
 import org.apache.seatunnel.connectors.seatunnel.file.source.state.FileSourceOperationState;
@@ -45,6 +46,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -128,6 +130,55 @@ class ContinuousMultipleTableFileSourceSplitEnumeratorTest {
             Assertions.assertEquals(0, enumerator.currentUnassignedSplitSize());
         } finally {
             enumerator.close();
+        }
+    }
+
+    @Test
+    void testStrictChecksumFallbackSkipsEqualContentWithDifferentReadChunkSizes() throws Exception {
+        Path srcDir = Files.createDirectories(tempDir.resolve("chunked-src"));
+        Path dstDir = Files.createDirectories(tempDir.resolve("chunked-dst"));
+        Path srcFile = srcDir.resolve("test.bin");
+        Path dstFile = dstDir.resolve("test.bin");
+        byte[] content = "identical-content".getBytes(StandardCharsets.UTF_8);
+        Files.write(srcFile, content);
+        Files.write(dstFile, content);
+
+        Map<String, Object> extraConfig = new HashMap<>();
+        extraConfig.put(FileBaseSourceOptions.UPDATE_STRATEGY.key(), "strict");
+        extraConfig.put(FileBaseSourceOptions.COMPARE_MODE.key(), "checksum");
+        EnumeratorWithContext enumeratorWithContext =
+                createEnumerator(
+                        srcDir,
+                        dstDir,
+                        "earliest",
+                        new FileSourceState(Collections.emptySet()),
+                        extraConfig);
+        try {
+            HadoopFileSystemProxy originalFileSystem =
+                    getTableScanContextFileSystem(enumeratorWithContext.enumerator, "sourceFs");
+            originalFileSystem.close();
+            HadoopFileSystemProxy chunkedFileSystem =
+                    new ChunkedInputHadoopFileSystemProxy(
+                            new LocalConf(FS_DEFAULT_NAME_DEFAULT),
+                            srcFile,
+                            content,
+                            3,
+                            dstFile,
+                            content,
+                            5);
+            setTableScanContextFileSystem(
+                    enumeratorWithContext.enumerator, "sourceFs", chunkedFileSystem);
+            setTableScanContextFileSystem(
+                    enumeratorWithContext.enumerator, "targetFs", chunkedFileSystem);
+
+            enumeratorWithContext.enumerator.scanOnceForTest();
+
+            Assertions.assertEquals(
+                    0,
+                    enumeratorWithContext.enumerator.currentUnassignedSplitSize(),
+                    "equal content must be skipped regardless of stream read chunk sizes");
+        } finally {
+            enumeratorWithContext.enumerator.close();
         }
     }
 


### PR DESCRIPTION
### Purpose of this pull request

Closes #12078.

This PR fixes strict checksum fallback in both file update paths. The previous implementation compared the byte counts returned by paired `InputStream.read(byte[])` calls. Identical streams can legally return different chunk sizes, so equal files could be classified as changed and copied or enqueued again.

Both production paths now use the module's existing Apache Commons IO `IOUtils.contentEquals` implementation. It compares the complete byte sequences independently of read boundaries, uses constant-size buffers, and adds no dependency.

The change retains try-with-resources ownership and the existing fail-open-to-copy behavior when checksum or content comparison raises an I/O error.

### Does this PR introduce _any_ user-facing change?

Yes.

When `sync_mode = "update"`, `update_strategy = "strict"`, and `compare_mode = "checksum"` fall back to content comparison, an unchanged file is no longer recopied merely because its source and target streams return different numbers of bytes per read.

Configuration, defaults, behavior for different content, and failure handling remain unchanged.

### How was this patch tested?

* Java 8 (`1.8.0_172`): the complete `connector-file-base` test suite passed, 276/276.
* Java 11 (`11.0.19`): the complete `connector-file-base` test suite passed, 276/276.
* Java 11 skip-tests module verification passed, including Spotless, compilation, and packaging.
* `git diff --check` passed.

The tests exercise the real batch and continuous update-mode paths with checksum-unavailable streams. Coverage includes equal content returned in 3-byte versus 5-byte chunks, different bytes, different lengths, empty streams, and continuous split enumeration.

### Check list

* [x] No new Jar binary package or dependency is added; Commons IO 2.11 is already used by this module.
* [x] Documentation is not required because no option, default, or supported behavior changes.
* [x] `incompatible-changes.md` is not required; the patch corrects equality detection for existing strict comparison semantics.
* [x] No connector mapping, distribution POM, label scope, or new connector E2E entry is required; this is an internal fix in the existing shared file connector base.