### PR TITLE
[Test][E2E] Extend Gravitino readiness timeout in MetalakeIT

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-jdbc-e2e/connector-jdbc-e2e-part-7/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/MetalakeIT.java
@@ -154,7 +154,7 @@ public class MetalakeIT extends SeaTunnelContainer {
         given().ignoreExceptions()
                 .await()
                 .pollInterval(2, TimeUnit.SECONDS)
-                .atMost(180, TimeUnit.SECONDS)
+                .atMost(300, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> {
                             Container.ExecResult result =


### PR DESCRIPTION
## What does this PR do?

`MetalakeIT#startUp()` downloads and starts a Gravitino server (tarball fetch from `dlcdn.apache.org`, extract, then `bin/gravitino.sh start`) before polling `curl http://127.0.0.1:8090/api/metalakes` with a 180-second awaitility budget. On a loaded or slower CI runner, the download+start sequence can occasionally exceed that budget, and `curl` fails with exit code 7 (connection refused) — indistinguishable, from the assertion's point of view, from Gravitino simply not being ready yet.

Observed on CI as:
```
org.awaitility.core.ConditionTimeoutException: ... expected: <0> but was: <7> within 3 minutes.
	at org.apache.seatunnel.connectors.seatunnel.jdbc.MetalakeIT.startUp(MetalakeIT.java:158)
```

## Why is this needed?

This flake has independently cost multiple unrelated PRs (e.g. #11458) a CI cycle on `jdbc-connectors-it-part-7`, none of which touch this test or Gravitino at all.

## How was this patch tested?

Bumped the wait budget from 180s to 300s, matching the more generous 360s wait already used later in the same method for the JDBC connection (which anticipates similar startup variance). Test-only change — no production code touched, no assertion weakened, just more runway for a slow-starting external process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
