### PR TITLE
[Improve][Benchmark] Expose JMH CV and error in comparison report

### DIFF
--- a/tools/benchmarks/regression_report.py
+++ b/tools/benchmarks/regression_report.py
@@ -405,19 +405,12 @@ def jmh_comparison_lines(baselines, candidates):
     )
     if not names:
         return []
-    baseline_ref, _ = source_summary(baselines)
-    candidate_ref, _ = source_summary(candidates)
     lines = [
         "### JMH comparison",
         "",
-        "| Benchmark | Parameters | {} | {} | Score Change | {} CV | {} CV | CV Change | {} Error | {} Error | Error Change | Unit |".format(
-            baseline_ref,
-            candidate_ref,
-            baseline_ref,
-            candidate_ref,
-            baseline_ref,
-            candidate_ref,
-        ),
+        "`B` = Baseline, `C` = Candidate.",
+        "",
+        "| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | CV Change | Error B | Error C | Error Change | Unit |",
         "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     names.sort(

--- a/tools/benchmarks/regression_report.py
+++ b/tools/benchmarks/regression_report.py
@@ -408,7 +408,7 @@ def jmh_comparison_lines(baselines, candidates):
     lines = [
         "### JMH comparison",
         "",
-        "`B` = Baseline, `C` = Candidate.",
+        "`B` = Baseline, `C` = Candidate. Score is the median JMH score; CV and Error are the medians of the per-run relative statistics.",
         "",
         "| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | CV Change | Error B | Error C | Error Change | Unit |",
         "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",

--- a/tools/benchmarks/regression_report.py
+++ b/tools/benchmarks/regression_report.py
@@ -370,10 +370,22 @@ def median_value(metrics, target_unit=None):
     return statistics.median(values) if values else None
 
 
-def adjusted_change(baseline, candidate, direction):
+def median_statistic(metrics, statistic):
+    values = [statistic(metric) for metric in metrics]
+    values = [value for value in values if value is not None]
+    return statistics.median(values) if values else None
+
+
+def relative_change(baseline, candidate):
     if baseline in (None, 0.0) or candidate is None:
         return None
-    raw = (candidate / baseline - 1.0) * 100.0
+    return (candidate / baseline - 1.0) * 100.0
+
+
+def adjusted_change(baseline, candidate, direction):
+    raw = relative_change(baseline, candidate)
+    if raw is None:
+        return None
     return -raw if direction == "lower" else raw
 
 
@@ -393,11 +405,20 @@ def jmh_comparison_lines(baselines, candidates):
     )
     if not names:
         return []
+    baseline_ref, _ = source_summary(baselines)
+    candidate_ref, _ = source_summary(candidates)
     lines = [
         "### JMH comparison",
         "",
-        "| Benchmark | Parameters | Baseline | Candidate | Change | Unit |",
-        "| --- | --- | ---: | ---: | ---: | --- |",
+        "| Benchmark | Parameters | {} | {} | Score Change | {} CV | {} CV | CV Change | {} Error | {} Error | Error Change | Unit |".format(
+            baseline_ref,
+            candidate_ref,
+            baseline_ref,
+            candidate_ref,
+            baseline_ref,
+            candidate_ref,
+        ),
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
     ]
     names.sort(
         key=lambda name: jmh_sort_key(
@@ -411,13 +432,23 @@ def jmh_comparison_lines(baselines, candidates):
         target_unit = (candidate_group or baseline_group)[0]["unit"]
         baseline = median_value(baseline_group, target_unit)
         candidate = median_value(candidate_group, target_unit)
+        baseline_cv = median_statistic(baseline_group, coefficient_of_variation)
+        candidate_cv = median_statistic(candidate_group, coefficient_of_variation)
+        baseline_error = median_statistic(baseline_group, relative_error)
+        candidate_error = median_statistic(candidate_group, relative_error)
         lines.append(
-            "| `{}` | `{}` | {} | {} | {} | {} |".format(
+            "| `{}` | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} |".format(
                 short_benchmark_name(metric),
                 compact_params(metric.get("params", {})),
                 format_number(baseline),
                 format_number(candidate),
                 format_percent(adjusted_change(baseline, candidate, metric["direction"])),
+                format_percent(baseline_cv, signed=False),
+                format_percent(candidate_cv, signed=False),
+                format_percent(relative_change(baseline_cv, candidate_cv)),
+                format_percent(baseline_error, signed=False),
+                format_percent(candidate_error, signed=False),
+                format_percent(relative_change(baseline_error, candidate_error)),
                 target_unit,
             )
         )
@@ -556,8 +587,9 @@ def comparison_lines(baselines, candidates):
         "- Runner image: `{}`".format(environment.get("runner_image", "unknown")),
         "- CPU: `{}`".format(environment.get("cpu_model", "unknown")),
         "",
-        "> Baseline and candidate ran alternately on the same worker. Positive adjusted change is "
-        "favorable, but this observational report does not enforce a regression threshold.",
+        "> Baseline and candidate ran alternately on the same worker. Score and pipeline changes "
+        "are direction-adjusted so positive is favorable; CV and Error changes are relative "
+        "changes. This observational report does not enforce a regression threshold.",
     ]
     for section in (
         jmh_comparison_lines(baselines, candidates),

--- a/tools/benchmarks/regression_report.py
+++ b/tools/benchmarks/regression_report.py
@@ -408,8 +408,8 @@ def jmh_comparison_lines(baselines, candidates):
     lines = [
         "### JMH comparison",
         "",
-        "`B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures variability and Error represents the relative JMH confidence interval, both aggregated as medians across runs.",
-        "Score Change is direction-adjusted so positive is favorable; CV and Error changes are relative changes.",
+        "> `B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures variability and Error represents the relative JMH confidence interval, both aggregated as medians across runs.",
+        "> Score Change is direction-adjusted so positive is favorable; CV and Error changes are relative changes.",
         "",
         "| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | CV Change | Error B | Error C | Error Change | Unit |",
         "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",

--- a/tools/benchmarks/regression_report.py
+++ b/tools/benchmarks/regression_report.py
@@ -408,7 +408,8 @@ def jmh_comparison_lines(baselines, candidates):
     lines = [
         "### JMH comparison",
         "",
-        "`B` = Baseline, `C` = Candidate. Score is the median JMH score; CV and Error are the medians of the per-run relative statistics.",
+        "`B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures variability and Error represents the relative JMH confidence interval, both aggregated as medians across runs.",
+        "Score Change is direction-adjusted so positive is favorable; CV and Error changes are relative changes.",
         "",
         "| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | CV Change | Error B | Error C | Error Change | Unit |",
         "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
@@ -580,9 +581,7 @@ def comparison_lines(baselines, candidates):
         "- Runner image: `{}`".format(environment.get("runner_image", "unknown")),
         "- CPU: `{}`".format(environment.get("cpu_model", "unknown")),
         "",
-        "> Baseline and candidate ran alternately on the same worker. Score and pipeline changes "
-        "are direction-adjusted so positive is favorable; CV and Error changes are relative "
-        "changes. This observational report does not enforce a regression threshold.",
+        "> Baseline and candidate ran alternately on the same worker.",
     ]
     for section in (
         jmh_comparison_lines(baselines, candidates),

--- a/tools/benchmarks/test_regression_report.py
+++ b/tools/benchmarks/test_regression_report.py
@@ -55,7 +55,7 @@ class RegressionReportTest(unittest.TestCase):
         self.assertIn("+10.00%", markdown)
         self.assertIn("ops/ms", markdown)
 
-    def test_jmh_comparison_reports_refs_cv_error_and_changes(self):
+    def test_jmh_comparison_reports_score_cv_error_and_changes(self):
         baseline_one = self.jmh_metric(100.0, "ops/s")
         baseline_one.update({"score_error": 10.0, "sample_standard_deviation": 20.0})
         baseline_two = self.jmh_metric(100.0, "ops/s")
@@ -77,9 +77,10 @@ class RegressionReportTest(unittest.TestCase):
             regression_report.jmh_comparison_lines(baselines, candidates)
         )
 
+        self.assertIn("`B` = Baseline, `C` = Candidate.", markdown)
         self.assertIn(
-            "| Benchmark | Parameters | dev | PR #123 | Score Change | dev CV | PR #123 CV | "
-            "CV Change | dev Error | PR #123 Error | Error Change | Unit |",
+            "| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | "
+            "CV Change | Error B | Error C | Error Change | Unit |",
             markdown,
         )
         self.assertIn("15.00%", markdown)

--- a/tools/benchmarks/test_regression_report.py
+++ b/tools/benchmarks/test_regression_report.py
@@ -55,6 +55,37 @@ class RegressionReportTest(unittest.TestCase):
         self.assertIn("+10.00%", markdown)
         self.assertIn("ops/ms", markdown)
 
+    def test_jmh_comparison_reports_refs_cv_error_and_changes(self):
+        baseline_one = self.jmh_metric(100.0, "ops/s")
+        baseline_one.update({"score_error": 10.0, "sample_standard_deviation": 20.0})
+        baseline_two = self.jmh_metric(100.0, "ops/s")
+        baseline_two.update({"score_error": 20.0, "sample_standard_deviation": 10.0})
+        candidate_one = self.jmh_metric(110.0, "ops/s")
+        candidate_one.update({"score_error": 11.0, "sample_standard_deviation": 11.0})
+        candidate_two = self.jmh_metric(110.0, "ops/s")
+        candidate_two.update({"score_error": 11.0, "sample_standard_deviation": 11.0})
+        baselines = [
+            self.report("dev", baseline_one),
+            self.report("dev", baseline_two),
+        ]
+        candidates = [
+            self.report("PR #123", candidate_one),
+            self.report("PR #123", candidate_two),
+        ]
+
+        markdown = "\n".join(
+            regression_report.jmh_comparison_lines(baselines, candidates)
+        )
+
+        self.assertIn(
+            "| Benchmark | Parameters | dev | PR #123 | Score Change | dev CV | PR #123 CV | "
+            "CV Change | dev Error | PR #123 Error | Error Change | Unit |",
+            markdown,
+        )
+        self.assertIn("15.00%", markdown)
+        self.assertIn("10.00%", markdown)
+        self.assertIn("-33.33%", markdown)
+
     def test_lower_is_better_change_is_reported_as_positive(self):
         metric = self.jmh_metric(10.0, "ms/op", direction="lower")
         baseline = self.report("dev", metric)

--- a/tools/benchmarks/test_regression_report.py
+++ b/tools/benchmarks/test_regression_report.py
@@ -59,11 +59,11 @@ class RegressionReportTest(unittest.TestCase):
         baseline_one = self.jmh_metric(100.0, "ops/s")
         baseline_one.update({"score_error": 10.0, "sample_standard_deviation": 20.0})
         baseline_two = self.jmh_metric(100.0, "ops/s")
-        baseline_two.update({"score_error": 20.0, "sample_standard_deviation": 10.0})
+        baseline_two.update({"score_error": 10.0, "sample_standard_deviation": 10.0})
         candidate_one = self.jmh_metric(110.0, "ops/s")
-        candidate_one.update({"score_error": 11.0, "sample_standard_deviation": 11.0})
+        candidate_one.update({"score_error": 22.0, "sample_standard_deviation": 11.0})
         candidate_two = self.jmh_metric(110.0, "ops/s")
-        candidate_two.update({"score_error": 11.0, "sample_standard_deviation": 11.0})
+        candidate_two.update({"score_error": 22.0, "sample_standard_deviation": 11.0})
         baselines = [
             self.report("dev", baseline_one),
             self.report("dev", baseline_two),
@@ -77,15 +77,21 @@ class RegressionReportTest(unittest.TestCase):
             regression_report.jmh_comparison_lines(baselines, candidates)
         )
 
-        self.assertIn("`B` = Baseline, `C` = Candidate.", markdown)
+        self.assertIn(
+            "`B` = Baseline, `C` = Candidate. Score is the median JMH score; CV and Error are "
+            "the medians of the per-run relative statistics.",
+            markdown,
+        )
         self.assertIn(
             "| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | "
             "CV Change | Error B | Error C | Error Change | Unit |",
             markdown,
         )
-        self.assertIn("15.00%", markdown)
-        self.assertIn("10.00%", markdown)
-        self.assertIn("-33.33%", markdown)
+        self.assertIn(
+            "| `Queue.publish` | `capacity=1024` | 100.000 | 110.000 | +10.00% | "
+            "15.00% | 10.00% | -33.33% | 10.00% | 20.00% | +100.00% | ops/s |",
+            markdown,
+        )
 
     def test_lower_is_better_change_is_reported_as_positive(self):
         metric = self.jmh_metric(10.0, "ms/op", direction="lower")

--- a/tools/benchmarks/test_regression_report.py
+++ b/tools/benchmarks/test_regression_report.py
@@ -78,13 +78,13 @@ class RegressionReportTest(unittest.TestCase):
         )
 
         self.assertIn(
-            "`B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures "
+            "> `B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures "
             "variability and Error represents the relative JMH confidence interval, both "
             "aggregated as medians across runs.",
             markdown,
         )
         self.assertIn(
-            "Score Change is direction-adjusted so positive is favorable; CV and Error changes "
+            "> Score Change is direction-adjusted so positive is favorable; CV and Error changes "
             "are relative changes.",
             markdown,
         )

--- a/tools/benchmarks/test_regression_report.py
+++ b/tools/benchmarks/test_regression_report.py
@@ -78,8 +78,14 @@ class RegressionReportTest(unittest.TestCase):
         )
 
         self.assertIn(
-            "`B` = Baseline, `C` = Candidate. Score is the median JMH score; CV and Error are "
-            "the medians of the per-run relative statistics.",
+            "`B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures "
+            "variability and Error represents the relative JMH confidence interval, both "
+            "aggregated as medians across runs.",
+            markdown,
+        )
+        self.assertIn(
+            "Score Change is direction-adjusted so positive is favorable; CV and Error changes "
+            "are relative changes.",
             markdown,
         )
         self.assertIn(


### PR DESCRIPTION
## Purpose

Improve the JMH comparison report so reviewers can evaluate measurement quality together with the score change.

## Changes

- expose Baseline/Candidate Score, CV, and Error values in the comparison table
- add relative changes for CV and Error
- keep Score Change direction-adjusted so positive is favorable
- use compact `B`/`C` labels for Baseline/Candidate in the table
- keep the real baseline/candidate refs and commits in the report summary
- add regression-report tests

## Scope

This is reporting-only. It does not change JMH execution, benchmark inputs, normalized result collection, JSON schema, or the ABBA comparison workflow.

## examples

### SeaTunnel benchmark comparison:

- Baseline: `dev` at `98182ca59c93c10390717af4a49b8806f5c555f1` (2 runs)
- Candidate: `PR #12081` at `fa12fbd60c73a8d3d5458eae95abd356812207f9` (2 runs)
- Suite: `checkpoint`
- Java: `1.8.0_...`
- Runner image: `ubuntu-24.04`
- CPU: `AMD EPYC 9V74 80-Core Processor`

> Baseline and candidate ran alternately on the same worker.

### JMH comparison

>  `B` = Baseline, `C` = Candidate. Score is the median benchmark result; CV measures variability and Error represents >the relative JMH confidence interval, both aggregated as medians across runs.  
>Score Change is direction-adjusted so positive is favorable; CV and Error changes are relative changes.

| Benchmark | Parameters | Score B | Score C | Score Change | CV B | CV C | CV Change | Error B | Error C | Error Change | Unit |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `CheckpointStorage.checkpointIdAtomicIncrement` | `default` | 117.727 | 115.894 | +1.56% | 10.25% | 13.00% | +26.83% | 39.47% | 50.08% | +26.88% | us/op |
| `CheckpointStorage.checkpointOverviewIncrementalUpdate` | `default` | 348.524 | 335.939 | +3.61% | 25.94% | 19.55% | -24.63% | 99.87% | 75.29% | -24.61% | us/op |
| `CheckpointStorage.checkpointPersistenceTransaction` | `default` | 1,961.800 | 1,991.395 | -1.51% | 5.00% | 7.06% | +41.20% | 19.25% | 27.18% | +41.19% | us/op |