### PR TITLE
[Test][E2E] Document healthy-pipeline cascade-cancel on sibling failure

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/ClusterFaultToleranceTwoPipelineIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/ClusterFaultToleranceTwoPipelineIT.java
@@ -28,7 +28,12 @@ import org.apache.seatunnel.engine.common.config.ConfigProvider;
 import org.apache.seatunnel.engine.common.config.JobConfig;
 import org.apache.seatunnel.engine.common.config.SeaTunnelConfig;
 import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
 import org.apache.seatunnel.engine.server.SeaTunnelServerStarter;
+import org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan;
+import org.apache.seatunnel.engine.server.dag.physical.SubPlan;
+import org.apache.seatunnel.engine.server.master.JobMaster;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
@@ -44,6 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +65,14 @@ public class ClusterFaultToleranceTwoPipelineIT {
 
     public static final String TEST_TEMPLATE_FILE_NAME =
             "cluster_batch_fake_to_localfile_two_pipeline_template.conf";
+
+    /**
+     * Two independent pipelines: table_healthy is an ordinary bounded FakeSource -> LocalFile
+     * pipeline, table_doomed's Assert sink always throws so its pipeline permanently fails. Used by
+     * {@link #testOneUnrecoverablePipelineForceCancelsHealthySiblingPipeline()}.
+     */
+    public static final String ONE_PIPELINE_PERMANENTLY_FAILED_TEMPLATE_FILE_NAME =
+            "cluster_batch_one_pipeline_permanently_failed_template.conf";
 
     public static final String DYNAMIC_TEST_CASE_NAME = "dynamic_test_case_name";
 
@@ -794,5 +808,180 @@ public class ClusterFaultToleranceTwoPipelineIT {
                 node2.shutdown();
             }
         }
