### PR TITLE
[Improve][Core] Add JSON config validation output

### DIFF
--- a/docs/en/engines/zeta/user-command.md
+++ b/docs/en/engines/zeta/user-command.md
@@ -29,6 +29,7 @@ Usage: seatunnel.sh [options]
     -d, --dry-run                               Validate or preview without running sinks. Supported modes: [static, connect, sample].
     -m, --master, -e, --deploy-mode             SeaTunnel job submit master, support [local, cluster] (default: cluster).
     --encrypt                                   Encrypt the config file. When both --decrypt and --encrypt are specified, only --encrypt will take effect (default: false).
+    --format                                    Validation output format. Supported values: [text, json] (default: text).
     --get_running_job_metrics                   Get metrics for running jobs (default: false).
     -h, --help                                  Show the usage message.
     -j, --job-id                                Get the job status by JobId.
@@ -69,6 +70,12 @@ sh bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --d
 ```
 
 The `--dry-run static` (or `--check`) option validates the configuration file **without submitting a job** (for example HOCON/YAML syntax, plugin loadability, DAG topology, missing required options, and unknown connector keys). It does not run the full data pipeline. Plugin loading may read local JARs, so this is offline validation of the configuration file, not a strict zero-I/O sandbox.
+
+For machine-readable validation, add `--format json` to `--check`, `--dry-run static`, or `--dry-run connect`. The JSON document is written to standard output on both success and validation failure; a failed validation still exits with a non-zero status.
+
+```shell
+sh bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --check --format json
+```
 
 ```shell
 sh bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --dry-run connect

--- a/docs/en/engines/zeta/user-command.md
+++ b/docs/en/engines/zeta/user-command.md
@@ -71,7 +71,7 @@ sh bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --d
 
 The `--dry-run static` (or `--check`) option validates the configuration file **without submitting a job** (for example HOCON/YAML syntax, plugin loadability, DAG topology, missing required options, and unknown connector keys). It does not run the full data pipeline. Plugin loading may read local JARs, so this is offline validation of the configuration file, not a strict zero-I/O sandbox.
 
-For machine-readable validation, add `--format json` to `--check`, `--dry-run static`, or `--dry-run connect`. The JSON document is written to standard output on both success and validation failure; a failed validation still exits with a non-zero status.
+For machine-readable validation, add `--format json` to `--check`, `--dry-run static`, or `--dry-run connect`. The validation result is written to standard output on both success and validation failure; a failed validation still exits with a non-zero status. Existing diagnostic messages from the validation path may also be written to standard output, so callers should select the result line as the machine-readable record.
 
 The JSON contract contains `schemaVersion`, `valid`, `phase` (`static` or `connectivity`), and `errors`. Each entry in `errors` has `location`, `plugin`, `optionPath`, `ruleCategory`, and a sanitized `message`; unavailable fields are `null`.
 

--- a/docs/en/engines/zeta/user-command.md
+++ b/docs/en/engines/zeta/user-command.md
@@ -73,6 +73,8 @@ The `--dry-run static` (or `--check`) option validates the configuration file **
 
 For machine-readable validation, add `--format json` to `--check`, `--dry-run static`, or `--dry-run connect`. The JSON document is written to standard output on both success and validation failure; a failed validation still exits with a non-zero status.
 
+The JSON contract contains `schemaVersion`, `valid`, `phase` (`static` or `connectivity`), and `errors`. Each entry in `errors` has `location`, `plugin`, `optionPath`, `ruleCategory`, and a sanitized `message`; unavailable fields are `null`.
+
 ```shell
 sh bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --check --format json
 ```

--- a/docs/zh/engines/zeta/user-command.md
+++ b/docs/zh/engines/zeta/user-command.md
@@ -40,6 +40,7 @@ Usage: seatunnel.sh [options]
                                               and --encrypt are specified, only
                                               --encrypt will take effect (default:
                                               false)
+    --format                                  校验输出格式。支持：[text, json]（默认：text）
     --get_running_job_metrics                 Gets metrics for running jobs (default:
                                               false)
     -h, --help                                Show the usage message
@@ -85,6 +86,12 @@ bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --dry-
 ```
 
 使用 `--dry-run static`（或者 `--check`）参数可以在**不提交作业**的前提下静态校验配置文件（包括 HOCON/YAML 语法、插件可加载性、DAG 拓扑、必填项与未知配置键等）。它不会执行完整的数据管道。插件加载可能读取本地 JAR，因此这是配置文件的离线校验，不是严格的零 I/O 沙箱。
+
+需要机器可读的校验结果时，可在 `--check`、`--dry-run static` 或 `--dry-run connect` 后添加 `--format json`。无论校验成功还是失败，JSON 文档都会写入标准输出；校验失败仍会以非零状态码退出。
+
+```shell
+bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --check --format json
+```
 
 ```shell
 bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --dry-run connect

