### PR TITLE
[Test][E2E] Add regression coverage for WAIT-strategy head-of-line blocking

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterPendingJobLifecycleFailoverIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SplitClusterPendingJobLifecycleFailoverIT.java
@@ -60,6 +60,8 @@ import java.util.concurrent.TimeUnit;
 
 public class SplitClusterPendingJobLifecycleFailoverIT {
     private static final String JOB_CONFIG_FILE = "pending_jobs_streaming_lifecycle.conf";
+    private static final String UNSCHEDULABLE_JOB_CONFIG_FILE =
+            "pending_jobs_streaming_unschedulable.conf";
 
     @Test
     public void testPendingJobLifecycleInMasterFailover() {
@@ -252,6 +254,150 @@ public class SplitClusterPendingJobLifecycleFailoverIT {
 
             pendingJob.cancelJob();
             assertEventuallyCanceled(pendingJob);
+        } finally {
+            if (engineClient != null) {
+                engineClient.close();
+            }
+            if (masterNode != null) {
+                masterNode.shutdown();
+            }
+            if (workerNode != null) {
+                workerNode.shutdown();
+            }
+        }
+    }
+
+    /**
+     * Verifies the current (as of this writing) head-of-line blocking behavior of {@code
+     * CoordinatorService#pendingJobSchedule} under {@link ScheduleStrategy#WAIT}: a job whose
+     * resource request can never be satisfied is retried at the queue head forever, and every job
+     * submitted after it -- however trivially schedulable -- is starved for as long as the stuck
+     * head job remains queued.
+     *
+     * <p>{@code pendingJobSchedule} is driven by a single long-lived scheduler thread per master
+     * epoch (see {@code CoordinatorService#startPendingJobScheduleThread}), so under normal
+     * single-master operation (no failover, i.e. no epoch transition) there is never more than one
+     * thread calling {@code reservePendingJobInfo}/{@code releasePendingJobInfo} at a time. Because
+     * {@code releasePendingJobInfo} always runs before the scheduler loop peeks again, {@code
+     * schedulingPendingJobIds} is empty at the start of every peek, so {@link
+     * org.apache.seatunnel.engine.server.utils.PeekBlockingQueue#peekBlocking(java.util.function.Predicate)}
+     * always matches the FIFO head. Under {@code WAIT}, a failed resource pre-check does not
+     * dequeue the head job (unlike {@code REJECT}, which fails and removes it); it just sleeps 3
+     * seconds and retries the same head job next iteration, uncapped -- {@code
+     * PendingJobInfo#checkTimes} is tracked only for diagnostics, never compared against a limit. A
+     * later, easily-schedulable job is never even peeked while the head remains queued.
+     *
+     * <p>This is the same area of code touched by <a
+     * href="https://github.com/apache/seatunnel/pull/11653">#11653</a> ("[Fix][Zeta] Avoid
+     * duplicate pending job scheduling after failover"), which introduced {@code
+     * reservePendingJobInfo}/{@code releasePendingJobInfo} and the predicate-based peek precisely
+     * so a second scheduler generation started after a master flip can skip a head job already
+     * reserved by a stale, still-in-flight generation, avoiding duplicate dispatch. That predicate
+     * only ever excludes a job id present in {@code schedulingPendingJobIds}, which is populated
+     * solely to mark "another concurrent scheduler thread is mid-evaluation of this job id" -- it
+     * is not, and was never intended to be, a "this job already failed its resource check" marker.
+     * {@code clearCoordinatorService} also unconditionally drains the entire queue and bumps the
+     * epoch on every step-down, so two scheduler generations can only ever coexist transiently
+     * around a real master activation/deactivation. Outside that narrow failover window -- which is
+     * exactly the steady-state single-master scenario this test drives -- the mechanism never
+     * triggers, so it does not change the outcome verified here: head-of-line blocking under {@code
+     * WAIT} is still fully reproducible on current {@code dev}.
+     *
+     * <p>The test proves job B was schedulable the entire time -- not merely slow -- by cancelling
+     * the stuck head job (job A) and observing job B reach {@code RUNNING} promptly immediately
+     * afterward, with no other change to cluster resources.
+     */
+    @Test
+    public void testPermanentlyStuckWaitJobBlocksSchedulableJobBehindIt() {
+        String testClusterName =
+                "SplitClusterPendingJobLifecycleFailoverIT_"
+                        + "testPermanentlyStuckWaitJobBlocksSchedulableJobBehindIt";
+        HazelcastInstanceImpl masterNode = null;
+        HazelcastInstanceImpl workerNode = null;
+        SeaTunnelClient engineClient = null;
+        ClientJobProxy neverSchedulableJob = null;
+        ClientJobProxy schedulableJob = null;
+
+        SeaTunnelConfig masterNodeConfig = getSeaTunnelConfig(testClusterName);
+        SeaTunnelConfig workerNodeConfig = getSeaTunnelConfig(testClusterName);
+        configurePendingLifecycleTest(masterNodeConfig);
+        configurePendingLifecycleTest(workerNodeConfig);
+
+        try {
+            masterNode = SeaTunnelServerStarter.createMasterHazelcastInstance(masterNodeConfig);
+            workerNode = SeaTunnelServerStarter.createWorkerHazelcastInstance(workerNodeConfig);
+
+            HazelcastInstanceImpl finalMasterNode = masterNode;
+            Awaitility.await()
+                    .atMost(10, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            2, finalMasterNode.getCluster().getMembers().size()));
+
+            Common.setDeployMode(DeployMode.CLUSTER);
+            ClientConfig clientConfig = ConfigProvider.locateAndGetClientConfig();
+            clientConfig.setClusterName(TestUtils.getClusterName(testClusterName));
+            engineClient = new SeaTunnelClient(clientConfig);
+
+            HazelcastInstanceImpl activeMaster = waitAndFindActiveMaster(masterNode, null);
+            assertPendingQueueState(activeMaster, null, 0);
+
+            // Job A requests 999-way parallelism against a 4-slot, dynamicSlot=false cluster (see
+            // configurePendingLifecycleTest): a shortfall no worker count this suite ever
+            // provisions can close, so its resource pre-check can never succeed, not even
+            // transiently.
+            neverSchedulableJob =
+                    submitJob(
+                            engineClient,
+                            masterNodeConfig,
+                            "hol_blocking_never_schedulable_job",
+                            TestUtils.getResource(UNSCHEDULABLE_JOB_CONFIG_FILE));
+            long neverSchedulableJobId = neverSchedulableJob.getJobId();
+            assertJobStatusWithTimeout(neverSchedulableJob, JobStatus.PENDING, 60);
+            assertPendingQueueState(activeMaster, neverSchedulableJobId, 1);
+
+            // Job B requests parallelism 2, comfortably inside the 4 free slots: job A never holds
+            // any slot (JobMaster#preApplyResources releases every partial grant back on failure),
+            // so the cluster has full capacity available for job B the moment it is submitted.
+            schedulableJob =
+                    submitJob(
+                            engineClient,
+                            masterNodeConfig,
+                            "hol_blocking_schedulable_job",
+                            TestUtils.getResource(JOB_CONFIG_FILE));
+            long schedulableJobId = schedulableJob.getJobId();
+            assertJobStatusWithTimeout(schedulableJob, JobStatus.PENDING, 60);
+            assertPendingQueueContainsJob(activeMaster, schedulableJobId, 2);
+
+            // Current architecture: the scheduler only ever evaluates the queue head, so job B
+            // stays behind the permanently-stuck job A for as long as A remains queued. Hold this
+            // over a stability window, not a single check, before concluding it is truly stuck
+            // rather than merely slow.
+            final ClientJobProxy finalSchedulableJob = schedulableJob;
+            Awaitility.await()
+                    .during(10, TimeUnit.SECONDS)
+                    .atMost(20, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> {
+                                Assertions.assertEquals(
+                                        JobStatus.PENDING,
+                                        finalSchedulableJob.getJobStatus(),
+                                        "Job B must still be head-of-line blocked by the "
+                                                + "permanently stuck job A");
+                                assertPendingQueueContainsJob(activeMaster, schedulableJobId, 2);
+                            });
+
+            // Remove the stuck head job. If job B was truly schedulable all along -- and not
+            // itself resource-starved -- it must now reach RUNNING quickly with no other change to
+            // cluster resources.
+            neverSchedulableJob.cancelJob();
+            assertEventuallyCanceled(neverSchedulableJob);
+            assertJobStatusWithTimeout(schedulableJob, JobStatus.RUNNING, 60);
+            assertPendingQueueNotContainsJob(activeMaster, schedulableJobId);
+
+            schedulableJob.cancelJob();
+            assertEventuallyCanceled(schedulableJob);
         } finally {
             if (engineClient != null) {
                 engineClient.close();

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/pending_jobs_streaming_unschedulable.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/pending_jobs_streaming_unschedulable.conf
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  job.mode = "STREAMING"
+}
+
+source {
+  FakeSource {
+    parallelism = 999
+    row.num = 1000000
+    split.read-interval = 100
+    schema = {
+      fields {
+        c_int = int
+      }
+    }
+  }
+}
+
+transform {
+}
+
+sink {
+  InMemory {
+    writer_sleep = true
+  }
+}


### PR DESCRIPTION
## Purpose

Adds E2E coverage documenting a verified, currently-open architectural gap:
under `ScheduleStrategy.WAIT`, `CoordinatorService#pendingJobSchedule`
retries a permanently-unschedulable head-of-queue job every ~3s forever,
uncapped, and never dequeues it. Since the single-threaded scheduler always
re-peeks the FIFO head, this starves every job submitted after it
indefinitely, even ones that are trivially schedulable with
currently-available resources.

This is not a regression test for a past fix — it's a test that documents
today's actual behavior precisely, so any future change to it is a
deliberate, visible diff rather than a silent one.

## Why this needed fresh verification, not just trusting an older analysis

This same area of code was previously touched by #11653 (already merged),
which added `reservePendingJobInfo`/`releasePendingJobInfo` (an
epoch-based reservation mechanism) and a predicate-based
`PeekBlockingQueue#peekBlocking`, specifically to stop a stale scheduler
generation from double-dispatching a job after a master failover.

I traced this mechanism against current `CoordinatorService.java` and
`PeekBlockingQueue.java` directly rather than assuming the older finding
still held: that reservation set only excludes a job id already reserved
by *another in-flight scheduler thread across overlapping generations*
during a master flip — it is not, and was never meant to be, a "this job
already failed its resource check" marker. In steady state (single
scheduler generation, no failover in progress), `schedulingPendingJobIds`
is empty at every peek, so the head job always matches and is returned
again. The head-of-line blocking is real and fully reproducible on
current `dev`.

## What the test does

`SplitClusterPendingJobLifecycleFailoverIT#testPermanentlyStuckWaitJobBlocksSchedulableJobBehindIt`:

1. Submits a job with unsatisfiable parallelism (999) under
   `ScheduleStrategy.WAIT` — it can never acquire enough slots.
2. Submits a second, easily-schedulable job right behind it.
3. Confirms the second job stays in `PENDING` for a sustained window
   (proving it isn't merely slow — it's genuinely blocked).
4. Cancels the stuck first job and confirms the second job reaches
   `RUNNING` promptly, with no other change to cluster resources —
   proving it was schedulable the entire time.

## Test plan

- New test method + one new minimal test-resource config; no production
  code changed.
- `./mvnw spotless:apply` on the affected module — succeeded.
- `./mvnw install -DskipTests` (module + dependency chain,
  `seatunnel-engine-ui` excluded since unmodified) — confirmed genuine
  compilation via the actual `.class` file present under
  `target/test-classes` with `javap -p` showing the new test method and
  constant in the compiled bytecode (not run with
  `-Dmaven.test.skip=true`, which skips test compilation entirely rather
  than just execution).
- Full test execution is left to CI per this repository's E2E conventions
  (Hazelcast-cluster-backed, not run in this sandbox).