+    }
+
+    /**
+     * Documents PhysicalPlan's current, hardcoded cascade-cancel behavior: {@code
+     * PhysicalPlan#makeJobEndWhenPipelineEnded} is unconditionally {@code true} (no config or
+     * setter exists for it), so the moment ANY pipeline in a multi-pipeline job exhausts its
+     * restore budget ({@code SubPlan#canRestorePipeline}, gated by {@code job.retry.times}) and
+     * reaches a terminal {@link PipelineStatus#FAILED}, {@code PhysicalPlan#addPipelineEndCallback}
+     * unconditionally calls {@code updateJobState(JobStatus.FAILING)}. That job-level transition's
+     * {@code stateProcess()} then calls {@code jobMaster.neverNeedRestore()} followed by {@code
+     * SubPlan#cancelPipeline} on every pipeline of the job, including ones that never touched the
+     * failure and are still healthily RUNNING.
+     *
+     * <p>This is a documentation-of-current-behavior test, not a regression test for a fix: nothing
+     * in the engine today isolates one pipeline's terminal failure from its siblings, so this test
+     * intentionally PASSES by observing the cascade happen exactly as coded. If a future change
+     * makes pipeline failures isolated (for example by making {@code makeJobEndWhenPipelineEnded}
+     * configurable or conditional), this test will start failing and must be revisited deliberately
+     * instead of silently.
+     *
+     * <p>The job submitted here has two independent pipelines built from {@link
+     * #ONE_PIPELINE_PERMANENTLY_FAILED_TEMPLATE_FILE_NAME}: table_healthy is an ordinary bounded
+     * FakeSource -> LocalFile pipeline that is paced (via {@code split.read-interval}) to still be
+     * RUNNING for tens of seconds, and table_doomed's Assert sink always throws on its first row,
+     * so it permanently fails and exhausts its (deliberately small, explicit) {@code
+     * job.retry.times} restore budget within a few seconds. A single embedded node is enough here,
+     * unlike the sibling tests in this class: this test targets {@code PhysicalPlan}'s
+     * pipeline-level cascade logic, not cross-node fault tolerance, and {@code
+     * slot-service.dynamic-slot} (see seatunnel.yaml) lets one node run both pipelines concurrently
+     * without resource contention.
+     */
+    @Test
+    public void testOneUnrecoverablePipelineForceCancelsHealthySiblingPipeline() throws Exception {
+        String testCaseName = "testOneUnrecoverablePipelineForceCancelsHealthySiblingPipeline";
+        String testClusterName = "ClusterFaultToleranceTwoPipelineIT_" + testCaseName;
+        long testRowNumber = 500;
+        int testParallelism = 2;
+
+        HazelcastInstanceImpl node = null;
+        SeaTunnelClient engineClient = null;
+
+        SeaTunnelConfig seaTunnelConfig = ConfigProvider.locateAndGetSeaTunnelConfig();
+        seaTunnelConfig
+                .getHazelcastConfig()
+                .setClusterName(TestUtils.getClusterName(testClusterName));
+        seaTunnelConfig.getEngineConfig().getHttpConfig().setEnabled(false);
+
+        try {
+            node = SeaTunnelServerStarter.createHazelcastInstance(seaTunnelConfig);
+
+            Common.setDeployMode(DeployMode.CLIENT);
+            ImmutablePair<String, String> testResources =
+                    createTestResources(
+                            testCaseName,
+                            JobMode.BATCH,
+                            testRowNumber,
+                            testParallelism,
+                            ONE_PIPELINE_PERMANENTLY_FAILED_TEMPLATE_FILE_NAME);
+            JobConfig jobConfig = new JobConfig();
+            jobConfig.setName(testCaseName);
+
+            ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            clientConfig.setClusterName(TestUtils.getClusterName(testClusterName));
+            engineClient = new SeaTunnelClient(clientConfig);
+            ClientJobExecutionEnvironment jobExecutionEnv =
+                    engineClient.createExecutionContext(
+                            testResources.getRight(), jobConfig, seaTunnelConfig);
+            ClientJobProxy clientJobProxy = jobExecutionEnv.execute();
+            long jobId = clientJobProxy.getJobId();
+
+            Awaitility.await()
+                    .atMost(60, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            JobStatus.RUNNING, clientJobProxy.getJobStatus()));
+
+            // Resolve the physical plan now, while the job is confirmedly RUNNING, and keep this
+            // reference for the post-completion assertions below instead of re-resolving it via
+            // CoordinatorService#getJobMaster(jobId) after the job ends. SubPlan#getPipelineState
+            // reads a volatile field on the SubPlan instance itself, so holding this reference is
+            // race-free; re-resolving after completion would not be. The client observing
+            // completion (via the waitForJobComplete RPC round trip below) and the server
+            // forgetting the job (CoordinatorService#runningJobMasterMap.remove, in JobMaster#run's
+            // finally block, once JobMaster#jobMasterCompleteFuture completes) are both triggered
+            // by the same completion event with no ordering guarantee between them, so
+            // getJobMaster(jobId) can already return null by the time a caller reacts to job
+            // completion.
+            PhysicalPlan physicalPlan = getPhysicalPlan(node, jobId);
+            Assertions.assertNotNull(
+                    physicalPlan, "Physical plan should be reachable while RUNNING");
+            List<SubPlan> pipelines = physicalPlan.getPipelineList();
+            Assertions.assertEquals(2, pipelines.size(), "Job should have exactly two pipelines");
+
+            CompletableFuture<JobStatus> jobCompleteFuture =
+                    CompletableFuture.supplyAsync(clientJobProxy::waitForJobComplete);
+
+            // job.retry.times=2 and job.retry.interval.seconds=1 in the template bound table_
+            // doomed to 3 attempts (1 original + 2 restores) and 2 one-second sleeps between
+            // them; each attempt fails instantly on the Assert sink's first row. 120s is a
+            // generous bound even on a heavily loaded machine.
+            Awaitility.await()
+                    .atMost(120, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertTrue(jobCompleteFuture.isDone());
+                                // Documents today's actual, hardcoded outcome: the job ends
+                                // FAILED, not a partial success, even though one of its two
+                                // pipelines was healthy and would otherwise have finished on its
+                                // own.
+                                Assertions.assertEquals(JobStatus.FAILED, jobCompleteFuture.get());
+                            });
+
+            SubPlan doomedPipeline =
+                    pipelines.stream()
+                            .filter(p -> p.getPipelineState() == PipelineStatus.FAILED)
+                            .findFirst()
+                            .orElseThrow(
+                                    () ->
+                                            new AssertionError(
+                                                    "Expected exactly one pipeline (table_doomed) to end FAILED"));
+            SubPlan healthyPipeline =
+                    pipelines.stream()
+                            .filter(p -> p != doomedPipeline)
+                            .findFirst()
+                            .orElseThrow(
+                                    () ->
+                                            new AssertionError(
+                                                    "Expected a second pipeline (table_healthy)"));
+
+            // This is the crux of the documented behavior: the healthy pipeline never reached its
+            // own natural FINISHED state. PhysicalPlan#stateProcess (case FAILING/CANCELING)
+            // force-cancelled it purely as a side effect of the sibling pipeline's failure.
+            // SubPlan#cancelPipeline() is a no-op on an already-terminal pipeline, so seeing
+            // CANCELED here (rather than FINISHED) also proves it had not already finished on its
+            // own before the cascade reached it.
+            Assertions.assertEquals(
+                    PipelineStatus.CANCELED,
+                    healthyPipeline.getPipelineState(),
+                    "Healthy pipeline should have been force-cancelled by the doomed sibling's cascade, not left to finish");
+
+            // Corroborate from the data plane: the healthy pipeline's transactional LocalFile
+            // sink only commits when the pipeline reaches its own natural completion. No periodic
+            // checkpoint fires within this test's runtime (the cluster default checkpoint.interval
+            // is 300s, see seatunnel.yaml), so a force-cancel before that point commits nothing,
+            // and the committed line count must stay below the full expected total.
+            long healthyPipelineLineCount =
+                    FileUtils.getFileLineNumberFromDir(testResources.getLeft());
+            Assertions.assertTrue(
+                    healthyPipelineLineCount < testRowNumber * testParallelism,
+                    "Healthy pipeline output should be incomplete because it was cancelled before "
+                            + "it could finish, but found "
+                            + healthyPipelineLineCount
+                            + " lines");
+        } finally {
+            if (engineClient != null) {
+                engineClient.close();
+            }
+
+            if (node != null) {
+                node.shutdown();
+            }
+        }
+    }
+
+    /**
+     * Reads the current job master's physical plan from the SeaTunnel server embedded in the given
+     * Hazelcast instance, so a test can inspect per-pipeline state directly rather than only the
+     * aggregate job-level status.
+     */
+    private static PhysicalPlan getPhysicalPlan(HazelcastInstanceImpl node, long jobId) {
+        SeaTunnelServer server = node.node.getNodeEngine().getService(SeaTunnelServer.SERVICE_NAME);
+        JobMaster jobMaster = server.getCoordinatorService().getJobMaster(jobId);
+        return jobMaster == null ? null : jobMaster.getPhysicalPlan();
     }
 }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/cluster_batch_one_pipeline_permanently_failed_template.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/cluster_batch_one_pipeline_permanently_failed_template.conf
