### PR TITLE
[Test][E2E] Start the RocketMQ broker with a single identity and wait for name-server routes

### DIFF
--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqContainer.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqContainer.java
@@ -18,65 +18,87 @@
 package org.apache.seatunnel.e2e.connector.rocketmq;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import lombok.SneakyThrows;
-
+import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.net.ServerSocket;
 import java.net.SocketException;
-import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.List;
 
-/** rocketmq container */
+/**
+ * RocketMQ container for the connector E2E suite.
+ *
+ * <p>The broker identity (broker name, advertised address and listen port) is fixed through a
+ * broker.conf that is copied into the container before the broker process starts, so the broker
+ * registers with the name server exactly once and under a single identity. The previous approach
+ * started the broker with the image defaults and renamed it afterwards through {@code mqadmin
+ * updateBrokerConfig}. That left the name server with two broker entries for the same process (the
+ * container hostname with the container-internal address plus {@code broker-a} with the host
+ * address). Until the stale entry was purged the default-topic route only referenced the hostname
+ * broker, so {@code producer.send(msg, new MessageQueue(topic, "broker-a", 0))} failed with "The
+ * broker[broker-a] not exist" and the admin client could not see consume offsets of {@code
+ * broker-a}. In CI that window covered most of the test run (apache/seatunnel PRs #12115 and
+ * #12099, job rocketmq-connector-it).
+ *
+ * <p>RocketMQ binds and advertises the same {@code listenPort}, so a single identity requires the
+ * host port to equal the container port. The broker port is therefore published as a fixed binding
+ * on a free host port chosen at construction time, while the name server keeps a dynamic mapping.
+ */
 public class RocketMqContainer extends GenericContainer<RocketMqContainer> {
 
     public static final int NAMESRV_PORT = 9876;
-    public static final int BROKER_PORT = 10911;
     public static final String BROKER_NAME = "broker-a";
     private static final int DEFAULT_BROKER_PERMISSION = 6;
     static final int DEFAULT_TOPIC_QUEUE_NUMS = 4;
+    private static final String BROKER_CONF_PATH = "/home/rocketmq/broker.conf";
+    private static final int FREE_PORT_ATTEMPTS = 20;
+
+    /** Broker listen port inside the container, published 1:1 on the host. */
+    private final int brokerPort;
 
     public RocketMqContainer(DockerImageName image) {
         super(image);
-        withExposedPorts(NAMESRV_PORT, BROKER_PORT, BROKER_PORT - 2);
+        this.brokerPort = findFreeBrokerPort();
+        withExposedPorts(NAMESRV_PORT);
+        // listenPort is both the bind port and the advertised port, so it must be published 1:1.
+        // The VIP channel listens on listenPort - 2 and is published the same way.
+        addFixedExposedPort(brokerPort, brokerPort);
+        addFixedExposedPort(brokerPort - 2, brokerPort - 2);
         this.withEnv("JAVA_OPT_EXT", "-Xms512m -Xmx512m");
     }
 
     @Override
     protected void configure() {
+        // Written before the broker starts so its very first registration already carries the
+        // final name, advertised address and permissions; nothing is renamed at runtime.
+        String brokerConf =
+                "brokerClusterName=DefaultCluster\n"
+                        + "brokerName="
+                        + BROKER_NAME
+                        + "\n"
+                        + "brokerId=0\n"
+                        + "brokerIP1="
+                        + getLinuxLocalIp()
+                        + "\n"
+                        + "listenPort="
+                        + brokerPort
+                        + "\n"
+                        + "autoCreateTopicEnable=true\n"
+                        + "defaultTopicQueueNums="
+                        + DEFAULT_TOPIC_QUEUE_NUMS
+                        + "\n"
+                        + "brokerPermission="
+                        + DEFAULT_BROKER_PERMISSION
+                        + "\n";
+        withCopyToContainer(Transferable.of(brokerConf), BROKER_CONF_PATH);
         String command = "#!/bin/bash\n";
         command += "./mqnamesrv &\n";
-        command += "./mqbroker -n localhost:" + NAMESRV_PORT;
+        command += "./mqbroker -n localhost:" + NAMESRV_PORT + " -c " + BROKER_CONF_PATH;
         withCommand("sh", "-c", command);
-    }
-
-    @Override
-    @SneakyThrows
-    protected void containerIsStarted(InspectContainerResponse containerInfo) {
-        List<String> updateBrokerConfigCommands = new ArrayList<>();
-        updateBrokerConfigCommands.add(updateBrokerConfig("autoCreateTopicEnable", true));
-        updateBrokerConfigCommands.add(
-                updateBrokerConfig("defaultTopicQueueNums", DEFAULT_TOPIC_QUEUE_NUMS));
-        updateBrokerConfigCommands.add(updateBrokerConfig("brokerName", BROKER_NAME));
-        updateBrokerConfigCommands.add(updateBrokerConfig("brokerIP1", getLinuxLocalIp()));
-        updateBrokerConfigCommands.add(
-                updateBrokerConfig("listenPort", getMappedPort(BROKER_PORT)));
-        updateBrokerConfigCommands.add(
-                updateBrokerConfig("brokerPermission", DEFAULT_BROKER_PERMISSION));
-        final String command = String.join(" && ", updateBrokerConfigCommands);
-        ExecResult result = execInContainer("/bin/sh", "-c", command);
-        if (result != null && result.getExitCode() != 0) {
-            throw new IllegalStateException(result.toString());
-        }
-    }
-
-    private String updateBrokerConfig(final String key, final Object val) {
-        final String brokerAddr = "localhost:" + BROKER_PORT;
-        return "./mqadmin updateBrokerConfig -b " + brokerAddr + " -k " + key + " -v " + val;
     }
 
     public String getNameSrvAddr() {
@@ -102,5 +124,38 @@ public class RocketMqContainer extends GenericContainer<RocketMqContainer> {
             ex.printStackTrace();
         }
         return ip;
+    }
+
+    /**
+     * Picks a free host port whose VIP channel port (port - 2) is free as well, so both fixed
+     * bindings can be published.
+     */
+    private static int findFreeBrokerPort() {
+        for (int i = 0; i < FREE_PORT_ATTEMPTS; i++) {
+            int port = findFreePort();
+            if (port > 2 && isPortFree(port - 2)) {
+                return port;
+            }
+        }
+        throw new IllegalStateException(
+                "Could not find a free host port pair for the RocketMQ broker");
+    }
+
+    private static int findFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not allocate a free host port", e);
+        }
+    }
+
+    private static boolean isPortFree(int port) {
+        try (ServerSocket socket = new ServerSocket(port)) {
+            socket.setReuseAddress(true);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
@@ -486,6 +486,20 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
                             Assertions.assertFalse(
                                     producer.fetchPublishMessageQueues(topic).isEmpty(),
                                     "Topic route is not ready: " + topic);
+                            // The producer above may answer from its own route cache, primed by
+                            // createTopic() against the broker, before the name server has
+                            // published the route. The connector resolves routes through a
+                            // fresh admin client (RocketMqAdminUtil#offsetTopics ->
+                            // examineTopicStats), which is exactly what failed with
+                            // "No topic route info in name server" in CI, so require the route
+                            // to be visible on that path too before returning.
+                            Assertions.assertFalse(
+                                    RocketMqAdminUtil.offsetTopics(
+                                                    newConfiguration(),
+                                                    Collections.singletonList(topic))
+                                            .get(0)
+                                            .isEmpty(),
+                                    "Topic route is not visible in the name server: " + topic);
                         });
     }
 

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-rocketmq-e2e/src/test/java/org/apache/seatunnel/e2e/connector/rocketmq/RocketMqIT.java
@@ -759,8 +759,11 @@ public class RocketMqIT extends TestSuiteBase implements TestResource {
                         + (srcEndAfterAll - srcEndBeforeStart));
 
         // The name server can briefly drop an auto-created topic route while the job is stopped
