### PR TITLE
[Improve][Connector-V2][Aerospike] Migrate data format validation to OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-aerospike/src/main/java/org/apache/seatunnel/connectors/seatunnel/aerospike/sink/AerospikeSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-aerospike/src/main/java/org/apache/seatunnel/connectors/seatunnel/aerospike/sink/AerospikeSinkFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.aerospike.sink;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -47,8 +48,11 @@ public class AerospikeSinkFactory implements TableSinkFactory {
                         AerospikeSinkOptions.PASSWORD,
                         AerospikeSinkOptions.KEY_FIELD,
                         AerospikeSinkOptions.BIN_NAME,
-                        AerospikeSinkOptions.DATA_FORMAT,
                         AerospikeSinkOptions.WRITE_TIMEOUT)
+                .optional(
+                        AerospikeSinkOptions.DATA_FORMAT,
+                        Conditions.matches(
+                                AerospikeSinkOptions.DATA_FORMAT, "(?i)^(map|string|kv)$"))
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-aerospike/src/test/java/org/apache/seatunnel/connectors/seatunnel/aerospike/AerospikeFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-aerospike/src/test/java/org/apache/seatunnel/connectors/seatunnel/aerospike/AerospikeFactoryTest.java
@@ -17,16 +17,68 @@
 
 package org.apache.seatunnel.connectors.seatunnel.aerospike;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.aerospike.config.AerospikeSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.aerospike.sink.AerospikeSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class AerospikeFactoryTest {
 
+    private final OptionRule sinkRule = new AerospikeSinkFactory().optionRule();
+
     @Test
-    void optionRule() {
-        Assertions.assertNotNull((new AerospikeSinkFactory()).optionRule());
-        Assertions.assertNotNull((new AerospikeSinkFactory()).optionRule());
+    void supportedDataFormatsPassValidation() {
+        for (String dataFormat : new String[] {"map", "string", "kv"}) {
+            Assertions.assertDoesNotThrow(() -> validate(dataFormat));
+        }
+    }
+
+    @Test
+    void dataFormatValidationIsCaseInsensitive() {
+        for (String dataFormat : new String[] {"MAP", "String", "Kv"}) {
+            Assertions.assertDoesNotThrow(() -> validate(dataFormat));
+        }
+    }
+
+    @Test
+    void unsupportedDataFormatFailsValidation() {
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validate("unsupported"));
+
+        Assertions.assertTrue(
+                exception.getMessage().contains(AerospikeSinkOptions.DATA_FORMAT.key()));
+    }
+
+    @Test
+    void defaultDataFormatPassesValidation() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    private void validate(String dataFormat) {
+        Map<String, Object> config = validConfig();
+        config.put(AerospikeSinkOptions.DATA_FORMAT.key(), dataFormat);
+        validate(config);
+    }
+
+    private void validate(Map<String, Object> config) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(config)).validate(sinkRule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(AerospikeSinkOptions.HOST.key(), "localhost");
+        config.put(AerospikeSinkOptions.PORT.key(), 3000);
+        config.put(AerospikeSinkOptions.NAMESPACE.key(), "test");
+        config.put(AerospikeSinkOptions.SET.key(), "test-set");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Related to #11007.

This PR moves deterministic Aerospike sink `data_format` validation into `AerospikeSinkFactory.optionRule()` so invalid values are rejected during factory validation instead of later when the writer processes a record.

The validation accepts `map`, `string`, and `kv` case-insensitively. The existing default and all valid configurations remain unchanged. Network, server, schema-dependent, and record-dependent checks remain at runtime.

### Does this PR introduce _any_ user-facing change?

Yes. An unsupported `data_format` is now rejected earlier during factory configuration validation. Supported values, case-insensitive behavior, and the default value remain unchanged.

### How was this patch tested?

Added focused factory validation tests covering:

- all supported `data_format` values;
- case-insensitive values;
- an unsupported value; and
- the default value when `data_format` is omitted.

```shell
./mvnw -pl seatunnel-connectors-v2/connector-aerospike \
  -DskipITs -Dtest=AerospikeFactoryTest test

./mvnw -pl seatunnel-connectors-v2/connector-aerospike \
  -DskipTests verify
```

Result: 4 focused tests passed with no failures or errors. The Aerospike connector module verification also completed successfully.

### Check list

* [x] No new Jar binary package is added.
* [x] No documentation update is required because the documented valid values and default remain unchanged.
* [x] No incompatible-changes entry is required because existing valid configurations keep the same behavior.
* [x] No connector registration, distribution, label, or E2E updates are required because this PR only changes configuration validation and focused unit tests.