@@ -1,0 +1,104 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+######
+###### Batch template with two independent pipelines. table_healthy is an ordinary bounded
+###### FakeSource -> LocalFile pipeline that would finish normally on its own. table_doomed's
+###### Assert sink always throws on its very first row (rule_type = MAX_LENGTH with rule_value = 0
+###### on a string field whose generated length is always greater than 0), so its pipeline
+###### permanently fails and exhausts job.retry.times. This is used to document PhysicalPlan's
+###### current, hardcoded makeJobEndWhenPipelineEnded=true cascade: one pipeline exhausting its
+###### restore budget force-cancels every OTHER pipeline in the same job, healthy or not.
+######
+
+env {
+  job.mode = "BATCH"
+  # Deliberately small and explicit here (the engine default is 3 retries / 3 seconds, see
+  # EnvCommonOptions#JOB_RETRY_TIMES / JOB_RETRY_INTERVAL_SECONDS) purely so table_doomed exhausts
+  # its restore budget quickly and predictably. The cascade mechanism under test
+  # (PhysicalPlan#makeJobEndWhenPipelineEnded) is hardcoded and does not depend on these values.
+  job.retry.times = 2
+  job.retry.interval.seconds = 1
+}
+
+source {
+  FakeSource {
+    plugin_output = table_healthy
+    row.num = ${dynamic_test_row_num_per_parallelism}
+    # split.num/split.read-interval pace this source so it is still RUNNING for tens of seconds,
+    # comfortably longer than table_doomed needs to exhaust its restore budget above.
+    split.num = 10
+    split.read-interval = 3000
+    parallelism = ${dynamic_test_parallelism}
+    schema = {
+      fields {
+        c_int = int
+        c_string = string
+      }
+    }
+  }
+
+  FakeSource {
+    plugin_output = table_doomed
+    row.num = 1
+    split.num = 1
+    parallelism = 1
+    # Fixed, non-zero generated string length so the Assert sink's MAX_LENGTH = 0 rule below is
+    # guaranteed to fail on every row.
+    string.length = 5
+    schema = {
+      fields {
+        c_int = int
+        c_string = string
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    plugin_input = table_healthy
+    path = "/tmp/hive/warehouse/${dynamic_test_case_name}" # dynamic_test_case_name will be replace to the final file name before test run
+    field_delimiter = "\t"
+    row_delimiter = "\n"
+    file_name_expression = "${transactionId}_${now}"
+    file_format_type = "text"
+    filename_time_format = "yyyy.MM.dd"
+    is_enable_transaction = true
+    save_mode = "error"
+  }
+
+  Assert {
+    plugin_input = table_doomed
+    rules = {
+      field_rules = [
+        {
+          field_name = "c_string"
+          field_type = "string"
+          # c_string is always generated at string.length = 5 characters (FakeSource has no way
+          # to generate an empty string here), so a MAX_LENGTH = 0 rule fails on every single row,
+          # on every restore attempt, deterministically.
+          field_value = [
+            { rule_type = MAX_LENGTH, rule_value = 0 }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Part of the Zeta-engine-core E2E test initiative, Tier 2: coverage for verified-fragile current architecture that has no existing test coverage today. Unlike Tier 1 (#12027-#12035, #12095, #12098), which guards past incident fixes, this test documents today's actual, verified behavior so an unintentional future change to it is caught deliberately instead of silently.

## Verified finding

`PhysicalPlan#makeJobEndWhenPipelineEnded` is hardcoded `true` with no config binding or setter:

```java
/** Whether we make the job end when pipeline turn to end state. */
private boolean makeJobEndWhenPipelineEnded = true;
```

`PhysicalPlan#addPipelineEndCallback` uses it unconditionally: the moment ANY pipeline in a multi-pipeline job exhausts its restore budget (`SubPlan#canRestorePipeline`, gated by `job.retry.times`, default 3) and reaches terminal `FAILED`, it calls `updateJobState(JobStatus.FAILING)`. That job-level transition's `stateProcess()` then calls `jobMaster.neverNeedRestore()` followed by `SubPlan#cancelPipeline` on **every** pipeline in the job - including ones that never touched the failure and were still healthily `RUNNING` toward their own success.

## What the test does

Adds `testOneUnrecoverablePipelineForceCancelsHealthySiblingPipeline` to `ClusterFaultToleranceTwoPipelineIT`, backed by a new template `cluster_batch_one_pipeline_permanently_failed_template.conf`:

- `table_healthy`: an ordinary bounded FakeSource -> LocalFile pipeline, paced via `split.read-interval` to stay `RUNNING` for tens of seconds.
- `table_doomed`: a FakeSource -> Assert pipeline whose Assert sink rule (`MAX_LENGTH = 0` against a non-empty generated string) fails deterministically on every row, so it permanently fails and exhausts a deliberately small `job.retry.times = 2` (3 attempts total) within a few seconds.

Assertions:
- the job ends `FAILED` overall (not a partial success);
- the doomed pipeline's own terminal state is `FAILED`;
- **the crux of the documented behavior**: the healthy pipeline's terminal state is `CANCELED`, not `FINISHED` - it never reached its own natural completion and was force-cancelled purely as a side effect of its sibling's failure;
- corroborated from the data plane: the healthy pipeline's transactional LocalFile sink commits strictly fewer rows than the full expected total, since a force-cancel before its own completion (and before any checkpoint interval elapses) commits nothing.

Per-pipeline state is read from a `PhysicalPlan`/`SubPlan` reference resolved once the job is confirmed `RUNNING` (while the job master is definitely still registered) and held for the rest of the test, rather than re-resolved through `CoordinatorService#getJobMaster(jobId)` after the job ends - the latter races the client observing job completion against the coordinator's own executor thread forgetting the completed job (`runningJobMasterMap.remove`), both triggered by the same completion event with no ordering guarantee between them.

This test intentionally **passes** today by observing the cascade happen exactly as coded. If a future change makes pipeline failures isolated (for example by making `makeJobEndWhenPipelineEnded` configurable or conditional), this test will start failing and must be revisited deliberately.

## Test plan

- `./mvnw spotless:apply -pl seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base -am -nsu` - passed, no outstanding formatting diffs.
- `./mvnw install -pl 'seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base,!seatunnel-engine/seatunnel-engine-ui' -am -nsu -Dmaven.gitcommitid.skip=true -DskipTests -Dspotless.check.skip=true -T 3C` - `BUILD SUCCESS`; confirmed the new test method actually compiled (not just skipped) by inspecting the resulting `.class` file's bytecode (`javap -p`) for `testOneUnrecoverablePipelineForceCancelsHealthySiblingPipeline` and its helper `getPhysicalPlan`.
- Test-only change: no `src/main/**` files touched.

CI will run the new test; no local execution was performed for this PR (per this fork's local-verification policy for the Apache SeaTunnel repo, local runs are limited to build/format checks and GitHub CI is authoritative for actual test execution).