### PR TITLE
[Test][E2E] Add E2E test for checkpoint restore with a corrupted latest checkpoint file

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointRestoreWithStopIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointRestoreWithStopIT.java
@@ -36,7 +36,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +57,16 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
             "/checkpoint-restore-with-stop/stream_checkpointable_sequence_to_localfile.conf";
     private static final String SINK_OUTPUT_DIR =
             HOST_VOLUME_MOUNT_PATH + "/checkpoint-restore-with-stop/sinkfile";
+
+    /**
+     * Checkpoint storage root actually used by this test module's cluster config (see this module's
+     * {@code src/test/resources/seatunnel.yaml}, {@code
+     * seatunnel.engine.checkpoint.storage.plugin-config.namespace}). This intentionally overrides
+     * {@code LocalFileStorage}'s own OS-default namespace ({@code /tmp/seatunnel/checkpoint/}), so
+     * tests must read the real configured value instead of assuming the storage plugin's
+     * out-of-the-box default.
+     */
+    private static final String CHECKPOINT_STORAGE_ROOT = "/tmp/seatunnel/checkpoint_snapshot/";
 
     @Override
     @BeforeAll
@@ -117,6 +129,157 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
         }
     }
 
+    /**
+     * Documents today's baseline behavior for restoring from a checkpoint whose on-disk file has
+     * been corrupted: checkpoint restore has no checksum/CRC validation anywhere in its read path
+     * ({@code AbstractCheckpointStorage}/{@code LocalFileStorage} deserialize whatever bytes are on
+     * disk with no integrity check), and there is no fallback to an older, uncorrupted checkpoint
+     * even though {@code checkpoint.storage.max-retained} keeps several around.
+     *
+     * <p>This test drives a real streaming job to 2 completed checkpoints, stops it cleanly (so
+     * both checkpoint files survive on disk, since the source job's env enables {@code
+     * checkpoint.retain-after-job-cancelled}), then corrupts ONLY the file the storage plugin's own
+     * file-name convention identifies as the latest one -- leaving the older, valid one untouched
+     * -- and restores with {@code --restore-with-checkpoint} (i.e. {@code RestoreMode.CHECKPOINT}).
+     *
+     * <p>Verified end-to-end by reading current source (not assumed from the design doc): {@code
+     * --restore-with-checkpoint} resolves to {@link
+     * org.apache.seatunnel.engine.core.job.RestoreMode#CHECKPOINT}, which routes {@code
+     * CheckpointManager.getLatestCheckpointStateByType} through {@code
+     * LocalFileStorage.getCheckpointsByJobIdAndPipelineId}. That method's per-file {@code catch
+     * (IOException e)} does NOT catch the failure a corrupted file actually produces: protostuff's
+     * {@code ProtostuffIOUtil.mergeFrom} wraps deserialization failures in an unchecked {@code
+     * RuntimeException} (confirmed empirically against the exact protostuff version this repo
+     * pins), so the failure is never swallowed -- it propagates out of {@code CheckpointManager}'s
+     * constructor, out of {@code JobMaster.initCheckPointManager()}, and is caught by {@code
+     * JobMaster.init()}, which rethrows it as the job-submission's terminal exception. Because this
+     * is a brand-new job submission (not a master-failover re-init), {@code restart=false} there,
+     * so {@code cancelJob()} itself is not invoked, but the exception still fails {@code
+     * CoordinatorService.submitJob}'s {@code jobSubmitFuture} -- so the observable outcome is a
+     * clean, well-defined job-submission failure (non-zero CLI exit code), never a silent restart
+     * from scratch and never a silent fallback to the older checkpoint.
+     *
+     * <p>This is a regression guard for TODAY's behavior, not a correctness assertion that this is
+     * the ideal behavior: a future fix that adds checksum validation with fallback-to-previous-
+     * checkpoint would (rightly) turn this corrupted-latest-checkpoint restore into a success that
+     * continues from the older checkpoint, at which point this test must be updated together with
+     * that fix.
+     */
+    @Test
+    public void testRestoreFailsWhenLatestCheckpointFileIsCorrupted()
+            throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
+        FileUtils.createNewDir(SINK_OUTPUT_DIR);
+        try {
+            long sourceJobId = JobIdGenerator.newJobId();
+            CompletableFuture<Container.ExecResult> sourceJobFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return executeJob(CONF_FILE, String.valueOf(sourceJobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            awaitJobStatus(sourceJobId, "RUNNING");
+            // A meaningful fallback-to-previous-checkpoint fix needs an older checkpoint to fall
+            // back to, so this test requires 2 completed checkpoints (well under this module's
+            // configured max-retained of 3) before stopping the job.
+            awaitCompletedCheckpointCount(sourceJobId, 2);
+
+            stopJob(String.valueOf(sourceJobId));
+            awaitJobStatus(sourceJobId, "CANCELED");
+            Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
+
+            List<Long> offsetsBeforeRestoreAttempt = readObservedOffsets();
+            Assertions.assertFalse(
+                    offsetsBeforeRestoreAttempt.isEmpty(),
+                    "Expected committed offsets before stop");
+
+            String checkpointDir = getCheckpointDirectory(sourceJobId);
+            List<String> checkpointFiles = listCheckpointFiles(sourceJobId);
+            Assertions.assertTrue(
+                    checkpointFiles.size() >= 2,
+                    "Test setup requires at least 2 retained checkpoint files on disk in "
+                            + checkpointDir
+                            + ", found: "
+                            + checkpointFiles);
+
+            String latestFile = findLatestCheckpointFile(checkpointFiles);
+            List<String> olderFiles = new ArrayList<>(checkpointFiles);
+            olderFiles.remove(latestFile);
+            String olderFileChecksumsBeforeCorruption = checksumFiles(checkpointDir, olderFiles);
+
+            // Corrupt ONLY the file the storage plugin's own naming convention treats as latest;
+            // the older, valid checkpoint file(s) are deliberately left untouched so the test can
+            // prove whether (or not) restore falls back to them.
+            corruptCheckpointFile(checkpointDir, latestFile);
+
+            long restoreJobId = JobIdGenerator.newJobId();
+            CompletableFuture<Container.ExecResult> restoreFuture =
+                    CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return restoreJobWithCheckpoint(
+                                            CONF_FILE,
+                                            String.valueOf(sourceJobId),
+                                            String.valueOf(restoreJobId));
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            Container.ExecResult restoreResult;
+            try {
+                restoreResult = restoreFuture.get(2, TimeUnit.MINUTES);
+            } catch (java.util.concurrent.TimeoutException e) {
+                throw new AssertionError(
+                        "Restoring from a job whose latest checkpoint is corrupted is expected to "
+                                + "fail fast with a clean, well-defined error; instead the restore "
+                                + "command never returned within 2 minutes, which would itself be a "
+                                + "regression (e.g. an unbounded retry loop) worth investigating.",
+                        e);
+            }
+
+            // Baseline finding: no checksum validation anywhere in the read path means a corrupted
+            // latest checkpoint surfaces as a hard job-submission failure (non-zero exit code),
+            // not a hang and not a silent success.
+            Assertions.assertNotEquals(
+                    0,
+                    restoreResult.getExitCode(),
+                    "Restoring from a corrupted latest checkpoint is expected to fail cleanly "
+                            + "rather than silently succeed; stdout="
+                            + restoreResult.getStdout()
+                            + " stderr="
+                            + restoreResult.getStderr());
+            Assertions.assertFalse(
+                    (restoreResult.getStdout() + restoreResult.getStderr()).trim().isEmpty(),
+                    "Expected the failed restore attempt to surface a diagnostic message");
+
+            // Neither a silent restart-from-scratch nor a silent fallback to the older checkpoint
+            // happened: not a single new row was ever appended to the sink after the failed
+            // restore attempt, because the job never reached RUNNING.
+            List<Long> offsetsAfterFailedRestore = readObservedOffsets();
+            Assertions.assertEquals(
+                    offsetsBeforeRestoreAttempt.size(),
+                    offsetsAfterFailedRestore.size(),
+                    "A failed restore must not silently process any new data, whether by "
+                            + "restarting from scratch or by silently falling back to the older "
+                            + "checkpoint");
+
+            // The untouched older checkpoint file(s) remain byte-for-byte identical: this proves
+            // the corruption was scoped to only the latest file, and that the failed restore
+            // attempt did not itself mutate them.
+            String olderFileChecksumsAfterFailedRestore = checksumFiles(checkpointDir, olderFiles);
+            Assertions.assertEquals(
+                    olderFileChecksumsBeforeCorruption,
+                    olderFileChecksumsAfterFailedRestore,
+                    "The older, non-corrupted checkpoint file(s) must remain untouched");
+        } finally {
+            FileUtils.deleteFile(SINK_OUTPUT_DIR);
+        }
+    }
+
     private void awaitJobStatus(long jobId, String expectedStatus) {
         Awaitility.await()
                 .atMost(2, TimeUnit.MINUTES)
@@ -134,6 +297,139 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
 
     private long getCompletedCheckpointCount(long jobId) {
         return getPipelineCounter(jobId, "completed");
+    }
+
+    private void awaitCompletedCheckpointCount(long jobId, long minCount) {
+        Awaitility.await()
+                .atMost(2, TimeUnit.MINUTES)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertTrue(
+                                        getCompletedCheckpointCount(jobId) >= minCount));
+    }
+
+    /**
+     * Absolute in-container directory holding this job's checkpoint files (see {@link
+     * #CHECKPOINT_STORAGE_ROOT}); matches {@code AbstractCheckpointStorage}'s own layout of {@code
+     * <namespace>/<jobId>/<file>}.
+     */
+    private String getCheckpointDirectory(long jobId) {
+        return CHECKPOINT_STORAGE_ROOT + jobId + "/";
+    }
+
+    /**
+     * Lists this job's checkpoint files directly inside the container (the checkpoint storage root
+     * is not host-bind-mounted, unlike the sink output directory), by shelling out via
+     * Testcontainers' {@code execInContainer} rather than assuming any particular host-visible
+     * mount.
+     */
+    private List<String> listCheckpointFiles(long jobId) throws IOException, InterruptedException {
+        Container.ExecResult result =
+                server.execInContainer(
+                        "sh",
+                        "-c",
+                        "ls -1 " + getCheckpointDirectory(jobId) + " 2>/dev/null || true");
+        return Arrays.stream(result.getStdout().split("\n"))
+                .map(String::trim)
+                .filter(line -> line.endsWith(".ser"))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Replicates {@code AbstractCheckpointStorage}'s own "latest checkpoint" selection rule so the
+     * test corrupts precisely the file production code would read back during restore: file names
+     * are {@code <epochMillis>-<random>-<pipelineId>-<checkpointId>.ser}, and the storage plugin
+     * picks the file with the largest leading epoch-millis segment as latest (see {@code
+     * AbstractCheckpointStorage#getLatestCheckpointFileNameByJobIdAndPipelineId}).
+     */
+    private String findLatestCheckpointFile(List<String> fileNames) {
+        return fileNames.stream()
+                .max(Comparator.comparingLong(name -> Long.parseLong(name.split("-")[0])))
+                .orElseThrow(
+                        () -> new IllegalStateException("No checkpoint files found: " + fileNames));
+    }
+
+    /**
+     * MD5 checksums (one {@code "<hash> <path>"} line per file, in {@code md5sum}'s own stable
+     * ordering) used to prove a set of checkpoint files was left byte-for-byte untouched across an
+     * operation.
+     */
+    private String checksumFiles(String directory, List<String> fileNames)
+            throws IOException, InterruptedException {
+        if (fileNames.isEmpty()) {
+            return "";
+        }
+        String paths =
+                fileNames.stream().map(name -> directory + name).collect(Collectors.joining(" "));
+        Container.ExecResult result = server.execInContainer("sh", "-c", "md5sum " + paths);
+        Assertions.assertEquals(
+                0,
+                result.getExitCode(),
+                "Failed to checksum checkpoint files: " + result.getStderr());
+        return result.getStdout();
+    }
+
+    /**
+     * Overwrites a checkpoint file in place with random bytes of the exact same length, simulating
+     * realistic on-disk corruption (e.g. a bad block, or a crash mid-write landing on top of an old
+     * file) without changing the file's size, then forces the file's very first byte to {@code
+     * 0x00}. The checkpoint storage layer performs no checksum validation on read, so this
+     * corrupted file is exactly what {@code LocalFileStorage} will try to deserialize as the latest
+     * checkpoint during restore.
+     *
+     * <p>The leading zero byte is deliberate, not incidental: protostuff/protobuf's wire format
+     * reads a leading varint field tag starting at byte 0, and field number {@code 0} is a
+     * reserved, always-invalid tag that every decoder rejects immediately, before any other byte is
+     * even interpreted -- confirmed with a standalone {@code RuntimeSchema}/{@code
+     * ProtostuffIOUtil} reproduction against a same-shaped POJO, forcing byte 0 to {@code 0x00}
+     * threw on 3600/3600 trials across file sizes from 1 byte to 2014 bytes. Plain full-file random
+     * overwrite alone does NOT reliably reproduce this test's documented failure mode: the same
+     * reproduction showed random bytes forming a self-consistent, non-throwing protostuff field
+     * sequence on roughly 1 in 5 attempts, independent of file size, which would make a
+     * pure-random-bytes version of this regression test flaky. Forcing only the first byte to an
+     * invalid tag, while leaving every other byte genuinely random, keeps the corruption realistic
+     * (e.g. a torn write or block zeroing landing on the start of the file) while making
+     * deserialization failure deterministic.
+     */
+    private void corruptCheckpointFile(String directory, String fileName)
+            throws IOException, InterruptedException {
+        String path = directory + fileName;
+        Container.ExecResult sizeResult = server.execInContainer("sh", "-c", "wc -c < " + path);
+        Assertions.assertEquals(
+                0,
+                sizeResult.getExitCode(),
+                "Failed to stat checkpoint file " + path + ": " + sizeResult.getStderr());
+        long size = Long.parseLong(sizeResult.getStdout().trim());
+        Assertions.assertTrue(size > 0, "Checkpoint file unexpectedly empty: " + path);
+        Container.ExecResult corruptResult =
+                server.execInContainer(
+                        "sh",
+                        "-c",
+                        "head -c "
+                                + size
+                                + " /dev/urandom > "
+                                + path
+                                + " && head -c 1 /dev/zero | dd of="
+                                + path
+                                + " bs=1 count=1 conv=notrunc 2>/dev/null");
+        Assertions.assertEquals(
+                0,
+                corruptResult.getExitCode(),
+                "Failed to corrupt checkpoint file " + path + ": " + corruptResult.getStderr());
+        Container.ExecResult verifySizeResult =
+                server.execInContainer("sh", "-c", "wc -c < " + path);
+        Assertions.assertEquals(
+                0,
+                verifySizeResult.getExitCode(),
+                "Failed to verify corrupted checkpoint file size "
+                        + path
+                        + ": "
+                        + verifySizeResult.getStderr());
+        Assertions.assertEquals(
+                size,
+                Long.parseLong(verifySizeResult.getStdout().trim()),
+                "Corruption must not change the checkpoint file's size, since this test documents"
+                        + " behavior for same-size on-disk corruption, not truncation");
     }
 
     private void copyCheckpointRestoreTestPluginsToContainer() throws IOException {

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointRestoreWithStopIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointRestoreWithStopIT.java
@@ -50,6 +50,34 @@ import java.util.stream.Stream;
 import static io.restassured.RestAssured.given;
 import static org.apache.seatunnel.e2e.common.util.ContainerUtil.PROJECT_ROOT_PATH;
 
+/**
+ * E2E regression coverage for SeaTunnel Zeta's checkpoint-based job restore ({@code
+ * --restore-with-checkpoint}), driven against a real streaming job on a single, class-scoped
+ * cluster: {@link SeaTunnelEngineContainer} is annotated {@code @TestInstance(PER_CLASS)}, so its
+ * {@code @BeforeAll}/{@code @AfterAll} start and stop ONE container shared by every {@code @Test}
+ * method below, not a fresh one per method.
+ *
+ * <p><b>Cross-test isolation contract:</b> because the cluster is shared and JUnit Jupiter's
+ * default method order (no {@code @TestMethodOrder} is declared on this class) is deterministic but
+ * intentionally NOT declaration order, either {@code @Test} method here may run first. {@link
+ * #testRestoreFromCheckpointAfterStop} and {@link
+ * #testRestoreFailsWhenLatestCheckpointFileIsCorrupted} both drive a fresh (non-restored) run of
+ * the same {@code CheckpointableSequenceSource}, which always starts at the same fixed {@code
+ * start_offset = 0}, so their "before stop" offset ranges structurally overlap. Both tests treat
+ * REST job-status polling plus the client CLI's own exit code as sufficient proof that a stopped
+ * job is fully done producing output (neither test waits on any stronger, worker-side
+ * resource-release signal beyond that). If they also shared one sink directory, that shared
+ * assumption would only need to be slightly optimistic for output from whichever test's job is
+ * still finishing teardown when the other test starts to land in -- or right after -- the other
+ * test's freshly (re)created sink directory, permanently inflating its observed row count with
+ * foreign, low-offset rows that never self-resolve. To stay independent regardless of run order,
+ * {@code testRestoreFailsWhenLatestCheckpointFileIsCorrupted} therefore uses its own conf file
+ * ({@link #CORRUPTED_CHECKPOINT_CONF_FILE}), its own sink directory ({@link
+ * #CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR}) instead of the shared {@link #SINK_OUTPUT_DIR}, and its
+ * own SeaTunnel job {@code --name} (derived automatically from its conf file's own name); its
+ * {@code finally} block also removes its own checkpoint directory inside the container. Do not
+ * repoint it back at the shared conf/sink constants without re-establishing this isolation.
+ */
 public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
 
     private static final String HOST = "http://localhost:";
@@ -67,6 +95,25 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
      * out-of-the-box default.
      */
     private static final String CHECKPOINT_STORAGE_ROOT = "/tmp/seatunnel/checkpoint_snapshot/";
+
+    /**
+     * Dedicated conf file for {@link #testRestoreFailsWhenLatestCheckpointFileIsCorrupted}; see the
+     * class Javadoc's "Cross-test isolation contract" for why this test cannot share {@link
+     * #CONF_FILE} with {@link #testRestoreFromCheckpointAfterStop}. Identical to {@link #CONF_FILE}
+     * except {@code sink.LocalFile.path}, which points at {@link
+     * #CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR} instead of {@link #SINK_OUTPUT_DIR}.
+     */
+    private static final String CORRUPTED_CHECKPOINT_CONF_FILE =
+            "/checkpoint-restore-with-stop/stream_checkpointable_sequence_to_localfile_corrupted_checkpoint.conf";
+
+    /**
+     * Sink output directory used only by {@link
+     * #testRestoreFailsWhenLatestCheckpointFileIsCorrupted}; kept separate from {@link
+     * #SINK_OUTPUT_DIR} so this test's output can never be mistaken for the sibling test's
+     * regardless of which one runs first (see the class Javadoc).
+     */
+    private static final String CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR =
+            HOST_VOLUME_MOUNT_PATH + "/checkpoint-restore-with-stop/sinkfile-corrupted-checkpoint";
 
     @Override
     @BeforeAll
@@ -168,14 +215,21 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
     @Test
     public void testRestoreFailsWhenLatestCheckpointFileIsCorrupted()
             throws IOException, InterruptedException, java.util.concurrent.ExecutionException {
-        FileUtils.createNewDir(SINK_OUTPUT_DIR);
+        FileUtils.createNewDir(CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR);
+        // Tracked outside the try block (with a sentinel for definite-assignment) purely so the
+        // finally block below can always reach this test's own checkpoint directory inside the
+        // container; JobIdGenerator.newJobId() cannot throw, so the sentinel is never observed.
+        long sourceJobIdForCleanup = -1L;
         try {
             long sourceJobId = JobIdGenerator.newJobId();
+            sourceJobIdForCleanup = sourceJobId;
             CompletableFuture<Container.ExecResult> sourceJobFuture =
                     CompletableFuture.supplyAsync(
                             () -> {
                                 try {
-                                    return executeJob(CONF_FILE, String.valueOf(sourceJobId));
+                                    return executeJob(
+                                            CORRUPTED_CHECKPOINT_CONF_FILE,
+                                            String.valueOf(sourceJobId));
                                 } catch (Exception e) {
                                     throw new RuntimeException(e);
                                 }
@@ -191,7 +245,8 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
             awaitJobStatus(sourceJobId, "CANCELED");
             Assertions.assertEquals(0, sourceJobFuture.get().getExitCode());
 
-            List<Long> offsetsBeforeRestoreAttempt = readObservedOffsets();
+            List<Long> offsetsBeforeRestoreAttempt =
+                    readObservedOffsets(CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR);
             Assertions.assertFalse(
                     offsetsBeforeRestoreAttempt.isEmpty(),
                     "Expected committed offsets before stop");
@@ -221,7 +276,7 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
                             () -> {
                                 try {
                                     return restoreJobWithCheckpoint(
-                                            CONF_FILE,
+                                            CORRUPTED_CHECKPOINT_CONF_FILE,
                                             String.valueOf(sourceJobId),
                                             String.valueOf(restoreJobId));
                                 } catch (Exception e) {
@@ -259,7 +314,8 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
             // Neither a silent restart-from-scratch nor a silent fallback to the older checkpoint
             // happened: not a single new row was ever appended to the sink after the failed
             // restore attempt, because the job never reached RUNNING.
-            List<Long> offsetsAfterFailedRestore = readObservedOffsets();
+            List<Long> offsetsAfterFailedRestore =
+                    readObservedOffsets(CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR);
             Assertions.assertEquals(
                     offsetsBeforeRestoreAttempt.size(),
                     offsetsAfterFailedRestore.size(),
@@ -276,7 +332,19 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
                     olderFileChecksumsAfterFailedRestore,
                     "The older, non-corrupted checkpoint file(s) must remain untouched");
         } finally {
-            FileUtils.deleteFile(SINK_OUTPUT_DIR);
+            // Sink-directory cleanup runs first: it is what directly prevents this test's output
+            // from leaking into a sibling test that may run immediately afterward (see the class
+            // Javadoc), so it must not be skipped even if the checkpoint-directory cleanup below
+            // throws.
+            FileUtils.deleteFile(CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR);
+            if (sourceJobIdForCleanup != -1L) {
+                // Best-effort: remove this test's own checkpoint directory inside the shared,
+                // class-scoped container so the deliberately-corrupted file and the retained
+                // older checkpoints cannot outlive this test method or accumulate for the rest of
+                // the class's lifetime.
+                server.execInContainer(
+                        "sh", "-c", "rm -rf " + getCheckpointDirectory(sourceJobIdForCleanup));
+            }
         }
     }
 
@@ -514,8 +582,23 @@ public class CheckpointRestoreWithStopIT extends SeaTunnelEngineContainer {
         return offsets.stream().mapToLong(Long::longValue).max().orElse(-1L);
     }
 
+    /**
+     * Reads {@link #SINK_OUTPUT_DIR}; used only by {@link #testRestoreFromCheckpointAfterStop} and
+     * its helpers. See {@link #readObservedOffsets(String)} for the corruption test's own,
+     * separately-directoried variant.
+     */
     private List<Long> readObservedOffsets() {
-        Path outputDir = Paths.get(SINK_OUTPUT_DIR);
+        return readObservedOffsets(SINK_OUTPUT_DIR);
+    }
+
+    /**
+     * Reads every observed sink offset from the given output directory. Kept parameterized (rather
+     * than hardcoding {@link #SINK_OUTPUT_DIR}) so {@link
+     * #testRestoreFailsWhenLatestCheckpointFileIsCorrupted} can read its own, separate {@link
+     * #CORRUPTED_CHECKPOINT_SINK_OUTPUT_DIR} without ever mixing rows with the sibling test.
+     */
+    private List<Long> readObservedOffsets(String sinkOutputDir) {
+        Path outputDir = Paths.get(sinkOutputDir);
         if (!Files.exists(outputDir)) {
             return Collections.emptyList();
         }

--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/checkpoint-restore-with-stop/stream_checkpointable_sequence_to_localfile_corrupted_checkpoint.conf
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/resources/checkpoint-restore-with-stop/stream_checkpointable_sequence_to_localfile_corrupted_checkpoint.conf
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Dedicated to CheckpointRestoreWithStopIT#testRestoreFailsWhenLatestCheckpointFileIsCorrupted.
+# Identical to stream_checkpointable_sequence_to_localfile.conf except for sink.LocalFile.path:
+# this test needs its own sink directory (and, via this file's own name, its own SeaTunnel job
+# --name) so it can never share output with the sibling testRestoreFromCheckpointAfterStop, which
+# uses the same fixed start_offset = 0 and could otherwise run right before or after it depending
+# on JUnit Jupiter's default (deterministic but non-declaration-order) test method order.
+env {
+  parallelism = 1
+  job.mode = "STREAMING"
+  checkpoint.interval = 3000
+  checkpoint.retain-after-job-cancelled = true
+}
+
+source {
+  CheckpointableSequenceSource {
+    start_offset = 0
+    end_offset = 1000000
+    split_num = 1
+    emit_interval_ms = 50
+    records_per_poll = 1
+  }
+}
+
+transform {
+}
+
+sink {
+  LocalFile {
+    path = "/tmp/seatunnel_mnt/checkpoint-restore-with-stop/sinkfile-corrupted-checkpoint/"
+    row_delimiter = "\n"
+    file_name_expression = "offset_${transactionId}"
+    file_format_type = "text"
+    is_enable_transaction = true
+  }
+}


### PR DESCRIPTION
## Purpose

This E2E test documents Zeta's actual, current behavior when `--restore-with-checkpoint` is asked to restore from a job whose **latest** on-disk checkpoint file is corrupted, while an **older** checkpoint (still within `checkpoint.storage.max-retained`) remains intact and untouched.

Verified by reading current `dev` HEAD source (not assumed):

- Checkpoint restore reads the latest checkpoint via the configured storage plugin (`LocalFileStorage` by default) and deserializes it with **no checksum/CRC validation anywhere in the read path**.
- `LocalFileStorage.getCheckpointsByJobIdAndPipelineId` only catches `IOException` per file
  (`checkpoint-storage-plugins/checkpoint-storage-local-file/.../LocalFileStorage.java`), but a corrupted file's deserialization failure comes out of `ProtoStuffSerializer.deserialize` as an **unchecked** exception (its method signature carries no `throws` clause at all — verified both by inspecting `serializer-protobuf/.../ProtoStuffSerializer.java` and by an isolated, non-Docker reproduction described below), so the failure is never swallowed.
- The exception propagates out of `CheckpointManager`'s constructor (via `ExceptionUtil.sneakyThrow` in `CheckpointManager.java`), out of `JobMaster.initCheckPointManager()`, and is caught by `JobMaster.init()`.
- For a brand-new job submission via `--restore-with-checkpoint` (as opposed to a master-failover re-init), `JobMaster.init(..., restart=false)` is what `CoordinatorService.submitJob` calls (`CoordinatorService.java`), so `cancelJob()` itself is not invoked — but `init()` unconditionally rethrows the captured exception, which fails `submitJob`'s `jobSubmitFuture`, which fails the CLI's job submission with a non-zero exit code.
- There is **no fallback to the older, intact checkpoint**, even though `checkpoint.storage.max-retained: 3` (this module's test config) keeps several around.

This is Tier 2 of the ongoing Zeta-engine-core E2E initiative: a verified-fragile behavior of the current architecture with no existing regression coverage, documented as today's baseline (not a claim that this is the *ideal* behavior — a future fix adding checksum validation + fallback would rightly flip this test's outcome, and this test would need updating alongside that fix).

## What the test does

`CheckpointRestoreWithStopIT#testRestoreFailsWhenLatestCheckpointFileIsCorrupted`:

1. Runs a real streaming job (`CheckpointableSequenceSource` -> `LocalFile` sink) to **2 completed checkpoints** (`checkpoint.interval = 3000`, `checkpoint.retain-after-job-cancelled = true`), then stops it cleanly so both checkpoint files survive on disk.
2. Lists the job's checkpoint files directly inside the container (`/tmp/seatunnel/checkpoint_snapshot/<jobId>/`, matching this module's configured `namespace`) and replicates `AbstractCheckpointStorage`'s own "latest" selection rule (largest leading `<epochMillis>` segment of the `<epochMillis>-<random>-<pipelineId>-<checkpointId>.ser` file name) to find precisely the file production code would read back.
3. Corrupts **only** that latest file, leaving the older one byte-for-byte untouched (checksummed before/after to prove it).
4. Attempts `--restore-with-checkpoint` against the original (now-terminal) job id, bounded by a 2-minute timeout so a hang would fail the test loudly instead of blocking forever.
5. Asserts the restore attempt fails with a non-zero exit code and a non-empty diagnostic, that no new sink rows appear (no silent restart-from-scratch and no silent fallback), and that the untouched older checkpoint file(s) remain byte-for-byte identical.

### How the corruption is constructed, and why

The corruption overwrites the file in place with random bytes of the **same length** (no truncation — this documents same-size on-disk corruption, e.g. a bad block or a crash mid-write, not a truncated file), then forces the file's **first byte** to `0x00`.

That last part matters and is not incidental. Protostuff/protobuf's wire format reads a leading varint field tag starting at byte 0, and field number `0` is a reserved, always-invalid tag every decoder rejects immediately — before any other byte is even interpreted. Plain full-file random overwrite alone does **not** reliably reproduce this test's documented failure: I built a standalone, non-Docker reproduction (`RuntimeSchema`/`ProtostuffIOUtil` against a POJO with the same field shape as `PipelineState` — `String, int, long, byte[]`) and found random bytes form a self-consistent, non-throwing protostuff field sequence on roughly 1 in 5 attempts, independent of file size (sampled sizes 8 through 2014 bytes, 200 trials each, ~78-82% throw rate — never 100%). That would make a pure-random-bytes version of this test flaky. Forcing only the first byte to an invalid tag while leaving every other byte genuinely random keeps the corruption realistic (e.g. a torn write or block-zeroing landing on the start of the file) while making the deserialization failure deterministic: the same reproduction threw on 3600/3600 trials across file sizes from 1 to 2014 bytes once the leading byte was forced to `0x00`.

## Test plan

- `./mvnw spotless:apply -pl seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base -am -nsu` — BUILD SUCCESS.
- `./mvnw install -pl 'seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base,!seatunnel-engine/seatunnel-engine-ui' -am -nsu -Dmaven.gitcommitid.skip=true -DskipTests -Dspotless.check.skip=true -T 3C` — BUILD SUCCESS; confirmed the compiled test class exists under `target/test-classes`.
- Per this repository's local-verification policy for Apache SeaTunnel, the new E2E test itself (Docker/Testcontainers-based) is not executed locally in this change; it runs as part of this module's existing E2E suite in CI. The behavioral claims above are substantiated by direct inspection of `dev` HEAD source across the full call chain (`ClientCommandArgs` -> `SeaTunnelClient` -> `CheckpointManager` -> `LocalFileStorage`/`AbstractCheckpointStorage` -> `ProtoStuffSerializer` -> `JobMaster.init()` -> `CoordinatorService.submitJob`) plus the standalone protostuff reproduction described above.
- No changes to `src/main/**`; this is a test-only addition to `CheckpointRestoreWithStopIT.java`.