-        // for a savepoint. Restore only after the dynamic source topic is visible again.
+        // for a savepoint. Restore only after both dynamic topics are visible again: the restored
+        // job's sink publishes to sinkTopic first, and a dropped sink route fails every send with
+        // "No topic route info in name server" until the route is re-published.
         waitForTopicRoute(sourceTopic);
+        waitForTopicRoute(sinkTopic);
         CompletableFuture.runAsync(
                 () -> {
                     try {


### PR DESCRIPTION
## What does this PR do?

Two test-only changes to the RocketMQ E2E suite that remove the root causes of the `rocketmq-connector-it` failures seen on unrelated PRs (#11503, #11077, #12099, #11727) and on this PR's own earlier run.

### 1. Start the broker with its final identity (`RocketMqContainer`)

`RocketMqContainer` started the broker with the image defaults (`brokerName` = container hostname, `brokerIP1` = container IP, `listenPort` 10911) and then renamed it with `mqadmin updateBrokerConfig` once the container was up. The name server therefore held **two entries for the same process**: the hostname broker with the container-internal address, and `broker-a` with the host address. In the failing runs the default-topic (`TBW102`) route kept referencing only the hostname broker, so:

- `producer.send(msg, new MessageQueue(topic, "broker-a", 0))` failed with `The broker[broker-a] not exist` (`testSourceRocketMqTextTagToConsole`, `testSourceRocketMqTextErrorTagToConsole`, `testSourceRocketMqStartConfig`, `testSourceRocketMqMultiTableToAssert`);
- `RocketMqAdminUtil.currentOffsets` could not see the consume offset of `[test_topic, broker-a, 0]` (`testSinkRocketMq`);
- source jobs reading `test_topic_source` failed on every engine leg (`testRocketMqEarliestToConsole`, `testRocketMqSpecificOffsetsToConsole`).

Evidence: run 33982135238 (this PR, JDK 8 leg) and run 33976852050 attempt 2 (#12099, JDK 11 leg): the `TBW102` route `brokerDatas` listed only the hostname broker from 18:07:12 through 18:19:35, every test that ran in that window failed on all seven engine containers, and every test that ran after it passed. The green run 33973708060 had the same two identities, but there the stale entry happened to be purged early.

The broker now reads a `broker.conf` that is copied into the container **before** the broker process starts, so its first registration already carries the final name, advertised address, permissions and topic defaults; nothing is renamed at runtime. RocketMQ binds and advertises the same `listenPort`, so the broker port is published as a fixed 1:1 binding on a free host port chosen at construction time (a random free port keeps the JDK 8 / JDK 11 parallel-job safety that #11574 introduced); the name server keeps its dynamic mapping. `RocketMqIT` is unchanged by this part.

### 2. Wait for the route in the name server, not just the producer cache (`RocketMqIT`)

`RocketMqIT#waitForTopicRoute` confirmed a topic's route through the test producer's `fetchPublishMessageQueues()`, which can be answered from the producer's own route cache (primed by `createTopic()` against the broker) before the **name server** has published the route. The connector resolves routes with a fresh admin client (`RocketMqAdminUtil#offsetTopics` -> `DefaultMQAdminExt#examineTopicStats`), so a job could still start and fail with `ROCKETMQ-11` <- `MQClientException CODE: 17 No topic route info in name server for the topic` right after the wait returned. The wait now additionally requires the route to be visible through the connector's own resolution path within the same 1-minute budget, and `testSourceRocketMqRestore` waits for its sink topic before restoring. Nothing is relaxed; only stronger readiness conditions are added.

## Does this PR introduce any user-facing change?

No. Test-only (`seatunnel-e2e/.../connector-rocketmq-e2e`).

## How was this patch tested?

Test-only; validated by this PR's `rocketmq-connector-it` jobs on both JDK legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
