### PR TITLE
[Fix][Connector-V2][AmazonSqs] Wrap JSON parse failures with connector error code

### DIFF
--- a/seatunnel-connectors-v2/connector-amazonsqs/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazonsqs/deserialize/AmazonSqsDeserializer.java
+++ b/seatunnel-connectors-v2/connector-amazonsqs/src/main/java/org/apache/seatunnel/connectors/seatunnel/amazonsqs/deserialize/AmazonSqsDeserializer.java
@@ -19,6 +19,8 @@ package org.apache.seatunnel.connectors.seatunnel.amazonsqs.deserialize;
 
 import org.apache.seatunnel.api.serialization.DeserializationSchema;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.exception.CommonErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.connectors.seatunnel.amazonsqs.exception.AmazonSqsConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.amazonsqs.exception.AmazonSqsConnectorException;
 
@@ -37,22 +39,32 @@ public class AmazonSqsDeserializer implements SeaTunnelRowDeserializer {
 
     @Override
     public SeaTunnelRow deserializeRow(String row) {
+        SeaTunnelRow seaTunnelRow;
         try {
-            SeaTunnelRow seaTunnelRow = deserializationSchema.deserialize(row.getBytes());
-            if (seaTunnelRow == null && !ignoreParseErrors) {
-                throw new AmazonSqsConnectorException(
-                        AmazonSqsConnectorErrorCode.DESERIALIZE_FAILED,
-                        "Failed to deserialize Amazon SQS message");
+            seaTunnelRow = deserializationSchema.deserialize(row.getBytes());
+        } catch (SeaTunnelRuntimeException e) {
+            if (!CommonErrorCode.JSON_OPERATION_FAILED.equals(e.getSeaTunnelErrorCode())) {
+                throw e;
             }
-            return seaTunnelRow;
+            return handleDeserializationFailure(e);
         } catch (IOException e) {
-            if (ignoreParseErrors) {
-                return null;
-            }
+            return handleDeserializationFailure(e);
+        }
+        if (seaTunnelRow == null && !ignoreParseErrors) {
             throw new AmazonSqsConnectorException(
                     AmazonSqsConnectorErrorCode.DESERIALIZE_FAILED,
-                    "Failed to deserialize Amazon SQS message",
-                    e);
+                    "Failed to deserialize Amazon SQS message");
         }
+        return seaTunnelRow;
+    }
+
+    private SeaTunnelRow handleDeserializationFailure(Throwable cause) {
+        if (ignoreParseErrors) {
+            return null;
+        }
+        throw new AmazonSqsConnectorException(
+                AmazonSqsConnectorErrorCode.DESERIALIZE_FAILED,
+                "Failed to deserialize Amazon SQS message",
+                cause);
     }
 }

--- a/seatunnel-connectors-v2/connector-amazonsqs/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazonsqs/source/AmazonSqsSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-amazonsqs/src/test/java/org/apache/seatunnel/connectors/seatunnel/amazonsqs/source/AmazonSqsSourceReaderTest.java
@@ -31,7 +31,11 @@ import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.CommonError;
+import org.apache.seatunnel.common.exception.CommonErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.connectors.seatunnel.amazonsqs.config.AmazonSqsSourceConfig;
+import org.apache.seatunnel.connectors.seatunnel.amazonsqs.exception.AmazonSqsConnectorErrorCode;
 import org.apache.seatunnel.connectors.seatunnel.amazonsqs.exception.AmazonSqsConnectorException;
 import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
 
@@ -254,6 +258,72 @@ class AmazonSqsSourceReaderTest {
         Assertions.assertEquals(1, context.noMoreElementSignals);
     }
 