--- a/docs/zh/engines/zeta/user-command.md
+++ b/docs/zh/engines/zeta/user-command.md
@@ -89,6 +89,8 @@ bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --dry-
 
 需要机器可读的校验结果时，可在 `--check`、`--dry-run static` 或 `--dry-run connect` 后添加 `--format json`。无论校验成功还是失败，JSON 文档都会写入标准输出；校验失败仍会以非零状态码退出。
 
+JSON 契约包含 `schemaVersion`、`valid`、`phase`（`static` 或 `connectivity`）和 `errors`。`errors` 的每一项包含 `location`、`plugin`、`optionPath`、`ruleCategory` 与已脱敏的 `message`；无法提供的字段为 `null`。
+
 ```shell
 bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --check --format json
 ```

--- a/docs/zh/engines/zeta/user-command.md
+++ b/docs/zh/engines/zeta/user-command.md
@@ -87,7 +87,7 @@ bin/seatunnel.sh --config $SEATUNNEL_HOME/config/v2.batch.config.template --dry-
 
 使用 `--dry-run static`（或者 `--check`）参数可以在**不提交作业**的前提下静态校验配置文件（包括 HOCON/YAML 语法、插件可加载性、DAG 拓扑、必填项与未知配置键等）。它不会执行完整的数据管道。插件加载可能读取本地 JAR，因此这是配置文件的离线校验，不是严格的零 I/O 沙箱。
 
-需要机器可读的校验结果时，可在 `--check`、`--dry-run static` 或 `--dry-run connect` 后添加 `--format json`。无论校验成功还是失败，JSON 文档都会写入标准输出；校验失败仍会以非零状态码退出。
+需要机器可读的校验结果时，可在 `--check`、`--dry-run static` 或 `--dry-run connect` 后添加 `--format json`。无论校验成功还是失败，校验结果都会写入标准输出；校验失败仍会以非零状态码退出。校验路径中已有的诊断信息也可能写入标准输出，调用方应从输出中选取结果行作为机器可读记录。
 
 JSON 契约包含 `schemaVersion`、`valid`、`phase`（`static` 或 `connectivity`）和 `errors`。`errors` 的每一项包含 `location`、`plugin`、`optionPath`、`ruleCategory` 与已脱敏的 `message`；无法提供的字段为 `null`。
 

--- a/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/validation/ConfigValidationResultTest.java
+++ b/seatunnel-core/seatunnel-core-starter/src/test/java/org/apache/seatunnel/core/starter/validation/ConfigValidationResultTest.java
@@ -63,4 +63,20 @@ public class ConfigValidationResultTest {
                         .at("/errors/0/ruleCategory")
                         .asText());
     }
+
+    @Test
+    void escapesSpecialCharactersInErrorMessages() throws Exception {
+        String message = "Invalid value: \"quoted\"\nnext line\tcontrol";
+        ConfigValidationResult result =
+                ConfigValidationResult.failure(
+                        "static",
+                        new ConfigValidationError(null, null, null, "validation", message));
+
+        Assertions.assertEquals(
+                message,
+                JsonUtils.readTree(
+                                result.toJson().getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                        .at("/errors/0/message")
+                        .asText());
+    }
 }

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/enums/OutputFormat.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/enums/OutputFormat.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.enums;
+
+public enum OutputFormat {
+    TEXT,
+    JSON
+}

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgs.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgs.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.core.starter.command.ConfDecryptCommand;
 import org.apache.seatunnel.core.starter.command.ConfEncryptCommand;
 import org.apache.seatunnel.core.starter.enums.DryRun;
 import org.apache.seatunnel.core.starter.enums.MasterType;
+import org.apache.seatunnel.core.starter.enums.OutputFormat;
 import org.apache.seatunnel.core.starter.seatunnel.command.ClientExecuteCommand;
 import org.apache.seatunnel.core.starter.seatunnel.command.SeaTunnelConfValidateCommand;
 import org.apache.seatunnel.engine.common.config.DryRunSampleConfig;
@@ -50,6 +51,12 @@ public class ClientCommandArgs extends AbstractCommandArgs {
                     "Validate or preview without running sinks. Supported modes: [static, connect, sample].",
             converter = DryRunConverter.class)
     protected DryRun dryRun = null;
