### PR TITLE
[Improve] [Zeta] Add JobStatus ordinal guard test and replace ordinal comparisons with explicit state sets

### DIFF
--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JobStatusTest {
@@ -36,5 +37,33 @@ public class JobStatusTest {
         } finally {
             Locale.setDefault(originalLocale);
         }
+    }
+
+    /**
+     * {@code JobStatus}'s ordinal is relied on directly: it is transported raw over the internal
+     * RPC (see {@code GetJobStatusOperation}/{@code ClientJobProxy}/{@code JobClient}) and used to
+     * index the {@code stateTimestamps} array in {@code PhysicalPlan}. Reordering or inserting a
+     * new constant would silently corrupt both without this test failing. If this test breaks
+     * because a new state was intentionally added, update the expected array below to match and
+     * double check every ordinal-based array index and RPC decode site still lines up.
+     */
+    @Test
+    void testOrdinalTableIsPinned() {
+        JobStatus[] expected = {
+            JobStatus.INITIALIZING,
+            JobStatus.CREATED,
+            JobStatus.PENDING,
+            JobStatus.SCHEDULED,
+            JobStatus.RUNNING,
+            JobStatus.FAILING,
+            JobStatus.FAILED,
+            JobStatus.DOING_SAVEPOINT,
+            JobStatus.SAVEPOINT_DONE,
+            JobStatus.CANCELING,
+            JobStatus.CANCELED,
+            JobStatus.FINISHED,
+            JobStatus.UNKNOWABLE
+        };
+        assertArrayEquals(expected, JobStatus.values());
     }
 }

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JobStatusTest {
@@ -40,12 +39,22 @@ public class JobStatusTest {
     }
 
     /**
-     * {@code JobStatus}'s ordinal is relied on directly: it is transported raw over the internal
-     * RPC (see {@code GetJobStatusOperation}/{@code ClientJobProxy}/{@code JobClient}) and used to
-     * index the {@code stateTimestamps} array in {@code PhysicalPlan}. Reordering or inserting a
-     * new constant would silently corrupt both without this test failing. If this test breaks
-     * because a new state was intentionally added, update the expected array below to match and
-     * double check every ordinal-based array index and RPC decode site still lines up.
+     * Pins the exact order of {@link JobStatus#values()} so that reordering or inserting a constant
+     * fails this test loudly instead of silently corrupting the two things that rely on the ordinal
+     * within a single build: the raw {@code int} sent over the internal RPC (see {@code
+     * GetJobStatusOperation}/{@code ClientJobProxy}/{@code JobClient}) and the index into the
+     * {@code stateTimestamps} array in {@code PhysicalPlan}.
+     *
+     * <p><b>This guard only covers same-build code.</b> It says nothing about a rolling upgrade
+     * where a client and coordinator run different builds with a reordered or differently-sized
+     * {@code JobStatus}: decoding the raw ordinal back via {@code JobStatus.values()[ordinal]} at
+     * {@code ClientJobProxy}/{@code JobClient} can still throw {@code
+     * ArrayIndexOutOfBoundsException} or silently resolve to the wrong constant in that scenario.
+     * Closing that gap needs a name-based, versioned RPC transport, which is a separate, larger
+     * design item and out of scope here.
+     *
+     * <p>If this test fails because a new state was intentionally added or reordered, update the
+     * expected array below to match, and audit every ordinal-based site named above by hand.
      */
     @Test
     void testOrdinalTableIsPinned() {
@@ -64,6 +73,14 @@ public class JobStatusTest {
             JobStatus.FINISHED,
             JobStatus.UNKNOWABLE
         };
-        assertArrayEquals(expected, JobStatus.values());
+        JobStatus[] actual = JobStatus.values();
+        assertEquals(
+                expected.length, actual.length, "JobStatus constant count changed unexpectedly");
+        for (int ordinal = 0; ordinal < expected.length; ordinal++) {
+            assertEquals(
+                    expected[ordinal],
+                    actual[ordinal],
+                    "JobStatus ordinal " + ordinal + " drifted from the pinned constant");
+        }
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
@@ -39,15 +39,24 @@ import com.hazelcast.map.IMap;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 public class PhysicalPlan {
+
+    /**
+     * Job states reached before the job has actually started running. A job in one of these states
+     * can be cancelled directly rather than going through {@code CANCELING}.
+     */
+    private static final Set<JobStatus> NOT_YET_STARTED_STATES =
+            EnumSet.of(JobStatus.INITIALIZING, JobStatus.CREATED, JobStatus.PENDING);
 
     private final List<SubPlan> pipelineList;
 
@@ -204,7 +213,7 @@ public class PhysicalPlan {
             return;
         }
 
-        if (((JobStatus) runningJobStateIMap.get(jobId)).ordinal() <= JobStatus.PENDING.ordinal()) {
+        if (NOT_YET_STARTED_STATES.contains((JobStatus) runningJobStateIMap.get(jobId))) {
             // Tasks with the status 'INITIALIZING', 'CREATED', 'PENDING' need to be set directly to
             // the 'CANCELLED' state because it has not yet started running
             updateJobState(JobStatus.CANCELED);
@@ -251,7 +260,7 @@ public class PhysicalPlan {
             return;
         }
 
-        if (jobStatus.ordinal() <= JobStatus.PENDING.ordinal()) {
+        if (NOT_YET_STARTED_STATES.contains(jobStatus)) {
             // Tasks with the status 'INITIALIZING', 'CREATED', 'PENDING' need to be set directly to
             // the 'CANCELLED' state because it has not yet started running
             updateJobState(JobStatus.CANCELED);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
@@ -39,6 +39,7 @@ import com.hazelcast.map.IMap;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -54,9 +55,16 @@ public class PhysicalPlan {
     /**
      * Job states reached before the job has actually started running. A job in one of these states
      * can be cancelled directly rather than going through {@code CANCELING}.
+     *
+     * <p>{@link JobStatus#SCHEDULED} is deliberately excluded: by that point pipelines have already
+     * been dispatched to workers, and only the {@code CANCELING} path (see the {@code CANCELING}
+     * case in {@link #stateProcess()}) actually calls {@link SubPlan#cancelPipeline()} on them.
+     * Treating {@code SCHEDULED} as "not yet started" would complete the job as {@code CANCELED}
+     * without ever cancelling those already-dispatched pipelines, orphaning their resources.
      */
     private static final Set<JobStatus> NOT_YET_STARTED_STATES =
-            EnumSet.of(JobStatus.INITIALIZING, JobStatus.CREATED, JobStatus.PENDING);
+            Collections.unmodifiableSet(
+                    EnumSet.of(JobStatus.INITIALIZING, JobStatus.CREATED, JobStatus.PENDING));
 
     private final List<SubPlan> pipelineList;
 
@@ -213,6 +221,9 @@ public class PhysicalPlan {
             return;
         }
 
+        // A null runningJobStateIMap.get(jobId) here would already have thrown NPE two lines
+        // above at jobStatus.isEndState(), which reads the same map entry - so contains(null)
+        // is unreachable, not silently treated as "not yet started".
         if (NOT_YET_STARTED_STATES.contains((JobStatus) runningJobStateIMap.get(jobId))) {
             // Tasks with the status 'INITIALIZING', 'CREATED', 'PENDING' need to be set directly to
             // the 'CANCELLED' state because it has not yet started running


### PR DESCRIPTION
### Purpose of this pull request

`JobStatus`'s ordinal is relied on directly in two ways with no guard against it changing:

- Transported raw over the internal RPC: `GetJobStatusOperation.java:81` sends `future.get().ordinal()`; `ClientJobProxy.java:154` and `JobClient.java:121` decode it back with `JobStatus.values()[ordinal]`.
- Used to index the `stateTimestamps` array in `PhysicalPlan` (`PhysicalPlan.java:105`, `:115`, `:300`, `:309`).

`PhysicalPlan.java:207` and `:254` additionally use `jobStatus.ordinal() <= JobStatus.PENDING.ordinal()` as a range check for "job hasn't started running yet" (`INITIALIZING`/`CREATED`/`PENDING`), which only works because those three happen to be the first three enum constants.

This is a hardening task — there's no current failure caused by the ordering, the goal is to make the existing coupling explicit and guarded, per the issue.

Changes:
- Added `JobStatusTest.testOrdinalTableIsPinned`, which pins the exact `JobStatus.values()` order and fails loudly if a future change reorders or inserts a constant.
- Replaced the two `ordinal() <= PENDING.ordinal()` range comparisons in `PhysicalPlan` with an explicit `NOT_YET_STARTED_STATES` `EnumSet` (`INITIALIZING`, `CREATED`, `PENDING`), so the actual intent is explicit instead of relying on enum declaration order.

Per the issue, a name-based/versioned RPC transport is a separate design item and out of scope here. The `stateTimestamps` array indexing is left as-is (still ordinal-based) — it's now covered by the pinning test, so a reorder will fail the test before it can silently corrupt the array or the RPC decode.

Fixes #12124

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added `JobStatusTest.testOrdinalTableIsPinned` (see above).
- `./mvnw -q spotless:apply` and `./mvnw -q -DskipTests compile -pl seatunnel-engine/seatunnel-engine-common,seatunnel-engine/seatunnel-engine-server -am` both succeed cleanly against this change.
- I was not able to get `./mvnw test` to run cleanly for these modules in my local environment — a shallow clone of the reactor hits a pre-existing module-ordering issue unpacking `seatunnel-config-shade`'s vendored typesafe-config sources (reproducible on unmodified `dev`, unrelated to this change: the same "cannot find symbol" failures occur in `seatunnel-common`'s `CheckConfigUtil`/`TypesafeConfigUtils`, files this PR doesn't touch). As a substitute, I compiled `JobStatus.java` standalone (zero external dependencies) and ran a small throwaway program executing both the new pinning assertion and the old-vs-new (`ordinal() <= PENDING.ordinal()` vs. the new `EnumSet.contains`) comparison against every current `JobStatus` value — confirmed identical results for all 13 states. Happy for a maintainer to confirm `mvn test` passes in CI.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — N/A, no new dependencies
* [ ] If necessary, please update the documentation to describe the new feature — N/A, internal hardening only, no user-facing behavior change
* [ ] If necessary, please update `incompatible-changes.md` — N/A, not an incompatible change
* [ ] Connector-code checklist items — N/A, this PR doesn't touch a connector