+    @Test
+    void shouldWrapJsonParseErrorCreatedByFactory() throws Exception {
+        RecordingSqsClient sqsClient = new RecordingSqsClient(message("invalid", "receipt-1"));
+        RecordingReaderContext context = new RecordingReaderContext();
+
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("value", "string");
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("fields", fields);
+        Map<String, Object> options = new HashMap<>();
+        options.put("url", "https://sqs.us-east-1.amazonaws.com/123456789012/orders");
+        options.put("region", "us-east-1");
+        options.put("schema", schema);
+        options.put("delete_message", true);
+
+        TableSource<?, ?, ?> tableSource =
+                new AmazonSqsSourceFactory()
+                        .createSource(
+                                new TableSourceFactoryContext(
+                                        ReadonlyConfig.fromMap(options),
+                                        Thread.currentThread().getContextClassLoader()));
+        AmazonSqsSource source = (AmazonSqsSource) tableSource.createSource();
+        AmazonSqsSourceReader reader =
+                (AmazonSqsSourceReader) source.createReader(new SingleSplitReaderContext(context));
+        reader.sqsClient = sqsClient.client;
+        RecordingCollector collector = new RecordingCollector();
+
+        AmazonSqsConnectorException exception =
+                Assertions.assertThrows(
+                        AmazonSqsConnectorException.class, () -> reader.pollNext(collector));
+
+        Assertions.assertEquals(
+                AmazonSqsConnectorErrorCode.DESERIALIZE_FAILED, exception.getSeaTunnelErrorCode());
+        Assertions.assertTrue(
+                exception.getMessage().contains("Failed to deserialize Amazon SQS message"));
+        SeaTunnelRuntimeException cause =
+                Assertions.assertInstanceOf(SeaTunnelRuntimeException.class, exception.getCause());
+        Assertions.assertEquals(
+                CommonErrorCode.JSON_OPERATION_FAILED, cause.getSeaTunnelErrorCode());
+        Assertions.assertNotNull(cause.getCause());
+        Assertions.assertTrue(collector.records.isEmpty());
+        Assertions.assertTrue(sqsClient.deletedRequests.isEmpty());
+        Assertions.assertEquals(0, context.noMoreElementSignals);
+    }
+
+    @Test
+    void shouldPropagateNonJsonRuntimeExceptionWhenParseErrorsIgnored() {
+        RecordingSqsClient sqsClient = new RecordingSqsClient(message("invalid", "receipt-1"));
+        RecordingReaderContext context = new RecordingReaderContext();
+        AmazonSqsSourceReader reader =
+                createReader(
+                        context, true, true, new UnsupportedDeserializationSchema(), sqsClient);
+        RecordingCollector collector = new RecordingCollector();
+
+        SeaTunnelRuntimeException exception =
+                Assertions.assertThrows(
+                        SeaTunnelRuntimeException.class, () -> reader.pollNext(collector));
+
+        Assertions.assertFalse(exception instanceof AmazonSqsConnectorException);
+        Assertions.assertEquals(
+                CommonErrorCode.OPERATION_NOT_SUPPORTED, exception.getSeaTunnelErrorCode());
+        Assertions.assertTrue(collector.records.isEmpty());
+        Assertions.assertTrue(sqsClient.deletedRequests.isEmpty());
+        Assertions.assertEquals(0, context.noMoreElementSignals);
+    }
+
     private static AmazonSqsSourceReader createReader(
             RecordingReaderContext context,
             boolean deleteMessage,
@@ -328,6 +398,13 @@ class AmazonSqsSourceReaderTest {
                 throw new IOException("invalid payload");
             }
             return super.deserialize(message);
+        }
+    }
+
+    private static final class UnsupportedDeserializationSchema extends TestDeserializationSchema {
+        @Override
+        public SeaTunnelRow deserialize(byte[] message) throws IOException {
+            throw CommonError.unsupportedOperation("AmazonSqs", "deserialize");
         }
     }
 


### PR DESCRIPTION
### Purpose of this pull request

Closes #12083.

This PR makes Amazon SQS JSON deserialization failures use the connector's existing error boundary consistently.

The change:

- wraps JSON-format failures carrying `CommonErrorCode.JSON_OPERATION_FAILED` with `AmazonSqsConnectorException` and `AmazonSqs-01`;
- preserves the original `COMMON-02` exception and parser failure in the cause chain;
- limits the catch boundary to schema deserialization;
- leaves unrelated runtime failures unchanged; and
- adds regression coverage for both the wrapped JSON path and the non-JSON runtime boundary.

Downstream collector failures remain outside the deserializer's catch scope. `AmazonSqsSourceReader` still deletes a message only after collection succeeds.

### Does this PR introduce _any_ user-facing change?

Yes, for error diagnostics only.

With `format = json` and `ignore_parse_errors = false`, malformed JSON now surfaces as `AmazonSqsConnectorException` with error code `AmazonSqs-01`. Previously, the format's `SeaTunnelRuntimeException` with `COMMON-02` escaped directly.

Failure, retry, and deletion behavior are unchanged: the poll aborts before collection or deletion, and the original `COMMON-02` exception remains available as the cause.

Existing `ignore_parse_errors = true` behavior is also unchanged.

### How was this patch tested?

- Reproduced the unfixed behavior on Java 8 and Java 11: the factory-to-reader path received `SeaTunnelRuntimeException`/`COMMON-02` instead of `AmazonSqsConnectorException`/`AmazonSqs-01`.
- Java 8: the complete `connector-amazonsqs` module passed, 12/12 tests.
- Java 11: the complete `connector-amazonsqs` module passed, 12/12 tests.
- The new tests verify the outer connector error code and message, the preserved JSON cause chain, and that no row is emitted or message deleted.
- A negative regression verifies that a non-JSON `SeaTunnelRuntimeException` remains unchanged even when parse errors are ignored, with no output or deletion.
- Java 11 module verification with tests skipped passed, including compilation, packaging, and Spotless.
- `git diff --check` passed.

The tests use a deterministic in-memory SQS client boundary and make no network calls.

### Check list

* [x] No new Jar binary package or dependency is added.
* [x] No documentation update is required because no option, default, or message-processing behavior changes.
* [x] No incompatible change is introduced, so `incompatible-changes.md` does not require an update.
* [x] Plugin mapping, distribution POM, CI labels, E2E wiring, and plugin configuration remain unchanged because this is a focused error-reporting fix for an existing connector.