+
+    @Parameter(
+            names = {"--format"},
+            description = "Validation output format. Supported values: [text, json].",
+            converter = OutputFormatConverter.class)
+    private OutputFormat outputFormat = OutputFormat.TEXT;
 
     @Parameter(
             names = {"--sample-limit"},
@@ -249,6 +256,24 @@ public class ClientCommandArgs extends AbstractCommandArgs {
         }
     }
 
+    public static class OutputFormatConverter implements IStringConverter<OutputFormat> {
+        @Override
+        public OutputFormat convert(String value) {
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException("Output format must not be empty.");
+            }
+            try {
+                return OutputFormat.valueOf(value.trim().toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        "Unsupported output format '"
+                                + value
+                                + "'. Currently only [text, json] are supported.",
+                        e);
+            }
+        }
+    }
+
     /** Returns the configured sample limit, or the default limit when it was not specified. */
     public int getSampleLimit() {
         return sampleLimit == null ? DryRunSampleConfig.DEFAULT_LIMIT : sampleLimit;
@@ -257,6 +282,11 @@ public class ClientCommandArgs extends AbstractCommandArgs {
     /** Validates options that depend on other command-line arguments. */
     public void validateCommandOptions() {
         validateSampleOptions();
+        if (outputFormat == OutputFormat.JSON
+                && (!checkConfig && dryRun == null || dryRun == DryRun.SAMPLE)) {
+            throw new ParameterException(
+                    "--format json requires --check, --dry-run static, or --dry-run connect.");
+        }
         if (dryRun == DryRun.SAMPLE) {
             validateSampleMode();
         }

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgs.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgs.java
@@ -283,7 +283,7 @@ public class ClientCommandArgs extends AbstractCommandArgs {
     public void validateCommandOptions() {
         validateSampleOptions();
         if (outputFormat == OutputFormat.JSON
-                && (!checkConfig && dryRun == null || dryRun == DryRun.SAMPLE)) {
+                && ((!checkConfig && dryRun == null) || dryRun == DryRun.SAMPLE)) {
             throw new ParameterException(
                     "--format json requires --check, --dry-run static, or --dry-run connect.");
         }

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommand.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommand.java
@@ -35,6 +35,7 @@ import org.apache.seatunnel.common.constants.PluginType;
 import org.apache.seatunnel.common.utils.DryRunConnectFailureMessageSanitizer;
 import org.apache.seatunnel.core.starter.command.Command;
 import org.apache.seatunnel.core.starter.enums.DryRun;
+import org.apache.seatunnel.core.starter.enums.OutputFormat;
 import org.apache.seatunnel.core.starter.exception.ConfigCheckException;
 import org.apache.seatunnel.core.starter.seatunnel.args.ClientCommandArgs;
 import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
@@ -101,9 +102,8 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
 
     @Override
     public void execute() throws ConfigCheckException {
-        Path configPath = FileUtils.getConfigPath(clientCommandArgs);
-
         try {
+            Path configPath = FileUtils.getConfigPath(clientCommandArgs);
             Config config = ConfigBuilder.of(configPath, clientCommandArgs.getVariables());
 
             if (config.hasPath("env")) {
@@ -183,6 +183,8 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
                         .validate();
             }
 
+            printJsonResultIfRequested(ConfigValidationResult.success(validationPhase()));
+
         } catch (Exception e) {
             String validationMode =
                     clientCommandArgs.getDryRun() == DryRun.CONNECT
@@ -191,9 +193,28 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
             String message = e.getMessage();
             if (clientCommandArgs.getDryRun() == DryRun.CONNECT) {
                 message = DryRunConnectFailureMessageSanitizer.sanitize(message);
+                printJsonResultIfRequested(
+                        ConfigValidationResult.failure(
+                                validationPhase(),
+                                toValidationError(
+                                        message == null ? "Validation failed" : message)));
                 throw new ConfigCheckException(validationMode + " failed: " + message);
             }
+            String sanitizedMessage = DryRunConnectFailureMessageSanitizer.sanitize(message);
+            printJsonResultIfRequested(
+                    ConfigValidationResult.failure(
+                            validationPhase(),
+                            toValidationError(
+                                    sanitizedMessage == null
+                                            ? "Validation failed"
+                                            : sanitizedMessage)));
             throw new ConfigCheckException(validationMode + " failed: " + message, e);
+        }
+    }
+
+    private void printJsonResultIfRequested(ConfigValidationResult result) {
+        if (clientCommandArgs.getOutputFormat() == OutputFormat.JSON) {
+            System.out.println(result.toJson());
         }
     }
 

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommand.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommand.java
@@ -208,7 +208,7 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
                                     sanitizedMessage == null
                                             ? "Validation failed"
                                             : sanitizedMessage)));
-            throw new ConfigCheckException(validationMode + " failed: " + message, e);
+            throw new ConfigCheckException(validationMode + " failed: " + sanitizedMessage, e);
         }
     }
 

