### PR TITLE
[Test][E2E] Stop pinning one stack frame in DorisErrorIT stream-load failure check

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisErrorIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-doris-e2e/src/test/java/org/apache/seatunnel/e2e/connector/doris/DorisErrorIT.java
@@ -82,11 +82,19 @@ public class DorisErrorIT extends AbstractDorisIT {
                 future.get()
                         .getStderr()
                         .contains(DorisConnectorErrorCode.STREAM_LOAD_FAILED.getCode()));
+        // The failure must surface through the sink's stream-load layer. Which internal frame
+        // raises STREAM_LOAD_FAILED depends on how quickly the stopped container's network alias
+        // disappears: an HTTP-level error is reported via
+        // RecordBuffer#checkErrorMessageByStreamLoad,
+        // while a connect/DNS-level error is wrapped by DorisStreamLoad (stopLoad/abortPreCommit/
+        // startStreamLoad). Both are the same contract; pinning one frame made this test race.
+        String stderr = future.get().getStderr();
         Assertions.assertTrue(
-                future.get()
-                        .getStderr()
-                        .contains(
-                                "at org.apache.seatunnel.connectors.doris.sink.writer.RecordBuffer.checkErrorMessageByStreamLoad"));
+                stderr.contains(
+                                "at org.apache.seatunnel.connectors.doris.sink.writer.RecordBuffer.checkErrorMessageByStreamLoad")
+                        || stderr.contains(
+                                "at org.apache.seatunnel.connectors.doris.sink.writer.DorisStreamLoad."),
+                "STREAM_LOAD_FAILED was not raised from the Doris stream-load layer:\n" + stderr);
         log.info("doris error log: \n" + future.get().getStderr());
         super.container.start();
         // wait for the container to restart


### PR DESCRIPTION
## What does this PR do?

`DorisErrorIT#testDoris` stops the Doris container mid-stream-load and asserts the job fails with `STREAM_LOAD_FAILED`. It additionally required stderr to contain one exact frame, `RecordBuffer.checkErrorMessageByStreamLoad`. That frame only appears when the broker still answers the HTTP request with an error; when the stopped container's network alias is already gone, the same `STREAM_LOAD_FAILED` is raised by `DorisStreamLoad` (`stopLoad` / `abortPreCommit` / `startStreamLoad`) wrapping the connect/DNS failure (`UnknownHostException: doris_e2e`). Which path wins is a Docker teardown race.

This keeps the contract unchanged — non-zero exit and `STREAM_LOAD_FAILED` present — and requires the failure to surface from the sink's stream-load layer via either legitimate frame family, instead of pinning one implementation detail.

## Why is this needed?

Seen intermittently on unrelated PRs #11503 and #11727. In both CI runs the `STREAM_LOAD_FAILED` code assertion passed and only the frame check failed, with `DorisStreamLoad.stopLoad` → `Doris-01 stream load error` ← `UnknownHostException: doris_e2e: Temporary failure in name resolution` in the captured stderr.

## Does this PR introduce any user-facing change?

No. Test-only.

## How was this patch tested?

Test-only; the assertion still fails for an early submission failure or any non-stream-load error (the error-code check and the "raised from the stream-load layer" check both remain), and passes for both observed legitimate paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
