### PR TITLE
[Test][E2E] Add savepoint restore ITs covering parallelism rescale (scale-up and scale-down)

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/AbstractSavepointRescaleIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/AbstractSavepointRescaleIT.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.e2e;
+
+import org.apache.seatunnel.common.utils.FileUtils;
+import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
+import org.apache.seatunnel.engine.server.rest.RestConstant;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.Container;
+import org.testcontainers.utility.MountableFile;
+
+import io.restassured.common.mapper.TypeRef;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.LongPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
+
+/**
+ * Shared machinery for savepoint-restore ITs that change parallelism across the restore boundary,
+ * extracted from the near-identical bodies of {@link SavepointRestoreScaleUpIT} (2 -&gt; 4) and
+ * {@link SavepointRestoreScaleDownIT} (4 -&gt; 2) so the REST-polling helpers,
+ * offset-reconciliation assertions, and container plugin setup are defined exactly once instead of
+ * drifting between two hand-maintained copies.
+ *
+ * <p>Both directions exercise the modulo-based per-task state remap in {@code
+ * CheckpointCoordinator#restoreTaskState} with a genuinely different old/new parallelism pair -
+ * every other checkpoint/savepoint restore IT in this package (e.g. {@link
+ * CheckpointRestoreWithStopIT}, {@link SavepointRestoreIT}) restores at the SAME parallelism the
+ * checkpoint was taken at, so that remap's {@code currentParallelism !=
+ * actionState.getParallelism()} branch is never exercised end-to-end anywhere else.
+ *
+ * <p>Rigor mirrors {@link SavepointRestoreIT}: exact offset reconciliation (no loss, no
+ * duplication) across the savepoint boundary. In addition, this verifies the RESTORED job's actual
+ * physical task count via the {@code /trace/task-mapping} REST endpoint (backed by the live {@code
+ * JobMaster#getPhysicalPlan()}, the same white-box source of truth used elsewhere in this test
+ * family), rather than trusting that the configured parallelism was applied.
+ *
+ * <p>Subclasses supply the conf file pair, the original/restored parallelism, and a distinct sink
+ * output directory via the abstract hook methods below, and invoke {@link
+ * #verifySavepointRestoreWithRescale()} from their own {@code @Test} method so each retains its own
+ * JUnit test name.
+ */
+public abstract class AbstractSavepointRescaleIT extends SeaTunnelEngineContainer {
+
+    private static final String HOST = "http://localhost:";
+
+    /**
+     * Relative test-resource path to the conf submitted at {@link #originalParallelism()}, before
+     * the savepoint is taken.
+     */
+    protected abstract String originalConfFile();
+
+    /**
+     * Relative test-resource path to the conf used to restore the job at {@link
+     * #restoredParallelism()}, after the savepoint is taken.
+     */
+    protected abstract String restoreConfFile();
+
+    /**
+     * Host-mounted sink output directory for this test, scoped uniquely per subclass so the two
+     * rescale directions never read or clean up each other's output files.
+     */
+    protected abstract String sinkOutputDir();
+
+    /**
+     * Parallelism the original run is submitted and savepointed at. Must match {@code
+     * env.parallelism} in {@link #originalConfFile()}.
+     */
+    protected abstract int originalParallelism();
+
+    /**
+     * Parallelism the restore run is submitted at. Must match {@code env.parallelism} in {@link
+     * #restoreConfFile()}.
+     */
+    protected abstract int restoredParallelism();
+
+    /**
+     * Expected signed delta in physical task count between the original and restored runs.
+     *
+     * <p>The source and the sink are the only two parallelism-scaled actions in this pipeline (no
+     * transform stage), so every regular (non-coordinator) physical vertex list changes by exactly
+     * one task per action per unit of parallelism change - hence the factor of 2. The sign follows
+     * {@link #restoredParallelism()} minus {@link #originalParallelism()}, so this is positive for
+     * scale-up and negative for scale-down. Coordinator-type vertices (the source split enumerator,
+     * the sink aggregated committer) are singletons that never scale with parallelism, so they
+     * cancel out of this delta regardless of their exact count.
+     */
+    protected long expectedTaskCountDelta() {
+        return 2L * (restoredParallelism() - originalParallelism());
+    }
+
+    @Override
+    @BeforeAll
+    public void startUp() throws Exception {
+        super.startUp();
+        copyRescaleTestPluginsToContainer();
+    }
+
+    /**
+     * Runs the full savepoint-then-rescale-restore verification flow shared by {@link
+     * SavepointRestoreScaleUpIT} and {@link SavepointRestoreScaleDownIT}: submits a job at {@link
+     * #originalParallelism()}, waits for a completed checkpoint, takes a savepoint, restores the
+     * job at {@link #restoredParallelism()}, then asserts that (a) the restored job's live physical
+     * task count reflects the new parallelism, (b) execution resumes strictly after the savepoint
+     * boundary with no gap, and (c) no offset is observed more than once end-to-end (exactly-once).
+     * Concrete subclasses call this from their own {@code @Test} method so each keeps its own
+     * distinct JUnit test name.
+     */
+    protected void verifySavepointRestoreWithRescale()
+            throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
+        FileUtils.createNewDir(sinkOutputDir());
+        try {
+            long jobId = JobIdGenerator.newJobId();
+            CompletableFuture<Container.ExecResult> sourceJobFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return executeJob(originalConfFile(), String.valueOf(jobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(jobId, "RUNNING");
+            awaitCompletedCheckpoint(jobId);
+            // A completed checkpoint requires every subtask of every parallel instance to have
+            // acknowledged the barrier, so it is safe to treat the task count observed here as
+            // the fully-deployed baseline for the original parallelism.
+            long taskCountBeforeRestore =
+                    awaitTaskItemCount(
+                            jobId,
+                            count -> count > 0,
+                            "Expected at least one deployed task before restore");
+
+            Container.ExecResult savepointResult = savepointJob(String.valueOf(jobId));
+            Assertions.assertEquals(0, savepointResult.getExitCode(), savepointResult.getStderr());
+            awaitJobStatus(jobId, "SAVEPOINT_DONE");
+
+            List<Long> offsetsBeforeRestore = readObservedOffsets();
+            long maxOffsetBeforeRestore = getMaxOffset(offsetsBeforeRestore);
+            Assertions.assertFalse(
+                    offsetsBeforeRestore.isEmpty(), "Expected committed offsets before restore");
+            Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
+
+            CompletableFuture<Container.ExecResult> restoreFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return restoreJob(restoreConfFile(), String.valueOf(jobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(jobId, "RUNNING");
+            long expectedTaskCountAfterRestore = taskCountBeforeRestore + expectedTaskCountDelta();
+            awaitTaskItemCount(
+                    jobId,
+                    count -> count == expectedTaskCountAfterRestore,
+                    "Expected restored job's physical task count ("
+                            + taskCountBeforeRestore
+                            + " -> "
+                            + expectedTaskCountAfterRestore
+                            + ") to reflect the new parallelism ("
+                            + originalParallelism()
+                            + " -> "
+                            + restoredParallelism()
+                            + ")");
+            assertRestoreContinuesAfterBoundary(offsetsBeforeRestore, maxOffsetBeforeRestore);
+            assertNoOffsetDuplicates();
+
+            stopJob(String.valueOf(jobId));
+            awaitJobStatus(jobId, "CANCELED");
+            Container.ExecResult restoreResult = restoreFuture.get();
+            Assertions.assertEquals(0, restoreResult.getExitCode(), restoreResult.getStderr());
+        } finally {
+            FileUtils.deleteFile(sinkOutputDir());
+        }
+    }
+
+    /**
+     * Polls the job's REST-reported status until it equals {@code expectedStatus}, failing the test
+     * if the status has not converged within the timeout.
+     */
+    private void awaitJobStatus(long jobId, String expectedStatus) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        expectedStatus, getJobStatus(String.valueOf(jobId))));
+    }
+
+    /**
+     * Blocks until the job has completed at least one checkpoint, so callers can rely on a
+     * fully-acknowledged baseline (e.g. before reading the pre-restore physical task count).
+     */
+    private void awaitCompletedCheckpoint(long jobId) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> Assertions.assertTrue(getCompletedCheckpointCount(jobId) > 0));
+    }
+
+    /**
+     * Copies the test-only {@code CheckpointableSequenceSource} plugin jar and its plugin-mapping
+     * descriptor into the container so the rescale conf files can resolve it, reusing the same
+     * checkpoint-restore-with-stop mapping file that {@link SavepointRestoreIT} already relies on
+     * instead of duplicating it per test directory.
+     */
+    private void copyRescaleTestPluginsToContainer() throws IOException {
+        URL url =
+                FileUtils.searchJarFiles(
+                                Paths.get(
+                                        PROJECT_ROOT_PATH,
+                                        "seatunnel-e2e",
+                                        "seatunnel-e2e-common",
+                                        "target"))
+                        .stream()
+                        .filter(jar -> jar.toString().endsWith("-tests.jar"))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Could not locate seatunnel-e2e-common test jar"));
+        server.copyFileToContainer(
+                MountableFile.forHostPath(Paths.get(url.getFile())),
+                Paths.get(
+                                SEATUNNEL_HOME,
+                                "connectors",
+                                Paths.get(url.getFile()).getFileName().toString())
+                        .toString());
+        // Reuse the checkpoint-restore-with-stop plugin mapping: it resolves the same test-only
+        // CheckpointableSequenceSource used here, and SavepointRestoreIT already establishes the
+        // precedent of sharing this file rather than duplicating it per directory.
+        server.copyFileToContainer(
+                MountableFile.forHostPath(
+                        Paths.get(
+                                PROJECT_ROOT_PATH,
+                                "seatunnel-e2e",
+                                "seatunnel-engine-e2e",
+                                "connector-seatunnel-e2e-base",
+                                "src",
+                                "test",
+                                "resources",
+                                "checkpoint-restore-with-stop",
+                                "plugin-mapping.properties")),
+                Paths.get(SEATUNNEL_HOME, "connectors", "plugin-mapping.properties").toString());
+    }
+
+    /**
+     * Waits until offsets are observed past {@code maxOffsetBeforeRestore}, then asserts the
+     * post-restore offset count equals the pre-restore count plus exactly the newly-observed
+     * offsets past that boundary. This only confirms the restored run continues without a gap in
+     * count; it does not by itself rule out replayed (duplicate) offsets - {@link
+     * #assertNoOffsetDuplicates()} is the complementary check that directly enforces exactly-once.
+     */
+    private void assertRestoreContinuesAfterBoundary(
+            List<Long> offsetsBeforeRestore, long maxOffsetBeforeRestore) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            List<Long> offsetsAfterRestore = readObservedOffsets();
+                            List<Long> restoredOffsets = new ArrayList<>();
+                            for (Long offset : offsetsAfterRestore) {
+                                if (offset > maxOffsetBeforeRestore) {
+                                    restoredOffsets.add(offset);
+                                }
+                            }
+
+                            Assertions.assertTrue(
+                                    !restoredOffsets.isEmpty(),
+                                    "Expected restored run to continue from savepoint boundary "
+                                            + maxOffsetBeforeRestore);
+
+                            Assertions.assertEquals(
+                                    offsetsBeforeRestore.size() + restoredOffsets.size(),
+                                    offsetsAfterRestore.size(),
+                                    "Expected restore to append only new offsets after savepoint boundary "
+                                            + maxOffsetBeforeRestore);
+                        });
+    }
+
+    /**
+     * Asserts that every offset written to the sink output directory (across the pre- and
+     * post-restore runs combined) was observed exactly once. A non-empty duplicate set indicates
+     * the restored run replayed data the original run had already committed, i.e. an exactly-once
+     * violation of the rescale-restore path.
+     */
+    private void assertNoOffsetDuplicates() {
+        Map<Long, Long> counts =
+                readObservedOffsets().stream()
+                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        List<Long> duplicates =
+                counts.entrySet().stream()
+                        .filter(entry -> entry.getValue() > 1)
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
+        Assertions.assertTrue(
+                duplicates.isEmpty(),
+                "Found duplicate offsets (exactly-once violated): " + duplicates);
+    }
+
+    private long getMaxOffset(List<Long> offsets) {
+        return offsets.stream().mapToLong(Long::longValue).max().orElse(-1L);
+    }
+
+    /**
+     * Reads every line written under {@link #sinkOutputDir()} across all sink output files and
+     * parses each as a {@code long} offset. Returns an empty list if the output directory does not
+     * exist yet (e.g. before the job has flushed its first record).
+     */
+    private List<Long> readObservedOffsets() {
+        Path outputDir = Paths.get(sinkOutputDir());
+        if (!Files.exists(outputDir)) {
+            return Collections.emptyList();
+        }
+        try (Stream<Path> paths = Files.walk(outputDir)) {
+            return paths.filter(Files::isRegularFile)
+                    .flatMap(
+                            path -> {
+                                try {
+                                    return Files.readAllLines(path).stream();
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .map(Long::parseLong)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long getCompletedCheckpointCount(long jobId) {
+        return getPipelineCounter(jobId, "completed");
+    }
+
+    /**
+     * Reads a single named counter (e.g. {@code "completed"}) from the first pipeline's {@code
+     * counts} object in the {@code /jobs/checkpoints} REST overview for {@code jobId}, returning 0
+     * if the job, its pipelines, or the requested counter are not yet present in the response.
+     */
+    private long getPipelineCounter(long jobId, String counterKey) {
+        Map<String, Object> overview =
+                given().get(
+                                getRestBaseUrl()
+                                        + RestConstant.REST_URL_CHECKPOINT_OVERVIEW
+                                        + "/"
+                                        + jobId)
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .as(new TypeRef<Map<String, Object>>() {});
+        List<Map<String, Object>> pipelines = castList(overview.get("pipelines"));
+        if (pipelines == null || pipelines.isEmpty()) {
+            return 0L;
+        }
+        Map<String, Object> counts = castMap(pipelines.get(0).get("counts"));
+        if (counts == null) {
+            return 0L;
+        }
+        Object counter = counts.get(counterKey);
+        return counter instanceof Number ? ((Number) counter).longValue() : 0L;
+    }
+
+    /**
+     * Polls the live physical task mapping for {@code jobId} until {@code condition} holds,
+     * returning the last observed count.
+     *
+     * <p>Awaitility's {@code untilAsserted} only retries on {@link AssertionError}, so the actual
+     * REST call is isolated in {@link #getTaskItemCount(long)} which translates any transport
+     * failure into an assertion failure instead of letting a checked/unchecked transport exception
+     * escape and abort the poll on the first attempt.
+     */
+    private long awaitTaskItemCount(long jobId, LongPredicate condition, String description) {
+        AtomicLong result = new AtomicLong();
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            long count = getTaskItemCount(jobId);
+                            Assertions.assertTrue(
+                                    condition.test(count),
+                                    description + " (actual physical task count=" + count + ")");
+                            result.set(count);
+                        });
+        return result.get();
+    }
+
+    /**
+     * Reads the live {@code /trace/task-mapping} REST endpoint (backed by {@code
+     * JobMaster#getPhysicalPlan()} on the active master) and counts how many physical tasks are
+     * currently deployed for {@code jobId}, across every pipeline, regular and coordinator vertex
+     * alike. This is a white-box count of the actually-running plan, not the submitted config.
+     *
+     * <p>Uses RestAssured's {@code JsonPath} extraction (rather than {@code .as(TypeRef)}) because
+     * this endpoint is served by the Hazelcast member's own text-command processor on port 5801 - a
+     * different REST stack than the port 8080 job-info/checkpoint-overview endpoints used elsewhere
+     * in this class - and {@code JsonPath} parses the body as JSON directly instead of relying on a
+     * possibly-absent/unrecognized Content-Type header to select a deserializer.
+     */
+    private long getTaskItemCount(long jobId) {
+        try {
+            List<?> items =
+                    given().get(
+                                    "http://localhost:"
+                                            + server.getMappedPort(5801)
+                                            + RestConstant.CONTEXT_PATH
+                                            + RestConstant.REST_URL_TRACE_TASK_MAPPING
+                                            + "/"
+                                            + jobId)
+                            .then()
+                            .statusCode(200)
+                            .extract()
+                            .response()
+                            .jsonPath()
+                            .getList("items");
+            return items == null ? 0L : items.size();
+        } catch (RuntimeException e) {
+            // Awaitility's untilAsserted only retries on AssertionError, so translate a
+            // transient REST-call failure (e.g. endpoint not ready yet) into a JUnit assertion
+            // failure instead of letting it escape unretried and abort the poll immediately.
+            throw new AssertionError("Failed to fetch task mapping for job " + jobId, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> castList(Object value) {
+        return (List<Map<String, Object>>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> castMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    private String getRestBaseUrl() {
+        return HOST + server.getMappedPort(8080);
+    }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleDownIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleDownIT.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.e2e;
+
+import org.apache.seatunnel.common.utils.FileUtils;
+import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
+import org.apache.seatunnel.engine.server.rest.RestConstant;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.utility.MountableFile;
+
+import io.restassured.common.mapper.TypeRef;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.LongPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
+
+/**
+ * Verifies that a savepoint taken at one parallelism can be restored at a LOWER parallelism
+ * (scale-down), exercising the modulo-based per-task state remap in {@code
+ * CheckpointCoordinator#restoreTaskState} with a genuinely different old/new parallelism pair.
+ *
+ * <p>Companion of {@link SavepointRestoreScaleUpIT}: that test covers scale-up (2 -> 4), this one
+ * covers scale-down (4 -> 2). The remap formula is asymmetric between the two directions - scaling
+ * down merges multiple old subtask indices' state onto every new instance (every new reader
+ * inherits {@code oldParallelism / newParallelism} old readers' state when evenly divisible),
+ * whereas scaling up leaves new instances whose index is {@code >=} the old parallelism with no
+ * inherited subtask state at all. Both directions must independently be proven safe (no data loss,
+ * no duplication), which is why this is a separate test rather than a parameterized variant.
+ *
+ * <p>Rigor mirrors {@link SavepointRestoreIT}: exact offset reconciliation (no loss, no
+ * duplication) across the savepoint boundary. In addition, this test verifies the RESTORED job's
+ * actual physical task count via the {@code /trace/task-mapping} REST endpoint (backed by the live
+ * {@code JobMaster#getPhysicalPlan()}, the same white-box source of truth used elsewhere in this
+ * test family), rather than trusting that the configured parallelism was applied.
+ */
+public class SavepointRestoreScaleDownIT extends SeaTunnelEngineContainer {
+
+    private static final String HOST = "http://localhost:";
+    private static final String ORIGINAL_CONF_FILE =
+            "/savepoint-restore-rescale/stream_p4_to_localfile_scaledown.conf";
+    private static final String RESTORE_CONF_FILE =
+            "/savepoint-restore-rescale/stream_p2_to_localfile_scaledown.conf";
+    private static final String SINK_OUTPUT_DIR =
+            HOST_VOLUME_MOUNT_PATH + "/savepoint-restore-rescale/scale-down/sinkfile";
+
+    // Must match env.parallelism in stream_p4_to_localfile_scaledown.conf.
+    private static final int ORIGINAL_PARALLELISM = 4;
+    // Must match env.parallelism in stream_p2_to_localfile_scaledown.conf.
+    private static final int RESTORED_PARALLELISM = 2;
+    // The source and the sink are the only two parallelism-scaled actions in this pipeline (no
+    // transform stage), so every regular (non-coordinator) physical vertex list shrinks by
+    // exactly one task per action per unit of parallelism decrease. Coordinator-type vertices (the
+    // source split enumerator, the sink aggregated committer) are singletons that never scale with
+    // parallelism, so they cancel out of this delta regardless of their exact count.
+    private static final long EXPECTED_TASK_COUNT_DELTA =
+            2L * (RESTORED_PARALLELISM - ORIGINAL_PARALLELISM);
+
+    @Override
+    @BeforeAll
+    public void startUp() throws Exception {
+        super.startUp();
+        copyRescaleTestPluginsToContainer();
+    }
+
+    @Test
+    public void testRestoreFromSavepointWithLowerParallelism()
+            throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
+        FileUtils.createNewDir(SINK_OUTPUT_DIR);
+        try {
+            long jobId = JobIdGenerator.newJobId();
+            CompletableFuture<Container.ExecResult> sourceJobFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return executeJob(ORIGINAL_CONF_FILE, String.valueOf(jobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(jobId, "RUNNING");
+            awaitCompletedCheckpoint(jobId);
+            // A completed checkpoint requires every subtask of every parallel instance to have
+            // acknowledged the barrier, so it is safe to treat the task count observed here as
+            // the fully-deployed baseline for the original parallelism.
+            long taskCountBeforeRestore =
+                    awaitTaskItemCount(
+                            jobId,
+                            count -> count > 0,
+                            "Expected at least one deployed task before restore");
+
+            Container.ExecResult savepointResult = savepointJob(String.valueOf(jobId));
+            Assertions.assertEquals(0, savepointResult.getExitCode(), savepointResult.getStderr());
+            awaitJobStatus(jobId, "SAVEPOINT_DONE");
+
+            List<Long> offsetsBeforeRestore = readObservedOffsets();
+            long maxOffsetBeforeRestore = getMaxOffset(offsetsBeforeRestore);
+            Assertions.assertFalse(
+                    offsetsBeforeRestore.isEmpty(), "Expected committed offsets before restore");
+            Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
+
+            CompletableFuture<Container.ExecResult> restoreFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return restoreJob(RESTORE_CONF_FILE, String.valueOf(jobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(jobId, "RUNNING");
+            long expectedTaskCountAfterRestore = taskCountBeforeRestore + EXPECTED_TASK_COUNT_DELTA;
+            awaitTaskItemCount(
+                    jobId,
+                    count -> count == expectedTaskCountAfterRestore,
+                    "Expected restored job's physical task count ("
+                            + taskCountBeforeRestore
+                            + " -> "
+                            + expectedTaskCountAfterRestore
+                            + ") to reflect the new parallelism ("
+                            + ORIGINAL_PARALLELISM
+                            + " -> "
+                            + RESTORED_PARALLELISM
+                            + ")");
+            assertRestoreContinuesAfterBoundary(offsetsBeforeRestore, maxOffsetBeforeRestore);
+            assertNoOffsetDuplicates();
+
+            stopJob(String.valueOf(jobId));
+            awaitJobStatus(jobId, "CANCELED");
+            Container.ExecResult restoreResult = restoreFuture.get();
+            Assertions.assertEquals(0, restoreResult.getExitCode(), restoreResult.getStderr());
+        } finally {
+            FileUtils.deleteFile(SINK_OUTPUT_DIR);
+        }
+    }
+
+    private void awaitJobStatus(long jobId, String expectedStatus) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        expectedStatus, getJobStatus(String.valueOf(jobId))));
+    }
+
+    private void awaitCompletedCheckpoint(long jobId) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> Assertions.assertTrue(getCompletedCheckpointCount(jobId) > 0));
+    }
+
+    private void copyRescaleTestPluginsToContainer() throws IOException {
+        URL url =
+                FileUtils.searchJarFiles(
+                                Paths.get(
+                                        PROJECT_ROOT_PATH,
+                                        "seatunnel-e2e",
+                                        "seatunnel-e2e-common",
+                                        "target"))
+                        .stream()
+                        .filter(jar -> jar.toString().endsWith("-tests.jar"))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Could not locate seatunnel-e2e-common test jar"));
+        server.copyFileToContainer(
+                MountableFile.forHostPath(Paths.get(url.getFile())),
+                Paths.get(
+                                SEATUNNEL_HOME,
+                                "connectors",
+                                Paths.get(url.getFile()).getFileName().toString())
+                        .toString());
+        // Reuse the checkpoint-restore-with-stop plugin mapping: it resolves the same test-only
+        // CheckpointableSequenceSource used here, and SavepointRestoreIT already establishes the
+        // precedent of sharing this file rather than duplicating it per directory.
+        server.copyFileToContainer(
+                MountableFile.forHostPath(
+                        Paths.get(
+                                PROJECT_ROOT_PATH,
+                                "seatunnel-e2e",
+                                "seatunnel-engine-e2e",
+                                "connector-seatunnel-e2e-base",
+                                "src",
+                                "test",
+                                "resources",
+                                "checkpoint-restore-with-stop",
+                                "plugin-mapping.properties")),
+                Paths.get(SEATUNNEL_HOME, "connectors", "plugin-mapping.properties").toString());
+    }
+
+    private void assertRestoreContinuesAfterBoundary(
+            List<Long> offsetsBeforeRestore, long maxOffsetBeforeRestore) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            List<Long> offsetsAfterRestore = readObservedOffsets();
+                            List<Long> restoredOffsets = new ArrayList<>();
+                            for (Long offset : offsetsAfterRestore) {
+                                if (offset > maxOffsetBeforeRestore) {
+                                    restoredOffsets.add(offset);
+                                }
+                            }
+
+                            Assertions.assertTrue(
+                                    !restoredOffsets.isEmpty(),
+                                    "Expected restored run to continue from savepoint boundary "
+                                            + maxOffsetBeforeRestore);
+
+                            Assertions.assertEquals(
+                                    offsetsBeforeRestore.size() + restoredOffsets.size(),
+                                    offsetsAfterRestore.size(),
+                                    "Expected restore to append only new offsets after savepoint boundary "
+                                            + maxOffsetBeforeRestore);
+                        });
+    }
+
+    private void assertNoOffsetDuplicates() {
+        Map<Long, Long> counts =
+                readObservedOffsets().stream()
+                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        List<Long> duplicates =
+                counts.entrySet().stream()
+                        .filter(entry -> entry.getValue() > 1)
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
+        Assertions.assertTrue(
+                duplicates.isEmpty(),
+                "Found duplicate offsets (exactly-once violated): " + duplicates);
+    }
+
+    private long getMaxOffset(List<Long> offsets) {
+        return offsets.stream().mapToLong(Long::longValue).max().orElse(-1L);
+    }
+
+    private List<Long> readObservedOffsets() {
+        Path outputDir = Paths.get(SINK_OUTPUT_DIR);
+        if (!Files.exists(outputDir)) {
+            return Collections.emptyList();
+        }
+        try (Stream<Path> paths = Files.walk(outputDir)) {
+            return paths.filter(Files::isRegularFile)
+                    .flatMap(
+                            path -> {
+                                try {
+                                    return Files.readAllLines(path).stream();
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .map(Long::parseLong)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long getCompletedCheckpointCount(long jobId) {
+        return getPipelineCounter(jobId, "completed");
+    }
+
+    private long getPipelineCounter(long jobId, String counterKey) {
+        Map<String, Object> overview =
+                given().get(
+                                getRestBaseUrl()
+                                        + RestConstant.REST_URL_CHECKPOINT_OVERVIEW
+                                        + "/"
+                                        + jobId)
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .as(new TypeRef<Map<String, Object>>() {});
+        List<Map<String, Object>> pipelines = castList(overview.get("pipelines"));
+        if (pipelines == null || pipelines.isEmpty()) {
+            return 0L;
+        }
+        Map<String, Object> counts = castMap(pipelines.get(0).get("counts"));
+        if (counts == null) {
+            return 0L;
+        }
+        Object counter = counts.get(counterKey);
+        return counter instanceof Number ? ((Number) counter).longValue() : 0L;
+    }
+
+    /**
+     * Polls the live physical task mapping for {@code jobId} until {@code condition} holds,
+     * returning the last observed count.
+     *
+     * <p>Awaitility's {@code untilAsserted} only retries on {@link AssertionError}, so the actual
+     * REST call is isolated in {@link #getTaskItemCount(long)} which translates any transport
+     * failure into an assertion failure instead of letting a checked/unchecked transport exception
+     * escape and abort the poll on the first attempt.
+     */
+    private long awaitTaskItemCount(long jobId, LongPredicate condition, String description) {
+        AtomicLong result = new AtomicLong();
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            long count = getTaskItemCount(jobId);
+                            Assertions.assertTrue(
+                                    condition.test(count),
+                                    description + " (actual physical task count=" + count + ")");
+                            result.set(count);
+                        });
+        return result.get();
+    }
+
+    /**
+     * Reads the live {@code /trace/task-mapping} REST endpoint (backed by {@code
+     * JobMaster#getPhysicalPlan()} on the active master) and counts how many physical tasks are
+     * currently deployed for {@code jobId}, across every pipeline, regular and coordinator vertex
+     * alike. This is a white-box count of the actually-running plan, not the submitted config.
+     *
+     * <p>Uses RestAssured's {@code JsonPath} extraction (rather than {@code .as(TypeRef)}) because
+     * this endpoint is served by the Hazelcast member's own text-command processor on port 5801 - a
+     * different REST stack than the port 8080 job-info/checkpoint-overview endpoints used elsewhere
+     * in this class - and {@code JsonPath} parses the body as JSON directly instead of relying on a
+     * possibly-absent/unrecognized Content-Type header to select a deserializer.
+     */
+    private long getTaskItemCount(long jobId) {
+        try {
+            List<?> items =
+                    given().get(
+                                    "http://localhost:"
+                                            + server.getMappedPort(5801)
+                                            + "/hazelcast/rest/maps/trace/task-mapping/"
+                                            + jobId)
+                            .then()
+                            .statusCode(200)
+                            .extract()
+                            .response()
+                            .jsonPath()
+                            .getList("items");
+            return items == null ? 0L : items.size();
+        } catch (RuntimeException e) {
+            // Awaitility's untilAsserted only retries on AssertionError, so translate a
+            // transient REST-call failure (e.g. endpoint not ready yet) into a JUnit assertion
+            // failure instead of letting it escape unretried and abort the poll immediately.
+            throw new AssertionError("Failed to fetch task mapping for job " + jobId, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> castList(Object value) {
+        return (List<Map<String, Object>>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> castMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    private String getRestBaseUrl() {
+        return HOST + server.getMappedPort(8080);
+    }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleDownIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleDownIT.java
@@ -17,38 +17,9 @@
 
 package org.apache.seatunnel.engine.e2e;
 
-import org.apache.seatunnel.common.utils.FileUtils;
-import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
-import org.apache.seatunnel.engine.server.rest.RestConstant;
-
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.Container;
-import org.testcontainers.utility.MountableFile;
-
-import io.restassured.common.mapper.TypeRef;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.function.LongPredicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static io.restassured.RestAssured.given;
-import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
 
 /**
  * Verifies that a savepoint taken at one parallelism can be restored at a LOWER parallelism
@@ -69,9 +40,8 @@ import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PA
  * {@code JobMaster#getPhysicalPlan()}, the same white-box source of truth used elsewhere in this
  * test family), rather than trusting that the configured parallelism was applied.
  */
-public class SavepointRestoreScaleDownIT extends SeaTunnelEngineContainer {
+public class SavepointRestoreScaleDownIT extends AbstractSavepointRescaleIT {
 
-    private static final String HOST = "http://localhost:";
     private static final String ORIGINAL_CONF_FILE =
             "/savepoint-restore-rescale/stream_p4_to_localfile_scaledown.conf";
     private static final String RESTORE_CONF_FILE =
@@ -83,315 +53,35 @@ public class SavepointRestoreScaleDownIT extends SeaTunnelEngineContainer {
     private static final int ORIGINAL_PARALLELISM = 4;
     // Must match env.parallelism in stream_p2_to_localfile_scaledown.conf.
     private static final int RESTORED_PARALLELISM = 2;
-    // The source and the sink are the only two parallelism-scaled actions in this pipeline (no
-    // transform stage), so every regular (non-coordinator) physical vertex list shrinks by
-    // exactly one task per action per unit of parallelism decrease. Coordinator-type vertices (the
-    // source split enumerator, the sink aggregated committer) are singletons that never scale with
-    // parallelism, so they cancel out of this delta regardless of their exact count.
-    private static final long EXPECTED_TASK_COUNT_DELTA =
-            2L * (RESTORED_PARALLELISM - ORIGINAL_PARALLELISM);
 
     @Override
-    @BeforeAll
-    public void startUp() throws Exception {
-        super.startUp();
-        copyRescaleTestPluginsToContainer();
+    protected String originalConfFile() {
+        return ORIGINAL_CONF_FILE;
+    }
+
+    @Override
+    protected String restoreConfFile() {
+        return RESTORE_CONF_FILE;
+    }
+
+    @Override
+    protected String sinkOutputDir() {
+        return SINK_OUTPUT_DIR;
+    }
+
+    @Override
+    protected int originalParallelism() {
+        return ORIGINAL_PARALLELISM;
+    }
+
+    @Override
+    protected int restoredParallelism() {
+        return RESTORED_PARALLELISM;
     }
 
     @Test
     public void testRestoreFromSavepointWithLowerParallelism()
             throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
-        FileUtils.createNewDir(SINK_OUTPUT_DIR);
-        try {
-            long jobId = JobIdGenerator.newJobId();
-            CompletableFuture<Container.ExecResult> sourceJobFuture =
-                    CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return executeJob(ORIGINAL_CONF_FILE, String.valueOf(jobId));
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-            awaitJobStatus(jobId, "RUNNING");
-            awaitCompletedCheckpoint(jobId);
-            // A completed checkpoint requires every subtask of every parallel instance to have
-            // acknowledged the barrier, so it is safe to treat the task count observed here as
-            // the fully-deployed baseline for the original parallelism.
-            long taskCountBeforeRestore =
-                    awaitTaskItemCount(
-                            jobId,
-                            count -> count > 0,
-                            "Expected at least one deployed task before restore");
-
-            Container.ExecResult savepointResult = savepointJob(String.valueOf(jobId));
-            Assertions.assertEquals(0, savepointResult.getExitCode(), savepointResult.getStderr());
-            awaitJobStatus(jobId, "SAVEPOINT_DONE");
-
-            List<Long> offsetsBeforeRestore = readObservedOffsets();
-            long maxOffsetBeforeRestore = getMaxOffset(offsetsBeforeRestore);
-            Assertions.assertFalse(
-                    offsetsBeforeRestore.isEmpty(), "Expected committed offsets before restore");
-            Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
-
-            CompletableFuture<Container.ExecResult> restoreFuture =
-                    CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return restoreJob(RESTORE_CONF_FILE, String.valueOf(jobId));
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-            awaitJobStatus(jobId, "RUNNING");
-            long expectedTaskCountAfterRestore = taskCountBeforeRestore + EXPECTED_TASK_COUNT_DELTA;
-            awaitTaskItemCount(
-                    jobId,
-                    count -> count == expectedTaskCountAfterRestore,
-                    "Expected restored job's physical task count ("
-                            + taskCountBeforeRestore
-                            + " -> "
-                            + expectedTaskCountAfterRestore
-                            + ") to reflect the new parallelism ("
-                            + ORIGINAL_PARALLELISM
-                            + " -> "
-                            + RESTORED_PARALLELISM
-                            + ")");
-            assertRestoreContinuesAfterBoundary(offsetsBeforeRestore, maxOffsetBeforeRestore);
-            assertNoOffsetDuplicates();
-
-            stopJob(String.valueOf(jobId));
-            awaitJobStatus(jobId, "CANCELED");
-            Container.ExecResult restoreResult = restoreFuture.get();
-            Assertions.assertEquals(0, restoreResult.getExitCode(), restoreResult.getStderr());
-        } finally {
-            FileUtils.deleteFile(SINK_OUTPUT_DIR);
-        }
-    }
-
-    private void awaitJobStatus(long jobId, String expectedStatus) {
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(
-                        () ->
-                                Assertions.assertEquals(
-                                        expectedStatus, getJobStatus(String.valueOf(jobId))));
-    }
-
-    private void awaitCompletedCheckpoint(long jobId) {
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(() -> Assertions.assertTrue(getCompletedCheckpointCount(jobId) > 0));
-    }
-
-    private void copyRescaleTestPluginsToContainer() throws IOException {
-        URL url =
-                FileUtils.searchJarFiles(
-                                Paths.get(
-                                        PROJECT_ROOT_PATH,
-                                        "seatunnel-e2e",
-                                        "seatunnel-e2e-common",
-                                        "target"))
-                        .stream()
-                        .filter(jar -> jar.toString().endsWith("-tests.jar"))
-                        .findFirst()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Could not locate seatunnel-e2e-common test jar"));
-        server.copyFileToContainer(
-                MountableFile.forHostPath(Paths.get(url.getFile())),
-                Paths.get(
-                                SEATUNNEL_HOME,
-                                "connectors",
-                                Paths.get(url.getFile()).getFileName().toString())
-                        .toString());
-        // Reuse the checkpoint-restore-with-stop plugin mapping: it resolves the same test-only
-        // CheckpointableSequenceSource used here, and SavepointRestoreIT already establishes the
-        // precedent of sharing this file rather than duplicating it per directory.
-        server.copyFileToContainer(
-                MountableFile.forHostPath(
-                        Paths.get(
-                                PROJECT_ROOT_PATH,
-                                "seatunnel-e2e",
-                                "seatunnel-engine-e2e",
-                                "connector-seatunnel-e2e-base",
-                                "src",
-                                "test",
-                                "resources",
-                                "checkpoint-restore-with-stop",
-                                "plugin-mapping.properties")),
-                Paths.get(SEATUNNEL_HOME, "connectors", "plugin-mapping.properties").toString());
-    }
-
-    private void assertRestoreContinuesAfterBoundary(
-            List<Long> offsetsBeforeRestore, long maxOffsetBeforeRestore) {
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(
-                        () -> {
-                            List<Long> offsetsAfterRestore = readObservedOffsets();
-                            List<Long> restoredOffsets = new ArrayList<>();
-                            for (Long offset : offsetsAfterRestore) {
-                                if (offset > maxOffsetBeforeRestore) {
-                                    restoredOffsets.add(offset);
-                                }
-                            }
-
-                            Assertions.assertTrue(
-                                    !restoredOffsets.isEmpty(),
-                                    "Expected restored run to continue from savepoint boundary "
-                                            + maxOffsetBeforeRestore);
-
-                            Assertions.assertEquals(
-                                    offsetsBeforeRestore.size() + restoredOffsets.size(),
-                                    offsetsAfterRestore.size(),
-                                    "Expected restore to append only new offsets after savepoint boundary "
-                                            + maxOffsetBeforeRestore);
-                        });
-    }
-
-    private void assertNoOffsetDuplicates() {
-        Map<Long, Long> counts =
-                readObservedOffsets().stream()
-                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        List<Long> duplicates =
-                counts.entrySet().stream()
-                        .filter(entry -> entry.getValue() > 1)
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.toList());
-        Assertions.assertTrue(
-                duplicates.isEmpty(),
-                "Found duplicate offsets (exactly-once violated): " + duplicates);
-    }
-
-    private long getMaxOffset(List<Long> offsets) {
-        return offsets.stream().mapToLong(Long::longValue).max().orElse(-1L);
-    }
-
-    private List<Long> readObservedOffsets() {
-        Path outputDir = Paths.get(SINK_OUTPUT_DIR);
-        if (!Files.exists(outputDir)) {
-            return Collections.emptyList();
-        }
-        try (Stream<Path> paths = Files.walk(outputDir)) {
-            return paths.filter(Files::isRegularFile)
-                    .flatMap(
-                            path -> {
-                                try {
-                                    return Files.readAllLines(path).stream();
-                                } catch (IOException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            })
-                    .map(String::trim)
-                    .filter(line -> !line.isEmpty())
-                    .map(Long::parseLong)
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private long getCompletedCheckpointCount(long jobId) {
-        return getPipelineCounter(jobId, "completed");
-    }
-
-    private long getPipelineCounter(long jobId, String counterKey) {
-        Map<String, Object> overview =
-                given().get(
-                                getRestBaseUrl()
-                                        + RestConstant.REST_URL_CHECKPOINT_OVERVIEW
-                                        + "/"
-                                        + jobId)
-                        .then()
-                        .statusCode(200)
-                        .extract()
-                        .as(new TypeRef<Map<String, Object>>() {});
-        List<Map<String, Object>> pipelines = castList(overview.get("pipelines"));
-        if (pipelines == null || pipelines.isEmpty()) {
-            return 0L;
-        }
-        Map<String, Object> counts = castMap(pipelines.get(0).get("counts"));
-        if (counts == null) {
-            return 0L;
-        }
-        Object counter = counts.get(counterKey);
-        return counter instanceof Number ? ((Number) counter).longValue() : 0L;
-    }
-
-    /**
-     * Polls the live physical task mapping for {@code jobId} until {@code condition} holds,
-     * returning the last observed count.
-     *
-     * <p>Awaitility's {@code untilAsserted} only retries on {@link AssertionError}, so the actual
-     * REST call is isolated in {@link #getTaskItemCount(long)} which translates any transport
-     * failure into an assertion failure instead of letting a checked/unchecked transport exception
-     * escape and abort the poll on the first attempt.
-     */
-    private long awaitTaskItemCount(long jobId, LongPredicate condition, String description) {
-        AtomicLong result = new AtomicLong();
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(
-                        () -> {
-                            long count = getTaskItemCount(jobId);
-                            Assertions.assertTrue(
-                                    condition.test(count),
-                                    description + " (actual physical task count=" + count + ")");
-                            result.set(count);
-                        });
-        return result.get();
-    }
-
-    /**
-     * Reads the live {@code /trace/task-mapping} REST endpoint (backed by {@code
-     * JobMaster#getPhysicalPlan()} on the active master) and counts how many physical tasks are
-     * currently deployed for {@code jobId}, across every pipeline, regular and coordinator vertex
-     * alike. This is a white-box count of the actually-running plan, not the submitted config.
-     *
-     * <p>Uses RestAssured's {@code JsonPath} extraction (rather than {@code .as(TypeRef)}) because
-     * this endpoint is served by the Hazelcast member's own text-command processor on port 5801 - a
-     * different REST stack than the port 8080 job-info/checkpoint-overview endpoints used elsewhere
-     * in this class - and {@code JsonPath} parses the body as JSON directly instead of relying on a
-     * possibly-absent/unrecognized Content-Type header to select a deserializer.
-     */
-    private long getTaskItemCount(long jobId) {
-        try {
-            List<?> items =
-                    given().get(
-                                    "http://localhost:"
-                                            + server.getMappedPort(5801)
-                                            + "/hazelcast/rest/maps/trace/task-mapping/"
-                                            + jobId)
-                            .then()
-                            .statusCode(200)
-                            .extract()
-                            .response()
-                            .jsonPath()
-                            .getList("items");
-            return items == null ? 0L : items.size();
-        } catch (RuntimeException e) {
-            // Awaitility's untilAsserted only retries on AssertionError, so translate a
-            // transient REST-call failure (e.g. endpoint not ready yet) into a JUnit assertion
-            // failure instead of letting it escape unretried and abort the poll immediately.
-            throw new AssertionError("Failed to fetch task mapping for job " + jobId, e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> castList(Object value) {
-        return (List<Map<String, Object>>) value;
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> castMap(Object value) {
-        return (Map<String, Object>) value;
-    }
-
-    private String getRestBaseUrl() {
-        return HOST + server.getMappedPort(8080);
+        verifySavepointRestoreWithRescale();
     }
 }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleUpIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleUpIT.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.e2e;
+
+import org.apache.seatunnel.common.utils.FileUtils;
+import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
+import org.apache.seatunnel.engine.server.rest.RestConstant;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.utility.MountableFile;
+
+import io.restassured.common.mapper.TypeRef;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.LongPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
+
+/**
+ * Verifies that a savepoint taken at one parallelism can be restored at a HIGHER parallelism
+ * (scale-up), exercising the modulo-based per-task state remap in {@code
+ * CheckpointCoordinator#restoreTaskState} with a genuinely different old/new parallelism pair.
+ *
+ * <p>Every other checkpoint/savepoint restore IT in this package (e.g. {@link
+ * CheckpointRestoreWithStopIT}, {@link SavepointRestoreIT}) restores at the SAME parallelism the
+ * checkpoint was taken at, so the remap's {@code currentParallelism !=
+ * actionState.getParallelism()} branch is never exercised end-to-end anywhere else.
+ *
+ * <p>Rigor mirrors {@link SavepointRestoreIT}: exact offset reconciliation (no loss, no
+ * duplication) across the savepoint boundary. In addition, this test verifies the RESTORED job's
+ * actual physical task count via the {@code /trace/task-mapping} REST endpoint (backed by the live
+ * {@code JobMaster#getPhysicalPlan()}, the same white-box source of truth used elsewhere in this
+ * test family), rather than trusting that the configured parallelism was applied.
+ */
+public class SavepointRestoreScaleUpIT extends SeaTunnelEngineContainer {
+
+    private static final String HOST = "http://localhost:";
+    private static final String ORIGINAL_CONF_FILE =
+            "/savepoint-restore-rescale/stream_p2_to_localfile_scaleup.conf";
+    private static final String RESTORE_CONF_FILE =
+            "/savepoint-restore-rescale/stream_p4_to_localfile_scaleup.conf";
+    private static final String SINK_OUTPUT_DIR =
+            HOST_VOLUME_MOUNT_PATH + "/savepoint-restore-rescale/scale-up/sinkfile";
+
+    // Must match env.parallelism in stream_p2_to_localfile_scaleup.conf.
+    private static final int ORIGINAL_PARALLELISM = 2;
+    // Must match env.parallelism in stream_p4_to_localfile_scaleup.conf.
+    private static final int RESTORED_PARALLELISM = 4;
+    // The source and the sink are the only two parallelism-scaled actions in this pipeline (no
+    // transform stage), so every regular (non-coordinator) physical vertex list grows by exactly
+    // one task per action per unit of parallelism increase. Coordinator-type vertices (the source
+    // split enumerator, the sink aggregated committer) are singletons that never scale with
+    // parallelism, so they cancel out of this delta regardless of their exact count.
+    private static final long EXPECTED_TASK_COUNT_DELTA =
+            2L * (RESTORED_PARALLELISM - ORIGINAL_PARALLELISM);
+
+    @Override
+    @BeforeAll
+    public void startUp() throws Exception {
+        super.startUp();
+        copyRescaleTestPluginsToContainer();
+    }
+
+    @Test
+    public void testRestoreFromSavepointWithHigherParallelism()
+            throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
+        FileUtils.createNewDir(SINK_OUTPUT_DIR);
+        try {
+            long jobId = JobIdGenerator.newJobId();
+            CompletableFuture<Container.ExecResult> sourceJobFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return executeJob(ORIGINAL_CONF_FILE, String.valueOf(jobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(jobId, "RUNNING");
+            awaitCompletedCheckpoint(jobId);
+            // A completed checkpoint requires every subtask of every parallel instance to have
+            // acknowledged the barrier, so it is safe to treat the task count observed here as
+            // the fully-deployed baseline for the original parallelism.
+            long taskCountBeforeRestore =
+                    awaitTaskItemCount(
+                            jobId,
+                            count -> count > 0,
+                            "Expected at least one deployed task before restore");
+
+            Container.ExecResult savepointResult = savepointJob(String.valueOf(jobId));
+            Assertions.assertEquals(0, savepointResult.getExitCode(), savepointResult.getStderr());
+            awaitJobStatus(jobId, "SAVEPOINT_DONE");
+
+            List<Long> offsetsBeforeRestore = readObservedOffsets();
+            long maxOffsetBeforeRestore = getMaxOffset(offsetsBeforeRestore);
+            Assertions.assertFalse(
+                    offsetsBeforeRestore.isEmpty(), "Expected committed offsets before restore");
+            Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
+
+            CompletableFuture<Container.ExecResult> restoreFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return restoreJob(RESTORE_CONF_FILE, String.valueOf(jobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(jobId, "RUNNING");
+            long expectedTaskCountAfterRestore = taskCountBeforeRestore + EXPECTED_TASK_COUNT_DELTA;
+            awaitTaskItemCount(
+                    jobId,
+                    count -> count == expectedTaskCountAfterRestore,
+                    "Expected restored job's physical task count ("
+                            + taskCountBeforeRestore
+                            + " -> "
+                            + expectedTaskCountAfterRestore
+                            + ") to reflect the new parallelism ("
+                            + ORIGINAL_PARALLELISM
+                            + " -> "
+                            + RESTORED_PARALLELISM
+                            + ")");
+            assertRestoreContinuesAfterBoundary(offsetsBeforeRestore, maxOffsetBeforeRestore);
+            assertNoOffsetDuplicates();
+
+            stopJob(String.valueOf(jobId));
+            awaitJobStatus(jobId, "CANCELED");
+            Container.ExecResult restoreResult = restoreFuture.get();
+            Assertions.assertEquals(0, restoreResult.getExitCode(), restoreResult.getStderr());
+        } finally {
+            FileUtils.deleteFile(SINK_OUTPUT_DIR);
+        }
+    }
+
+    private void awaitJobStatus(long jobId, String expectedStatus) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        expectedStatus, getJobStatus(String.valueOf(jobId))));
+    }
+
+    private void awaitCompletedCheckpoint(long jobId) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(() -> Assertions.assertTrue(getCompletedCheckpointCount(jobId) > 0));
+    }
+
+    private void copyRescaleTestPluginsToContainer() throws IOException {
+        URL url =
+                FileUtils.searchJarFiles(
+                                Paths.get(
+                                        PROJECT_ROOT_PATH,
+                                        "seatunnel-e2e",
+                                        "seatunnel-e2e-common",
+                                        "target"))
+                        .stream()
+                        .filter(jar -> jar.toString().endsWith("-tests.jar"))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Could not locate seatunnel-e2e-common test jar"));
+        server.copyFileToContainer(
+                MountableFile.forHostPath(Paths.get(url.getFile())),
+                Paths.get(
+                                SEATUNNEL_HOME,
+                                "connectors",
+                                Paths.get(url.getFile()).getFileName().toString())
+                        .toString());
+        // Reuse the checkpoint-restore-with-stop plugin mapping: it resolves the same test-only
+        // CheckpointableSequenceSource used here, and SavepointRestoreIT already establishes the
+        // precedent of sharing this file rather than duplicating it per directory.
+        server.copyFileToContainer(
+                MountableFile.forHostPath(
+                        Paths.get(
+                                PROJECT_ROOT_PATH,
+                                "seatunnel-e2e",
+                                "seatunnel-engine-e2e",
+                                "connector-seatunnel-e2e-base",
+                                "src",
+                                "test",
+                                "resources",
+                                "checkpoint-restore-with-stop",
+                                "plugin-mapping.properties")),
+                Paths.get(SEATUNNEL_HOME, "connectors", "plugin-mapping.properties").toString());
+    }
+
+    private void assertRestoreContinuesAfterBoundary(
+            List<Long> offsetsBeforeRestore, long maxOffsetBeforeRestore) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            List<Long> offsetsAfterRestore = readObservedOffsets();
+                            List<Long> restoredOffsets = new ArrayList<>();
+                            for (Long offset : offsetsAfterRestore) {
+                                if (offset > maxOffsetBeforeRestore) {
+                                    restoredOffsets.add(offset);
+                                }
+                            }
+
+                            Assertions.assertTrue(
+                                    !restoredOffsets.isEmpty(),
+                                    "Expected restored run to continue from savepoint boundary "
+                                            + maxOffsetBeforeRestore);
+
+                            Assertions.assertEquals(
+                                    offsetsBeforeRestore.size() + restoredOffsets.size(),
+                                    offsetsAfterRestore.size(),
+                                    "Expected restore to append only new offsets after savepoint boundary "
+                                            + maxOffsetBeforeRestore);
+                        });
+    }
+
+    private void assertNoOffsetDuplicates() {
+        Map<Long, Long> counts =
+                readObservedOffsets().stream()
+                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+        List<Long> duplicates =
+                counts.entrySet().stream()
+                        .filter(entry -> entry.getValue() > 1)
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
+        Assertions.assertTrue(
+                duplicates.isEmpty(),
+                "Found duplicate offsets (exactly-once violated): " + duplicates);
+    }
+
+    private long getMaxOffset(List<Long> offsets) {
+        return offsets.stream().mapToLong(Long::longValue).max().orElse(-1L);
+    }
+
+    private List<Long> readObservedOffsets() {
+        Path outputDir = Paths.get(SINK_OUTPUT_DIR);
+        if (!Files.exists(outputDir)) {
+            return Collections.emptyList();
+        }
+        try (Stream<Path> paths = Files.walk(outputDir)) {
+            return paths.filter(Files::isRegularFile)
+                    .flatMap(
+                            path -> {
+                                try {
+                                    return Files.readAllLines(path).stream();
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .map(Long::parseLong)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private long getCompletedCheckpointCount(long jobId) {
+        return getPipelineCounter(jobId, "completed");
+    }
+
+    private long getPipelineCounter(long jobId, String counterKey) {
+        Map<String, Object> overview =
+                given().get(
+                                getRestBaseUrl()
+                                        + RestConstant.REST_URL_CHECKPOINT_OVERVIEW
+                                        + "/"
+                                        + jobId)
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .as(new TypeRef<Map<String, Object>>() {});
+        List<Map<String, Object>> pipelines = castList(overview.get("pipelines"));
+        if (pipelines == null || pipelines.isEmpty()) {
+            return 0L;
+        }
+        Map<String, Object> counts = castMap(pipelines.get(0).get("counts"));
+        if (counts == null) {
+            return 0L;
+        }
+        Object counter = counts.get(counterKey);
+        return counter instanceof Number ? ((Number) counter).longValue() : 0L;
+    }
+
+    /**
+     * Polls the live physical task mapping for {@code jobId} until {@code condition} holds,
+     * returning the last observed count.
+     *
+     * <p>Awaitility's {@code untilAsserted} only retries on {@link AssertionError}, so the actual
+     * REST call is isolated in {@link #getTaskItemCount(long)} which translates any transport
+     * failure into an assertion failure instead of letting a checked/unchecked transport exception
+     * escape and abort the poll on the first attempt.
+     */
+    private long awaitTaskItemCount(long jobId, LongPredicate condition, String description) {
+        AtomicLong result = new AtomicLong();
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () -> {
+                            long count = getTaskItemCount(jobId);
+                            Assertions.assertTrue(
+                                    condition.test(count),
+                                    description + " (actual physical task count=" + count + ")");
+                            result.set(count);
+                        });
+        return result.get();
+    }
+
+    /**
+     * Reads the live {@code /trace/task-mapping} REST endpoint (backed by {@code
+     * JobMaster#getPhysicalPlan()} on the active master) and counts how many physical tasks are
+     * currently deployed for {@code jobId}, across every pipeline, regular and coordinator vertex
+     * alike. This is a white-box count of the actually-running plan, not the submitted config.
+     *
+     * <p>Uses RestAssured's {@code JsonPath} extraction (rather than {@code .as(TypeRef)}) because
+     * this endpoint is served by the Hazelcast member's own text-command processor on port 5801 - a
+     * different REST stack than the port 8080 job-info/checkpoint-overview endpoints used elsewhere
+     * in this class - and {@code JsonPath} parses the body as JSON directly instead of relying on a
+     * possibly-absent/unrecognized Content-Type header to select a deserializer.
+     */
+    private long getTaskItemCount(long jobId) {
+        try {
+            List<?> items =
+                    given().get(
+                                    "http://localhost:"
+                                            + server.getMappedPort(5801)
+                                            + "/hazelcast/rest/maps/trace/task-mapping/"
+                                            + jobId)
+                            .then()
+                            .statusCode(200)
+                            .extract()
+                            .response()
+                            .jsonPath()
+                            .getList("items");
+            return items == null ? 0L : items.size();
+        } catch (RuntimeException e) {
+            // Awaitility's untilAsserted only retries on AssertionError, so translate a
+            // transient REST-call failure (e.g. endpoint not ready yet) into a JUnit assertion
+            // failure instead of letting it escape unretried and abort the poll immediately.
+            throw new AssertionError("Failed to fetch task mapping for job " + jobId, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> castList(Object value) {
+        return (List<Map<String, Object>>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> castMap(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    private String getRestBaseUrl() {
+        return HOST + server.getMappedPort(8080);
+    }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleUpIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleUpIT.java
@@ -17,38 +17,9 @@
 
 package org.apache.seatunnel.engine.e2e;
 
-import org.apache.seatunnel.common.utils.FileUtils;
-import org.apache.seatunnel.e2e.common.util.JobIdGenerator;
-import org.apache.seatunnel.engine.server.rest.RestConstant;
-
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.Container;
-import org.testcontainers.utility.MountableFile;
-
-import io.restassured.common.mapper.TypeRef;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.function.LongPredicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static io.restassured.RestAssured.given;
-import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
 
 /**
  * Verifies that a savepoint taken at one parallelism can be restored at a HIGHER parallelism
@@ -66,9 +37,8 @@ import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PA
  * {@code JobMaster#getPhysicalPlan()}, the same white-box source of truth used elsewhere in this
  * test family), rather than trusting that the configured parallelism was applied.
  */
-public class SavepointRestoreScaleUpIT extends SeaTunnelEngineContainer {
+public class SavepointRestoreScaleUpIT extends AbstractSavepointRescaleIT {
 
-    private static final String HOST = "http://localhost:";
     private static final String ORIGINAL_CONF_FILE =
             "/savepoint-restore-rescale/stream_p2_to_localfile_scaleup.conf";
     private static final String RESTORE_CONF_FILE =
@@ -80,315 +50,35 @@ public class SavepointRestoreScaleUpIT extends SeaTunnelEngineContainer {
     private static final int ORIGINAL_PARALLELISM = 2;
     // Must match env.parallelism in stream_p4_to_localfile_scaleup.conf.
     private static final int RESTORED_PARALLELISM = 4;
-    // The source and the sink are the only two parallelism-scaled actions in this pipeline (no
-    // transform stage), so every regular (non-coordinator) physical vertex list grows by exactly
-    // one task per action per unit of parallelism increase. Coordinator-type vertices (the source
-    // split enumerator, the sink aggregated committer) are singletons that never scale with
-    // parallelism, so they cancel out of this delta regardless of their exact count.
-    private static final long EXPECTED_TASK_COUNT_DELTA =
-            2L * (RESTORED_PARALLELISM - ORIGINAL_PARALLELISM);
 
     @Override
-    @BeforeAll
-    public void startUp() throws Exception {
-        super.startUp();
-        copyRescaleTestPluginsToContainer();
+    protected String originalConfFile() {
+        return ORIGINAL_CONF_FILE;
+    }
+
+    @Override
+    protected String restoreConfFile() {
+        return RESTORE_CONF_FILE;
+    }
+
+    @Override
+    protected String sinkOutputDir() {
+        return SINK_OUTPUT_DIR;
+    }
+
+    @Override
+    protected int originalParallelism() {
+        return ORIGINAL_PARALLELISM;
+    }
+
+    @Override
+    protected int restoredParallelism() {
+        return RESTORED_PARALLELISM;
     }
 
     @Test
     public void testRestoreFromSavepointWithHigherParallelism()
             throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
-        FileUtils.createNewDir(SINK_OUTPUT_DIR);
-        try {
-            long jobId = JobIdGenerator.newJobId();
-            CompletableFuture<Container.ExecResult> sourceJobFuture =
-                    CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return executeJob(ORIGINAL_CONF_FILE, String.valueOf(jobId));
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-            awaitJobStatus(jobId, "RUNNING");
-            awaitCompletedCheckpoint(jobId);
-            // A completed checkpoint requires every subtask of every parallel instance to have
-            // acknowledged the barrier, so it is safe to treat the task count observed here as
-            // the fully-deployed baseline for the original parallelism.
-            long taskCountBeforeRestore =
-                    awaitTaskItemCount(
-                            jobId,
-                            count -> count > 0,
-                            "Expected at least one deployed task before restore");
-
-            Container.ExecResult savepointResult = savepointJob(String.valueOf(jobId));
-            Assertions.assertEquals(0, savepointResult.getExitCode(), savepointResult.getStderr());
-            awaitJobStatus(jobId, "SAVEPOINT_DONE");
-
-            List<Long> offsetsBeforeRestore = readObservedOffsets();
-            long maxOffsetBeforeRestore = getMaxOffset(offsetsBeforeRestore);
-            Assertions.assertFalse(
-                    offsetsBeforeRestore.isEmpty(), "Expected committed offsets before restore");
-            Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
-
-            CompletableFuture<Container.ExecResult> restoreFuture =
-                    CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return restoreJob(RESTORE_CONF_FILE, String.valueOf(jobId));
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-            awaitJobStatus(jobId, "RUNNING");
-            long expectedTaskCountAfterRestore = taskCountBeforeRestore + EXPECTED_TASK_COUNT_DELTA;
-            awaitTaskItemCount(
-                    jobId,
-                    count -> count == expectedTaskCountAfterRestore,
-                    "Expected restored job's physical task count ("
-                            + taskCountBeforeRestore
-                            + " -> "
-                            + expectedTaskCountAfterRestore
-                            + ") to reflect the new parallelism ("
-                            + ORIGINAL_PARALLELISM
-                            + " -> "
-                            + RESTORED_PARALLELISM
-                            + ")");
-            assertRestoreContinuesAfterBoundary(offsetsBeforeRestore, maxOffsetBeforeRestore);
-            assertNoOffsetDuplicates();
-
-            stopJob(String.valueOf(jobId));
-            awaitJobStatus(jobId, "CANCELED");
-            Container.ExecResult restoreResult = restoreFuture.get();
-            Assertions.assertEquals(0, restoreResult.getExitCode(), restoreResult.getStderr());
-        } finally {
-            FileUtils.deleteFile(SINK_OUTPUT_DIR);
-        }
-    }
-
-    private void awaitJobStatus(long jobId, String expectedStatus) {
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(
-                        () ->
-                                Assertions.assertEquals(
-                                        expectedStatus, getJobStatus(String.valueOf(jobId))));
-    }
-
-    private void awaitCompletedCheckpoint(long jobId) {
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(() -> Assertions.assertTrue(getCompletedCheckpointCount(jobId) > 0));
-    }
-
-    private void copyRescaleTestPluginsToContainer() throws IOException {
-        URL url =
-                FileUtils.searchJarFiles(
-                                Paths.get(
-                                        PROJECT_ROOT_PATH,
-                                        "seatunnel-e2e",
-                                        "seatunnel-e2e-common",
-                                        "target"))
-                        .stream()
-                        .filter(jar -> jar.toString().endsWith("-tests.jar"))
-                        .findFirst()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalStateException(
-                                                "Could not locate seatunnel-e2e-common test jar"));
-        server.copyFileToContainer(
-                MountableFile.forHostPath(Paths.get(url.getFile())),
-                Paths.get(
-                                SEATUNNEL_HOME,
-                                "connectors",
-                                Paths.get(url.getFile()).getFileName().toString())
-                        .toString());
-        // Reuse the checkpoint-restore-with-stop plugin mapping: it resolves the same test-only
-        // CheckpointableSequenceSource used here, and SavepointRestoreIT already establishes the
-        // precedent of sharing this file rather than duplicating it per directory.
-        server.copyFileToContainer(
-                MountableFile.forHostPath(
-                        Paths.get(
-                                PROJECT_ROOT_PATH,
-                                "seatunnel-e2e",
-                                "seatunnel-engine-e2e",
-                                "connector-seatunnel-e2e-base",
-                                "src",
-                                "test",
-                                "resources",
-                                "checkpoint-restore-with-stop",
-                                "plugin-mapping.properties")),
-                Paths.get(SEATUNNEL_HOME, "connectors", "plugin-mapping.properties").toString());
-    }
-
-    private void assertRestoreContinuesAfterBoundary(
-            List<Long> offsetsBeforeRestore, long maxOffsetBeforeRestore) {
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(
-                        () -> {
-                            List<Long> offsetsAfterRestore = readObservedOffsets();
-                            List<Long> restoredOffsets = new ArrayList<>();
-                            for (Long offset : offsetsAfterRestore) {
-                                if (offset > maxOffsetBeforeRestore) {
-                                    restoredOffsets.add(offset);
-                                }
-                            }
-
-                            Assertions.assertTrue(
-                                    !restoredOffsets.isEmpty(),
-                                    "Expected restored run to continue from savepoint boundary "
-                                            + maxOffsetBeforeRestore);
-
-                            Assertions.assertEquals(
-                                    offsetsBeforeRestore.size() + restoredOffsets.size(),
-                                    offsetsAfterRestore.size(),
-                                    "Expected restore to append only new offsets after savepoint boundary "
-                                            + maxOffsetBeforeRestore);
-                        });
-    }
-
-    private void assertNoOffsetDuplicates() {
-        Map<Long, Long> counts =
-                readObservedOffsets().stream()
-                        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-        List<Long> duplicates =
-                counts.entrySet().stream()
-                        .filter(entry -> entry.getValue() > 1)
-                        .map(Map.Entry::getKey)
-                        .collect(Collectors.toList());
-        Assertions.assertTrue(
-                duplicates.isEmpty(),
-                "Found duplicate offsets (exactly-once violated): " + duplicates);
-    }
-
-    private long getMaxOffset(List<Long> offsets) {
-        return offsets.stream().mapToLong(Long::longValue).max().orElse(-1L);
-    }
-
-    private List<Long> readObservedOffsets() {
-        Path outputDir = Paths.get(SINK_OUTPUT_DIR);
-        if (!Files.exists(outputDir)) {
-            return Collections.emptyList();
-        }
-        try (Stream<Path> paths = Files.walk(outputDir)) {
-            return paths.filter(Files::isRegularFile)
-                    .flatMap(
-                            path -> {
-                                try {
-                                    return Files.readAllLines(path).stream();
-                                } catch (IOException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            })
-                    .map(String::trim)
-                    .filter(line -> !line.isEmpty())
-                    .map(Long::parseLong)
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private long getCompletedCheckpointCount(long jobId) {
-        return getPipelineCounter(jobId, "completed");
-    }
-
-    private long getPipelineCounter(long jobId, String counterKey) {
-        Map<String, Object> overview =
-                given().get(
-                                getRestBaseUrl()
-                                        + RestConstant.REST_URL_CHECKPOINT_OVERVIEW
-                                        + "/"
-                                        + jobId)
-                        .then()
-                        .statusCode(200)
-                        .extract()
-                        .as(new TypeRef<Map<String, Object>>() {});
-        List<Map<String, Object>> pipelines = castList(overview.get("pipelines"));
-        if (pipelines == null || pipelines.isEmpty()) {
-            return 0L;
-        }
-        Map<String, Object> counts = castMap(pipelines.get(0).get("counts"));
-        if (counts == null) {
-            return 0L;
-        }
-        Object counter = counts.get(counterKey);
-        return counter instanceof Number ? ((Number) counter).longValue() : 0L;
-    }
-
-    /**
-     * Polls the live physical task mapping for {@code jobId} until {@code condition} holds,
-     * returning the last observed count.
-     *
-     * <p>Awaitility's {@code untilAsserted} only retries on {@link AssertionError}, so the actual
-     * REST call is isolated in {@link #getTaskItemCount(long)} which translates any transport
-     * failure into an assertion failure instead of letting a checked/unchecked transport exception
-     * escape and abort the poll on the first attempt.
-     */
-    private long awaitTaskItemCount(long jobId, LongPredicate condition, String description) {
-        AtomicLong result = new AtomicLong();
-        Awaitility.await()
-                .atMost(2, TimeUnit.MINUTES)
-                .untilAsserted(
-                        () -> {
-                            long count = getTaskItemCount(jobId);
-                            Assertions.assertTrue(
-                                    condition.test(count),
-                                    description + " (actual physical task count=" + count + ")");
-                            result.set(count);
-                        });
-        return result.get();
-    }
-
-    /**
-     * Reads the live {@code /trace/task-mapping} REST endpoint (backed by {@code
-     * JobMaster#getPhysicalPlan()} on the active master) and counts how many physical tasks are
-     * currently deployed for {@code jobId}, across every pipeline, regular and coordinator vertex
-     * alike. This is a white-box count of the actually-running plan, not the submitted config.
-     *
-     * <p>Uses RestAssured's {@code JsonPath} extraction (rather than {@code .as(TypeRef)}) because
-     * this endpoint is served by the Hazelcast member's own text-command processor on port 5801 - a
-     * different REST stack than the port 8080 job-info/checkpoint-overview endpoints used elsewhere
-     * in this class - and {@code JsonPath} parses the body as JSON directly instead of relying on a
-     * possibly-absent/unrecognized Content-Type header to select a deserializer.
-     */
-    private long getTaskItemCount(long jobId) {
-        try {
-            List<?> items =
-                    given().get(
-                                    "http://localhost:"
-                                            + server.getMappedPort(5801)
-                                            + "/hazelcast/rest/maps/trace/task-mapping/"
-                                            + jobId)
-                            .then()
-                            .statusCode(200)
-                            .extract()
-                            .response()
-                            .jsonPath()
-                            .getList("items");
-            return items == null ? 0L : items.size();
-        } catch (RuntimeException e) {
-            // Awaitility's untilAsserted only retries on AssertionError, so translate a
-            // transient REST-call failure (e.g. endpoint not ready yet) into a JUnit assertion
-            // failure instead of letting it escape unretried and abort the poll immediately.
-            throw new AssertionError("Failed to fetch task mapping for job " + jobId, e);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> castList(Object value) {
-        return (List<Map<String, Object>>) value;
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> castMap(Object value) {
-        return (Map<String, Object>) value;
-    }
-
-    private String getRestBaseUrl() {
-        return HOST + server.getMappedPort(8080);
+        verifySavepointRestoreWithRescale();
     }
 }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p2_to_localfile_scaledown.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p2_to_localfile_scaledown.conf
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Restore counterpart of stream_p4_to_localfile_scaledown.conf: same
+# source/sink definition and the same sink output directory, but a halved
+# parallelism so the restored job rescales down (4 -> 2) across the
+# savepoint boundary.
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+  checkpoint.retain-after-job-cancelled = true
+}
+
+source {
+  CheckpointableSequenceSource {
+    start_offset = 0
+    end_offset = 1000000
+    split_num = 1
+    emit_interval_ms = 50
+    records_per_poll = 1
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel_mnt/savepoint-restore-rescale/scale-down/sinkfile/"
+    row_delimiter = "\n"
+    file_name_expression = "offset_${transactionId}"
+    file_format_type = "text"
+    is_enable_transaction = true
+  }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p2_to_localfile_scaleup.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p2_to_localfile_scaleup.conf
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+env {
+  parallelism = 2
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+  checkpoint.retain-after-job-cancelled = true
+}
+
+source {
+  CheckpointableSequenceSource {
+    start_offset = 0
+    end_offset = 1000000
+    split_num = 1
+    emit_interval_ms = 50
+    records_per_poll = 1
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel_mnt/savepoint-restore-rescale/scale-up/sinkfile/"
+    row_delimiter = "\n"
+    file_name_expression = "offset_${transactionId}"
+    file_format_type = "text"
+    is_enable_transaction = true
+  }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p4_to_localfile_scaledown.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p4_to_localfile_scaledown.conf
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+env {
+  parallelism = 4
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+  checkpoint.retain-after-job-cancelled = true
+}
+
+source {
+  CheckpointableSequenceSource {
+    start_offset = 0
+    end_offset = 1000000
+    split_num = 1
+    emit_interval_ms = 50
+    records_per_poll = 1
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel_mnt/savepoint-restore-rescale/scale-down/sinkfile/"
+    row_delimiter = "\n"
+    file_name_expression = "offset_${transactionId}"
+    file_format_type = "text"
+    is_enable_transaction = true
+  }
+}

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p4_to_localfile_scaleup.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p4_to_localfile_scaleup.conf
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Restore counterpart of stream_p2_to_localfile_scaleup.conf: same source/sink
+# definition and the same sink output directory, but a doubled parallelism so
+# the restored job rescales up (2 -> 4) across the savepoint boundary.
+env {
+  parallelism = 4
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+  checkpoint.retain-after-job-cancelled = true
+}
+
+source {
+  CheckpointableSequenceSource {
+    start_offset = 0
+    end_offset = 1000000
+    split_num = 1
+    emit_interval_ms = 50
+    records_per_poll = 1
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel_mnt/savepoint-restore-rescale/scale-up/sinkfile/"
+    row_delimiter = "\n"
+    file_name_expression = "offset_${transactionId}"
+    file_format_type = "text"
+    is_enable_transaction = true
+  }
+}


### PR DESCRIPTION
### Purpose

`CheckpointCoordinator#restoreTaskState` has a modulo-based per-task state remap specifically for handling **parallelism changes** across a checkpoint/savepoint restore (`seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java`):

```java
for (int i = tuple.f1(); i < actionState.getParallelism(); i += currentParallelism) {
    ActionSubtaskState subtaskState = actionState.getSubtaskStates().get(i);
    ...
}
```

This branch is only meaningfully exercised when `currentParallelism != actionState.getParallelism()` (the restored parallelism differs from the parallelism the checkpoint was taken at). Every existing restore IT in this package (`CheckpointRestoreWithStopIT`, `SavepointRestoreIT`) restores at the **same** parallelism the checkpoint was taken at, so this remap path has never been exercised end-to-end by any test.

### What this PR adds

Two new E2E tests under `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base`:

- `SavepointRestoreScaleUpIT` — runs a job at parallelism 2, takes a savepoint, stops it, and restores it at parallelism 4 (scale-up).
- `SavepointRestoreScaleDownIT` — runs a job at parallelism 4, takes a savepoint, stops it, and restores it at parallelism 2 (scale-down).

Both sub-scenarios (scale-up **and** scale-down) are covered, since the remap formula is asymmetric between the two directions (scale-down merges multiple old subtask indices' state onto each new instance; scale-up leaves new instances whose index is `>=` the old parallelism with no inherited state at all).

Each test:
1. Submits the job via the normal `--config <conf> --set-job-id <id>` path, waits for a completed checkpoint, then takes a savepoint (`-s`) and confirms the source job exits cleanly.
2. Restores the **same job id** with a **different** conf file (`--config <restoreConf> -r <id>`) whose only difference is `env.parallelism`. This is the same CLI restore path (`ClientCommandArgs.getRestoreJobId()` → `SeaTunnelClient#restoreExecutionContext` → `ClientJobExecutionEnvironment` → `MultipleTableJobConfigParser`) already used by `SavepointRestoreIT`; it always parses a fresh `LogicalDag`/parallelism from the config passed on that invocation, restore or not, so this is a real, already-supported mechanism — not an assumed one.
3. Verifies exact offset reconciliation (no loss, no duplication) across the savepoint boundary, matching the rigor of `SavepointRestoreIT` (`assertRestoreContinuesAfterBoundary` / `assertNoOffsetDuplicates`, byte-for-byte copied assertions).
4. Additionally verifies the **restored job's actual physical task count** via the `/trace/task-mapping` REST endpoint (`RestConstant.REST_URL_TRACE_TASK_MAPPING`, served by `RestHttpGetCommandProcessor` → `TraceTaskMappingService` → `TaskMappingBuilder.build()`, which reads the live `JobMaster#getPhysicalPlan()` on the active master) — a genuine white-box check of the deployed plan, not just trusting that the configured parallelism was applied. The expected task-count delta (`2 * (new - old)` parallelism) was derived by tracing `ExecutionPlanGenerator`/`PhysicalPlanGenerator`: with no transform stage, source and sink each contribute one task per parallel instance, and coordinator-type vertices (split enumerator, aggregated committer) are singletons that cancel out of the delta regardless of their exact count.

### Files changed

- `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleUpIT.java` (new)
- `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleDownIT.java` (new)
- `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p2_to_localfile_scaleup.conf` (new)
- `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p4_to_localfile_scaleup.conf` (new)
- `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p4_to_localfile_scaledown.conf` (new)
- `seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/savepoint-restore-rescale/stream_p2_to_localfile_scaledown.conf` (new)

No `src/main/**` changes — this is test-only.

### Test plan

- `./mvnw spotless:apply -pl seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base -am -nsu` — passed, no formatting changes needed for the new files.
- `./mvnw install -pl 'seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base,!seatunnel-engine/seatunnel-engine-ui' -am -nsu -Dmaven.gitcommitid.skip=true -DskipTests -Dspotless.check.skip=true -T 3C` — passed; the full ~64-module reactor built and installed successfully (fail-fast reactor reached and installed the last module, `connector-seatunnel-e2e-base`), and both new test classes were confirmed compiled on disk: `target/test-classes/org/apache/seatunnel/engine/e2e/SavepointRestoreScaleUpIT.class` and `SavepointRestoreScaleDownIT.class` (plus their anonymous `$1` inner classes from the `TypeRef` usage).
- Docker/Testcontainers-based execution of the new ITs themselves was not run locally for this PR (consistent with this repository's standard practice of validating E2E/Testcontainers runs through CI); CI is the authoritative signal for the actual container-based run.