--- a/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommand.java
+++ b/seatunnel-core/seatunnel-starter/src/main/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommand.java
@@ -102,6 +102,7 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
 
     @Override
     public void execute() throws ConfigCheckException {
+        ConfigValidationResult successResult;
         try {
             Path configPath = FileUtils.getConfigPath(clientCommandArgs);
             Config config = ConfigBuilder.of(configPath, clientCommandArgs.getVariables());
@@ -183,7 +184,7 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
                         .validate();
             }
 
-            printJsonResultIfRequested(ConfigValidationResult.success(validationPhase()));
+            successResult = ConfigValidationResult.success(validationPhase());
 
         } catch (Exception e) {
             String validationMode =
@@ -210,6 +211,9 @@ public class SeaTunnelConfValidateCommand implements Command<ClientCommandArgs> 
                                             : sanitizedMessage)));
             throw new ConfigCheckException(validationMode + " failed: " + sanitizedMessage, e);
         }
+        // Keep serialization outside the validation try/catch so an output failure
+        // cannot be reported as a configuration-validation failure.
+        printJsonResultIfRequested(successResult);
     }
 
     private void printJsonResultIfRequested(ConfigValidationResult result) {

--- a/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgsTest.java
+++ b/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/args/ClientCommandArgsTest.java
@@ -81,6 +81,29 @@ public class ClientCommandArgsTest {
     }
 
     @Test
+    public void testJsonFormatRequiresValidationCommand() {
+        ClientCommandArgs args =
+                CommandLineUtils.parse(
+                        new String[] {"-c", "app.conf", "--format", "json"},
+                        new ClientCommandArgs(),
+                        "seatunnel-client",
+                        true);
+        Assertions.assertThrows(com.beust.jcommander.ParameterException.class, args::buildCommand);
+    }
+
+    @Test
+    public void testJsonFormatIsAcceptedForCheck() {
+        ClientCommandArgs args =
+                CommandLineUtils.parse(
+                        new String[] {"-c", "app.conf", "--check", "--format", "json"},
+                        new ClientCommandArgs(),
+                        "seatunnel-client",
+                        true);
+        Assertions.assertEquals(
+                org.apache.seatunnel.core.starter.enums.OutputFormat.JSON, args.getOutputFormat());
+    }
+
+    @Test
     public void testConnectDryRunParam() {
         String[] args = {"-c", "app.conf", "--dry-run", "connect"};
         ClientCommandArgs clientCommandArgs =

--- a/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommandTest.java
+++ b/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommandTest.java
@@ -40,6 +40,8 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
+
 public class SeaTunnelConfValidateCommandTest {
 
     @Test
@@ -60,6 +62,45 @@ public class SeaTunnelConfValidateCommandTest {
         Assertions.assertTrue(result.isValid());
         Assertions.assertEquals("static", result.getPhase());
         Assertions.assertTrue(result.getErrors().isEmpty());
+    }
+
+    @Test
+    public void testJsonOutputForSuccessfulValidation() throws Exception {
+        SeaTunnelConfValidateCommand command =
+                new SeaTunnelConfValidateCommand(buildJsonArgs("config/valid_static_dryrun.json"));
+
+        String output = tapSystemOutNormalized(command::execute);
+
+        Assertions.assertTrue(output.contains("\"valid\":true"), output);
+        Assertions.assertTrue(output.contains("\"phase\":\"static\""), output);
+        Assertions.assertTrue(output.contains("\"errors\":[]"), output);
+    }
+
+    @Test
+    public void testJsonOutputForFailedValidationRetainsFailure() throws Exception {
+        SeaTunnelConfValidateCommand command =
+                new SeaTunnelConfValidateCommand(
+                        buildJsonArgs("config/invalid_dryrun_missing_required.json"));
+
+        String output =
+                tapSystemOutNormalized(
+                        () ->
+                                Assertions.assertThrows(
+                                        ConfigCheckException.class, command::execute));
+
+        Assertions.assertTrue(output.contains("\"valid\":false"), output);
+        Assertions.assertTrue(output.contains("\"phase\":\"static\""), output);
+        Assertions.assertTrue(output.contains("\"errors\":[{"), output);
+    }
+
+    @Test
+    public void testDefaultOutputDoesNotEmitJson() throws Exception {
+        SeaTunnelConfValidateCommand command =
+                new SeaTunnelConfValidateCommand(buildArgs("config/valid_static_dryrun.json"));
+
+        String output = tapSystemOutNormalized(command::execute);
+
+        Assertions.assertFalse(output.contains("\"schemaVersion\""), output);
     }
 
     @Test
@@ -607,6 +648,13 @@ public class SeaTunnelConfValidateCommandTest {
 
     private ClientCommandArgs buildArgsFromPath(String configPath) {
         String[] args = {"-c", configPath, "--dry-run", "static"};
+        return CommandLineUtils.parse(args, new ClientCommandArgs(), "seatunnel.sh", true);
+    }
+
+    private ClientCommandArgs buildJsonArgs(String configFile) {
+        String[] args = {
+            "-c", resolveConfigPath(configFile), "--dry-run", "static", "--format", "json"
+        };
         return CommandLineUtils.parse(args, new ClientCommandArgs(), "seatunnel.sh", true);
     }
 

--- a/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommandTest.java
+++ b/seatunnel-core/seatunnel-starter/src/test/java/org/apache/seatunnel/core/starter/seatunnel/command/SeaTunnelConfValidateCommandTest.java
@@ -94,6 +94,33 @@ public class SeaTunnelConfValidateCommandTest {
     }
 
     @Test
+    public void testJsonStaticFailureSanitizesThrownException() throws Exception {
+        Path configFile = Files.createTempFile("seatunnel-static-sensitive-failure", ".json");
+        Files.write(
+                configFile,
+                ("{\n"
+                                + "  \"env\": {\"parallelism\": 1, \"job.mode\": \"BATCH\"},\n"
+                                + "  \"source\": [{\"plugin_name\": "
+                                + "\"jdbc:mysql://alice:secret-password@db.example.com:3306/orders\", "
+                                + "\"plugin_output\": \"fake\"}],\n"
+                                + "  \"sink\": [{\"plugin_name\": \"Console\", "
+                                + "\"plugin_input\": \"fake\"}]\n"
+                                + "}")
+                        .getBytes(StandardCharsets.UTF_8));
+        configFile.toFile().deleteOnExit();
+
+        SeaTunnelConfValidateCommand command =
+                new SeaTunnelConfValidateCommand(buildJsonArgsFromPath(configFile.toString()));
+        ConfigCheckException exception =
+                Assertions.assertThrows(ConfigCheckException.class, command::execute);
+
+        Assertions.assertFalse(
+                exception.getMessage().contains("secret-password"), exception.getMessage());
+        Assertions.assertTrue(
+                exception.getMessage().contains("the configured JDBC URL"), exception.getMessage());
+    }
+
+    @Test
     public void testDefaultOutputDoesNotEmitJson() throws Exception {
         SeaTunnelConfValidateCommand command =
                 new SeaTunnelConfValidateCommand(buildArgs("config/valid_static_dryrun.json"));
@@ -655,6 +682,11 @@ public class SeaTunnelConfValidateCommandTest {
         String[] args = {
             "-c", resolveConfigPath(configFile), "--dry-run", "static", "--format", "json"
         };
+        return CommandLineUtils.parse(args, new ClientCommandArgs(), "seatunnel.sh", true);
+    }
+
+    private ClientCommandArgs buildJsonArgsFromPath(String configPath) {
+        String[] args = {"-c", configPath, "--dry-run", "static", "--format", "json"};
         return CommandLineUtils.parse(args, new ClientCommandArgs(), "seatunnel.sh", true);
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in structured output mode for the existing CLI configuration-validation commands:

```bash
seatunnel.sh --config config.conf --check --format json
```

`--format json` is supported for `--check`, `--dry-run static`, and `--dry-run connect`. It emits a versioned validation result to stdout for both successful and failed validation. Failed validation continues to use the established non-zero process exit path.

## Compatibility

- Existing default text output is unchanged.
- JSON mode is rejected for job execution and `--dry-run sample`.
- Failure messages are sanitized before being serialized.

## Tests

- Added parser coverage for accepted and rejected format combinations.
- Added stdout coverage for successful JSON output, failed JSON output, and the default non-JSON mode.
- `./mvnw spotless:apply -pl seatunnel-core/seatunnel-starter -DskipTests` passes.
- The focused Maven test command currently stops during baseline test compilation because `MultiTableSinkTest` cannot resolve the repository E2E InMemory test artifacts; the failure occurs before the new tests run. Main-source compilation and the prerequisite core-starter install were verified locally.