### PR TITLE
[Fix][Zeta] Restore checkpoint retention after coordinator recreation

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.common.utils.RetryUtils;
 import org.apache.seatunnel.common.utils.SeaTunnelException;
 import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorage;
+import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
 import org.apache.seatunnel.engine.common.Constant;
 import org.apache.seatunnel.engine.common.config.server.CheckpointConfig;
 import org.apache.seatunnel.engine.common.utils.ExceptionUtil;
@@ -60,6 +61,7 @@ import lombok.SneakyThrows;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -265,6 +267,15 @@ public class CheckpointCoordinator {
         // For job restore from master node active switch
         CheckpointCoordinatorStatus checkpointCoordinatorStatus =
                 (CheckpointCoordinatorStatus) runningJobStateIMap.get(checkpointStateImapKey);
+
+        boolean restoresCurrentJob =
+                pipelineState != null && String.valueOf(jobId).equals(pipelineState.getJobId());
+        boolean recreatesRunningCoordinator =
+                checkpointCoordinatorStatus != null && !checkpointCoordinatorStatus.isEndState();
+        if (coordinatorConfig.isCheckpointEnable()
+                && (restoresCurrentJob || recreatesRunningCoordinator)) {
+            restoreCompletedCheckpointRetentionState();
+        }
 
         // This is not a new job
         if (isStartWithSavePoint) {
@@ -1324,7 +1335,6 @@ public class CheckpointCoordinator {
                 completedCheckpoint.getCheckpointTimestamp(),
                 completedCheckpoint.getCompletedTimestamp());
         final long checkpointId = completedCheckpoint.getCheckpointId();
-        completedCheckpointIds.addLast(String.valueOf(completedCheckpoint.getCheckpointId()));
         try {
             if (completedCheckpoint.getCheckpointType().notCompletedCheckpoint()) {
                 byte[] states = serializer.serialize(completedCheckpoint);
@@ -1335,23 +1345,8 @@ public class CheckpointCoordinator {
                                 .pipelineId(pipelineId)
                                 .states(states)
                                 .build());
-            }
-            if (completedCheckpointIds.size()
-                                    % coordinatorConfig.getStorage().getMaxRetainedCheckpoints()
-                            == 0
-                    && completedCheckpointIds.size()
-                                    / coordinatorConfig.getStorage().getMaxRetainedCheckpoints()
-                            > 1) {
-                List<String> needDeleteCheckpointId = new ArrayList<>();
-                for (int i = 0;
-                        i < coordinatorConfig.getStorage().getMaxRetainedCheckpoints();
-                        i++) {
-                    needDeleteCheckpointId.add(completedCheckpointIds.removeFirst());
-                }
-                checkpointStorage.deleteCheckpoint(
-                        String.valueOf(completedCheckpoint.getJobId()),
-                        String.valueOf(completedCheckpoint.getPipelineId()),
-                        needDeleteCheckpointId);
+                completedCheckpointIds.addLast(String.valueOf(checkpointId));
+                cleanExpiredCheckpointsSafely();
             }
         } catch (Throwable e) {
             LOG.error("store checkpoint states failed.", e);
@@ -1590,5 +1585,72 @@ public class CheckpointCoordinator {
     @VisibleForTesting
     public Map<Long, SeaTunnelTaskState> getPipelineTaskStatus() {
         return pipelineTaskStatus;
+    }
+
+    /**
+     * Restores the retention queue from durable storage when this coordinator is recreated.
+     * Checkpoint storage implementations do not guarantee enumeration order, so checkpoint IDs must
+     * be sorted before the oldest entries are selected for deletion.
+     */
+    private void restoreCompletedCheckpointRetentionState() {
+        List<PipelineState> pipelineStates;
+        try {
+            pipelineStates =
+                    checkpointStorage.getCheckpointsByJobIdAndPipelineId(
+                            String.valueOf(jobId), String.valueOf(pipelineId));
+        } catch (CheckpointStorageException e) {
+            LOG.warn(
+                    "Failed to restore checkpoint retention state, job id: {}, pipeline id: {}. The coordinator will continue without the previous retention state.",
+                    jobId,
+                    pipelineId,
+                    e);
+            return;
+        }
+
+        pipelineStates.stream()
+                .sorted(Comparator.comparingLong(PipelineState::getCheckpointId))
+                .map(PipelineState::getCheckpointId)
+                .map(String::valueOf)
+                .forEach(completedCheckpointIds::addLast);
+        cleanExpiredCheckpointsSafely();
+        LOG.info(
+                "Restore checkpoint retention state, job id: {}, pipeline id: {}, retained checkpoint count: {}.",
+                jobId,
+                pipelineId,
+                completedCheckpointIds.size());
+    }
+
+    private void cleanExpiredCheckpointsSafely() {
+        try {
+            cleanExpiredCheckpoints();
+        } catch (CheckpointStorageException e) {
+            LOG.warn(
+                    "Failed to clean checkpoint retention state, job id: {}, pipeline id: {}. The coordinator will retry cleanup after the next checkpoint.",
+                    jobId,
+                    pipelineId,
+                    e);
+        }
+    }
+
+    /**
+     * Deletes the oldest durable checkpoints until the configured retention bound is satisfied.
+     * Queue entries are removed only after storage deletion succeeds, so failed deletions remain
+     * available for the next cleanup attempt.
+     */
+    private void cleanExpiredCheckpoints() throws CheckpointStorageException {
+        int numberToDelete =
+                completedCheckpointIds.size()
+                        - coordinatorConfig.getStorage().getMaxRetainedCheckpoints();
+        if (numberToDelete <= 0) {
+            return;
+        }
+
+        List<String> checkpointIdsToDelete =
+                completedCheckpointIds.stream().limit(numberToDelete).collect(Collectors.toList());
+        checkpointStorage.deleteCheckpoint(
+                String.valueOf(jobId), String.valueOf(pipelineId), checkpointIdsToDelete);
+        for (int i = 0; i < numberToDelete; i++) {
+            completedCheckpointIds.removeFirst();
+        }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -18,13 +18,16 @@
 package org.apache.seatunnel.engine.server.checkpoint;
 
 import org.apache.seatunnel.common.utils.ReflectionUtils;
+import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.api.CheckpointStorage;
+import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
 import org.apache.seatunnel.engine.common.config.server.CheckpointConfig;
 import org.apache.seatunnel.engine.common.config.server.CheckpointStorageConfig;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.checkpoint.CheckpointIDCounter;
 import org.apache.seatunnel.engine.core.checkpoint.CheckpointType;
 import org.apache.seatunnel.engine.core.job.RestoreMode;
+import org.apache.seatunnel.engine.serializer.protobuf.ProtoStuffSerializer;
 import org.apache.seatunnel.engine.server.AbstractSeaTunnelServerTest;
 import org.apache.seatunnel.engine.server.checkpoint.monitor.CheckpointMonitorService;
 import org.apache.seatunnel.engine.server.checkpoint.operation.TaskAcknowledgeOperation;
@@ -391,6 +394,200 @@ public class CheckpointCoordinatorTest
         Assertions.assertEquals(1, checkpointManager.operations.size());
 
         executor.shutdownNow();
+    }
+
+    @Test
+    void restoresCheckpointRetentionAfterActiveMasterSwitch() throws Exception {
+        CheckpointStorageConfig storageConfig = new CheckpointStorageConfig();
+        storageConfig.setMaxRetainedCheckpoints(3);
+        CheckpointConfig checkpointConfig = new CheckpointConfig();
+        checkpointConfig.setStorage(storageConfig);
+
+        CheckpointStorage checkpointStorage = Mockito.mock(CheckpointStorage.class);
+        Mockito.when(checkpointStorage.getCheckpointsByJobIdAndPipelineId("1", "1"))
+                .thenReturn(
+                        Arrays.asList(
+                                PipelineState.builder().checkpointId(4L).build(),
+                                PipelineState.builder().checkpointId(1L).build(),
+                                PipelineState.builder().checkpointId(5L).build(),
+                                PipelineState.builder().checkpointId(2L).build(),
+                                PipelineState.builder().checkpointId(3L).build()));
+
+        CheckpointPlan plan = CheckpointPlan.builder().pipelineId(1).build();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            @SuppressWarnings("unchecked")
+            IMap<Object, Object> runningJobStateIMap = Mockito.mock(IMap.class);
+            Mockito.when(runningJobStateIMap.get(Mockito.anyString()))
+                    .thenReturn(CheckpointCoordinatorStatus.RUNNING);
+            CheckpointCoordinator coordinator =
+                    new CheckpointCoordinator(
+                            Mockito.mock(CheckpointManager.class),
+                            checkpointStorage,
+                            checkpointConfig,
+                            1L,
+                            plan,
+                            Mockito.mock(CheckpointIDCounter.class),
+                            null,
+                            executorService,
+                            runningJobStateIMap,
+                            false,
+                            null);
+
+            Mockito.verify(checkpointStorage).deleteCheckpoint("1", "1", Arrays.asList("1", "2"));
+
+            coordinator.completePendingCheckpoint(
+                    new CompletedCheckpoint(
+                            1L,
+                            1,
+                            6L,
+                            1L,
+                            CheckpointType.CHECKPOINT_TYPE,
+                            2L,
+                            new HashMap<>(),
+                            new HashMap<>()));
+
+            Mockito.verify(checkpointStorage).deleteCheckpoint("1", "1", Arrays.asList("3"));
+            Mockito.verify(checkpointStorage).storeCheckPoint(Mockito.any(PipelineState.class));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void doesNotRestoreCheckpointRetentionFromDifferentSourceJob() throws Exception {
+        CheckpointStorageConfig storageConfig = new CheckpointStorageConfig();
+        storageConfig.setMaxRetainedCheckpoints(3);
+        CheckpointConfig checkpointConfig = new CheckpointConfig();
+        checkpointConfig.setStorage(storageConfig);
+
+        CheckpointStorage checkpointStorage = Mockito.mock(CheckpointStorage.class);
+        CheckpointPlan plan = CheckpointPlan.builder().pipelineId(1).build();
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            @SuppressWarnings("unchecked")
+            IMap<Object, Object> runningJobStateIMap = Mockito.mock(IMap.class);
+
+            new CheckpointCoordinator(
+                    Mockito.mock(CheckpointManager.class),
+                    checkpointStorage,
+                    checkpointConfig,
+                    1L,
+                    plan,
+                    Mockito.mock(CheckpointIDCounter.class),
+                    PipelineState.builder()
+                            .jobId("2")
+                            .pipelineId(1)
+                            .checkpointId(3L)
+                            .states(
+                                    new ProtoStuffSerializer()
+                                            .serialize(createCompletedCheckpoint(3L)))
+                            .build(),
+                    executorService,
+                    runningJobStateIMap,
+                    true,
+                    null);
+
+            Mockito.verify(checkpointStorage, Mockito.never())
+                    .getCheckpointsByJobIdAndPipelineId(Mockito.anyString(), Mockito.anyString());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void retriesCheckpointRetentionCleanupAfterDeleteFailure() throws Exception {
+        CheckpointStorageConfig storageConfig = new CheckpointStorageConfig();
+        storageConfig.setMaxRetainedCheckpoints(2);
+        CheckpointConfig checkpointConfig = new CheckpointConfig();
+        checkpointConfig.setStorage(storageConfig);
+
+        CheckpointStorage checkpointStorage = Mockito.mock(CheckpointStorage.class);
+        Mockito.doThrow(new CheckpointStorageException("delete failed"))
+                .doNothing()
+                .when(checkpointStorage)
+                .deleteCheckpoint(Mockito.eq("1"), Mockito.eq("1"), Mockito.anyList());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            CheckpointCoordinator coordinator =
+                    new CheckpointCoordinator(
+                            Mockito.mock(CheckpointManager.class),
+                            checkpointStorage,
+                            checkpointConfig,
+                            1L,
+                            CheckpointPlan.builder().pipelineId(1).build(),
+                            Mockito.mock(CheckpointIDCounter.class),
+                            null,
+                            executorService,
+                            Mockito.mock(IMap.class),
+                            false,
+                            null);
+
+            coordinator.completePendingCheckpoint(createCompletedCheckpoint(1L));
+            coordinator.completePendingCheckpoint(createCompletedCheckpoint(2L));
+            Assertions.assertDoesNotThrow(
+                    () -> coordinator.completePendingCheckpoint(createCompletedCheckpoint(3L)));
+            coordinator.completePendingCheckpoint(createCompletedCheckpoint(4L));
+
+            Mockito.verify(checkpointStorage).deleteCheckpoint("1", "1", Arrays.asList("1"));
+            Mockito.verify(checkpointStorage).deleteCheckpoint("1", "1", Arrays.asList("1", "2"));
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    void continuesCoordinatorRecreationWhenRetentionCleanupFails() throws Exception {
+        CheckpointStorageConfig storageConfig = new CheckpointStorageConfig();
+        storageConfig.setMaxRetainedCheckpoints(3);
+        CheckpointConfig checkpointConfig = new CheckpointConfig();
+        checkpointConfig.setStorage(storageConfig);
+
+        CheckpointStorage checkpointStorage = Mockito.mock(CheckpointStorage.class);
+        Mockito.when(checkpointStorage.getCheckpointsByJobIdAndPipelineId("1", "1"))
+                .thenReturn(
+                        Arrays.asList(
+                                PipelineState.builder().checkpointId(1L).build(),
+                                PipelineState.builder().checkpointId(2L).build(),
+                                PipelineState.builder().checkpointId(3L).build(),
+                                PipelineState.builder().checkpointId(4L).build()));
+        Mockito.doThrow(new CheckpointStorageException("delete failed"))
+                .doNothing()
+                .when(checkpointStorage)
+                .deleteCheckpoint(Mockito.eq("1"), Mockito.eq("1"), Mockito.anyList());
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            @SuppressWarnings("unchecked")
+            IMap<Object, Object> runningJobStateIMap = Mockito.mock(IMap.class);
+            Mockito.when(runningJobStateIMap.get(Mockito.anyString()))
+                    .thenReturn(CheckpointCoordinatorStatus.RUNNING);
+
+            CheckpointCoordinator coordinator =
+                    Assertions.assertDoesNotThrow(
+                            () ->
+                                    new CheckpointCoordinator(
+                                            Mockito.mock(CheckpointManager.class),
+                                            checkpointStorage,
+                                            checkpointConfig,
+                                            1L,
+                                            CheckpointPlan.builder().pipelineId(1).build(),
+                                            Mockito.mock(CheckpointIDCounter.class),
+                                            null,
+                                            executorService,
+                                            runningJobStateIMap,
+                                            false,
+                                            null));
+
+            coordinator.completePendingCheckpoint(createCompletedCheckpoint(5L));
+
+            Mockito.verify(checkpointStorage)
+                    .deleteCheckpoint("1", "1", Collections.singletonList("1"));
+            Mockito.verify(checkpointStorage).deleteCheckpoint("1", "1", Arrays.asList("1", "2"));
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
     @Test
@@ -1134,6 +1331,18 @@ public class CheckpointCoordinatorTest
         } finally {
             executorService.shutdownNow();
         }
+    }
+
+    private CompletedCheckpoint createCompletedCheckpoint(long checkpointId) {
+        return new CompletedCheckpoint(
+                1L,
+                1,
+                checkpointId,
+                1L,
+                CheckpointType.CHECKPOINT_TYPE,
+                2L,
+                new HashMap<>(),
+                new HashMap<>());
     }
 }
 

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorage.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorage.java
@@ -311,25 +311,27 @@ public class HdfsStorage extends AbstractCheckpointStorage {
             throw new CheckpointStorageException(
                     "No checkpoint found for job, job id is: " + jobId);
         }
-        fileNames.forEach(
-                fileName -> {
-                    String checkpointIdByFileName = getCheckpointIdByFileName(fileName);
-                    if (pipelineId.equals(getPipelineIdByFileName(fileName))
-                            && checkpointIdList.contains(checkpointIdByFileName)) {
-                        try {
+        for (String fileName : fileNames) {
+            String checkpointIdByFileName = getCheckpointIdByFileName(fileName);
+            if (pipelineId.equals(getPipelineIdByFileName(fileName))
+                    && checkpointIdList.contains(checkpointIdByFileName)) {
+                try {
+                    boolean deleted =
                             fs.delete(
                                     new Path(path + DEFAULT_CHECKPOINT_FILE_PATH_SPLIT + fileName),
                                     false);
-                        } catch (Exception e) {
-                            log.error(
-                                    "Failed to delete checkpoint {} for job {}, pipeline {}",
-                                    checkpointIdByFileName,
-                                    jobId,
-                                    pipelineId,
-                                    e);
-                        }
+                    if (!deleted) {
+                        throw new IOException("File system returned false");
                     }
-                });
+                } catch (Exception e) {
+                    throw new CheckpointStorageException(
+                            String.format(
+                                    "Failed to delete checkpoint %s for job %s, pipeline %s",
+                                    checkpointIdByFileName, jobId, pipelineId),
+                            e);
+                }
+            }
+        }
     }
 
     public List<String> getFileNames(String path) throws CheckpointStorageException {

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorageDeleteTest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/hdfs/HdfsStorageDeleteTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.seatunnel.engine.checkpoint.storage.hdfs;
+
+import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class HdfsStorageDeleteTest {
+
+    @Test
+    public void testBatchDeletePropagatesFailure() throws Exception {
+        HdfsStorage storage = Mockito.mock(HdfsStorage.class, Mockito.CALLS_REAL_METHODS);
+        storage.fs = Mockito.mock(FileSystem.class);
+        Mockito.doReturn(Collections.singletonList("1-1-1-1.ser"))
+                .when(storage)
+                .getFileNames(Mockito.anyString());
+        Mockito.when(storage.fs.delete(Mockito.any(Path.class), Mockito.eq(false)))
+                .thenReturn(false);
+
+        Assertions.assertThrows(
+                CheckpointStorageException.class,
+                () -> storage.deleteCheckpoint("1", "1", Collections.singletonList("1")));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-local-file/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/localfile/LocalFileStorage.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-local-file/src/main/java/org/apache/seatunnel/engine/checkpoint/storage/localfile/LocalFileStorage.java
@@ -371,23 +371,21 @@ public class LocalFileStorage extends AbstractCheckpointStorage {
             throw new CheckpointStorageException(
                     "No checkpoint found for job, job id is: " + jobId);
         }
-        fileList.forEach(
-                file -> {
-                    String fileName = file.getName();
-                    String checkpointIdByFileName = getCheckpointIdByFileName(fileName);
-                    if (pipelineId.equals(getPipelineIdByFileName(fileName))
-                            && checkpointIdList.contains(checkpointIdByFileName)) {
-                        try {
-                            FileUtils.delete(file);
-                        } catch (Exception e) {
-                            log.error(
-                                    "Failed to delete checkpoint {} for job {}, pipeline {}",
-                                    checkpointIdByFileName,
-                                    jobId,
-                                    pipelineId,
-                                    e);
-                        }
-                    }
-                });
+        for (File file : fileList) {
+            String fileName = file.getName();
+            String checkpointIdByFileName = getCheckpointIdByFileName(fileName);
+            if (pipelineId.equals(getPipelineIdByFileName(fileName))
+                    && checkpointIdList.contains(checkpointIdByFileName)) {
+                try {
+                    FileUtils.delete(file);
+                } catch (Exception e) {
+                    throw new CheckpointStorageException(
+                            String.format(
+                                    "Failed to delete checkpoint %s for job %s, pipeline %s",
+                                    checkpointIdByFileName, jobId, pipelineId),
+                            e);
+                }
+            }
+        }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-local-file/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/localfile/LocalFileStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-local-file/src/test/java/org/apache/seatunnel/engine/checkpoint/storage/localfile/LocalFileStorageTest.java
@@ -23,12 +23,19 @@ package org.apache.seatunnel.engine.checkpoint.storage.localfile;
 import org.apache.seatunnel.engine.checkpoint.storage.PipelineState;
 import org.apache.seatunnel.engine.checkpoint.storage.exception.CheckpointStorageException;
 
+import org.apache.commons.io.FileUtils;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.condition.OS.LINUX;
@@ -80,6 +87,29 @@ public class LocalFileStorageTest {
     public void testGetCheckpointsByJobIdAndPipelineId() throws CheckpointStorageException {
         List<PipelineState> state = STORAGE.getCheckpointsByJobIdAndPipelineId(JOB_ID, "1");
         Assertions.assertEquals(2, state.size());
+    }
+
+    @Test
+    public void testBatchDeletePropagatesFailure() throws Exception {
+        LocalFileStorage storage = new LocalFileStorage(null);
+        File checkpointFile = new File("1-1-1-1.ser");
+        try (MockedStatic<FileUtils> fileUtils = Mockito.mockStatic(FileUtils.class)) {
+            fileUtils
+                    .when(
+                            () ->
+                                    FileUtils.listFiles(
+                                            Mockito.any(File.class),
+                                            Mockito.any(String[].class),
+                                            Mockito.eq(false)))
+                    .thenReturn(Collections.singletonList(checkpointFile));
+            fileUtils
+                    .when(() -> FileUtils.delete(Mockito.any(File.class)))
+                    .thenThrow(new IOException("delete failed"));
+
+            Assertions.assertThrows(
+                    CheckpointStorageException.class,
+                    () -> storage.deleteCheckpoint("1", "1", Collections.singletonList("1")));
+        }
     }
 
     @AfterAll


### PR DESCRIPTION
### Purpose of this pull request

Fixes #12094.

`CheckpointCoordinator` previously rebuilt `completedCheckpointIds` as an empty queue after an active-master failover. Checkpoints written by earlier coordinator instances were therefore invisible to retention cleanup and could accumulate beyond `checkpoint.storage.max-retained`.

This patch:

- rebuilds the durable checkpoint retention queue for the current job and pipeline when a running coordinator is recreated;
- sorts storage enumeration results by checkpoint ID before selecting the oldest files;
- enforces the configured maximum after recovery and after every subsequent durable checkpoint;
- keeps explicit checkpoint restores to a different destination job isolated from the source job's retention state;
- makes LocalFile and HDFS batch deletion failures observable while keeping retention cleanup best-effort at the coordinator layer, so cleanup failures do not fail checkpoint completion or active-master recovery and remain eligible for retry.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, a running Zeta job could retain more checkpoint files than `checkpoint.storage.max-retained` after one or more active-master failovers. After this change, the coordinator restores the existing checkpoint IDs and removes the oldest files until the configured bound is satisfied. A transient cleanup failure is logged and retried after the next completed checkpoint without interrupting the job.

### How was this patch tested?

Added regression tests covering:

- unordered checkpoint enumeration and exact cleanup during active-master coordinator recreation;
- exact retention on the next completed checkpoint;
- isolation when restoring from a different source job;
- cleanup failure not interrupting coordinator recreation or checkpoint completion, with retry on the next checkpoint;
- LocalFile delete exceptions and HDFS `FileSystem.delete` returning `false`.

Formatting verification completed successfully:

```shell
./mvnw -nsu -pl seatunnel-engine/seatunnel-engine-server,seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-local-file,seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs -am spotless:apply
./mvnw -nsu -pl seatunnel-engine/seatunnel-engine-server,seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-local-file,seatunnel-engine/seatunnel-engine-storage/checkpoint-storage-plugins/checkpoint-storage-hdfs -am spotless:check
```

Functional tests are delegated to GitHub CI and were not executed locally.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation changes are not required because no configuration or public API changes.
* [x] `incompatible-changes.md` changes are not required because the patch restores the documented retention behavior.
* [x] This PR does not change connector code.
