### PR TITLE
[Feature][Zeta] Add advisory autoscaling for Zeta engine Phase 1

### DIFF
--- a/config/seatunnel.yaml
+++ b/config/seatunnel.yaml
@@ -25,6 +25,23 @@ seatunnel:
     print-job-metrics-info-interval: 60
     slot-service:
       dynamic-slot: true
+    autoscaler:
+      enabled: false
+      evaluation-interval-seconds: 30
+      metrics-freshness-seconds: 120
+      max-future-skew-seconds: 5
+      scale-out-stabilization-seconds: 300
+      scale-in-stabilization-seconds: 600
+      scale-out-cpu-threshold: 0.8
+      scale-out-jvm-memory-threshold: 0.8
+      scale-in-cpu-threshold: 0.3
+      scale-in-jvm-memory-threshold: 0.3
+      fixed-slot-scale-out-threshold: 0.8
+      fixed-slot-scale-in-threshold: 0.3
+      scale-step: 1
+      min-workers: 1
+      max-workers: 2147483647
+      history-size: 20
     checkpoint:
       interval: 10000
       timeout: 60000

--- a/docs/STIP-Zeta-Autoscaling-Design-EN.md
+++ b/docs/STIP-Zeta-Autoscaling-Design-EN.md
@@ -1,0 +1,701 @@
+# STIP: Zeta Engine Autoscaling
+
+| Field | Value |
+| --- | --- |
+| STIP | Zeta Engine Autoscaling |
+| Issue | [#11663](https://github.com/apache/seatunnel/issues/11663) |
+| Status | Draft |
+| Last Updated | 2026-09-04 |
+
+## 1. Abstract
+
+This STIP proposes a native autoscaling framework for the SeaTunnel Zeta Engine.
+
+The proposal is intentionally phased:
+
+- **Phase 1** introduces an **advisory-only** autoscaling control loop that evaluates worker-capacity pressure and publishes structured scaling recommendations through REST APIs and Prometheus metrics.
+- **Later phases** introduce pluggable scale-out execution, worker drain, and safe scale-in.
+
+The scope of this STIP is **worker cluster capacity scaling**. It does not include running-job parallelism rescaling, execution graph reconstruction, or live task migration.
+
+The key Phase 1 design decisions are:
+
+- **Phase 1 is advisory-only and does not change actual worker count**
+- **Both Fixed Slot and Dynamic Slot are supported, but Dynamic Slot does not use slot utilization**
+
+## 2. Motivation, Scope, and Non-Goals
+
+### 2.1 Motivation
+
+Zeta already exposes several prerequisites for autoscaling:
+
+- worker heartbeat reporting
+- slot-aware scheduling
+- partial worker system-load reporting
+- pending-job visibility
+- Prometheus and realtime metrics exposure
+
+However, Zeta still lacks a native control loop that can translate scheduler pressure and worker saturation into a consistent autoscaling recommendation.
+
+This creates three practical gaps:
+
+- Kubernetes users must rely on external HPA or custom controllers that do not understand Zeta-native scheduling pressure.
+- Non-Kubernetes deployments have no standard autoscaling mechanism.
+- Worker removal is unsafe today because it is treated as a worker failure and may restart affected pipelines.
+
+### 2.2 Scope
+
+This STIP covers **worker capacity scaling** only.
+
+It includes:
+
+- adding worker capacity for jobs blocked by insufficient cluster resources
+- evaluating cluster pressure from scheduler and worker-level signals
+- producing structured scale-out and scale-in recommendations
+- exposing those recommendations through machine-readable interfaces
+- converging external worker capacity toward the desired target in later phases
+
+### 2.3 Non-Goals
+
+This STIP does not include:
+
+- rescaling the parallelism of a running job
+- rebuilding a running execution graph
+- repartitioning source splits online
+- live task migration between workers
+- guaranteed throughput improvement for already running streaming jobs
+- automatic mitigation of connector-side, database-side, or sink-side bottlenecks
+
+Running-job rescaling should be addressed by a separate STIP because it requires state redistribution and connector-specific recovery guarantees.
+
+## 3. Current State and Design Constraints
+
+### 3.1 Current State
+
+The current master side already owns most of the data needed for a first autoscaling phase:
+
+- worker registry and heartbeat-derived worker profiles
+- cluster slot and resource overview
+- pending job queue
+- slot allocation strategy state
+- worker resource diagnostics and metrics endpoints
+
+Current recovery, however, still relies on **checkpoint plus pipeline restart**. Zeta does not provide a worker drain protocol or live task migration. As a result, direct worker removal is not a safe scale-in path.
+
+### 3.2 Phase 1 Constraints
+
+Phase 1 is the minimum reviewable unit and therefore stays intentionally narrow:
+
+- **advisory-only**
+- **single AutoScaler**
+- **single default scope**
+- **no actuator invocation**
+- **no worker drain**
+- **no job topology changes**
+
+### 3.3 Design Principles
+
+- **Advisory-first**: Phase 1 publishes recommendations only.
+- **Backward compatible**: autoscaling is disabled by default and does not change current scheduling behavior unless enabled.
+- **Transparent**: each recommendation must be explainable from its inputs.
+- **Safe by construction**: incomplete metrics may allow conservative scale-out but must block scale-in.
+- **Extensible**: the Phase 1 interfaces must remain compatible with later actuator and drain phases.
+
+### 3.4 Architecture Context
+
+```mermaid
+flowchart TD
+    subgraph WorkerCluster[Worker Cluster]
+        W1[Worker A]
+        W2[Worker B]
+        W3[Worker C]
+    end
+
+    subgraph MasterNode[Active Master]
+        RM[ResourceManager]
+        CS[CoordinatorService]
+        AS[AutoScaler]
+        PUB[Recommendation Publisher]
+    end
+
+    subgraph Consumers[External Consumers]
+        MET[Prometheus / OpenMetrics]
+        API[REST APIs]
+        CTRL[Operator / Controller<br/>Later Phases]
+    end
+
+    W1 -->|heartbeat, slot state,<br/>cpu/memory| RM
+    W2 -->|heartbeat, slot state,<br/>cpu/memory| RM
+    W3 -->|heartbeat, slot state,<br/>cpu/memory| RM
+    CS -->|pending jobs,<br/>scheduler state| AS
+    RM -->|worker/resource view| AS
+    AS --> PUB
+    PUB --> MET
+    PUB --> API
+    API --> CTRL
+```
+
+## 4. Proposed Architecture
+
+### 4.1 Core Model
+
+An `AutoScaler` module is introduced on the master side and integrated with the active-master lifecycle. Its job is to:
+
+1. collect worker and scheduler signals
+2. evaluate autoscaling policy
+3. publish a structured `ScalingRecommendation`
+4. invoke an actuator in later phases
+
+Exactly **one AutoScaler instance** is active in the cluster at any time.
+
+### 4.2 Active Master Ownership
+
+Ownership rules are:
+
+- the AutoScaler runs only on the active master
+- it stops immediately when the node loses active-master ownership
+- every recommendation and action carries a `masterEpoch`
+- stale actions from older epochs must be rejected
+- a new active master must reconcile persisted state instead of replaying incomplete actions blindly
+
+### 4.3 Recommendation Model
+
+Phase 1 recommendations are advisory-only, but they still need a stable identity and enough
+decision context to be auditable and safely consumed by later phases.
+
+Recommended **Phase 1** fields:
+
+| Field | Purpose |
+| --- | --- |
+| `masterEpoch` | active-master fencing identity |
+| `generation` | monotonic recommendation revision within one `masterEpoch` |
+| `action` | `SCALE_OUT`, `SCALE_IN_CANDIDATE`, `SCALE_IN_BLOCKED`, `NO_ACTION` |
+| `observedAt` | evaluation time at which the recommendation was produced |
+| `reason` | human-readable explanation |
+| `currentWorkers` | observed worker count |
+| `recommendedWorkers` | target worker count |
+| `triggerConditions` | matched signals that caused the decision |
+| `blockingConditions` | missing or failing conditions that prevented a stronger action |
+| `metricsSnapshot` | key input values used by the decision |
+| `metricsValid` | whether worker-level decision inputs were valid enough for safe evaluation |
+| `staleWorkerCount` | number of workers whose latest sample was stale at evaluation time |
+| `recommendationOnly` | whether the recommendation is advisory-only |
+| `validUntil` | optional expiry bound for consumers |
+| `timestamp` | recommendation generation time |
+
+Consumers must reject recommendations whose `masterEpoch` is older than the currently active
+control loop epoch. Within the same `masterEpoch`, consumers must also reject recommendations whose
+`generation` is older than the latest accepted generation.
+
+Within one `masterEpoch`, `generation` must increase strictly monotonically for every newly emitted
+recommendation. When a new active master takes ownership and starts a new `masterEpoch`, the
+generation sequence is reset for that new epoch.
+
+Later phases may extend the recommendation contract with stronger reconciliation fields for active
+execution.
+
+Recommended **later-phase** extensible fields:
+
+| Field | Purpose |
+| --- | --- |
+| `recommendationId` | stable identity for the decision |
+| `triggerConditions` | matched conditions |
+| `blockingConditions` | unmet safety conditions |
+| `convergenceStatus` | whether an external actuator has accepted and converged on the target |
+| `appliedAt` | later-phase execution timestamp |
+
+### 4.4 Worker Drain as a Later-Phase Dependency
+
+Worker drain is not part of Phase 1, but the STIP must define it because safe scale-in depends on it.
+
+```mermaid
+stateDiagram-v2
+    [*] --> ACTIVE
+    ACTIVE --> DRAINING : mark for scale-in
+    DRAINING --> DRAINED : no new slots + workloads drained
+    DRAINED --> DECOMMISSIONING : actuator removes worker
+    DECOMMISSIONING --> DECOMMISSIONED : worker count converged
+    DRAINING --> ACTIVE : drain cancelled / rollback
+    DECOMMISSIONING --> FAILED : remove or recovery failed
+    FAILED --> ACTIVE : reconciled
+```
+
+## 5. Decision Model and Scaling Policy
+
+### 5.1 Signal Classes
+
+The autoscaling policy must not treat all metrics as signals of the same kind.
+
+It must also be explicit that scaling decisions are **not** made from a single utilization metric.
+In particular, `slot-level utilization` and `worker-level utilization` can disagree:
+
+- a worker may appear busy in terms of slots while remaining light on CPU or memory
+- a worker may appear light in terms of slots while already being saturated on CPU or memory
+
+This is expected because slot pressure reflects scheduling shape, while CPU and memory reflect
+actual runtime resource consumption. CPU-bound, memory-bound, and I/O-bound workloads can produce
+very different relationships between these signals.
+
+The proposal uses a **hierarchical multi-signal model**:
+
+| Signal Class | Question It Answers | Examples | Priority |
+| --- | --- | --- | --- |
+| Scheduler blocking signals | Is scheduling already blocked by insufficient capacity? | `WAIT`, `REJECT`, unsatisfied `ResourceProfile` | highest |
+| Worker saturation signals | Are compute or memory resources actually saturated? | average CPU, average memory, stale samples | medium |
+| Slot-capacity heuristic signals | Is scheduling capacity tight under the current slot configuration? | slot utilization in Fixed Slot mode | lowest |
+
+This distinction matters because slot occupancy and worker-level resource utilization can disagree.
+
+For Phase 1, these scheduler blocking signals should be grounded in explicit master-side state:
+
+- `WAIT` should be derived from pending scheduling state, including blocked job count, oldest
+  blocked age, and unsatisfied resource demand
+- `REJECT` should be derived from structured resource-allocation rejection events or equivalent
+  scheduler-side shortage records, rather than inferred from utilization alone
+
+Normative decision rule:
+
+- scaling decisions must not be based on slot utilization alone
+- worker-level utilization is the **primary resource-saturation signal**
+- slot utilization is a **strong but secondary scheduling signal**
+- scheduler blocking signals such as `WAIT`, `REJECT`, and unsatisfied `ResourceProfile` demand take precedence over both
+
+### 5.2 Fixed Slot and Dynamic Slot Semantics
+
+| Slot Mode | Slot Utilization Semantics | Phase 1 Decision Inputs |
+| --- | --- | --- |
+| Fixed Slot | `assignedSlots / configuredTotalSlots` | slot utilization, CPU, memory, `WAIT`, `REJECT` |
+| Dynamic Slot | `UNKNOWN` | CPU, memory, unassigned resources, `WAIT`, `REJECT` |
+
+Normative rules:
+
+- `slot utilization` is a **scheduling-capacity heuristic**, not a direct measure of real resource saturation
+- `slot utilization` must never be the single source of truth for cluster pressure
+- `slot utilization` is valid only in **Fixed Slot** mode
+- **Dynamic Slot** must report slot utilization as `UNKNOWN`
+- Dynamic Slot decisions must rely on worker-level signals and scheduler blocking signals
+- even in **Fixed Slot** mode, slot utilization must not override stronger evidence from worker saturation or scheduler blocking
+
+### 5.3 Conflict Resolution
+
+The decision policy must define how conflicting signals are interpreted.
+
+| Case | Interpretation | Policy Guidance |
+| --- | --- | --- |
+| high slot utilization, low CPU/memory | many lightweight tasks or tight slot configuration | do not scale out from slot pressure alone; require sustained demand or scheduler blocking |
+| low slot utilization, high CPU/memory | few but resource-heavy tasks | scale-out may still be justified from worker saturation |
+| low slot utilization, low average CPU/memory, but `WAIT/REJECT` exists | resource-shape mismatch or fragmented capacity | treat as scheduler pressure; do not suppress scale-out because averages look low |
+| high slot utilization, high CPU/memory | scheduling pressure and resource pressure both exist | strong scale-out signal |
+| low slot utilization, low CPU/memory, no `WAIT/REJECT` | cluster appears idle and schedulable | possible scale-in candidate, subject to safety checks |
+
+The resulting priority order is:
+
+1. scheduler blocking signals
+2. worker-level utilization
+3. slot utilization in Fixed Slot mode only
+
+This means the autoscaler should not scale solely because slot pressure is high if the stronger
+signals do not support that conclusion, and it should still be able to recommend scale-out when
+worker saturation or scheduler blocking exists even if slot pressure appears low.
+
+### 5.4 Phase 1 Policy Shape
+
+Phase 1 uses **explicit hierarchical rules**, not a weighted pressure score, as the primary decision contract.
+
+That choice is intentional:
+
+- it is easier to review and explain
+- it keeps `WAIT` and `REJECT` as explicit hard signals
+- it avoids diluting scheduler blocking signals into a generic score
+- it keeps future score-based refinement possible without changing Phase 1 semantics
+
+A weighted score or feature model may be introduced in a later phase as a secondary refinement layer, but it must not override hard triggers or hard blockers.
+
+### 5.5 Worker Sample Freshness and Snapshot Semantics
+
+Phase 1 does not evaluate every raw worker metric event as an independent decision input.
+Instead, the active AutoScaler maintains at most one **latest valid sample** for each worker.
+
+A worker sample is considered **ingest-valid** only when:
+
+- it carries a worker-observed `eventTime`
+- `masterNow - eventTime <= freshnessWindow + clockSkewTolerance`
+
+Phase 1 should define a conservative default `clockSkewTolerance`, such as **5s**, to absorb small
+clock offsets between workers and the active master without making sample freshness ambiguous across
+nodes.
+
+If `eventTime > masterNow + clockSkewTolerance`, the sample must be treated as invalid or
+suspicious and excluded from evaluation input, because the worker-observed time is too far ahead of
+the active master to be trusted safely.
+
+If a sample is ingest-valid, it replaces the previously stored sample for that worker only when its
+`eventTime` is newer than the currently stored one. If a sample is already stale on arrival, it
+must not enter the effective evaluation state, although it may still be counted for diagnostics.
+
+This gives Phase 1 two explicit guarantees:
+
+- the control loop evaluates a **cluster snapshot of latest valid worker samples**
+- the control loop does **not** depend on storing a full history of raw worker metric events
+
+Scheduler-side signals such as `WAIT`, `REJECT`, and unsatisfied `ResourceProfile` demand are
+evaluated from active-master state directly and are not subject to worker-sample freshness checks.
+
+```mermaid
+flowchart TD
+    A[Worker reports sample with eventTime] --> B{eventTime fresh at ingest?}
+    B -->|No| C[Reject from evaluation input<br/>count as stale diagnostic]
+    B -->|Yes| D{Newer than stored sample?}
+    D -->|No| E[Ignore as out-of-order duplicate]
+    D -->|Yes| F[Replace worker latestValidSample]
+```
+
+### 5.6 Evaluation Cadence and Stabilization Semantics
+
+Phase 1 separates three time concepts:
+
+- `freshnessWindow`: maximum allowed age of a worker sample for decision use
+- `evaluationInterval`: how often the autoscaling control loop evaluates the current cluster snapshot
+- `stabilizationWindow`: how long a scale condition must remain continuously satisfied before a recommendation is emitted
+
+The stabilization window is defined semantically as an **elapsed wall-clock duration**, not as a
+fixed number of evaluator ticks. A scale condition becomes eligible only when it has remained
+continuously satisfied from `firstSatisfiedAt` until `now`, and
+`now - firstSatisfiedAt >= stabilizationWindow`.
+
+In implementation, this elapsed duration should be measured with a **monotonic engine clock** so
+that stabilization timing is not distorted by wall-clock jumps, NTP correction, or host time
+adjustments. Wall-clock timestamps remain useful for diagnostics, audit payloads, and operator
+visibility.
+
+For each evaluation result, the AutoScaler maintains a condition tracker such as
+`scaleOutFirstSatisfiedAt` or `scaleInFirstSatisfiedAt`. A tracker must be reset when:
+
+- the current evaluation result is not firing
+- a required decision input becomes invalid or missing
+- the active master changes and a new `masterEpoch` begins
+
+For scale-in, any loss of worker-sample freshness resets the scale-in stabilization state
+immediately, because scale-in is a safety-sensitive decision.
+
+For scale-out, explicit scheduler shortage signals such as `WAIT`, `REJECT`, or unsatisfied demand
+may continue to sustain the scale-out condition even when some worker resource samples are
+temporarily unavailable.
+
+### 5.7 Scale-Out Policy
+
+Scale-out is triggered when a worker-level utilization signal or an explicit scheduler shortage
+signal remains above threshold for the stabilization window. Slot pressure is only an auxiliary
+signal and must not trigger scale-out by itself.
+
+Default scale-out policy:
+
+| Signal | Default Rule |
+| --- | --- |
+| `WAIT` oldest blocked age | sustained beyond threshold |
+| unsatisfied resource demand | sustained beyond threshold |
+| `REJECT` shortage evidence | sustained beyond threshold |
+| average CPU utilization | > `0.8` |
+| average memory utilization | > `0.8` |
+| fixed-slot utilization | > `0.8`, Fixed Slot only |
+
+Signal collection guidance:
+
+| Signal | Phase 1 Collection Guidance |
+| --- | --- |
+| `WAIT` oldest blocked age | derived from pending scheduling state on the active master |
+| unsatisfied resource demand | derived from resource profiles that remain unschedulable |
+| `REJECT` shortage evidence | derived from explicit allocation rejection or no-enough-resource events |
+| average CPU utilization | aggregated from worker heartbeat-reported load |
+| average memory utilization | aggregated from worker heartbeat-reported load |
+| fixed-slot utilization | derived from assigned vs configured slots in Fixed Slot mode |
+
+Additional rules:
+
+- scheduler blocking signals are evaluated first
+- worker CPU and memory are the primary utilization inputs
+- Fixed Slot utilization is auxiliary only
+- Dynamic Slot never uses slot utilization
+- default stabilization window is **300s**
+- default recommendation step is **`+1 worker per cycle`**
+
+### 5.8 Scale-In Policy
+
+Scale-in is more restrictive. It is triggered only when **all required conditions** remain satisfied for a longer stabilization window.
+
+Default scale-in policy:
+
+| Requirement | Default Rule |
+| --- | --- |
+| no `WAIT` blocking | required |
+| no `REJECT` shortage evidence | required |
+| valid and fresh metrics | required |
+| average CPU utilization | < `0.3` |
+| average memory utilization | < `0.3` |
+| fixed-slot utilization | < `0.3`, Fixed Slot only |
+| above `minWorkers` | required |
+
+Additional rules:
+
+- scale-in is fundamentally a **worker-level safety** decision
+- slot-level idleness alone must not trigger scale-in
+- Dynamic Slot supports scale-in, but the slot-utilization condition is skipped
+- if scheduler safety cannot be established from fresh worker-level metrics, scale-in must be blocked
+- default stabilization window is **600s**
+
+### 5.9 Anti-Oscillation
+
+The design uses three layers of protection:
+
+| Mechanism | Purpose |
+| --- | --- |
+| stabilization window | suppress transient spikes |
+| cooldown | prevent repeated actions after convergence |
+| hysteresis | separate scale-out and scale-in thresholds |
+
+Default hysteresis is approximately:
+
+- scale-out region around `0.8`
+- scale-in region around `0.3`
+
+In advisory mode, generating a recommendation does **not** start cooldown. In active mode, cooldown starts only after the action has converged and actual worker count reaches the target.
+
+Advisory recommendations must be idempotent. Re-publishing the same recommendation identity does
+not create additional side effects, and it must not start cooldown before an external actuator in a
+later phase reports convergence.
+
+### 5.10 Phase 1 Control Loop
+
+```mermaid
+flowchart TD
+    A[Every evaluationInterval] --> B[Load each worker latestValidSample]
+    B --> C[Re-check sample freshness at evaluation time]
+    C --> D[Build current cluster snapshot]
+    D --> E{WAIT / REJECT / unsatisfied demand firing?}
+    E -->|Yes| F[SCALE_OUT_FIRING]
+    E -->|No| G{CPU / memory saturation firing?}
+    G -->|Yes| F
+    G -->|No| H{Fixed Slot auxiliary pressure firing?}
+    H -->|Yes| F
+    H -->|No| I{All scale-in conditions satisfied?}
+    I -->|Yes| J[SCALE_IN_FIRING]
+    I -->|No| K{Metrics invalid for safe scale-in?}
+    K -->|Yes| L[SCALE_IN_BLOCKED]
+    K -->|No| M[NO_ACTION]
+    F --> N[Update scale-out stabilization tracker]
+    J --> O[Update scale-in stabilization tracker]
+    L --> P[Reset firing trackers as required]
+    M --> P
+    N --> Q{stabilizationWindow reached?}
+    O --> R{stabilizationWindow reached?}
+    Q -->|Yes| S[Publish advisory SCALE_OUT recommendation]
+    Q -->|No| T[Wait for next evaluation]
+    R -->|Yes| U[Publish advisory SCALE_IN recommendation]
+    R -->|No| T
+    P --> T
+```
+
+Phase 1 evaluation runs as a periodic control loop on the active master:
+
+1. Every `evaluationInterval`, build the current cluster snapshot from the latest stored worker samples.
+2. For each worker sample, re-check whether it is still fresh at evaluation time.
+3. Exclude stale samples from safe worker-level decisions and count them in freshness diagnostics.
+4. Read scheduler-side blocking signals, including `WAIT`, `REJECT`, and unsatisfied resource demand.
+5. Evaluate the hierarchical rules in priority order:
+   - scheduler blocking signals first
+   - worker CPU and memory saturation next
+   - slot utilization only as an auxiliary signal in Fixed Slot mode
+6. Produce the current evaluation result as one of:
+   - `SCALE_OUT_FIRING`
+   - `SCALE_IN_FIRING`
+   - `NO_ACTION`
+   - `SCALE_IN_BLOCKED`
+7. If the same firing condition remains continuously satisfied for at least the configured
+   `stabilizationWindow`, emit an advisory recommendation.
+8. If the condition is broken at any later evaluation, reset the corresponding stabilization tracker.
+
+## 6. Interfaces, Observability, and Compatibility
+
+### 6.1 Prometheus and OpenMetrics
+
+The autoscaler should expose a dedicated `seatunnel_autoscaler_*` metric family.
+
+Because **Phase 1** has only one default `ScalingScope`, the initial metric set does not need
+scope-aware labels.
+
+Recommended metrics:
+
+| Metric | Meaning |
+| --- | --- |
+| `recommended_workers` | recommended worker count |
+| `current_workers` | observed worker count |
+| `recommended_delta` | signed worker-count delta |
+| `recommendations_total{action}` | recommendation counter |
+| `action_status{status}` | later-phase execution status |
+| `cooldown_remaining_seconds` | later-phase cooldown visibility |
+| `metrics_valid` | whether safe decision inputs are valid |
+| `stale_workers` | stale worker sample count |
+| `input_avg_cpu` | aggregated CPU input |
+| `input_slot_utilization{slot_mode}` | slot utilization, Fixed Slot only |
+| `input_blocked_jobs` | scheduler blocking visibility |
+| `input_resource_rejections` | scheduler rejection visibility |
+
+`recommended_workers` is an **absolute target value**. It is suitable for an operator, webhook controller, or custom consumer, but it is **not** directly compatible with standard Kubernetes HPA replica semantics.
+
+If multi-scope support is introduced in a later phase, scope-aware labels can be added through an
+explicit compatibility strategy instead of being pre-allocated in the Phase 1 metric schema.
+
+### 6.2 REST APIs
+
+Recommended endpoints:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/autoscaler/status` | latest recommendation and summary status |
+| `GET` | `/autoscaler/history` | recent recommendation history |
+| `GET` | `/autoscaler/metrics` | current aggregated metrics snapshot |
+| `PUT` | `/autoscaler/config` | runtime config update, later phase |
+| `POST` | `/autoscaler/pause` | pause autoscaling, later phase |
+| `POST` | `/autoscaler/resume` | resume autoscaling, later phase |
+
+Every recommendation record should contain both machine-readable fields and a human-readable reason string so operators can audit why a recommendation was emitted.
+
+A Phase 1 recommendation payload should expose enough information for an operator to reproduce the
+decision from observable inputs. At minimum, the REST payload should include:
+
+- `masterEpoch`
+- `generation`
+- `observedAt`
+- `action`
+- `currentWorkers`
+- `recommendedWorkers`
+- `recommendationOnly`
+- `metricsValid`
+- `staleWorkerCount`
+- `triggerConditions`
+- `blockingConditions`
+- `metricsSnapshot`
+- `reason`
+
+At minimum, `metricsSnapshot` should expose the observability fields required to reconstruct the
+decision basis:
+
+- `avgCpuUtilization`
+- `avgMemoryUtilization`
+- `slotUtilization` in Fixed Slot mode, otherwise `UNKNOWN`
+- `blockedJobCount`
+- `oldestWaitAgeMillis`
+- `unsatisfiedResourceDemandCount`
+- `resourceRejectCount`
+- `freshWorkerCount`
+- `staleWorkerCount`
+- `evaluationIntervalMillis`
+- `stabilizationWindowMillis`
+- `firstSatisfiedAt`
+
+### 6.3 Compatibility
+
+| Area | Compatibility Rule |
+| --- | --- |
+| runtime behavior | disabled by default |
+| scheduling semantics | unchanged unless autoscaling is enabled |
+| REST APIs | no breaking changes to existing endpoints |
+| slot-service semantics | no change to existing contracts |
+| extension path | new functionality is additive |
+
+### 6.4 Controller Boundary
+
+Only **one replica writer** may control a target workload. HPA, operator, built-in Kubernetes actuator, and webhook controller must be mutually exclusive in active execution phases.
+
+## 7. Delivery Plan
+
+### 7.1 Phase Overview
+
+| Phase | Scope | Result |
+| --- | --- | --- |
+| Phase 1 | advisory-only control loop | pressure collection, evaluation model, recommendations |
+| Phase 2 | actuator integration and scale-out execution | external scale-out convergence |
+| Phase 3 | safe scale-in execution | controlled worker removal with drain |
+
+### 7.2 Phase 1 Deliverables
+
+Phase 1 delivers:
+
+- a singleton AutoScaler on the active master
+- a single default `ScalingScope`
+- metric validity and freshness semantics
+- support for both Fixed Slot and Dynamic Slot
+- explicit Dynamic Slot rule: **do not use slot utilization**
+- hierarchical rule-based recommendation generation
+- recommendation publication through REST APIs and Prometheus metrics
+- periodic snapshot-based evaluation driven by `evaluationInterval`
+- per-condition stabilization tracking driven by wall-clock `stabilizationWindow`
+- no actuator invocation
+- no worker drain
+- no direct worker-count mutation
+
+### 7.3 Phase-by-Phase Goals
+
+The three phases are designed to be incremental.
+
+- **Phase 1** establishes the full advisory loop: collect cluster pressure signals, build the evaluation model, generate structured scaling recommendations, and make the end-to-end recommendation flow observable through REST APIs and metrics.
+- **Phase 2** consumes the Phase 1 scale-out recommendation output and connects it to external capacity management, starting with scale-out execution in environments such as Kubernetes.
+- **Phase 3** consumes the Phase 1 scale-in recommendation output and introduces the controlled drain and recovery workflow required for safe worker removal.
+
+These later phases extend Phase 1 without changing its core recommendation semantics.
+
+## 8. Risks and Validation
+
+### 8.1 Key Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| scaling oscillation | unstable worker count | stabilization windows, cooldown, hysteresis |
+| slot-pressure semantics diverge from worker resource saturation | unstable or confusing recommendations | explicit signal hierarchy and auxiliary-only slot semantics |
+| stale or incomplete metrics | premature scale-in or misleading decisions | scale-in blocked unless worker-level metrics are valid and fresh |
+| stale master actions after failover | duplicate execution | `masterEpoch` fencing and reconciliation |
+| misleading Dynamic Slot capacity semantics | incorrect decisions | slot utilization is `UNKNOWN` in Dynamic Slot mode |
+| deleting the wrong StatefulSet worker in later phases | drain and replica mismatch | highest-ordinal mapping before removal |
+| multi-controller replica conflicts | repeated capacity overwrite | one replica writer only |
+| savepoint succeeds but restore fails in later phases | prolonged streaming downtime | drain transaction, retry/backoff, alerting |
+
+### 8.2 Validation Strategy
+
+Validation should cover:
+
+- unit tests for Fixed Slot and Dynamic Slot decision semantics
+- unit tests for `WAIT` and `REJECT` pressure evaluation
+- unit tests for signal-conflict cases such as slot busy but CPU idle, and slot idle but CPU busy
+- unit tests for resource-shape mismatch where averages are low but scheduler blocking still exists
+- unit tests for stabilization windows, min/max bounds, and metrics validity
+- contract tests for stale worker-sample rejection at ingest time
+- contract tests for future-skewed `eventTime` rejection beyond `clockSkewTolerance`
+- contract tests for stale `generation` rejection within one `masterEpoch`
+- contract tests for duplicate advisory recommendation idempotency
+- contract tests for stabilization tracker reset on missing or invalid worker samples
+- contract tests for restart recovery and tracker reset after active-master failover
+- integration tests for REST APIs and Prometheus metrics
+- HA tests for master failover, stale `masterEpoch`, and reconciliation
+- idempotency tests for repeated action identifiers in later phases
+- end-to-end tests for scale-out convergence in active mode
+- end-to-end tests for batch drain and streaming stop-and-restore in later phases
+
+### 8.3 Summary
+
+This STIP proposes a native, phased, and safety-first autoscaling framework for SeaTunnel Zeta Engine.
+
+The proposal is organized into three implementation phases:
+
+- **Phase 1** focuses on collecting cluster pressure signals, defining the evaluation model, and producing advisory scaling recommendations so the full recommendation path can run end to end.
+- **Phase 2** focuses on taking the scale-out recommendations from Phase 1 and connecting them to external systems, such as Kubernetes, to make worker scale-out executable.
+- **Phase 3** focuses on taking the scale-in recommendations from Phase 1 and making scale-in safe through worker drain and controlled recovery.
+
+The core Phase 1 contract remains:
+
+- one active-master AutoScaler
+- advisory-only recommendations
+- hierarchical multi-signal policy
+- support for both Fixed Slot and Dynamic Slot
+- **no slot-utilization decision signal in Dynamic Slot mode**
+
+This gives SeaTunnel a reviewable and backward-compatible foundation for autoscaling, while keeping safe scale-in and active execution as explicit later phases.

--- a/docs/en/engines/zeta/autoscaling.md
+++ b/docs/en/engines/zeta/autoscaling.md
@@ -1,0 +1,72 @@
+# Autoscaling Recommendation
+
+SeaTunnel Engine can run a Phase 1 autoscaling loop on the active master. In this phase the engine
+collects scheduling pressure, worker CPU, worker JVM memory, and fixed-slot utilization, then emits
+scaling recommendations through REST APIs and OpenMetrics. It does not add or remove workers.
+
+Autoscaling is disabled by default.
+
+```yaml
+seatunnel:
+  engine:
+    autoscaler:
+      enabled: false
+      evaluation-interval-seconds: 30
+      metrics-freshness-seconds: 120
+      max-future-skew-seconds: 5
+      scale-out-stabilization-seconds: 300
+      scale-in-stabilization-seconds: 600
+      scale-out-cpu-threshold: 0.8
+      scale-out-jvm-memory-threshold: 0.8
+      scale-in-cpu-threshold: 0.3
+      scale-in-jvm-memory-threshold: 0.3
+      fixed-slot-scale-out-threshold: 0.8
+      fixed-slot-scale-in-threshold: 0.3
+      scale-step: 1
+      min-workers: 1
+      max-workers: 2147483647
+      history-size: 20
+```
+
+## Decision Signals
+
+Scale-out can be recommended when scheduler shortage signals are observed, such as workers waiting
+for slots or rejecting resource requests, or when worker CPU or JVM memory remains above the
+configured scale-out threshold for the stabilization window.
+
+Slot pressure cannot trigger scale-out by itself. In fixed-slot mode, slot utilization is used only
+as an auxiliary scheduling-capacity signal. In dynamic-slot mode, slot utilization is reported as
+`UNKNOWN`.
+
+Scale-in is conservative. CPU and JVM memory must both stay below the configured scale-in
+thresholds, worker metrics must be fresh and complete, and fixed-slot mode must also satisfy the
+low slot-utilization threshold.
+
+## REST APIs
+
+The following endpoints return the recommendation state from the active master:
+
+| Endpoint | Description |
+| --- | --- |
+| `/autoscaler/status` | Current autoscaler view, including enabled/running state, latest recommendation, current snapshot, and bounded history |
+| `/autoscaler/metrics` | Current metrics snapshot used by the latest evaluation |
+| `/autoscaler/history` | Recent recommendation history |
+
+## OpenMetrics
+
+When engine metrics are enabled, `/openmetrics` includes autoscaler metrics such as:
+
+- `seatunnel_autoscaler_enabled`
+- `seatunnel_autoscaler_running`
+- `seatunnel_autoscaler_current_workers`
+- `seatunnel_autoscaler_recommended_workers`
+- `seatunnel_autoscaler_recommended_delta`
+- `seatunnel_autoscaler_recommendations_total`
+- `seatunnel_autoscaler_metrics_valid`
+- `seatunnel_autoscaler_input_cpu_utilization`
+- `seatunnel_autoscaler_input_jvm_memory_utilization`
+- `seatunnel_autoscaler_input_slot_utilization`
+- `seatunnel_autoscaler_worker_samples`
+- `seatunnel_autoscaler_resource_shortages_total`
+- `seatunnel_autoscaler_stabilization_seconds`
+- `seatunnel_autoscaler_info`

--- a/docs/en/engines/zeta/rest-api-v2.md
+++ b/docs/en/engines/zeta/rest-api-v2.md
@@ -1892,3 +1892,19 @@ There is no dedicated `pause`, `resume` or `delete` endpoint. Use the existing j
 
 **Note:** `isStartWithSavePoint: true` requires `jobId` to be provided in the request; submitting
 without a `jobId` in that case fails with `Please provide jobId when start with save point.`
+
+------------------------------------------------------------------------------------------
+
+### Autoscaling Recommendation
+
+Phase 1 autoscaling is advisory-only. These endpoints expose the evaluated state from the Active
+Master and never add, remove, or drain workers.
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| `GET` | `/autoscaler/status` | Current autoscaler status, latest recommendation, current metrics snapshot, and bounded history |
+| `GET` | `/autoscaler/metrics` | Current metrics snapshot used by the latest autoscaler evaluation |
+| `GET` | `/autoscaler/history` | Recent autoscaler recommendation history |
+
+See [Autoscaling Recommendation](autoscaling.md) for configuration, signal semantics, and payload
+behavior.

--- a/docs/en/engines/zeta/telemetry.md
+++ b/docs/en/engines/zeta/telemetry.md
@@ -270,3 +270,29 @@ the [Installation](https://grafana.com/docs/grafana/latest/setup-grafana/install
   - Import the `Seatunnel Cluster` monitoring dashboard JSON into Grafana.
 
 The [effect image](../../../images/grafana.png) of the dashboard
+
+### Autoscaler Metrics
+
+When Phase 1 autoscaling is enabled, the Active Master exports recommendation-only metrics. The
+scrape path reads the latest published `AutoscalerView`; it does not run policy evaluation or mutate
+recommendation history.
+
+| MetricName | Type | Labels | Description |
+| --- | --- | --- | --- |
+| seatunnel_autoscaler_enabled | Gauge | cluster, address | Whether autoscaling recommendation is enabled |
+| seatunnel_autoscaler_running | Gauge | cluster, address | Whether the master autoscaler loop is running |
+| seatunnel_autoscaler_current_workers | Gauge | cluster, address | Current worker count observed by the autoscaler |
+| seatunnel_autoscaler_recommended_workers | Gauge | cluster, address, action, recommendation_only | Latest recommended worker count |
+| seatunnel_autoscaler_recommended_delta | Gauge | cluster, address | Difference between recommended and current worker count |
+| seatunnel_autoscaler_recommendations_total | Counter | cluster, address, action | Published recommendation count by action |
+| seatunnel_autoscaler_metrics_valid | Gauge | cluster, address | Whether worker metrics are complete and valid for scale-in |
+| seatunnel_autoscaler_worker_samples | Gauge | cluster, address, status | Worker sample counts by status |
+| seatunnel_autoscaler_input_cpu_utilization | Gauge | cluster, address, status | Cluster CPU utilization input |
+| seatunnel_autoscaler_input_jvm_memory_utilization | Gauge | cluster, address, status | Cluster JVM memory utilization input |
+| seatunnel_autoscaler_input_slot_utilization | Gauge | cluster, address, status | Fixed-slot utilization input; omitted when slot mode is Dynamic, Mixed, or Unknown |
+| seatunnel_autoscaler_pending_jobs | Gauge | cluster, address | Pending job count observed by the autoscaler |
+| seatunnel_autoscaler_resource_shortages_total | Gauge | cluster, address, strategy | Cumulative WAIT and REJECT shortage counts |
+| seatunnel_autoscaler_stabilization_seconds | Gauge | cluster, address, direction | Configured scale-out and scale-in stabilization windows |
+| seatunnel_autoscaler_info | Gauge | cluster, address, slot_mode, action | Current recommendation labels |
+
+See [Autoscaling Recommendation](autoscaling.md) for the decision policy and configuration.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -284,6 +284,7 @@ const sidebars = {
                         "engines/zeta/busyness-and-backpressure",
                         "engines/zeta/live-metrics-chart",
                         "engines/zeta/slot-allocation-strategy",
+                        "engines/zeta/autoscaling",
                         "engines/zeta/benchmark",
                         "engines/zeta/tuning-guide"
                     ]

--- a/docs/zh/engines/zeta/autoscaling.md
+++ b/docs/zh/engines/zeta/autoscaling.md
@@ -1,0 +1,69 @@
+# 自动扩缩容推荐
+
+SeaTunnel Engine 可以在 Active Master 上运行 Phase 1 自动扩缩容循环。本阶段会采集调度压力、
+Worker CPU、Worker JVM 内存以及固定 Slot 利用率，并通过 REST API 和 OpenMetrics 输出扩缩容推荐。
+本阶段不会实际增加或删除 Worker。
+
+自动扩缩容默认关闭。
+
+```yaml
+seatunnel:
+  engine:
+    autoscaler:
+      enabled: false
+      evaluation-interval-seconds: 30
+      metrics-freshness-seconds: 120
+      max-future-skew-seconds: 5
+      scale-out-stabilization-seconds: 300
+      scale-in-stabilization-seconds: 600
+      scale-out-cpu-threshold: 0.8
+      scale-out-jvm-memory-threshold: 0.8
+      scale-in-cpu-threshold: 0.3
+      scale-in-jvm-memory-threshold: 0.3
+      fixed-slot-scale-out-threshold: 0.8
+      fixed-slot-scale-in-threshold: 0.3
+      scale-step: 1
+      min-workers: 1
+      max-workers: 2147483647
+      history-size: 20
+```
+
+## 决策信号
+
+当出现调度资源短缺信号时，例如 Worker 等待 Slot 或拒绝资源请求，或者 Worker CPU/JVM 内存
+在稳定窗口内持续高于扩容阈值时，Autoscaler 可以给出扩容推荐。
+
+Slot pressure 不能单独触发扩容。在固定 Slot 模式下，Slot 利用率只作为辅助的调度容量信号。
+在动态 Slot 模式下，Slot 利用率会报告为 `UNKNOWN`。
+
+缩容判断更保守。CPU 和 JVM 内存必须同时低于配置的缩容阈值，Worker 指标必须新鲜且完整；
+固定 Slot 模式还必须满足低 Slot 利用率阈值。
+
+## REST API
+
+以下接口会从 Active Master 返回推荐状态：
+
+| Endpoint | 说明 |
+| --- | --- |
+| `/autoscaler/status` | 当前 autoscaler 视图，包括 enabled/running 状态、最新推荐、当前快照和有限历史 |
+| `/autoscaler/metrics` | 最新评估使用的当前指标快照 |
+| `/autoscaler/history` | 最近的推荐历史 |
+
+## OpenMetrics
+
+启用 engine metrics 后，`/openmetrics` 会包含以下 autoscaler 指标：
+
+- `seatunnel_autoscaler_enabled`
+- `seatunnel_autoscaler_running`
+- `seatunnel_autoscaler_current_workers`
+- `seatunnel_autoscaler_recommended_workers`
+- `seatunnel_autoscaler_recommended_delta`
+- `seatunnel_autoscaler_recommendations_total`
+- `seatunnel_autoscaler_metrics_valid`
+- `seatunnel_autoscaler_input_cpu_utilization`
+- `seatunnel_autoscaler_input_jvm_memory_utilization`
+- `seatunnel_autoscaler_input_slot_utilization`
+- `seatunnel_autoscaler_worker_samples`
+- `seatunnel_autoscaler_resource_shortages_total`
+- `seatunnel_autoscaler_stabilization_seconds`
+- `seatunnel_autoscaler_info`

--- a/docs/zh/engines/zeta/rest-api-v2.md
+++ b/docs/zh/engines/zeta/rest-api-v2.md
@@ -1864,3 +1864,18 @@ Checkpoint 信息字段：
 
 **注意：** 当 `isStartWithSavePoint: true` 时必须提供 `jobId`；不提供 `jobId` 会导致请求失败，报错信息为
 `Please provide jobId when start with save point.`
+
+------------------------------------------------------------------------------------------
+
+### 自动扩缩容推荐
+
+Phase 1 自动扩缩容仅输出推荐。这些接口暴露 Active Master 上已经评估出的状态，不会增加、
+删除或 drain Worker。
+
+| Method | Endpoint | 说明 |
+| --- | --- | --- |
+| `GET` | `/autoscaler/status` | 当前 autoscaler 状态、最新推荐、当前指标快照和有限历史 |
+| `GET` | `/autoscaler/metrics` | 最新 autoscaler 评估使用的当前指标快照 |
+| `GET` | `/autoscaler/history` | 最近的 autoscaler 推荐历史 |
+
+配置、信号语义和响应行为参见[自动扩缩容推荐](autoscaling.md)。

--- a/docs/zh/engines/zeta/telemetry.md
+++ b/docs/zh/engines/zeta/telemetry.md
@@ -264,3 +264,28 @@ scrape_configs:
 - 将 `Seatunnel Cluster` 监控仪表板 JSON 导入到 Grafana 中。
 
 监控[效果图](../../../images/grafana.png)
+
+### Autoscaler 指标
+
+启用 Phase 1 自动扩缩容后，Active Master 会导出仅用于推荐的指标。Prometheus scrape
+只读取已经发布的 `AutoscalerView`，不会触发策略评估，也不会修改推荐历史。
+
+| MetricName | Type | Labels | 描述 |
+| --- | --- | --- | --- |
+| seatunnel_autoscaler_enabled | Gauge | cluster, address | 是否启用自动扩缩容推荐 |
+| seatunnel_autoscaler_running | Gauge | cluster, address | Master 上 autoscaler 循环是否运行 |
+| seatunnel_autoscaler_current_workers | Gauge | cluster, address | autoscaler 观察到的当前 Worker 数 |
+| seatunnel_autoscaler_recommended_workers | Gauge | cluster, address, action, recommendation_only | 最新推荐 Worker 数 |
+| seatunnel_autoscaler_recommended_delta | Gauge | cluster, address | 推荐 Worker 数与当前 Worker 数的差值 |
+| seatunnel_autoscaler_recommendations_total | Counter | cluster, address, action | 按 action 统计的已发布推荐数 |
+| seatunnel_autoscaler_metrics_valid | Gauge | cluster, address | Worker 指标是否完整且可用于缩容判断 |
+| seatunnel_autoscaler_worker_samples | Gauge | cluster, address, status | 按状态统计的 Worker 样本数 |
+| seatunnel_autoscaler_input_cpu_utilization | Gauge | cluster, address, status | 集群 CPU 利用率输入 |
+| seatunnel_autoscaler_input_jvm_memory_utilization | Gauge | cluster, address, status | 集群 JVM 内存利用率输入 |
+| seatunnel_autoscaler_input_slot_utilization | Gauge | cluster, address, status | 固定 Slot 利用率输入；Dynamic、Mixed 或 Unknown 模式不输出该数值 |
+| seatunnel_autoscaler_pending_jobs | Gauge | cluster, address | autoscaler 观察到的待调度作业数 |
+| seatunnel_autoscaler_resource_shortages_total | Gauge | cluster, address, strategy | WAIT 和 REJECT 资源短缺累计数 |
+| seatunnel_autoscaler_stabilization_seconds | Gauge | cluster, address, direction | 配置的扩容和缩容稳定窗口 |
+| seatunnel_autoscaler_info | Gauge | cluster, address, slot_mode, action | 当前推荐标签 |
+
+决策策略和配置参见[自动扩缩容推荐](autoscaling.md)。

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/Constant.java
@@ -22,6 +22,9 @@ public class Constant {
 
     public static final String SEATUNNEL_ID_GENERATOR_NAME = "SeaTunnelIdGenerator";
 
+    public static final String SEATUNNEL_AUTOSCALER_EPOCH_GENERATOR_NAME =
+            "SeaTunnelAutoscalerEpochGenerator";
+
     public static final String DEFAULT_SEATUNNEL_CLUSTER_NAME = "seatunnel";
 
     public static final String REST_SUBMIT_JOBS_PARAMS = "params";

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.common.config;
 
 import org.apache.seatunnel.api.metadata.MetadataConfig;
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
 import org.apache.seatunnel.engine.common.config.server.CheckpointConfig;
 import org.apache.seatunnel.engine.common.config.server.ConnectorJarStorageConfig;
 import org.apache.seatunnel.engine.common.config.server.CoordinatorServiceConfig;
@@ -106,6 +107,8 @@ public class EngineConfig {
 
     private HttpConfig httpConfig =
             ServerConfigOptions.MasterServerConfigOptions.HTTP.defaultValue();
+
+    private AutoscalerConfig autoscalerConfig = ServerConfigOptions.AUTOSCALER.defaultValue();
 
     /**
      * Stain trace sampling and persistence knobs used by source, transform, sink, and reporters.

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
 import org.apache.seatunnel.api.metadata.MetadataConfig;
 import org.apache.seatunnel.api.metadata.MetadataOptions;
 import org.apache.seatunnel.engine.common.config.server.AllocateStrategy;
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
 import org.apache.seatunnel.engine.common.config.server.CheckpointConfig;
 import org.apache.seatunnel.engine.common.config.server.CheckpointStorageConfig;
 import org.apache.seatunnel.engine.common.config.server.ConnectorJarHAStorageConfig;
@@ -330,6 +331,8 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                 engineConfig.setHttpConfig(parseHttpConfig(node));
             } else if (ServerConfigOptions.METADATA.key().equals(name)) {
                 engineConfig.setMetadataConfig(parseMetadataConfigConfig(node));
+            } else if (ServerConfigOptions.AUTOSCALER.key().equals(name)) {
+                engineConfig.setAutoscalerConfig(parseAutoscalerConfig(node));
             } else if (ServerConfigOptions.MasterServerConfigOptions.COORDINATOR_SERVICE
                     .key()
                     .equals(name)) {
@@ -344,6 +347,98 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
             LOGGER.info("Dynamic slot is enabled, the schedule strategy is set to REJECT");
             engineConfig.setScheduleStrategy(ScheduleStrategy.REJECT);
         }
+    }
+
+    private AutoscalerConfig parseAutoscalerConfig(Node autoscalerNode) {
+        AutoscalerConfig autoscalerConfig = new AutoscalerConfig();
+        for (Node node : childElements(autoscalerNode)) {
+            String name = cleanNodeName(node);
+            if (ServerConfigOptions.AUTOSCALER_ENABLED.key().equals(name)) {
+                autoscalerConfig.setEnabled(getBooleanValue(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_EVALUATION_INTERVAL_SECONDS
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setEvaluationIntervalSeconds(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_EVALUATION_INTERVAL_SECONDS.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_METRICS_FRESHNESS_SECONDS
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setMetricsFreshnessSeconds(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_METRICS_FRESHNESS_SECONDS.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_MAX_FUTURE_SKEW_SECONDS.key().equals(name)) {
+                autoscalerConfig.setMaxFutureSkewSeconds(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_MAX_FUTURE_SKEW_SECONDS.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_OUT_STABILIZATION_SECONDS
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setScaleOutStabilizationSeconds(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_SCALE_OUT_STABILIZATION_SECONDS
+                                        .key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_IN_STABILIZATION_SECONDS
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setScaleInStabilizationSeconds(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_SCALE_IN_STABILIZATION_SECONDS.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_OUT_CPU_THRESHOLD.key().equals(name)) {
+                autoscalerConfig.setScaleOutCpuThreshold(Double.parseDouble(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_OUT_JVM_MEMORY_THRESHOLD
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setScaleOutJvmMemoryThreshold(
+                        Double.parseDouble(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_IN_CPU_THRESHOLD.key().equals(name)) {
+                autoscalerConfig.setScaleInCpuThreshold(Double.parseDouble(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_IN_JVM_MEMORY_THRESHOLD
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setScaleInJvmMemoryThreshold(
+                        Double.parseDouble(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_OUT_THRESHOLD
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setFixedSlotScaleOutThreshold(
+                        Double.parseDouble(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_IN_THRESHOLD
+                    .key()
+                    .equals(name)) {
+                autoscalerConfig.setFixedSlotScaleInThreshold(
+                        Double.parseDouble(getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_SCALE_STEP.key().equals(name)) {
+                autoscalerConfig.setScaleStep(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_SCALE_STEP.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_MIN_WORKERS.key().equals(name)) {
+                autoscalerConfig.setMinWorkers(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_MIN_WORKERS.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_MAX_WORKERS.key().equals(name)) {
+                autoscalerConfig.setMaxWorkers(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_MAX_WORKERS.key(),
+                                getTextContent(node)));
+            } else if (ServerConfigOptions.AUTOSCALER_HISTORY_SIZE.key().equals(name)) {
+                autoscalerConfig.setHistorySize(
+                        getIntegerValue(
+                                ServerConfigOptions.AUTOSCALER_HISTORY_SIZE.key(),
+                                getTextContent(node)));
+            } else {
+                LOGGER.warning("Unrecognized element: " + name);
+            }
+        }
+        autoscalerConfig.validate();
+        return autoscalerConfig;
     }
 
     private CheckpointConfig parseCheckpointConfig(Node checkpointNode) {

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/AutoscalerConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/AutoscalerConfig.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.common.config.server;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+import static com.hazelcast.internal.util.Preconditions.checkPositive;
+
+/**
+ * Configuration for Zeta Phase 1 autoscaling recommendations.
+ *
+ * <p>The feature is disabled by default and setters validate user-facing safety bounds before
+ * runtime use.
+ */
+@Data
+public class AutoscalerConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean enabled = ServerConfigOptions.AUTOSCALER_ENABLED.defaultValue();
+    private int evaluationIntervalSeconds =
+            ServerConfigOptions.AUTOSCALER_EVALUATION_INTERVAL_SECONDS.defaultValue();
+    private int metricsFreshnessSeconds =
+            ServerConfigOptions.AUTOSCALER_METRICS_FRESHNESS_SECONDS.defaultValue();
+    private int maxFutureSkewSeconds =
+            ServerConfigOptions.AUTOSCALER_MAX_FUTURE_SKEW_SECONDS.defaultValue();
+    private int scaleOutStabilizationSeconds =
+            ServerConfigOptions.AUTOSCALER_SCALE_OUT_STABILIZATION_SECONDS.defaultValue();
+    private int scaleInStabilizationSeconds =
+            ServerConfigOptions.AUTOSCALER_SCALE_IN_STABILIZATION_SECONDS.defaultValue();
+    private double scaleOutCpuThreshold =
+            ServerConfigOptions.AUTOSCALER_SCALE_OUT_CPU_THRESHOLD.defaultValue();
+    private double scaleOutJvmMemoryThreshold =
+            ServerConfigOptions.AUTOSCALER_SCALE_OUT_JVM_MEMORY_THRESHOLD.defaultValue();
+    private double scaleInCpuThreshold =
+            ServerConfigOptions.AUTOSCALER_SCALE_IN_CPU_THRESHOLD.defaultValue();
+    private double scaleInJvmMemoryThreshold =
+            ServerConfigOptions.AUTOSCALER_SCALE_IN_JVM_MEMORY_THRESHOLD.defaultValue();
+    private double fixedSlotScaleOutThreshold =
+            ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_OUT_THRESHOLD.defaultValue();
+    private double fixedSlotScaleInThreshold =
+            ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_IN_THRESHOLD.defaultValue();
+    private int scaleStep = ServerConfigOptions.AUTOSCALER_SCALE_STEP.defaultValue();
+    private int minWorkers = ServerConfigOptions.AUTOSCALER_MIN_WORKERS.defaultValue();
+    private int maxWorkers = ServerConfigOptions.AUTOSCALER_MAX_WORKERS.defaultValue();
+    private int historySize = ServerConfigOptions.AUTOSCALER_HISTORY_SIZE.defaultValue();
+
+    public void setEvaluationIntervalSeconds(int evaluationIntervalSeconds) {
+        checkPositive(
+                evaluationIntervalSeconds,
+                ServerConfigOptions.AUTOSCALER_EVALUATION_INTERVAL_SECONDS.key() + " must be > 0");
+        this.evaluationIntervalSeconds = evaluationIntervalSeconds;
+    }
+
+    public void setMetricsFreshnessSeconds(int metricsFreshnessSeconds) {
+        checkPositive(
+                metricsFreshnessSeconds,
+                ServerConfigOptions.AUTOSCALER_METRICS_FRESHNESS_SECONDS.key() + " must be > 0");
+        this.metricsFreshnessSeconds = metricsFreshnessSeconds;
+    }
+
+    public void setMaxFutureSkewSeconds(int maxFutureSkewSeconds) {
+        if (maxFutureSkewSeconds < 0) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_MAX_FUTURE_SKEW_SECONDS.key() + " must be >= 0");
+        }
+        this.maxFutureSkewSeconds = maxFutureSkewSeconds;
+    }
+
+    public void setScaleOutStabilizationSeconds(int scaleOutStabilizationSeconds) {
+        if (scaleOutStabilizationSeconds < 0) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_SCALE_OUT_STABILIZATION_SECONDS.key()
+                            + " must be >= 0");
+        }
+        this.scaleOutStabilizationSeconds = scaleOutStabilizationSeconds;
+    }
+
+    public void setScaleInStabilizationSeconds(int scaleInStabilizationSeconds) {
+        if (scaleInStabilizationSeconds < 0) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_SCALE_IN_STABILIZATION_SECONDS.key()
+                            + " must be >= 0");
+        }
+        this.scaleInStabilizationSeconds = scaleInStabilizationSeconds;
+    }
+
+    public void setScaleOutCpuThreshold(double scaleOutCpuThreshold) {
+        checkThreshold(
+                ServerConfigOptions.AUTOSCALER_SCALE_OUT_CPU_THRESHOLD.key(), scaleOutCpuThreshold);
+        this.scaleOutCpuThreshold = scaleOutCpuThreshold;
+    }
+
+    public void setScaleOutJvmMemoryThreshold(double scaleOutJvmMemoryThreshold) {
+        checkThreshold(
+                ServerConfigOptions.AUTOSCALER_SCALE_OUT_JVM_MEMORY_THRESHOLD.key(),
+                scaleOutJvmMemoryThreshold);
+        this.scaleOutJvmMemoryThreshold = scaleOutJvmMemoryThreshold;
+    }
+
+    public void setScaleInCpuThreshold(double scaleInCpuThreshold) {
+        checkThreshold(
+                ServerConfigOptions.AUTOSCALER_SCALE_IN_CPU_THRESHOLD.key(), scaleInCpuThreshold);
+        this.scaleInCpuThreshold = scaleInCpuThreshold;
+    }
+
+    public void setScaleInJvmMemoryThreshold(double scaleInJvmMemoryThreshold) {
+        checkThreshold(
+                ServerConfigOptions.AUTOSCALER_SCALE_IN_JVM_MEMORY_THRESHOLD.key(),
+                scaleInJvmMemoryThreshold);
+        this.scaleInJvmMemoryThreshold = scaleInJvmMemoryThreshold;
+    }
+
+    public void setFixedSlotScaleOutThreshold(double fixedSlotScaleOutThreshold) {
+        checkThreshold(
+                ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_OUT_THRESHOLD.key(),
+                fixedSlotScaleOutThreshold);
+        this.fixedSlotScaleOutThreshold = fixedSlotScaleOutThreshold;
+    }
+
+    public void setFixedSlotScaleInThreshold(double fixedSlotScaleInThreshold) {
+        checkThreshold(
+                ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_IN_THRESHOLD.key(),
+                fixedSlotScaleInThreshold);
+        this.fixedSlotScaleInThreshold = fixedSlotScaleInThreshold;
+    }
+
+    public void setScaleStep(int scaleStep) {
+        checkPositive(scaleStep, ServerConfigOptions.AUTOSCALER_SCALE_STEP.key() + " must be > 0");
+        this.scaleStep = scaleStep;
+    }
+
+    public void setMinWorkers(int minWorkers) {
+        checkPositive(
+                minWorkers, ServerConfigOptions.AUTOSCALER_MIN_WORKERS.key() + " must be > 0");
+        this.minWorkers = minWorkers;
+    }
+
+    public void setMaxWorkers(int maxWorkers) {
+        checkPositive(
+                maxWorkers, ServerConfigOptions.AUTOSCALER_MAX_WORKERS.key() + " must be > 0");
+        this.maxWorkers = maxWorkers;
+    }
+
+    public void setHistorySize(int historySize) {
+        checkPositive(
+                historySize, ServerConfigOptions.AUTOSCALER_HISTORY_SIZE.key() + " must be > 0");
+        this.historySize = historySize;
+    }
+
+    public void validate() {
+        checkThresholdOrdering();
+        checkWorkerRange();
+    }
+
+    private void checkThresholdOrdering() {
+        if (scaleInCpuThreshold >= scaleOutCpuThreshold) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_SCALE_IN_CPU_THRESHOLD.key()
+                            + " must be lower than "
+                            + ServerConfigOptions.AUTOSCALER_SCALE_OUT_CPU_THRESHOLD.key());
+        }
+        if (scaleInJvmMemoryThreshold >= scaleOutJvmMemoryThreshold) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_SCALE_IN_JVM_MEMORY_THRESHOLD.key()
+                            + " must be lower than "
+                            + ServerConfigOptions.AUTOSCALER_SCALE_OUT_JVM_MEMORY_THRESHOLD.key());
+        }
+        if (fixedSlotScaleInThreshold >= fixedSlotScaleOutThreshold) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_IN_THRESHOLD.key()
+                            + " must be lower than "
+                            + ServerConfigOptions.AUTOSCALER_FIXED_SLOT_SCALE_OUT_THRESHOLD.key());
+        }
+    }
+
+    private void checkWorkerRange() {
+        if (maxWorkers < minWorkers) {
+            throw new IllegalArgumentException(
+                    ServerConfigOptions.AUTOSCALER_MAX_WORKERS.key()
+                            + " must be >= "
+                            + ServerConfigOptions.AUTOSCALER_MIN_WORKERS.key());
+        }
+    }
+
+    private static void checkThreshold(String key, double value) {
+        if (!Double.isFinite(value) || value < 0.0d || value > 1.0d) {
+            throw new IllegalArgumentException(key + " must be in [0.0, 1.0]");
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/server/ServerConfigOptions.java
@@ -137,6 +137,118 @@ public class ServerConfigOptions {
                     .type(new TypeReference<MetadataConfig>() {})
                     .defaultValue(new MetadataConfig())
                     .withDescription("The MetaData Center configuration.");
+
+    public static final Option<Boolean> AUTOSCALER_ENABLED =
+            Options.key("enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to enable the advisory Zeta autoscaler.");
+
+    public static final Option<Integer> AUTOSCALER_EVALUATION_INTERVAL_SECONDS =
+            Options.key("evaluation-interval-seconds")
+                    .intType()
+                    .defaultValue(30)
+                    .withDescription("The interval in seconds between autoscaler evaluations.");
+
+    public static final Option<Integer> AUTOSCALER_METRICS_FRESHNESS_SECONDS =
+            Options.key("metrics-freshness-seconds")
+                    .intType()
+                    .defaultValue(120)
+                    .withDescription(
+                            "How long a worker autoscaler metrics sample remains fresh, in seconds.");
+
+    public static final Option<Integer> AUTOSCALER_MAX_FUTURE_SKEW_SECONDS =
+            Options.key("max-future-skew-seconds")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription(
+                            "Maximum accepted future skew for worker-observed autoscaler metrics timestamps, in seconds.");
+
+    public static final Option<Integer> AUTOSCALER_SCALE_OUT_STABILIZATION_SECONDS =
+            Options.key("scale-out-stabilization-seconds")
+                    .intType()
+                    .defaultValue(300)
+                    .withDescription(
+                            "How long scale-out signals must remain continuous before publishing a scale-out recommendation.");
+
+    public static final Option<Integer> AUTOSCALER_SCALE_IN_STABILIZATION_SECONDS =
+            Options.key("scale-in-stabilization-seconds")
+                    .intType()
+                    .defaultValue(600)
+                    .withDescription(
+                            "How long scale-in signals must remain continuous before publishing a scale-in candidate.");
+
+    public static final Option<Double> AUTOSCALER_SCALE_OUT_CPU_THRESHOLD =
+            Options.key("scale-out-cpu-threshold")
+                    .doubleType()
+                    .defaultValue(0.8d)
+                    .withDescription("CPU utilization threshold for scale-out recommendation.");
+
+    public static final Option<Double> AUTOSCALER_SCALE_OUT_JVM_MEMORY_THRESHOLD =
+            Options.key("scale-out-jvm-memory-threshold")
+                    .doubleType()
+                    .defaultValue(0.8d)
+                    .withDescription(
+                            "JVM memory utilization threshold for scale-out recommendation.");
+
+    public static final Option<Double> AUTOSCALER_SCALE_IN_CPU_THRESHOLD =
+            Options.key("scale-in-cpu-threshold")
+                    .doubleType()
+                    .defaultValue(0.3d)
+                    .withDescription(
+                            "CPU utilization threshold for scale-in candidate recommendation.");
+
+    public static final Option<Double> AUTOSCALER_SCALE_IN_JVM_MEMORY_THRESHOLD =
+            Options.key("scale-in-jvm-memory-threshold")
+                    .doubleType()
+                    .defaultValue(0.3d)
+                    .withDescription(
+                            "JVM memory utilization threshold for scale-in candidate recommendation.");
+
+    public static final Option<Double> AUTOSCALER_FIXED_SLOT_SCALE_OUT_THRESHOLD =
+            Options.key("fixed-slot-scale-out-threshold")
+                    .doubleType()
+                    .defaultValue(0.8d)
+                    .withDescription(
+                            "Fixed-slot utilization threshold retained for diagnostics. Slot pressure cannot trigger scale-out by itself in Phase 1.");
+
+    public static final Option<Double> AUTOSCALER_FIXED_SLOT_SCALE_IN_THRESHOLD =
+            Options.key("fixed-slot-scale-in-threshold")
+                    .doubleType()
+                    .defaultValue(0.3d)
+                    .withDescription(
+                            "Fixed-slot utilization threshold for scale-in candidate recommendation.");
+
+    public static final Option<Integer> AUTOSCALER_SCALE_STEP =
+            Options.key("scale-step")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            "Worker-count step used when computing advisory recommendations.");
+
+    public static final Option<Integer> AUTOSCALER_MIN_WORKERS =
+            Options.key("min-workers")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("Minimum recommended worker count.");
+
+    public static final Option<Integer> AUTOSCALER_MAX_WORKERS =
+            Options.key("max-workers")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription("Maximum recommended worker count.");
+
+    public static final Option<Integer> AUTOSCALER_HISTORY_SIZE =
+            Options.key("history-size")
+                    .intType()
+                    .defaultValue(20)
+                    .withDescription("Maximum in-memory autoscaler recommendation history size.");
+
+    public static final Option<AutoscalerConfig> AUTOSCALER =
+            Options.key("autoscaler")
+                    .type(new TypeReference<AutoscalerConfig>() {})
+                    .defaultValue(new AutoscalerConfig())
+                    .withDescription("The advisory autoscaler configuration.");
     // The options for metrics end
     /////////////////////////////////////////////////
 

--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessorAutoscalerTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessorAutoscalerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.common.config;
+
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class YamlSeaTunnelDomConfigProcessorAutoscalerTest {
+
+    @TempDir private Path tempDir;
+
+    @Test
+    void absentAutoscalerBlockUsesDisabledDefaults() throws Exception {
+        AutoscalerConfig config =
+                parse("seatunnel:\n" + "  engine:\n" + "    backup-count: 1\n")
+                        .getEngineConfig()
+                        .getAutoscalerConfig();
+
+        Assertions.assertFalse(config.isEnabled());
+        Assertions.assertEquals(30, config.getEvaluationIntervalSeconds());
+        Assertions.assertEquals(120, config.getMetricsFreshnessSeconds());
+        Assertions.assertEquals(5, config.getMaxFutureSkewSeconds());
+        Assertions.assertEquals(300, config.getScaleOutStabilizationSeconds());
+        Assertions.assertEquals(600, config.getScaleInStabilizationSeconds());
+        Assertions.assertEquals(0.8d, config.getScaleOutCpuThreshold());
+        Assertions.assertEquals(0.8d, config.getScaleOutJvmMemoryThreshold());
+        Assertions.assertEquals(0.3d, config.getScaleInCpuThreshold());
+        Assertions.assertEquals(0.3d, config.getScaleInJvmMemoryThreshold());
+        Assertions.assertEquals(0.8d, config.getFixedSlotScaleOutThreshold());
+        Assertions.assertEquals(0.3d, config.getFixedSlotScaleInThreshold());
+        Assertions.assertEquals(1, config.getScaleStep());
+        Assertions.assertEquals(1, config.getMinWorkers());
+        Assertions.assertEquals(Integer.MAX_VALUE, config.getMaxWorkers());
+        Assertions.assertEquals(20, config.getHistorySize());
+    }
+
+    @Test
+    void parsesExplicitAutoscalerBlock() throws Exception {
+        AutoscalerConfig config =
+                parse(
+                                "seatunnel:\n"
+                                        + "  engine:\n"
+                                        + "    autoscaler:\n"
+                                        + "      enabled: true\n"
+                                        + "      evaluation-interval-seconds: 11\n"
+                                        + "      metrics-freshness-seconds: 22\n"
+                                        + "      max-future-skew-seconds: 3\n"
+                                        + "      scale-out-stabilization-seconds: 44\n"
+                                        + "      scale-in-stabilization-seconds: 55\n"
+                                        + "      scale-out-cpu-threshold: 0.91\n"
+                                        + "      scale-out-jvm-memory-threshold: 0.92\n"
+                                        + "      scale-in-cpu-threshold: 0.21\n"
+                                        + "      scale-in-jvm-memory-threshold: 0.22\n"
+                                        + "      fixed-slot-scale-out-threshold: 0.93\n"
+                                        + "      fixed-slot-scale-in-threshold: 0.23\n"
+                                        + "      scale-step: 2\n"
+                                        + "      min-workers: 3\n"
+                                        + "      max-workers: 7\n"
+                                        + "      history-size: 9\n")
+                        .getEngineConfig()
+                        .getAutoscalerConfig();
+
+        Assertions.assertTrue(config.isEnabled());
+        Assertions.assertEquals(11, config.getEvaluationIntervalSeconds());
+        Assertions.assertEquals(22, config.getMetricsFreshnessSeconds());
+        Assertions.assertEquals(3, config.getMaxFutureSkewSeconds());
+        Assertions.assertEquals(44, config.getScaleOutStabilizationSeconds());
+        Assertions.assertEquals(55, config.getScaleInStabilizationSeconds());
+        Assertions.assertEquals(0.91d, config.getScaleOutCpuThreshold());
+        Assertions.assertEquals(0.92d, config.getScaleOutJvmMemoryThreshold());
+        Assertions.assertEquals(0.21d, config.getScaleInCpuThreshold());
+        Assertions.assertEquals(0.22d, config.getScaleInJvmMemoryThreshold());
+        Assertions.assertEquals(0.93d, config.getFixedSlotScaleOutThreshold());
+        Assertions.assertEquals(0.23d, config.getFixedSlotScaleInThreshold());
+        Assertions.assertEquals(2, config.getScaleStep());
+        Assertions.assertEquals(3, config.getMinWorkers());
+        Assertions.assertEquals(7, config.getMaxWorkers());
+        Assertions.assertEquals(9, config.getHistorySize());
+    }
+
+    @Test
+    void rejectsInvalidThresholdOrdering() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        parse(
+                                "seatunnel:\n"
+                                        + "  engine:\n"
+                                        + "    autoscaler:\n"
+                                        + "      scale-out-cpu-threshold: 0.2\n"
+                                        + "      scale-in-cpu-threshold: 0.3\n"));
+    }
+
+    @Test
+    void rejectsInvalidWorkerRange() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        parse(
+                                "seatunnel:\n"
+                                        + "  engine:\n"
+                                        + "    autoscaler:\n"
+                                        + "      min-workers: 3\n"
+                                        + "      max-workers: 2\n"));
+    }
+
+    private SeaTunnelConfig parse(String yaml) throws Exception {
+        Path configFile = tempDir.resolve("seatunnel.yaml");
+        Files.write(configFile, yaml.getBytes(StandardCharsets.UTF_8));
+        return new YamlSeaTunnelConfigBuilder(new FileInputStream(configFile.toFile())).build();
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -1406,6 +1406,7 @@ public class CoordinatorService {
         if (!engineConfig.getAutoscalerConfig().isEnabled() || autoscalerRunning) {
             return;
         }
+        autoscalerStateStore.clear();
         long masterEpoch =
                 nodeEngine
                         .getHazelcastInstance()

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -1464,7 +1464,7 @@ public class CoordinatorService {
         DefaultAutoScaler current = autoScaler;
         autoScaler = null;
         if (current != null) {
-            current.reset(0L);
+            current.close();
         }
         ScheduledExecutorService scheduler = autoscalerScheduler;
         autoscalerScheduler = null;

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/CoordinatorService.java
@@ -53,6 +53,12 @@ import org.apache.seatunnel.engine.core.job.JobDAGInfo;
 import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
 import org.apache.seatunnel.engine.core.job.JobInfo;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerView;
+import org.apache.seatunnel.engine.server.autoscale.DefaultAutoScaler;
+import org.apache.seatunnel.engine.server.autoscale.DefaultAutoscalerSignalCollector;
+import org.apache.seatunnel.engine.server.autoscale.HierarchicalAutoscalingPolicy;
+import org.apache.seatunnel.engine.server.autoscale.InMemoryAutoscalerStateStore;
+import org.apache.seatunnel.engine.server.autoscale.SystemAutoscalerTimeSource;
 import org.apache.seatunnel.engine.server.common.SeaTunnelEngineContext;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.MetricsSnapshotStateStore;
 import org.apache.seatunnel.engine.server.dag.DAGUtils;
@@ -231,6 +237,14 @@ public class CoordinatorService {
 
     private final ScheduledExecutorService pipelineCleanupScheduler;
 
+    private ScheduledExecutorService autoscalerScheduler;
+
+    private final InMemoryAutoscalerStateStore autoscalerStateStore;
+
+    private volatile DefaultAutoScaler autoScaler;
+
+    private volatile boolean autoscalerRunning;
+
     private final EngineConfig engineConfig;
 
     private ConnectorPackageService connectorPackageService;
@@ -280,6 +294,9 @@ public class CoordinatorService {
                 PIPELINE_CLEANUP_INTERVAL_SECONDS,
                 PIPELINE_CLEANUP_INTERVAL_SECONDS,
                 TimeUnit.SECONDS);
+        autoscalerStateStore =
+                new InMemoryAutoscalerStateStore(
+                        engineConfig.getAutoscalerConfig().getHistorySize());
         scheduleStrategy = engineConfig.getScheduleStrategy();
         isWaitStrategy = scheduleStrategy.equals(ScheduleStrategy.WAIT);
     }
@@ -1250,6 +1267,7 @@ public class CoordinatorService {
                 pendingJobScheduleEpoch.incrementAndGet();
                 isActive = true;
                 startPendingJobScheduleThread();
+                startAutoscaler();
                 seaTunnelServer.startRealtimeMetricsService(this);
             } else if (isActive && !this.seaTunnelServer.isMasterNode()) {
                 isActive = false;
@@ -1288,6 +1306,7 @@ public class CoordinatorService {
         schedulingJobMasters.clear();
         schedulingPendingJobIds.clear();
         pendingJobQueue.release();
+        stopAutoscaler();
         // interrupt all JobMaster
         runningJobMasterMap.values().forEach(JobMaster::interrupt);
         // Interrupt and discard every JobMaster currently sitting in pendingJobQueue. This is
@@ -1368,6 +1387,102 @@ public class CoordinatorService {
      */
     public ResourceManager getInitializedResourceManager() {
         return resourceManager;
+    }
+
+    public AutoscalerView getAutoscalerView() {
+        DefaultAutoScaler current = autoScaler;
+        long currentMasterEpoch = current == null ? 0L : current.getMasterEpoch();
+        long nextGeneration = current == null ? 0L : current.getNextGeneration();
+        return autoscalerStateStore.view(
+                engineConfig.getAutoscalerConfig().isEnabled(),
+                autoscalerRunning,
+                currentMasterEpoch,
+                nextGeneration,
+                engineConfig.getAutoscalerConfig().getScaleOutStabilizationSeconds(),
+                engineConfig.getAutoscalerConfig().getScaleInStabilizationSeconds());
+    }
+
+    private synchronized void startAutoscaler() {
+        if (!engineConfig.getAutoscalerConfig().isEnabled() || autoscalerRunning) {
+            return;
+        }
+        long masterEpoch =
+                nodeEngine
+                        .getHazelcastInstance()
+                        .getFlakeIdGenerator(Constant.SEATUNNEL_AUTOSCALER_EPOCH_GENERATOR_NAME)
+                        .newId();
+        DefaultAutoScaler newAutoScaler =
+                new DefaultAutoScaler(
+                        masterEpoch,
+                        engineConfig.getAutoscalerConfig(),
+                        new DefaultAutoscalerSignalCollector(
+                                getResourceManager(),
+                                engineConfig.getAutoscalerConfig(),
+                                this::getPendingJobCount,
+                                this::getOldestPendingDurationMillis,
+                                System::currentTimeMillis),
+                        new HierarchicalAutoscalingPolicy(
+                                DefaultAutoScaler.policyConfig(engineConfig.getAutoscalerConfig())),
+                        DefaultAutoScaler.stabilizationTracker(engineConfig.getAutoscalerConfig()),
+                        autoscalerStateStore,
+                        new SystemAutoscalerTimeSource());
+        newAutoScaler.reset(masterEpoch);
+        autoScaler = newAutoScaler;
+        autoscalerScheduler =
+                Executors.newSingleThreadScheduledExecutor(
+                        new ThreadFactoryBuilder()
+                                .setNameFormat("seatunnel-autoscaler-%d")
+                                .setDaemon(true)
+                                .build());
+        autoscalerRunning = true;
+        autoscalerScheduler.scheduleAtFixedRate(
+                this::evaluateAutoscalerSafely,
+                0,
+                engineConfig.getAutoscalerConfig().getEvaluationIntervalSeconds(),
+                TimeUnit.SECONDS);
+    }
+
+    private void evaluateAutoscalerSafely() {
+        if (!isActive || !autoscalerRunning) {
+            return;
+        }
+        try {
+            DefaultAutoScaler current = autoScaler;
+            if (current != null) {
+                current.evaluateOnce();
+            }
+        } catch (Throwable t) {
+            logger.warning(
+                    String.format("Autoscaler evaluation failed: %s", ExceptionUtils.getMessage(t)),
+                    t);
+        }
+    }
+
+    private synchronized void stopAutoscaler() {
+        autoscalerRunning = false;
+        DefaultAutoScaler current = autoScaler;
+        autoScaler = null;
+        if (current != null) {
+            current.reset(0L);
+        }
+        ScheduledExecutorService scheduler = autoscalerScheduler;
+        autoscalerScheduler = null;
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            awaitSchedulerTermination("autoscaler", scheduler);
+        }
+    }
+
+    private long getOldestPendingDurationMillis() {
+        long oldestEnqueueTimestamp =
+                pendingJobQueue.getJobIdMap().values().stream()
+                        .mapToLong(PendingJobInfo::getEnqueueTimestamp)
+                        .min()
+                        .orElse(0L);
+        if (oldestEnqueueTimestamp <= 0L) {
+            return 0L;
+        }
+        return Math.max(0L, System.currentTimeMillis() - oldestEnqueueTimestamp);
     }
 
     /** call by client to submit job */

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/JettyService.java
@@ -31,6 +31,9 @@ import org.apache.seatunnel.engine.server.rest.filter.BasicAuthFilter;
 import org.apache.seatunnel.engine.server.rest.filter.ExceptionHandlingFilter;
 import org.apache.seatunnel.engine.server.rest.servlet.AllLogNameServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.AllNodeLogServlet;
+import org.apache.seatunnel.engine.server.rest.servlet.AutoscalerHistoryServlet;
+import org.apache.seatunnel.engine.server.rest.servlet.AutoscalerMetricsServlet;
+import org.apache.seatunnel.engine.server.rest.servlet.AutoscalerStatusServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.CheckpointHistoryServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.CheckpointOverviewServlet;
 import org.apache.seatunnel.engine.server.rest.servlet.CurrentNodeLogServlet;
@@ -68,6 +71,9 @@ import java.net.ServerSocket;
 import java.net.URL;
 import java.util.EnumSet;
 
+import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_AUTOSCALER_HISTORY;
+import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_AUTOSCALER_METRICS;
+import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_AUTOSCALER_STATUS;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_CHECKPOINT_HISTORY;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_CHECKPOINT_OVERVIEW;
 import static org.apache.seatunnel.engine.server.rest.RestConstant.REST_URL_ENCRYPT_CONFIG;
@@ -226,6 +232,12 @@ public class JettyService {
                 new ServletHolder(new CheckpointOverviewServlet(nodeEngine));
         ServletHolder checkpointHistoryHolder =
                 new ServletHolder(new CheckpointHistoryServlet(nodeEngine));
+        ServletHolder autoscalerStatusHolder =
+                new ServletHolder(new AutoscalerStatusServlet(nodeEngine));
+        ServletHolder autoscalerMetricsHolder =
+                new ServletHolder(new AutoscalerMetricsServlet(nodeEngine));
+        ServletHolder autoscalerHistoryHolder =
+                new ServletHolder(new AutoscalerHistoryServlet(nodeEngine));
 
         context.addServlet(overviewHolder, convertUrlToPath(REST_URL_OVERVIEW));
         context.addServlet(runningJobsHolder, convertUrlToPath(REST_URL_RUNNING_JOBS));
@@ -262,6 +274,9 @@ public class JettyService {
         context.addServlet(
                 checkpointOverviewHolder, convertUrlToPath(REST_URL_CHECKPOINT_OVERVIEW));
         context.addServlet(checkpointHistoryHolder, convertUrlToPath(REST_URL_CHECKPOINT_HISTORY));
+        context.addServlet(autoscalerStatusHolder, convertUrlToPath(REST_URL_AUTOSCALER_STATUS));
+        context.addServlet(autoscalerMetricsHolder, convertUrlToPath(REST_URL_AUTOSCALER_METRICS));
+        context.addServlet(autoscalerHistoryHolder, convertUrlToPath(REST_URL_AUTOSCALER_HISTORY));
 
         server.setHandler(context);
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/SeaTunnelServer.java
@@ -132,7 +132,8 @@ public class SeaTunnelServer
                             new DefaultSlotService(
                                     nodeEngine,
                                     taskExecutionService,
-                                    seaTunnelConfig.getEngineConfig().getSlotServiceConfig());
+                                    seaTunnelConfig.getEngineConfig().getSlotServiceConfig(),
+                                    seaTunnelConfig.getEngineConfig().getAutoscalerConfig());
                     service.init();
                     slotService = service;
                 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscaleEvaluation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscaleEvaluation.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class AutoscaleEvaluation implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ScalingAction action;
+    private final List<String> triggerReasons;
+    private final List<String> blockingReasons;
+
+    public AutoscaleEvaluation(
+            ScalingAction action, List<String> triggerReasons, List<String> blockingReasons) {
+        this.action = Objects.requireNonNull(action, "action");
+        this.triggerReasons = immutableCopy(triggerReasons);
+        this.blockingReasons = immutableCopy(blockingReasons);
+    }
+
+    public ScalingAction getAction() {
+        return action;
+    }
+
+    public List<String> getTriggerReasons() {
+        return triggerReasons;
+    }
+
+    public List<String> getBlockingReasons() {
+        return blockingReasons;
+    }
+
+    private static List<String> immutableCopy(List<String> values) {
+        return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerMetricsSnapshot.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerMetricsSnapshot.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Immutable input snapshot evaluated by the autoscaling policy.
+ *
+ * <p>Metric values carry explicit validity status so missing, stale, future, and unknown signals
+ * are not confused with numeric zero.
+ */
+public final class AutoscalerMetricsSnapshot implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long evaluationTimeMillis;
+    private final int currentWorkers;
+    private final int minWorkers;
+    private final int maxWorkers;
+    private final SlotMode slotMode;
+    private final int assignedSlots;
+    private final int unassignedSlots;
+    private final MetricValue fixedSlotUtilization;
+    private final MetricValue cpu;
+    private final MetricValue jvmMemory;
+    private final int totalWorkerSamples;
+    private final int validWorkerSamples;
+    private final int missingWorkerSamples;
+    private final int staleWorkerSamples;
+    private final int futureWorkerSamples;
+    private final int pendingJobCount;
+    private final long oldestPendingDurationMillis;
+    private final long resourceShortageCount;
+    private final long waitShortageCount;
+    private final long rejectShortageCount;
+    private final boolean waitShortage;
+    private final boolean rejectShortage;
+    private final boolean scaleInMetricsValid;
+
+    private AutoscalerMetricsSnapshot(Builder builder) {
+        this.evaluationTimeMillis = builder.evaluationTimeMillis;
+        this.currentWorkers = builder.currentWorkers;
+        this.minWorkers = builder.minWorkers;
+        this.maxWorkers = builder.maxWorkers;
+        this.slotMode = Objects.requireNonNull(builder.slotMode, "slotMode");
+        this.assignedSlots = builder.assignedSlots;
+        this.unassignedSlots = builder.unassignedSlots;
+        this.fixedSlotUtilization =
+                Objects.requireNonNull(builder.fixedSlotUtilization, "fixedSlotUtilization");
+        this.cpu = Objects.requireNonNull(builder.cpu, "cpu");
+        this.jvmMemory = Objects.requireNonNull(builder.jvmMemory, "jvmMemory");
+        this.totalWorkerSamples = builder.totalWorkerSamples;
+        this.validWorkerSamples = builder.validWorkerSamples;
+        this.missingWorkerSamples = builder.missingWorkerSamples;
+        this.staleWorkerSamples = builder.staleWorkerSamples;
+        this.futureWorkerSamples = builder.futureWorkerSamples;
+        this.pendingJobCount = builder.pendingJobCount;
+        this.oldestPendingDurationMillis = builder.oldestPendingDurationMillis;
+        this.resourceShortageCount = builder.resourceShortageCount;
+        this.waitShortageCount = builder.waitShortageCount;
+        this.rejectShortageCount = builder.rejectShortageCount;
+        this.waitShortage = builder.waitShortage;
+        this.rejectShortage = builder.rejectShortage;
+        this.scaleInMetricsValid = builder.scaleInMetricsValid;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public long getEvaluationTimeMillis() {
+        return evaluationTimeMillis;
+    }
+
+    public int getCurrentWorkers() {
+        return currentWorkers;
+    }
+
+    public int getMinWorkers() {
+        return minWorkers;
+    }
+
+    public int getMaxWorkers() {
+        return maxWorkers;
+    }
+
+    public SlotMode getSlotMode() {
+        return slotMode;
+    }
+
+    public int getAssignedSlots() {
+        return assignedSlots;
+    }
+
+    public int getUnassignedSlots() {
+        return unassignedSlots;
+    }
+
+    public MetricValue getFixedSlotUtilization() {
+        return fixedSlotUtilization;
+    }
+
+    public MetricValue getCpu() {
+        return cpu;
+    }
+
+    public MetricValue getJvmMemory() {
+        return jvmMemory;
+    }
+
+    public int getTotalWorkerSamples() {
+        return totalWorkerSamples;
+    }
+
+    public int getValidWorkerSamples() {
+        return validWorkerSamples;
+    }
+
+    public int getMissingWorkerSamples() {
+        return missingWorkerSamples;
+    }
+
+    public int getStaleWorkerSamples() {
+        return staleWorkerSamples;
+    }
+
+    public int getFutureWorkerSamples() {
+        return futureWorkerSamples;
+    }
+
+    public int getPendingJobCount() {
+        return pendingJobCount;
+    }
+
+    public long getOldestPendingDurationMillis() {
+        return oldestPendingDurationMillis;
+    }
+
+    public long getResourceShortageCount() {
+        return resourceShortageCount;
+    }
+
+    public long getWaitShortageCount() {
+        return waitShortageCount;
+    }
+
+    public long getRejectShortageCount() {
+        return rejectShortageCount;
+    }
+
+    public boolean isWaitShortage() {
+        return waitShortage;
+    }
+
+    public boolean isRejectShortage() {
+        return rejectShortage;
+    }
+
+    public boolean isScaleInMetricsValid() {
+        return scaleInMetricsValid;
+    }
+
+    public boolean hasSchedulerShortage() {
+        return resourceShortageCount > 0L || waitShortage || rejectShortage;
+    }
+
+    public static final class Builder {
+
+        private long evaluationTimeMillis;
+        private int currentWorkers;
+        private int minWorkers = 1;
+        private int maxWorkers = Integer.MAX_VALUE;
+        private SlotMode slotMode = SlotMode.UNKNOWN;
+        private int assignedSlots;
+        private int unassignedSlots;
+        private MetricValue fixedSlotUtilization = MetricValue.unknown();
+        private MetricValue cpu = MetricValue.missing();
+        private MetricValue jvmMemory = MetricValue.missing();
+        private int totalWorkerSamples;
+        private int validWorkerSamples;
+        private int missingWorkerSamples;
+        private int staleWorkerSamples;
+        private int futureWorkerSamples;
+        private int pendingJobCount;
+        private long oldestPendingDurationMillis;
+        private long resourceShortageCount;
+        private long waitShortageCount;
+        private long rejectShortageCount;
+        private boolean waitShortage;
+        private boolean rejectShortage;
+        private boolean scaleInMetricsValid;
+
+        public Builder evaluationTimeMillis(long evaluationTimeMillis) {
+            this.evaluationTimeMillis = evaluationTimeMillis;
+            return this;
+        }
+
+        public Builder currentWorkers(int currentWorkers) {
+            this.currentWorkers = currentWorkers;
+            return this;
+        }
+
+        public Builder minWorkers(int minWorkers) {
+            this.minWorkers = minWorkers;
+            return this;
+        }
+
+        public Builder maxWorkers(int maxWorkers) {
+            this.maxWorkers = maxWorkers;
+            return this;
+        }
+
+        public Builder slotMode(SlotMode slotMode) {
+            this.slotMode = slotMode;
+            return this;
+        }
+
+        public Builder assignedSlots(int assignedSlots) {
+            this.assignedSlots = assignedSlots;
+            return this;
+        }
+
+        public Builder unassignedSlots(int unassignedSlots) {
+            this.unassignedSlots = unassignedSlots;
+            return this;
+        }
+
+        public Builder fixedSlotUtilization(MetricValue fixedSlotUtilization) {
+            this.fixedSlotUtilization = fixedSlotUtilization;
+            return this;
+        }
+
+        public Builder cpu(MetricValue cpu) {
+            this.cpu = cpu;
+            return this;
+        }
+
+        public Builder jvmMemory(MetricValue jvmMemory) {
+            this.jvmMemory = jvmMemory;
+            return this;
+        }
+
+        public Builder totalWorkerSamples(int totalWorkerSamples) {
+            this.totalWorkerSamples = totalWorkerSamples;
+            return this;
+        }
+
+        public Builder validWorkerSamples(int validWorkerSamples) {
+            this.validWorkerSamples = validWorkerSamples;
+            return this;
+        }
+
+        public Builder missingWorkerSamples(int missingWorkerSamples) {
+            this.missingWorkerSamples = missingWorkerSamples;
+            return this;
+        }
+
+        public Builder staleWorkerSamples(int staleWorkerSamples) {
+            this.staleWorkerSamples = staleWorkerSamples;
+            return this;
+        }
+
+        public Builder futureWorkerSamples(int futureWorkerSamples) {
+            this.futureWorkerSamples = futureWorkerSamples;
+            return this;
+        }
+
+        public Builder pendingJobCount(int pendingJobCount) {
+            this.pendingJobCount = pendingJobCount;
+            return this;
+        }
+
+        public Builder oldestPendingDurationMillis(long oldestPendingDurationMillis) {
+            this.oldestPendingDurationMillis = oldestPendingDurationMillis;
+            return this;
+        }
+
+        public Builder resourceShortageCount(long resourceShortageCount) {
+            this.resourceShortageCount = resourceShortageCount;
+            return this;
+        }
+
+        public Builder waitShortageCount(long waitShortageCount) {
+            this.waitShortageCount = waitShortageCount;
+            return this;
+        }
+
+        public Builder rejectShortageCount(long rejectShortageCount) {
+            this.rejectShortageCount = rejectShortageCount;
+            return this;
+        }
+
+        public Builder waitShortage(boolean waitShortage) {
+            this.waitShortage = waitShortage;
+            return this;
+        }
+
+        public Builder rejectShortage(boolean rejectShortage) {
+            this.rejectShortage = rejectShortage;
+            return this;
+        }
+
+        public Builder scaleInMetricsValid(boolean scaleInMetricsValid) {
+            this.scaleInMetricsValid = scaleInMetricsValid;
+            return this;
+        }
+
+        public AutoscalerMetricsSnapshot build() {
+            return new AutoscalerMetricsSnapshot(this);
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerPolicyConfig.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerPolicyConfig.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public final class AutoscalerPolicyConfig {
+
+    private final double scaleOutCpuThreshold;
+    private final double scaleOutJvmMemoryThreshold;
+    private final double scaleInCpuThreshold;
+    private final double scaleInJvmMemoryThreshold;
+    private final double fixedSlotScaleOutThreshold;
+    private final double fixedSlotScaleInThreshold;
+
+    private AutoscalerPolicyConfig(Builder builder) {
+        this.scaleOutCpuThreshold = builder.scaleOutCpuThreshold;
+        this.scaleOutJvmMemoryThreshold = builder.scaleOutJvmMemoryThreshold;
+        this.scaleInCpuThreshold = builder.scaleInCpuThreshold;
+        this.scaleInJvmMemoryThreshold = builder.scaleInJvmMemoryThreshold;
+        this.fixedSlotScaleOutThreshold = builder.fixedSlotScaleOutThreshold;
+        this.fixedSlotScaleInThreshold = builder.fixedSlotScaleInThreshold;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public double getScaleOutCpuThreshold() {
+        return scaleOutCpuThreshold;
+    }
+
+    public double getScaleOutJvmMemoryThreshold() {
+        return scaleOutJvmMemoryThreshold;
+    }
+
+    public double getScaleInCpuThreshold() {
+        return scaleInCpuThreshold;
+    }
+
+    public double getScaleInJvmMemoryThreshold() {
+        return scaleInJvmMemoryThreshold;
+    }
+
+    public double getFixedSlotScaleOutThreshold() {
+        return fixedSlotScaleOutThreshold;
+    }
+
+    public double getFixedSlotScaleInThreshold() {
+        return fixedSlotScaleInThreshold;
+    }
+
+    public static final class Builder {
+
+        private double scaleOutCpuThreshold = 0.8d;
+        private double scaleOutJvmMemoryThreshold = 0.8d;
+        private double scaleInCpuThreshold = 0.3d;
+        private double scaleInJvmMemoryThreshold = 0.3d;
+        private double fixedSlotScaleOutThreshold = 0.8d;
+        private double fixedSlotScaleInThreshold = 0.3d;
+
+        public Builder scaleOutCpuThreshold(double scaleOutCpuThreshold) {
+            this.scaleOutCpuThreshold = scaleOutCpuThreshold;
+            return this;
+        }
+
+        public Builder scaleOutJvmMemoryThreshold(double scaleOutJvmMemoryThreshold) {
+            this.scaleOutJvmMemoryThreshold = scaleOutJvmMemoryThreshold;
+            return this;
+        }
+
+        public Builder scaleInCpuThreshold(double scaleInCpuThreshold) {
+            this.scaleInCpuThreshold = scaleInCpuThreshold;
+            return this;
+        }
+
+        public Builder scaleInJvmMemoryThreshold(double scaleInJvmMemoryThreshold) {
+            this.scaleInJvmMemoryThreshold = scaleInJvmMemoryThreshold;
+            return this;
+        }
+
+        public Builder fixedSlotScaleOutThreshold(double fixedSlotScaleOutThreshold) {
+            this.fixedSlotScaleOutThreshold = fixedSlotScaleOutThreshold;
+            return this;
+        }
+
+        public Builder fixedSlotScaleInThreshold(double fixedSlotScaleInThreshold) {
+            this.fixedSlotScaleInThreshold = fixedSlotScaleInThreshold;
+            return this;
+        }
+
+        public AutoscalerPolicyConfig build() {
+            return new AutoscalerPolicyConfig(this);
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerSignalCollector.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerSignalCollector.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public interface AutoscalerSignalCollector {
+
+    AutoscalerMetricsSnapshot collect();
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerStateStore.java
@@ -21,6 +21,8 @@ public interface AutoscalerStateStore {
 
     RecommendationFence.PublicationResult publish(ScalingRecommendation recommendation);
 
+    void clear();
+
     AutoscalerView view(
             boolean enabled,
             boolean running,

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerStateStore.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public interface AutoscalerStateStore {
+
+    RecommendationFence.PublicationResult publish(ScalingRecommendation recommendation);
+
+    AutoscalerView view(
+            boolean enabled,
+            boolean running,
+            long currentMasterEpoch,
+            long nextGeneration,
+            int scaleOutStabilizationSeconds,
+            int scaleInStabilizationSeconds);
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerTimeSource.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerTimeSource.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public interface AutoscalerTimeSource {
+
+    long currentTimeMillis();
+
+    long nanoTime();
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerView.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalerView.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read model shared by REST and OpenMetrics adapters.
+ *
+ * <p>It exposes already-published autoscaler state and never performs collection or policy
+ * evaluation.
+ */
+public final class AutoscalerView implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final boolean enabled;
+    private final boolean running;
+    private final long currentMasterEpoch;
+    private final long nextGeneration;
+    private final int scaleOutStabilizationSeconds;
+    private final int scaleInStabilizationSeconds;
+    private final ScalingRecommendation latestRecommendation;
+    private final AutoscalerMetricsSnapshot currentSnapshot;
+    private final List<ScalingRecommendation> history;
+    private final Map<ScalingAction, Long> recommendationCounts;
+
+    public AutoscalerView(
+            boolean enabled,
+            boolean running,
+            long currentMasterEpoch,
+            long nextGeneration,
+            int scaleOutStabilizationSeconds,
+            int scaleInStabilizationSeconds,
+            ScalingRecommendation latestRecommendation,
+            AutoscalerMetricsSnapshot currentSnapshot,
+            List<ScalingRecommendation> history,
+            Map<ScalingAction, Long> recommendationCounts) {
+        this.enabled = enabled;
+        this.running = running;
+        this.currentMasterEpoch = currentMasterEpoch;
+        this.nextGeneration = nextGeneration;
+        this.scaleOutStabilizationSeconds = scaleOutStabilizationSeconds;
+        this.scaleInStabilizationSeconds = scaleInStabilizationSeconds;
+        this.latestRecommendation = latestRecommendation;
+        this.currentSnapshot = currentSnapshot;
+        this.history = Collections.unmodifiableList(new ArrayList<>(history));
+        this.recommendationCounts = immutableCounts(recommendationCounts);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public long getCurrentMasterEpoch() {
+        return currentMasterEpoch;
+    }
+
+    public long getNextGeneration() {
+        return nextGeneration;
+    }
+
+    public int getScaleOutStabilizationSeconds() {
+        return scaleOutStabilizationSeconds;
+    }
+
+    public int getScaleInStabilizationSeconds() {
+        return scaleInStabilizationSeconds;
+    }
+
+    public ScalingRecommendation getLatestRecommendation() {
+        return latestRecommendation;
+    }
+
+    public AutoscalerMetricsSnapshot getCurrentSnapshot() {
+        return currentSnapshot;
+    }
+
+    public List<ScalingRecommendation> getHistory() {
+        return history;
+    }
+
+    public Map<ScalingAction, Long> getRecommendationCounts() {
+        return recommendationCounts;
+    }
+
+    private static Map<ScalingAction, Long> immutableCounts(Map<ScalingAction, Long> counts) {
+        EnumMap<ScalingAction, Long> copy = new EnumMap<>(ScalingAction.class);
+        for (ScalingAction action : ScalingAction.values()) {
+            copy.put(action, counts.getOrDefault(action, 0L));
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalingPolicy.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/AutoscalingPolicy.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public interface AutoscalingPolicy {
+
+    AutoscaleEvaluation evaluate(AutoscalerMetricsSnapshot snapshot);
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoScaler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoScaler.java
@@ -40,6 +40,7 @@ public final class DefaultAutoScaler {
 
     private long masterEpoch;
     private long generation;
+    private volatile boolean closed;
 
     public DefaultAutoScaler(
             long masterEpoch,
@@ -77,6 +78,9 @@ public final class DefaultAutoScaler {
     }
 
     public synchronized RecommendationFence.PublicationResult evaluateOnce() {
+        if (closed) {
+            return RecommendationFence.PublicationResult.REJECTED;
+        }
         AutoscalerMetricsSnapshot snapshot = signalCollector.collect();
         AutoscaleEvaluation evaluation = policy.evaluate(snapshot);
         boolean stabilized =
@@ -106,6 +110,10 @@ public final class DefaultAutoScaler {
                         .recommendationOnly(true)
                         .build();
         return stateStore.publish(recommendation);
+    }
+
+    public synchronized void close() {
+        closed = true;
     }
 
     public synchronized void reset(long masterEpoch) {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoScaler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoScaler.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Runs one advisory autoscaler evaluation at a time for the active master.
+ *
+ * <p>It collects signals, applies policy and stabilization, then publishes a fenced
+ * recommendation-only result.
+ */
+public final class DefaultAutoScaler {
+
+    private final AutoscalerConfig config;
+    private final AutoscalerSignalCollector signalCollector;
+    private final AutoscalingPolicy policy;
+    private final StabilizationTracker stabilizationTracker;
+    private final AutoscalerStateStore stateStore;
+    private final AutoscalerTimeSource timeSource;
+
+    private long masterEpoch;
+    private long generation;
+
+    public DefaultAutoScaler(
+            long masterEpoch,
+            AutoscalerConfig config,
+            AutoscalerSignalCollector signalCollector,
+            AutoscalingPolicy policy,
+            StabilizationTracker stabilizationTracker,
+            AutoscalerStateStore stateStore,
+            AutoscalerTimeSource timeSource) {
+        this.masterEpoch = masterEpoch;
+        this.config = Objects.requireNonNull(config, "config");
+        this.signalCollector = Objects.requireNonNull(signalCollector, "signalCollector");
+        this.policy = Objects.requireNonNull(policy, "policy");
+        this.stabilizationTracker =
+                Objects.requireNonNull(stabilizationTracker, "stabilizationTracker");
+        this.stateStore = Objects.requireNonNull(stateStore, "stateStore");
+        this.timeSource = Objects.requireNonNull(timeSource, "timeSource");
+    }
+
+    public static AutoscalerPolicyConfig policyConfig(AutoscalerConfig config) {
+        return AutoscalerPolicyConfig.builder()
+                .scaleOutCpuThreshold(config.getScaleOutCpuThreshold())
+                .scaleOutJvmMemoryThreshold(config.getScaleOutJvmMemoryThreshold())
+                .scaleInCpuThreshold(config.getScaleInCpuThreshold())
+                .scaleInJvmMemoryThreshold(config.getScaleInJvmMemoryThreshold())
+                .fixedSlotScaleOutThreshold(config.getFixedSlotScaleOutThreshold())
+                .fixedSlotScaleInThreshold(config.getFixedSlotScaleInThreshold())
+                .build();
+    }
+
+    public static StabilizationTracker stabilizationTracker(AutoscalerConfig config) {
+        return new StabilizationTracker(
+                TimeUnit.SECONDS.toNanos(config.getScaleOutStabilizationSeconds()),
+                TimeUnit.SECONDS.toNanos(config.getScaleInStabilizationSeconds()));
+    }
+
+    public synchronized RecommendationFence.PublicationResult evaluateOnce() {
+        AutoscalerMetricsSnapshot snapshot = signalCollector.collect();
+        AutoscaleEvaluation evaluation = policy.evaluate(snapshot);
+        boolean stabilized =
+                stabilizationTracker.isStabilized(evaluation.getAction(), timeSource.nanoTime());
+        ScalingAction publishedAction = evaluation.getAction();
+        ArrayList<String> blockingReasons = new ArrayList<>(evaluation.getBlockingReasons());
+        if (!stabilized) {
+            blockingReasons.add("stabilization_window_not_satisfied");
+            publishedAction = ScalingAction.NO_ACTION;
+        }
+
+        ScalingRecommendation recommendation =
+                ScalingRecommendation.builder()
+                        .masterEpoch(masterEpoch)
+                        .generation(generation++)
+                        .action(publishedAction)
+                        .currentWorkers(snapshot.getCurrentWorkers())
+                        .recommendedWorkers(recommendedWorkers(publishedAction, snapshot))
+                        .observedAtMillis(timeSource.currentTimeMillis())
+                        .validUntilMillis(
+                                timeSource.currentTimeMillis()
+                                        + TimeUnit.SECONDS.toMillis(
+                                                config.getEvaluationIntervalSeconds()))
+                        .triggerReasons(evaluation.getTriggerReasons())
+                        .blockingReasons(blockingReasons)
+                        .snapshot(snapshot)
+                        .recommendationOnly(true)
+                        .build();
+        return stateStore.publish(recommendation);
+    }
+
+    public synchronized void reset(long masterEpoch) {
+        this.masterEpoch = masterEpoch;
+        this.generation = 0L;
+        this.stabilizationTracker.reset();
+    }
+
+    public synchronized long getMasterEpoch() {
+        return masterEpoch;
+    }
+
+    public synchronized long getNextGeneration() {
+        return generation;
+    }
+
+    private int recommendedWorkers(
+            ScalingAction publishedAction, AutoscalerMetricsSnapshot snapshot) {
+        int currentWorkers = snapshot.getCurrentWorkers();
+        if (publishedAction == ScalingAction.SCALE_OUT) {
+            return Math.min(config.getMaxWorkers(), currentWorkers + config.getScaleStep());
+        }
+        if (publishedAction == ScalingAction.SCALE_IN_CANDIDATE) {
+            return Math.max(config.getMinWorkers(), currentWorkers - config.getScaleStep());
+        }
+        return currentWorkers;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoscalerSignalCollector.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoscalerSignalCollector.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
+import org.apache.seatunnel.engine.server.resourcemanager.ResourceManager;
+import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
+
+import com.hazelcast.cluster.Address;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+
+/**
+ * Builds immutable autoscaler snapshots from ResourceManager state.
+ *
+ * <p>The collector normalizes worker samples, slot mode, pending jobs, and scheduler shortage
+ * deltas; it does not evaluate policy.
+ */
+public final class DefaultAutoscalerSignalCollector implements AutoscalerSignalCollector {
+
+    private final ResourceManager resourceManager;
+    private final AutoscalerConfig config;
+    private final IntSupplier pendingJobCountSupplier;
+    private final LongSupplier oldestPendingDurationMillisSupplier;
+    private final LongSupplier currentTimeMillisSupplier;
+    private final AtomicLong lastShortageSequence = new AtomicLong();
+
+    public DefaultAutoscalerSignalCollector(
+            ResourceManager resourceManager,
+            AutoscalerConfig config,
+            IntSupplier pendingJobCountSupplier,
+            LongSupplier oldestPendingDurationMillisSupplier,
+            LongSupplier currentTimeMillisSupplier) {
+        this.resourceManager = Objects.requireNonNull(resourceManager, "resourceManager");
+        this.config = Objects.requireNonNull(config, "config");
+        this.pendingJobCountSupplier =
+                Objects.requireNonNull(pendingJobCountSupplier, "pendingJobCountSupplier");
+        this.oldestPendingDurationMillisSupplier =
+                Objects.requireNonNull(
+                        oldestPendingDurationMillisSupplier, "oldestPendingDurationMillisSupplier");
+        this.currentTimeMillisSupplier =
+                Objects.requireNonNull(currentTimeMillisSupplier, "currentTimeMillisSupplier");
+    }
+
+    @Override
+    public AutoscalerMetricsSnapshot collect() {
+        long nowMillis = currentTimeMillisSupplier.getAsLong();
+        HashSet<Address> currentWorkers =
+                new HashSet<>(resourceManager.getRegisterWorker().keySet());
+        resourceManager.getAutoscalerWorkerSampleStore().retainWorkers(currentWorkers);
+        WorkerSampleSummary workerSampleSummary =
+                resourceManager
+                        .getAutoscalerWorkerSampleStore()
+                        .summarize(
+                                currentWorkers,
+                                nowMillis,
+                                TimeUnit.SECONDS.toMillis(config.getMetricsFreshnessSeconds()));
+        ResourceShortageSnapshot shortageSnapshot =
+                resourceManager
+                        .getResourceShortageStats()
+                        .snapshotSince(lastShortageSequence.get());
+        lastShortageSequence.set(shortageSnapshot.getSequence());
+        SlotSummary slotSummary = summarizeSlots();
+
+        return AutoscalerMetricsSnapshot.builder()
+                .evaluationTimeMillis(nowMillis)
+                .currentWorkers(currentWorkers.size())
+                .minWorkers(config.getMinWorkers())
+                .maxWorkers(config.getMaxWorkers())
+                .slotMode(slotSummary.slotMode)
+                .assignedSlots(slotSummary.assignedSlots)
+                .unassignedSlots(slotSummary.unassignedSlots)
+                .fixedSlotUtilization(slotSummary.fixedSlotUtilization)
+                .cpu(workerSampleSummary.getCpu())
+                .jvmMemory(workerSampleSummary.getJvmMemory())
+                .totalWorkerSamples(workerSampleSummary.getTotalSamples())
+                .validWorkerSamples(workerSampleSummary.getValidSamples())
+                .missingWorkerSamples(workerSampleSummary.getMissingSamples())
+                .staleWorkerSamples(workerSampleSummary.getStaleSamples())
+                .futureWorkerSamples(workerSampleSummary.getFutureSamples())
+                .pendingJobCount(pendingJobCountSupplier.getAsInt())
+                .oldestPendingDurationMillis(oldestPendingDurationMillisSupplier.getAsLong())
+                .resourceShortageCount(shortageSnapshot.getShortageCount())
+                .waitShortageCount(shortageSnapshot.getWaitCount())
+                .rejectShortageCount(shortageSnapshot.getRejectCount())
+                .waitShortage(shortageSnapshot.isLatestWait())
+                .rejectShortage(shortageSnapshot.isLatestReject())
+                .scaleInMetricsValid(workerSampleSummary.isScaleInMetricsValid())
+                .build();
+    }
+
+    private SlotSummary summarizeSlots() {
+        int workerCount = resourceManager.getRegisterWorker().size();
+        if (workerCount == 0) {
+            return new SlotSummary(SlotMode.UNKNOWN, 0, 0, MetricValue.unknown());
+        }
+
+        int dynamicWorkers = 0;
+        int fixedWorkers = 0;
+        int assignedSlots = 0;
+        int unassignedSlots = 0;
+        for (WorkerProfile workerProfile : resourceManager.getRegisterWorker().values()) {
+            if (workerProfile.isDynamicSlot()) {
+                dynamicWorkers++;
+            } else {
+                fixedWorkers++;
+                assignedSlots += safeLength(workerProfile.getAssignedSlots());
+                unassignedSlots += safeLength(workerProfile.getUnassignedSlots());
+            }
+        }
+
+        if (fixedWorkers == workerCount) {
+            int totalSlots = assignedSlots + unassignedSlots;
+            MetricValue utilization =
+                    totalSlots == 0
+                            ? MetricValue.unknown()
+                            : MetricValue.valid((double) assignedSlots / (double) totalSlots);
+            return new SlotSummary(SlotMode.FIXED, assignedSlots, unassignedSlots, utilization);
+        }
+        if (dynamicWorkers == workerCount) {
+            return new SlotSummary(
+                    SlotMode.DYNAMIC, assignedSlots, unassignedSlots, MetricValue.unknown());
+        }
+        return new SlotSummary(
+                SlotMode.MIXED, assignedSlots, unassignedSlots, MetricValue.unknown());
+    }
+
+    private static int safeLength(Object[] values) {
+        return values == null ? 0 : values.length;
+    }
+
+    private static final class SlotSummary {
+        private final SlotMode slotMode;
+        private final int assignedSlots;
+        private final int unassignedSlots;
+        private final MetricValue fixedSlotUtilization;
+
+        private SlotSummary(
+                SlotMode slotMode,
+                int assignedSlots,
+                int unassignedSlots,
+                MetricValue fixedSlotUtilization) {
+            this.slotMode = slotMode;
+            this.assignedSlots = assignedSlots;
+            this.unassignedSlots = unassignedSlots;
+            this.fixedSlotUtilization = fixedSlotUtilization;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/HierarchicalAutoscalingPolicy.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/HierarchicalAutoscalingPolicy.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Deterministic Phase 1 policy for autoscaling recommendations.
+ *
+ * <p>Scheduler shortage and CPU/JVM-memory pressure may trigger scale-out; slot pressure is only
+ * auxiliary.
+ */
+public final class HierarchicalAutoscalingPolicy implements AutoscalingPolicy {
+
+    private final AutoscalerPolicyConfig config;
+
+    public HierarchicalAutoscalingPolicy(AutoscalerPolicyConfig config) {
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    @Override
+    public AutoscaleEvaluation evaluate(AutoscalerMetricsSnapshot snapshot) {
+        Objects.requireNonNull(snapshot, "snapshot");
+
+        List<String> triggers = new ArrayList<>();
+        List<String> blockers = new ArrayList<>();
+
+        if (snapshot.hasSchedulerShortage()) {
+            triggers.add("scheduler_resource_shortage");
+            if (snapshot.isWaitShortage()) {
+                triggers.add("scheduler_wait_shortage");
+            }
+            if (snapshot.isRejectShortage()) {
+                triggers.add("scheduler_reject_shortage");
+            }
+            return new AutoscaleEvaluation(ScalingAction.SCALE_OUT, triggers, blockers);
+        }
+
+        if (snapshot.getCpu().isGreaterThanOrEqualTo(config.getScaleOutCpuThreshold())) {
+            triggers.add("cpu_utilization_high");
+        }
+        if (snapshot.getJvmMemory()
+                .isGreaterThanOrEqualTo(config.getScaleOutJvmMemoryThreshold())) {
+            triggers.add("jvm_memory_utilization_high");
+        }
+        if (!triggers.isEmpty()) {
+            return new AutoscaleEvaluation(ScalingAction.SCALE_OUT, triggers, blockers);
+        }
+
+        if (snapshot.getFixedSlotUtilization()
+                .isGreaterThanOrEqualTo(config.getFixedSlotScaleOutThreshold())) {
+            blockers.add("slot_pressure_auxiliary_only");
+        }
+
+        if (snapshot.getCurrentWorkers() <= snapshot.getMinWorkers()) {
+            blockers.add("min_workers_reached");
+            return new AutoscaleEvaluation(ScalingAction.NO_ACTION, triggers, blockers);
+        }
+
+        if (!snapshot.isScaleInMetricsValid()) {
+            blockers.add("scale_in_metrics_incomplete");
+            return new AutoscaleEvaluation(ScalingAction.SCALE_IN_BLOCKED, triggers, blockers);
+        }
+
+        boolean lowCpu = snapshot.getCpu().isLessThan(config.getScaleInCpuThreshold());
+        boolean lowJvmMemory =
+                snapshot.getJvmMemory().isLessThan(config.getScaleInJvmMemoryThreshold());
+        boolean lowSlot = isLowSlot(snapshot);
+
+        if (lowCpu && lowJvmMemory && lowSlot) {
+            triggers.add("resource_utilization_low");
+            return new AutoscaleEvaluation(ScalingAction.SCALE_IN_CANDIDATE, triggers, blockers);
+        }
+
+        return new AutoscaleEvaluation(ScalingAction.NO_ACTION, triggers, blockers);
+    }
+
+    private boolean isLowSlot(AutoscalerMetricsSnapshot snapshot) {
+        if (snapshot.getSlotMode() != SlotMode.FIXED) {
+            return true;
+        }
+        return snapshot.getFixedSlotUtilization().isLessThan(config.getFixedSlotScaleInThreshold());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/InMemoryAutoscalerStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/InMemoryAutoscalerStateStore.java
@@ -51,6 +51,16 @@ public final class InMemoryAutoscalerStateStore implements AutoscalerStateStore 
     }
 
     @Override
+    public synchronized void clear() {
+        latest = null;
+        history.clear();
+        fence.reset();
+        for (ScalingAction action : ScalingAction.values()) {
+            recommendationCounts.put(action, 0L);
+        }
+    }
+
+    @Override
     public synchronized RecommendationFence.PublicationResult publish(
             ScalingRecommendation recommendation) {
         Objects.requireNonNull(recommendation, "recommendation");

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/InMemoryAutoscalerStateStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/InMemoryAutoscalerStateStore.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Bounded in-memory store for the latest autoscaler recommendation and recent history.
+ *
+ * <p>The store applies recommendation fencing and maintains scrape-safe cumulative counts by
+ * action.
+ */
+public final class InMemoryAutoscalerStateStore implements AutoscalerStateStore {
+
+    private final int historySize;
+    private final RecommendationFence fence = new RecommendationFence();
+    private final LinkedList<ScalingRecommendation> history = new LinkedList<>();
+    private final EnumMap<ScalingAction, Long> recommendationCounts =
+            new EnumMap<>(ScalingAction.class);
+    private ScalingRecommendation latest;
+
+    public InMemoryAutoscalerStateStore(int historySize) {
+        if (historySize <= 0) {
+            throw new IllegalArgumentException("historySize must be > 0");
+        }
+        this.historySize = historySize;
+        for (ScalingAction action : ScalingAction.values()) {
+            recommendationCounts.put(action, 0L);
+        }
+    }
+
+    @Override
+    public synchronized RecommendationFence.PublicationResult publish(
+            ScalingRecommendation recommendation) {
+        Objects.requireNonNull(recommendation, "recommendation");
+        RecommendationFence.PublicationResult result =
+                fence.tryPublish(recommendation.getMasterEpoch(), recommendation.getGeneration());
+        if (result != RecommendationFence.PublicationResult.ACCEPTED) {
+            return result;
+        }
+        latest = recommendation;
+        recommendationCounts.compute(
+                recommendation.getAction(), (action, count) -> count == null ? 1L : count + 1L);
+        history.add(recommendation);
+        while (history.size() > historySize) {
+            history.removeFirst();
+        }
+        return result;
+    }
+
+    @Override
+    public synchronized AutoscalerView view(
+            boolean enabled,
+            boolean running,
+            long currentMasterEpoch,
+            long nextGeneration,
+            int scaleOutStabilizationSeconds,
+            int scaleInStabilizationSeconds) {
+        List<ScalingRecommendation> historyCopy =
+                Collections.unmodifiableList(new ArrayList<>(history));
+        Map<ScalingAction, Long> countsCopy = new EnumMap<>(recommendationCounts);
+        AutoscalerMetricsSnapshot snapshot = latest == null ? null : latest.getSnapshot();
+        return new AutoscalerView(
+                enabled,
+                running,
+                currentMasterEpoch,
+                nextGeneration,
+                scaleOutStabilizationSeconds,
+                scaleInStabilizationSeconds,
+                latest,
+                snapshot,
+                historyCopy,
+                countsCopy);
+    }
+
+    public synchronized AutoscalerView view(boolean enabled, boolean running) {
+        return view(enabled, running, 0L, 0L, 0, 0);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/LatestWorkerSampleStore.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/LatestWorkerSampleStore.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import com.hazelcast.cluster.Address;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Keeps the latest accepted autoscaler metrics sample for each worker.
+ *
+ * <p>Samples with invalid utilization, excessive future skew, or non-increasing event time are
+ * rejected before they influence a snapshot.
+ */
+public final class LatestWorkerSampleStore {
+
+    private final long maxFutureSkewMillis;
+    private final Map<Address, WorkerMetricsSample> samples = new HashMap<>();
+
+    public LatestWorkerSampleStore(long maxFutureSkewMillis) {
+        this.maxFutureSkewMillis = maxFutureSkewMillis;
+    }
+
+    public synchronized boolean record(WorkerMetricsSample sample, long nowMillis) {
+        if (!isValidUtilization(sample.getCpuUtilization())
+                || !isValidUtilization(sample.getJvmMemoryUtilization())) {
+            return false;
+        }
+        if (sample.getEventTimeMillis() - nowMillis > maxFutureSkewMillis) {
+            return false;
+        }
+        WorkerMetricsSample previous = samples.get(sample.getWorkerAddress());
+        if (previous != null && sample.getEventTimeMillis() <= previous.getEventTimeMillis()) {
+            return false;
+        }
+        samples.put(sample.getWorkerAddress(), sample);
+        return true;
+    }
+
+    public synchronized Optional<WorkerMetricsSample> getLatest(Address workerAddress) {
+        return Optional.ofNullable(samples.get(workerAddress));
+    }
+
+    public synchronized void retainWorkers(Set<Address> currentWorkers) {
+        Iterator<Address> iterator = samples.keySet().iterator();
+        while (iterator.hasNext()) {
+            if (!currentWorkers.contains(iterator.next())) {
+                iterator.remove();
+            }
+        }
+    }
+
+    public synchronized void remove(Address workerAddress) {
+        samples.remove(workerAddress);
+    }
+
+    public synchronized WorkerSampleSummary summarize(
+            Set<Address> currentWorkers, long nowMillis, long freshnessMillis) {
+        int valid = 0;
+        int missing = 0;
+        int stale = 0;
+        int future = 0;
+        double cpuSum = 0.0d;
+        double jvmMemorySum = 0.0d;
+
+        for (Address currentWorker : currentWorkers) {
+            WorkerMetricsSample sample = samples.get(currentWorker);
+            if (sample == null) {
+                missing++;
+                continue;
+            }
+            if (sample.getEventTimeMillis() > nowMillis + maxFutureSkewMillis) {
+                future++;
+                continue;
+            }
+            if (nowMillis - sample.getEventTimeMillis() > freshnessMillis) {
+                stale++;
+                continue;
+            }
+            valid++;
+            cpuSum += sample.getCpuUtilization();
+            jvmMemorySum += sample.getJvmMemoryUtilization();
+        }
+
+        MetricValue cpu = valid == 0 ? MetricValue.missing() : MetricValue.valid(cpuSum / valid);
+        MetricValue jvmMemory =
+                valid == 0 ? MetricValue.missing() : MetricValue.valid(jvmMemorySum / valid);
+        boolean scaleInMetricsValid =
+                !currentWorkers.isEmpty()
+                        && valid == currentWorkers.size()
+                        && missing == 0
+                        && stale == 0
+                        && future == 0;
+
+        return new WorkerSampleSummary(
+                currentWorkers.size(),
+                valid,
+                missing,
+                stale,
+                future,
+                cpu,
+                jvmMemory,
+                scaleInMetricsValid);
+    }
+
+    private static boolean isValidUtilization(double value) {
+        return Double.isFinite(value) && value >= 0.0d && value <= 1.0d;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/MetricStatus.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/MetricStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public enum MetricStatus {
+    VALID,
+    MISSING,
+    STALE,
+    FUTURE,
+    INVALID,
+    UNKNOWN
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/MetricValue.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/MetricValue.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public final class MetricValue implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final MetricStatus status;
+    private final Double value;
+
+    private MetricValue(MetricStatus status, Double value) {
+        this.status = Objects.requireNonNull(status, "status");
+        this.value = value;
+    }
+
+    public static MetricValue valid(double value) {
+        if (!Double.isFinite(value) || value < 0.0d || value > 1.0d) {
+            return invalid();
+        }
+        return new MetricValue(MetricStatus.VALID, value);
+    }
+
+    public static MetricValue missing() {
+        return new MetricValue(MetricStatus.MISSING, null);
+    }
+
+    public static MetricValue stale() {
+        return new MetricValue(MetricStatus.STALE, null);
+    }
+
+    public static MetricValue future() {
+        return new MetricValue(MetricStatus.FUTURE, null);
+    }
+
+    public static MetricValue invalid() {
+        return new MetricValue(MetricStatus.INVALID, null);
+    }
+
+    public static MetricValue unknown() {
+        return new MetricValue(MetricStatus.UNKNOWN, null);
+    }
+
+    public MetricStatus getStatus() {
+        return status;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public boolean isValid() {
+        return status == MetricStatus.VALID;
+    }
+
+    public boolean isGreaterThanOrEqualTo(double threshold) {
+        return isValid() && value >= threshold;
+    }
+
+    public boolean isLessThan(double threshold) {
+        return isValid() && value < threshold;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/RecommendationFence.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/RecommendationFence.java
@@ -42,6 +42,11 @@ public final class RecommendationFence {
         return PublicationResult.ACCEPTED;
     }
 
+    public synchronized void reset() {
+        lastMasterEpoch = Long.MIN_VALUE;
+        lastGeneration = Long.MIN_VALUE;
+    }
+
     public enum PublicationResult {
         ACCEPTED,
         DUPLICATE,

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/RecommendationFence.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/RecommendationFence.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+/**
+ * Fences recommendation publication by active-master epoch and generation.
+ *
+ * <p>Duplicate identities are idempotent; stale epochs or non-increasing generations are rejected.
+ */
+public final class RecommendationFence {
+
+    private long lastMasterEpoch = Long.MIN_VALUE;
+    private long lastGeneration = Long.MIN_VALUE;
+
+    public synchronized PublicationResult tryPublish(long masterEpoch, long generation) {
+        if (masterEpoch == lastMasterEpoch && generation == lastGeneration) {
+            return PublicationResult.DUPLICATE;
+        }
+        if (masterEpoch < lastMasterEpoch) {
+            return PublicationResult.REJECTED;
+        }
+        if (masterEpoch == lastMasterEpoch && generation <= lastGeneration) {
+            return PublicationResult.REJECTED;
+        }
+        lastMasterEpoch = masterEpoch;
+        lastGeneration = generation;
+        return PublicationResult.ACCEPTED;
+    }
+
+    public enum PublicationResult {
+        ACCEPTED,
+        DUPLICATE,
+        REJECTED
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ResourceShortageSnapshot.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ResourceShortageSnapshot.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+
+public final class ResourceShortageSnapshot implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long sequence;
+    private final long shortageCount;
+    private final long waitCount;
+    private final long rejectCount;
+    private final boolean latestWait;
+    private final boolean latestReject;
+    private final int latestTaskGroupCount;
+    private final String latestResourceShape;
+
+    public ResourceShortageSnapshot(
+            long sequence,
+            long shortageCount,
+            long waitCount,
+            long rejectCount,
+            boolean latestWait,
+            boolean latestReject,
+            int latestTaskGroupCount,
+            String latestResourceShape) {
+        this.sequence = sequence;
+        this.shortageCount = shortageCount;
+        this.waitCount = waitCount;
+        this.rejectCount = rejectCount;
+        this.latestWait = latestWait;
+        this.latestReject = latestReject;
+        this.latestTaskGroupCount = latestTaskGroupCount;
+        this.latestResourceShape = latestResourceShape;
+    }
+
+    public long getSequence() {
+        return sequence;
+    }
+
+    public long getShortageCount() {
+        return shortageCount;
+    }
+
+    public long getWaitCount() {
+        return waitCount;
+    }
+
+    public long getRejectCount() {
+        return rejectCount;
+    }
+
+    public boolean isLatestWait() {
+        return latestWait;
+    }
+
+    public boolean isLatestReject() {
+        return latestReject;
+    }
+
+    public int getLatestTaskGroupCount() {
+        return latestTaskGroupCount;
+    }
+
+    public String getLatestResourceShape() {
+        return latestResourceShape;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ResourceShortageStats.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ResourceShortageStats.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+/**
+ * Compact accumulator for scheduler resource-shortage evidence.
+ *
+ * <p>It records cumulative WAIT/REJECT counts and exposes sequence deltas without retaining
+ * unbounded event history. All mutating and reading methods are synchronized to guarantee a
+ * consistent snapshot across fields.
+ */
+public final class ResourceShortageStats {
+
+    private long sequence;
+    private long waitCount;
+    private long rejectCount;
+    private long latestWaitSequence;
+    private long latestRejectSequence;
+    private int latestTaskGroupCount;
+    private String latestResourceShape;
+
+    public synchronized void recordWaitShortage(int taskGroupCount, String resourceShape) {
+        long currentSequence = ++sequence;
+        waitCount++;
+        latestWaitSequence = currentSequence;
+        latestTaskGroupCount = taskGroupCount;
+        latestResourceShape = resourceShape;
+    }
+
+    public synchronized void recordRejectShortage(int taskGroupCount, String resourceShape) {
+        long currentSequence = ++sequence;
+        rejectCount++;
+        latestRejectSequence = currentSequence;
+        latestTaskGroupCount = taskGroupCount;
+        latestResourceShape = resourceShape;
+    }
+
+    public synchronized ResourceShortageSnapshot snapshot() {
+        return snapshotSince(0L);
+    }
+
+    public synchronized ResourceShortageSnapshot snapshotSince(long previousSequence) {
+        long shortageCount = Math.max(0L, sequence - previousSequence);
+        boolean hasNewEvents = shortageCount > 0L;
+        return new ResourceShortageSnapshot(
+                sequence,
+                shortageCount,
+                waitCount,
+                rejectCount,
+                hasNewEvents && latestWaitSequence > previousSequence,
+                hasNewEvents && latestRejectSequence > previousSequence,
+                latestTaskGroupCount,
+                latestResourceShape);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ScalingAction.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ScalingAction.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public enum ScalingAction {
+    SCALE_OUT,
+    SCALE_IN_CANDIDATE,
+    SCALE_IN_BLOCKED,
+    NO_ACTION
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ScalingRecommendation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/ScalingRecommendation.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable autoscaler output for one evaluation generation.
+ *
+ * <p>Phase 1 recommendations are diagnostic only and include the input snapshot plus trigger and
+ * blocking reasons.
+ */
+public final class ScalingRecommendation implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long masterEpoch;
+    private final long generation;
+    private final ScalingAction action;
+    private final int currentWorkers;
+    private final int recommendedWorkers;
+    private final long observedAtMillis;
+    private final long validUntilMillis;
+    private final List<String> triggerReasons;
+    private final List<String> blockingReasons;
+    private final AutoscalerMetricsSnapshot snapshot;
+    private final boolean recommendationOnly;
+
+    private ScalingRecommendation(Builder builder) {
+        this.masterEpoch = builder.masterEpoch;
+        this.generation = builder.generation;
+        this.action = Objects.requireNonNull(builder.action, "action");
+        this.currentWorkers = builder.currentWorkers;
+        this.recommendedWorkers = builder.recommendedWorkers;
+        this.observedAtMillis = builder.observedAtMillis;
+        this.validUntilMillis = builder.validUntilMillis;
+        this.triggerReasons = immutableCopy(builder.triggerReasons);
+        this.blockingReasons = immutableCopy(builder.blockingReasons);
+        this.snapshot = Objects.requireNonNull(builder.snapshot, "snapshot");
+        this.recommendationOnly = builder.recommendationOnly;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public long getMasterEpoch() {
+        return masterEpoch;
+    }
+
+    public long getGeneration() {
+        return generation;
+    }
+
+    public ScalingAction getAction() {
+        return action;
+    }
+
+    public int getCurrentWorkers() {
+        return currentWorkers;
+    }
+
+    public int getRecommendedWorkers() {
+        return recommendedWorkers;
+    }
+
+    public long getObservedAtMillis() {
+        return observedAtMillis;
+    }
+
+    public long getValidUntilMillis() {
+        return validUntilMillis;
+    }
+
+    public List<String> getTriggerReasons() {
+        return triggerReasons;
+    }
+
+    public List<String> getBlockingReasons() {
+        return blockingReasons;
+    }
+
+    public AutoscalerMetricsSnapshot getSnapshot() {
+        return snapshot;
+    }
+
+    public boolean isRecommendationOnly() {
+        return recommendationOnly;
+    }
+
+    private static List<String> immutableCopy(List<String> values) {
+        return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    public static final class Builder {
+
+        private long masterEpoch;
+        private long generation;
+        private ScalingAction action = ScalingAction.NO_ACTION;
+        private int currentWorkers;
+        private int recommendedWorkers;
+        private long observedAtMillis;
+        private long validUntilMillis;
+        private List<String> triggerReasons = Collections.emptyList();
+        private List<String> blockingReasons = Collections.emptyList();
+        private AutoscalerMetricsSnapshot snapshot = AutoscalerMetricsSnapshot.builder().build();
+        private boolean recommendationOnly = true;
+
+        public Builder masterEpoch(long masterEpoch) {
+            this.masterEpoch = masterEpoch;
+            return this;
+        }
+
+        public Builder generation(long generation) {
+            this.generation = generation;
+            return this;
+        }
+
+        public Builder action(ScalingAction action) {
+            this.action = action;
+            return this;
+        }
+
+        public Builder currentWorkers(int currentWorkers) {
+            this.currentWorkers = currentWorkers;
+            return this;
+        }
+
+        public Builder recommendedWorkers(int recommendedWorkers) {
+            this.recommendedWorkers = recommendedWorkers;
+            return this;
+        }
+
+        public Builder observedAtMillis(long observedAtMillis) {
+            this.observedAtMillis = observedAtMillis;
+            return this;
+        }
+
+        public Builder validUntilMillis(long validUntilMillis) {
+            this.validUntilMillis = validUntilMillis;
+            return this;
+        }
+
+        public Builder triggerReasons(List<String> triggerReasons) {
+            this.triggerReasons = triggerReasons;
+            return this;
+        }
+
+        public Builder blockingReasons(List<String> blockingReasons) {
+            this.blockingReasons = blockingReasons;
+            return this;
+        }
+
+        public Builder snapshot(AutoscalerMetricsSnapshot snapshot) {
+            this.snapshot = snapshot;
+            return this;
+        }
+
+        public Builder recommendationOnly(boolean recommendationOnly) {
+            this.recommendationOnly = recommendationOnly;
+            return this;
+        }
+
+        public ScalingRecommendation build() {
+            return new ScalingRecommendation(this);
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/SlotMode.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/SlotMode.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public enum SlotMode {
+    FIXED,
+    DYNAMIC,
+    MIXED,
+    UNKNOWN
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/StabilizationTracker.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/StabilizationTracker.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+/**
+ * Tracks whether one scaling direction has remained true for its stabilization window.
+ *
+ * <p>It uses caller-supplied monotonic nanoseconds so wall-clock jumps cannot affect continuity.
+ */
+public final class StabilizationTracker {
+
+    private final long scaleOutWindowNanos;
+    private final long scaleInWindowNanos;
+    private ScalingAction activeAction;
+    private long activeSinceNanos;
+
+    public StabilizationTracker(long scaleOutWindowNanos, long scaleInWindowNanos) {
+        this.scaleOutWindowNanos = scaleOutWindowNanos;
+        this.scaleInWindowNanos = scaleInWindowNanos;
+    }
+
+    public synchronized boolean isStabilized(ScalingAction action, long monotonicNanos) {
+        if (action == ScalingAction.NO_ACTION || action == ScalingAction.SCALE_IN_BLOCKED) {
+            clear();
+            return true;
+        }
+        if (activeAction != action) {
+            activeAction = action;
+            activeSinceNanos = monotonicNanos;
+            return windowFor(action) <= 0L;
+        }
+        return monotonicNanos - activeSinceNanos >= windowFor(action);
+    }
+
+    public synchronized void reset() {
+        clear();
+    }
+
+    private void clear() {
+        activeAction = null;
+        activeSinceNanos = 0L;
+    }
+
+    private long windowFor(ScalingAction action) {
+        if (action == ScalingAction.SCALE_OUT) {
+            return scaleOutWindowNanos;
+        }
+        if (action == ScalingAction.SCALE_IN_CANDIDATE) {
+            return scaleInWindowNanos;
+        }
+        return 0L;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/SystemAutoscalerTimeSource.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/SystemAutoscalerTimeSource.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+public final class SystemAutoscalerTimeSource implements AutoscalerTimeSource {
+
+    @Override
+    public long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+
+    @Override
+    public long nanoTime() {
+        return System.nanoTime();
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/WorkerMetricsSample.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/WorkerMetricsSample.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import com.hazelcast.cluster.Address;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public final class WorkerMetricsSample implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Address workerAddress;
+    private final long eventTimeMillis;
+    private final double cpuUtilization;
+    private final double jvmMemoryUtilization;
+
+    public WorkerMetricsSample(
+            Address workerAddress,
+            long eventTimeMillis,
+            double cpuUtilization,
+            double jvmMemoryUtilization) {
+        this.workerAddress = Objects.requireNonNull(workerAddress, "workerAddress");
+        this.eventTimeMillis = eventTimeMillis;
+        this.cpuUtilization = cpuUtilization;
+        this.jvmMemoryUtilization = jvmMemoryUtilization;
+    }
+
+    public Address getWorkerAddress() {
+        return workerAddress;
+    }
+
+    public long getEventTimeMillis() {
+        return eventTimeMillis;
+    }
+
+    public double getCpuUtilization() {
+        return cpuUtilization;
+    }
+
+    public double getJvmMemoryUtilization() {
+        return jvmMemoryUtilization;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof WorkerMetricsSample)) {
+            return false;
+        }
+        WorkerMetricsSample that = (WorkerMetricsSample) o;
+        return eventTimeMillis == that.eventTimeMillis
+                && Double.compare(that.cpuUtilization, cpuUtilization) == 0
+                && Double.compare(that.jvmMemoryUtilization, jvmMemoryUtilization) == 0
+                && workerAddress.equals(that.workerAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(workerAddress, eventTimeMillis, cpuUtilization, jvmMemoryUtilization);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/WorkerSampleSummary.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/autoscale/WorkerSampleSummary.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public final class WorkerSampleSummary implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int totalSamples;
+    private final int validSamples;
+    private final int missingSamples;
+    private final int staleSamples;
+    private final int futureSamples;
+    private final MetricValue cpu;
+    private final MetricValue jvmMemory;
+    private final boolean scaleInMetricsValid;
+
+    public WorkerSampleSummary(
+            int totalSamples,
+            int validSamples,
+            int missingSamples,
+            int staleSamples,
+            int futureSamples,
+            MetricValue cpu,
+            MetricValue jvmMemory,
+            boolean scaleInMetricsValid) {
+        this.totalSamples = totalSamples;
+        this.validSamples = validSamples;
+        this.missingSamples = missingSamples;
+        this.staleSamples = staleSamples;
+        this.futureSamples = futureSamples;
+        this.cpu = Objects.requireNonNull(cpu, "cpu");
+        this.jvmMemory = Objects.requireNonNull(jvmMemory, "jvmMemory");
+        this.scaleInMetricsValid = scaleInMetricsValid;
+    }
+
+    public int getTotalSamples() {
+        return totalSamples;
+    }
+
+    public int getValidSamples() {
+        return validSamples;
+    }
+
+    public int getMissingSamples() {
+        return missingSamples;
+    }
+
+    public int getStaleSamples() {
+        return staleSamples;
+    }
+
+    public int getFutureSamples() {
+        return futureSamples;
+    }
+
+    public MetricValue getCpu() {
+        return cpu;
+    }
+
+    public MetricValue getJvmMemory() {
+        return jvmMemory;
+    }
+
+    public boolean isScaleInMetricsValid() {
+        return scaleInMetricsValid;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetAutoscalerViewOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/operation/GetAutoscalerViewOperation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.operation;
+
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerView;
+import org.apache.seatunnel.engine.server.serializable.ClientToServerOperationDataSerializerHook;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+
+/**
+ * Read-only operation used by followers to fetch the Active Master's autoscaler view.
+ *
+ * <p>The operation returns the published read model and does not trigger policy evaluation.
+ */
+public class GetAutoscalerViewOperation extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
+
+    private AutoscalerView response;
+
+    @Override
+    public int getFactoryId() {
+        return ClientToServerOperationDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ClientToServerOperationDataSerializerHook.GET_AUTOSCALER_VIEW_OPERATION;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+    }
+
+    @Override
+    public void run() {
+        SeaTunnelServer service = getService();
+        response = service.getCoordinatorService().getAutoscalerView();
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/AbstractResourceManager.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/AbstractResourceManager.java
@@ -18,8 +18,12 @@
 package org.apache.seatunnel.engine.server.resourcemanager;
 
 import org.apache.seatunnel.engine.common.config.EngineConfig;
+import org.apache.seatunnel.engine.common.config.server.ScheduleStrategy;
 import org.apache.seatunnel.engine.common.runtime.ExecutionMode;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.server.autoscale.LatestWorkerSampleStore;
+import org.apache.seatunnel.engine.server.autoscale.ResourceShortageStats;
+import org.apache.seatunnel.engine.server.autoscale.WorkerMetricsSample;
 import org.apache.seatunnel.engine.server.resourcemanager.allocation.strategy.RandomStrategy;
 import org.apache.seatunnel.engine.server.resourcemanager.allocation.strategy.SlotAllocationStrategy;
 import org.apache.seatunnel.engine.server.resourcemanager.allocation.strategy.SlotRatioStrategy;
@@ -49,6 +53,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -69,6 +74,10 @@ public abstract class AbstractResourceManager implements ResourceManager {
 
     @Getter private final SlotAllocationStrategy slotAllocationStrategy;
 
+    @Getter private final LatestWorkerSampleStore autoscalerWorkerSampleStore;
+
+    @Getter private final ResourceShortageStats resourceShortageStats = new ResourceShortageStats();
+
     // Track master-side slot request cost without changing allocation behavior.
     private final AtomicLong requestSlotOperationSuccessCount = new AtomicLong();
     private final AtomicLong requestSlotOperationNoSlotCount = new AtomicLong();
@@ -81,6 +90,10 @@ public abstract class AbstractResourceManager implements ResourceManager {
         this.nodeEngine = nodeEngine;
         this.engineConfig = engineConfig;
         this.mode = engineConfig.getMode();
+        this.autoscalerWorkerSampleStore =
+                new LatestWorkerSampleStore(
+                        TimeUnit.SECONDS.toMillis(
+                                engineConfig.getAutoscalerConfig().getMaxFutureSkewSeconds()));
 
         switch (engineConfig.getSlotServiceConfig().getAllocateStrategy()) {
             case SYSTEM_LOAD:
@@ -170,6 +183,7 @@ public abstract class AbstractResourceManager implements ResourceManager {
                         + "Node Address: "
                         + event.getMember().getAddress());
         registerWorker.remove(event.getMember().getAddress());
+        autoscalerWorkerSampleStore.remove(event.getMember().getAddress());
     }
 
     @Override
@@ -180,6 +194,7 @@ public abstract class AbstractResourceManager implements ResourceManager {
         ConcurrentMap<Address, WorkerProfile> matchedWorker = filterWorkerByTag(tagFilter);
         if (matchedWorker.isEmpty()) {
             log.error("No matched worker with tag filter {}.", tagFilter);
+            recordResourceShortage(resourceProfile.size(), String.valueOf(tagFilter));
             throw new NoEnoughResourceException();
         }
         return new ResourceRequestHandler(
@@ -241,6 +256,19 @@ public abstract class AbstractResourceManager implements ResourceManager {
                 requestSlotOperationFailureCount.get(),
                 requestSlotOperationLastInvocationLatencyMs.get(),
                 requestSlotOperationMaxInvocationLatencyMs.get());
+    }
+
+    @Override
+    public void reportAutoscalerMetrics(WorkerMetricsSample sample, long receiveTimeMillis) {
+        autoscalerWorkerSampleStore.record(sample, receiveTimeMillis);
+    }
+
+    private void recordResourceShortage(int taskGroupCount, String resourceShape) {
+        if (engineConfig.getScheduleStrategy() == ScheduleStrategy.WAIT) {
+            resourceShortageStats.recordWaitShortage(taskGroupCount, resourceShape);
+        } else {
+            resourceShortageStats.recordRejectShortage(taskGroupCount, resourceShape);
+        }
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/AbstractResourceManager.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/AbstractResourceManager.java
@@ -264,6 +264,9 @@ public abstract class AbstractResourceManager implements ResourceManager {
     }
 
     private void recordResourceShortage(int taskGroupCount, String resourceShape) {
+        if (!engineConfig.getAutoscalerConfig().isEnabled()) {
+            return;
+        }
         if (engineConfig.getScheduleStrategy() == ScheduleStrategy.WAIT) {
             resourceShortageStats.recordWaitShortage(taskGroupCount, resourceShape);
         } else {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceManager.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceManager.java
@@ -18,6 +18,9 @@
 package org.apache.seatunnel.engine.server.resourcemanager;
 
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.server.autoscale.LatestWorkerSampleStore;
+import org.apache.seatunnel.engine.server.autoscale.ResourceShortageStats;
+import org.apache.seatunnel.engine.server.autoscale.WorkerMetricsSample;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.ResourceProfile;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
 import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
@@ -74,4 +77,10 @@ public interface ResourceManager {
     ConcurrentMap<Address, WorkerProfile> getRegisterWorker();
 
     RequestSlotOperationStats getRequestSlotOperationStats();
+
+    void reportAutoscalerMetrics(WorkerMetricsSample sample, long receiveTimeMillis);
+
+    LatestWorkerSampleStore getAutoscalerWorkerSampleStore();
+
+    ResourceShortageStats getResourceShortageStats();
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.server.resourcemanager;
 import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
 
 import org.apache.seatunnel.engine.common.config.server.AllocateStrategy;
+import org.apache.seatunnel.engine.common.config.server.ScheduleStrategy;
 import org.apache.seatunnel.engine.common.runtime.DeployType;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.server.resourcemanager.allocation.strategy.SlotAllocationStrategy;
@@ -196,6 +197,7 @@ public class ResourceRequestHandler {
             } else {
                 // if no worker can provide the resource, we should return a failed future
                 LOGGER.fine("pre check worker resource failed, can't apply resource request: " + r);
+                recordShortage(r);
                 allRequestFuture.add(
                         CompletableFuture.supplyAsync(
                                 () -> {
@@ -246,6 +248,7 @@ public class ResourceRequestHandler {
                             } else {
                                 if (slotAndWorkerProfile.getSlotProfile() == null) {
                                     resourceManager.recordRequestSlotOperationNoSlot(elapsedMillis);
+                                    recordShortage(r);
                                 } else {
                                     resourceManager.recordRequestSlotOperationSuccess(
                                             elapsedMillis);
@@ -258,6 +261,20 @@ public class ResourceRequestHandler {
 
     private long elapsedMillisSince(long startNanos) {
         return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+    }
+
+    private void recordShortage(ResourceProfile resourceProfile) {
+        if (resourceManager.getEngineConfig().getScheduleStrategy() == ScheduleStrategy.WAIT) {
+            resourceManager
+                    .getResourceShortageStats()
+                    .recordWaitShortage(
+                            this.resourceProfile.size(), String.valueOf(resourceProfile));
+        } else {
+            resourceManager
+                    .getResourceShortageStats()
+                    .recordRejectShortage(
+                            this.resourceProfile.size(), String.valueOf(resourceProfile));
+        }
     }
 
     @VisibleForTesting

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/ResourceRequestHandler.java
@@ -264,6 +264,9 @@ public class ResourceRequestHandler {
     }
 
     private void recordShortage(ResourceProfile resourceProfile) {
+        if (!resourceManager.getEngineConfig().getAutoscalerConfig().isEnabled()) {
+            return;
+        }
         if (resourceManager.getEngineConfig().getScheduleStrategy() == ScheduleStrategy.WAIT) {
             resourceManager
                     .getResourceShortageStats()

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/opeartion/ReportAutoscalerMetricsOperation.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/resourcemanager/opeartion/ReportAutoscalerMetricsOperation.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.resourcemanager.opeartion;
+
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.autoscale.WorkerMetricsSample;
+import org.apache.seatunnel.engine.server.serializable.ResourceDataSerializerHook;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.operationservice.Operation;
+
+import java.io.IOException;
+
+/**
+ * Worker-to-master operation carrying one autoscaler CPU/JVM-memory sample.
+ *
+ * <p>The payload uses worker-observed event time and keeps autoscaler metrics out of WorkerProfile
+ * serialization.
+ */
+public class ReportAutoscalerMetricsOperation extends Operation
+        implements IdentifiedDataSerializable {
+
+    private Address workerAddress;
+    private long eventTimeMillis;
+    private double cpuUtilization;
+    private double jvmMemoryUtilization;
+
+    public ReportAutoscalerMetricsOperation() {}
+
+    public ReportAutoscalerMetricsOperation(
+            Address workerAddress,
+            long eventTimeMillis,
+            double cpuUtilization,
+            double jvmMemoryUtilization) {
+        this.workerAddress = workerAddress;
+        this.eventTimeMillis = eventTimeMillis;
+        this.cpuUtilization = cpuUtilization;
+        this.jvmMemoryUtilization = jvmMemoryUtilization;
+    }
+
+    @Override
+    public void run() throws Exception {
+        SeaTunnelServer server = getService();
+        server.getCoordinatorService()
+                .getResourceManager()
+                .reportAutoscalerMetrics(
+                        new WorkerMetricsSample(
+                                workerAddress,
+                                eventTimeMillis,
+                                cpuUtilization,
+                                jvmMemoryUtilization),
+                        System.currentTimeMillis());
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        out.writeObject(workerAddress);
+        out.writeLong(eventTimeMillis);
+        out.writeDouble(cpuUtilization);
+        out.writeDouble(jvmMemoryUtilization);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        workerAddress = in.readObject();
+        eventTimeMillis = in.readLong();
+        cpuUtilization = in.readDouble();
+        jvmMemoryUtilization = in.readDouble();
+    }
+
+    @Override
+    public String getServiceName() {
+        return SeaTunnelServer.SERVICE_NAME;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ResourceDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return ResourceDataSerializerHook.REPORT_AUTOSCALER_METRICS_TYPE;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/RestConstant.java
@@ -97,6 +97,9 @@ public class RestConstant {
     public static final String REST_URL_SYSTEM_MONITORING_INFORMATION =
             "/system-monitoring-information";
     public static final String REST_URL_WORKER_RESOURCES = "/resource/workers";
+    public static final String REST_URL_AUTOSCALER_STATUS = "/autoscaler/status";
+    public static final String REST_URL_AUTOSCALER_METRICS = "/autoscaler/metrics";
+    public static final String REST_URL_AUTOSCALER_HISTORY = "/autoscaler/history";
     public static final String REST_URL_SUBMIT_JOB = "/submit-job";
 
     public static final String REST_URL_SUBMIT_JOB_BY_UPLOAD_FILE = "/submit-job/upload";

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/AutoscalerService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/service/AutoscalerService.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.service;
+
+import org.apache.seatunnel.engine.common.exception.SeaTunnelEngineException;
+import org.apache.seatunnel.engine.server.SeaTunnelServer;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerMetricsSnapshot;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerView;
+import org.apache.seatunnel.engine.server.autoscale.ScalingAction;
+import org.apache.seatunnel.engine.server.operation.GetAutoscalerViewOperation;
+import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.util.Collections;
+import java.util.EnumMap;
+
+/**
+ * REST service facade for autoscaler read models.
+ *
+ * <p>Active Master reads are local; follower reads are forwarded to the current master and tolerate
+ * master transitions.
+ */
+public class AutoscalerService extends BaseService {
+
+    public AutoscalerService(NodeEngineImpl nodeEngine) {
+        super(nodeEngine);
+    }
+
+    public AutoscalerView getView() {
+        SeaTunnelServer seaTunnelServer = getSeaTunnelServer(true);
+        if (seaTunnelServer != null) {
+            return seaTunnelServer.getCoordinatorService().getAutoscalerView();
+        }
+        Address masterAddress = nodeEngine.getMasterAddress();
+        if (masterAddress == null) {
+            return unavailableView();
+        }
+        try {
+            return invokeOnMaster(masterAddress);
+        } catch (RuntimeException e) {
+            if (isTransientMasterFailure(e)) {
+                return unavailableView();
+            }
+            throw e;
+        }
+    }
+
+    public AutoscalerMetricsSnapshot getMetrics() {
+        AutoscalerMetricsSnapshot snapshot = getView().getCurrentSnapshot();
+        if (snapshot == null) {
+            return AutoscalerMetricsSnapshot.builder().build();
+        }
+        return snapshot;
+    }
+
+    protected AutoscalerView invokeOnMaster(Address masterAddress) {
+        return (AutoscalerView)
+                NodeEngineUtil.sendOperationToMemberNode(
+                                nodeEngine, new GetAutoscalerViewOperation(), masterAddress)
+                        .join();
+    }
+
+    private AutoscalerView unavailableView() {
+        return new AutoscalerView(
+                false,
+                false,
+                0L,
+                0L,
+                0,
+                0,
+                null,
+                null,
+                Collections.emptyList(),
+                new EnumMap<>(ScalingAction.class));
+    }
+
+    private boolean isTransientMasterFailure(Throwable error) {
+        Throwable current = error;
+        while (current != null) {
+            if (current instanceof TargetNotMemberException
+                    || current instanceof TargetDisconnectedException
+                    || current instanceof MemberLeftException
+                    || current instanceof HazelcastInstanceNotActiveException
+                    || current instanceof SeaTunnelEngineException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/AutoscalerHistoryServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/AutoscalerHistoryServlet.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.servlet;
+
+import org.apache.seatunnel.engine.server.rest.service.AutoscalerService;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class AutoscalerHistoryServlet extends BaseServlet {
+
+    private final AutoscalerService autoscalerService;
+
+    public AutoscalerHistoryServlet(NodeEngineImpl nodeEngine) {
+        this(nodeEngine, new AutoscalerService(nodeEngine));
+    }
+
+    AutoscalerHistoryServlet(NodeEngineImpl nodeEngine, AutoscalerService autoscalerService) {
+        super(nodeEngine);
+        this.autoscalerService = autoscalerService;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        writeJson(resp, autoscalerService.getView().getHistory());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/AutoscalerMetricsServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/AutoscalerMetricsServlet.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.servlet;
+
+import org.apache.seatunnel.engine.server.rest.service.AutoscalerService;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class AutoscalerMetricsServlet extends BaseServlet {
+
+    private final AutoscalerService autoscalerService;
+
+    public AutoscalerMetricsServlet(NodeEngineImpl nodeEngine) {
+        this(nodeEngine, new AutoscalerService(nodeEngine));
+    }
+
+    AutoscalerMetricsServlet(NodeEngineImpl nodeEngine, AutoscalerService autoscalerService) {
+        super(nodeEngine);
+        this.autoscalerService = autoscalerService;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        writeJson(resp, autoscalerService.getMetrics());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/AutoscalerStatusServlet.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/rest/servlet/AutoscalerStatusServlet.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.rest.servlet;
+
+import org.apache.seatunnel.engine.server.rest.service.AutoscalerService;
+
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class AutoscalerStatusServlet extends BaseServlet {
+
+    private final AutoscalerService autoscalerService;
+
+    public AutoscalerStatusServlet(NodeEngineImpl nodeEngine) {
+        this(nodeEngine, new AutoscalerService(nodeEngine));
+    }
+
+    AutoscalerStatusServlet(NodeEngineImpl nodeEngine, AutoscalerService autoscalerService) {
+        super(nodeEngine);
+        this.autoscalerService = autoscalerService;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        writeJson(resp, autoscalerService.getView());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHook.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHook.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.engine.server.serializable;
 
 import org.apache.seatunnel.engine.common.serializeable.SeaTunnelFactoryIdConstant;
 import org.apache.seatunnel.engine.server.operation.CancelJobOperation;
+import org.apache.seatunnel.engine.server.operation.GetAutoscalerViewOperation;
 import org.apache.seatunnel.engine.server.operation.GetCheckpointHistoryOperation;
 import org.apache.seatunnel.engine.server.operation.GetCheckpointOverviewOperation;
 import org.apache.seatunnel.engine.server.operation.GetClusterHealthMetricsOperation;
@@ -78,6 +79,7 @@ public final class ClientToServerOperationDataSerializerHook implements DataSeri
     public static final int GET_NODE_HTTP_PORT_OPERATION = 15;
     public static final int GET_JOB_TASK_MAPPING_OPERATION = 16;
     public static final int GET_JOB_DIAGNOSTICS_OPERATION = 17;
+    public static final int GET_AUTOSCALER_VIEW_OPERATION = 18;
 
     public static final int FACTORY_ID =
             FactoryIdHelper.getFactoryId(
@@ -139,6 +141,8 @@ public final class ClientToServerOperationDataSerializerHook implements DataSeri
                     return new GetJobTaskMappingOperation();
                 case GET_JOB_DIAGNOSTICS_OPERATION:
                     return new GetJobDiagnosticsOperation();
+                case GET_AUTOSCALER_VIEW_OPERATION:
+                    return new GetAutoscalerViewOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ResourceDataSerializerHook.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/serializable/ResourceDataSerializerHook.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetOverviewO
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetPendingJobsOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetWorkerResourcesOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ReleaseSlotOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ReportAutoscalerMetricsOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.RequestSlotOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ResetResourceOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.SyncWorkerProfileOperation;
@@ -64,6 +65,8 @@ public class ResourceDataSerializerHook implements DataSerializerHook {
     public static final int JOB_CLEANUP_RECORD_TYPE = 12;
 
     public static final int GET_WORKER_RESOURCES_TYPE = 13;
+
+    public static final int REPORT_AUTOSCALER_METRICS_TYPE = 14;
 
     public static final int FACTORY_ID =
             FactoryIdHelper.getFactoryId(
@@ -111,6 +114,8 @@ public class ResourceDataSerializerHook implements DataSerializerHook {
                     return new JobCleanupRecord();
                 case GET_WORKER_RESOURCES_TYPE:
                     return new GetWorkerResourcesOperation();
+                case REPORT_AUTOSCALER_METRICS_TYPE:
+                    return new ReportAutoscalerMetricsOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/service/slot/DefaultSlotService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/service/slot/DefaultSlotService.java
@@ -117,6 +117,7 @@ public class DefaultSlotService implements SlotService {
         AtomicInteger systemLoadSendCountDown = new AtomicInteger(SYSTEM_LOAD_SEND_INTERVAL);
         scheduledExecutorService.scheduleAtFixedRate(
                 () -> {
+                    SystemLoadInfo systemLoadInfo = null;
                     try {
                         LOGGER.fine(
                                 "start send heartbeat to resource manager, this address: "
@@ -130,7 +131,7 @@ public class DefaultSlotService implements SlotService {
                                         && (config.getAllocateStrategy()
                                                         == AllocateStrategy.SYSTEM_LOAD
                                                 || autoscalerConfig.isEnabled());
-                        SystemLoadInfo systemLoadInfo =
+                        systemLoadInfo =
                                 Optional.of(shouldCollectSystemLoad)
                                         .filter(Boolean::booleanValue)
                                         .map(
@@ -152,6 +153,12 @@ public class DefaultSlotService implements SlotService {
                         }
 
                         sendToMaster(new WorkerHeartbeatOperation(workerProfile)).join();
+                    } catch (Exception e) {
+                        LOGGER.warning(
+                                "failed send heartbeat to resource manager, will retry later. this address: "
+                                        + nodeEngine.getClusterService().getThisAddress());
+                    }
+                    try {
                         if (autoscalerConfig.isEnabled() && systemLoadInfo != null) {
                             long sampleTimeMillis = System.currentTimeMillis();
                             sendToMaster(
@@ -164,7 +171,7 @@ public class DefaultSlotService implements SlotService {
                         }
                     } catch (Exception e) {
                         LOGGER.warning(
-                                "failed send heartbeat to resource manager, will retry later. this address: "
+                                "failed send autoscaler metrics to resource manager, will retry later. this address: "
                                         + nodeEngine.getClusterService().getThisAddress());
                     }
                 },

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/service/slot/DefaultSlotService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/service/slot/DefaultSlotService.java
@@ -18,9 +18,11 @@
 package org.apache.seatunnel.engine.server.service.slot;
 
 import org.apache.seatunnel.engine.common.config.server.AllocateStrategy;
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
 import org.apache.seatunnel.engine.common.config.server.SlotServiceConfig;
 import org.apache.seatunnel.engine.common.utils.IdGenerator;
 import org.apache.seatunnel.engine.server.TaskExecutionService;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ReportAutoscalerMetricsOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.WorkerHeartbeatOperation;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.CPU;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.Memory;
@@ -69,6 +71,7 @@ public class DefaultSlotService implements SlotService {
     private ConcurrentMap<Integer, SlotProfile> unassignedSlots;
     private ScheduledExecutorService scheduledExecutorService;
     private final SlotServiceConfig config;
+    private final AutoscalerConfig autoscalerConfig;
     private volatile boolean initStatus;
     private final IdGenerator idGenerator;
     private final TaskExecutionService taskExecutionService;
@@ -81,9 +84,11 @@ public class DefaultSlotService implements SlotService {
     public DefaultSlotService(
             NodeEngineImpl nodeEngine,
             TaskExecutionService taskExecutionService,
-            SlotServiceConfig config) {
+            SlotServiceConfig config,
+            AutoscalerConfig autoscalerConfig) {
         this.nodeEngine = nodeEngine;
         this.config = config;
+        this.autoscalerConfig = autoscalerConfig;
         this.taskExecutionService = taskExecutionService;
         this.idGenerator = new IdGenerator();
     }
@@ -119,16 +124,17 @@ public class DefaultSlotService implements SlotService {
                         // Must first obtain SYSTEM_LOAD and then obtain workProfile. If you obtain
                         // workProfile first and then obtain SYSTEM_LOAD, resource information will
                         // be reported inaccurately.
+                        int countdown = systemLoadSendCountDown.decrementAndGet();
+                        boolean shouldCollectSystemLoad =
+                                countdown == 0
+                                        && (config.getAllocateStrategy()
+                                                        == AllocateStrategy.SYSTEM_LOAD
+                                                || autoscalerConfig.isEnabled());
                         SystemLoadInfo systemLoadInfo =
-                                Optional.of(systemLoadSendCountDown.decrementAndGet())
-                                        .filter(
-                                                count ->
-                                                        count == 0
-                                                                && config.getAllocateStrategy()
-                                                                        == AllocateStrategy
-                                                                                .SYSTEM_LOAD)
+                                Optional.of(shouldCollectSystemLoad)
+                                        .filter(Boolean::booleanValue)
                                         .map(
-                                                count -> {
+                                                ignored -> {
                                                     systemLoadSendCountDown.set(
                                                             SYSTEM_LOAD_SEND_INTERVAL);
                                                     SystemLoadInfo info = new SystemLoadInfo();
@@ -140,10 +146,22 @@ public class DefaultSlotService implements SlotService {
                                         .orElse(null);
 
                         WorkerProfile workerProfile = getWorkerProfile();
-                        Optional.ofNullable(systemLoadInfo)
-                                .ifPresent(workerProfile::setSystemLoadInfo);
+                        if (config.getAllocateStrategy() == AllocateStrategy.SYSTEM_LOAD) {
+                            Optional.ofNullable(systemLoadInfo)
+                                    .ifPresent(workerProfile::setSystemLoadInfo);
+                        }
 
                         sendToMaster(new WorkerHeartbeatOperation(workerProfile)).join();
+                        if (autoscalerConfig.isEnabled() && systemLoadInfo != null) {
+                            long sampleTimeMillis = System.currentTimeMillis();
+                            sendToMaster(
+                                            new ReportAutoscalerMetricsOperation(
+                                                    nodeEngine.getClusterService().getThisAddress(),
+                                                    sampleTimeMillis,
+                                                    systemLoadInfo.getCpuPercentage(),
+                                                    systemLoadInfo.getMemPercentage()))
+                                    .join();
+                        }
                     } catch (Exception e) {
                         LOGGER.warning(
                                 "failed send heartbeat to resource manager, will retry later. this address: "

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/ExportsInstanceInitializer.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/ExportsInstanceInitializer.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.server.telemetry.metrics;
 
 import org.apache.seatunnel.engine.server.NodeExtension;
+import org.apache.seatunnel.engine.server.telemetry.metrics.exports.AutoscalerExports;
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.ClusterMetricExports;
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.EngineStateStoreLogicalMetricExports;
 import org.apache.seatunnel.engine.server.telemetry.metrics.exports.EngineStateStoreMetricExports;
@@ -60,5 +61,7 @@ public final class ExportsInstanceInitializer {
         new EngineStateStoreLogicalMetricExports(node).register(collectorRegistry);
         // Cluster metrics
         new ClusterMetricExports(node).register(collectorRegistry);
+        // Autoscaler recommendation metrics
+        new AutoscalerExports(node).register(collectorRegistry);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/AutoscalerExports.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/telemetry/metrics/exports/AutoscalerExports.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.telemetry.metrics.exports;
+
+import org.apache.seatunnel.engine.server.CoordinatorService;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerMetricsSnapshot;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerView;
+import org.apache.seatunnel.engine.server.autoscale.MetricStatus;
+import org.apache.seatunnel.engine.server.autoscale.MetricValue;
+import org.apache.seatunnel.engine.server.autoscale.ScalingAction;
+import org.apache.seatunnel.engine.server.autoscale.ScalingRecommendation;
+import org.apache.seatunnel.engine.server.telemetry.metrics.AbstractCollector;
+
+import com.hazelcast.instance.impl.Node;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.GaugeMetricFamily;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Prometheus projection of the latest published autoscaler view.
+ *
+ * <p>Scrapes are read-only: they do not collect signals, evaluate policy, or mutate recommendation
+ * counters/history.
+ */
+public class AutoscalerExports extends AbstractCollector {
+
+    private static final String STATUS = "status";
+
+    public AutoscalerExports(Node node) {
+        super(node);
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> mfs = new ArrayList<>();
+        if (!isMaster() || !isCoordinatorReady()) {
+            return mfs;
+        }
+
+        CoordinatorService coordinatorService = getReadyCoordinatorService();
+        if (coordinatorService == null) {
+            return mfs;
+        }
+
+        AutoscalerView view = coordinatorService.getAutoscalerView();
+        String address = localAddress();
+        collectState(mfs, address, view);
+
+        AutoscalerMetricsSnapshot snapshot = view.getCurrentSnapshot();
+        if (snapshot != null) {
+            collectSnapshot(mfs, address, snapshot);
+        }
+
+        ScalingRecommendation recommendation = view.getLatestRecommendation();
+        if (recommendation != null) {
+            collectRecommendation(mfs, address, recommendation);
+        }
+        return mfs;
+    }
+
+    private void collectState(List<MetricFamilySamples> mfs, String address, AutoscalerView view) {
+        GaugeMetricFamily enabled =
+                new GaugeMetricFamily(
+                        "seatunnel_autoscaler_enabled",
+                        "Whether Zeta autoscaling recommendation is enabled",
+                        clusterLabelNames(ADDRESS));
+        enabled.addMetric(labelValues(address), booleanValue(view.isEnabled()));
+        mfs.add(enabled);
+
+        GaugeMetricFamily running =
+                new GaugeMetricFamily(
+                        "seatunnel_autoscaler_running",
+                        "Whether Zeta autoscaling recommendation loop is running on the master",
+                        clusterLabelNames(ADDRESS));
+        running.addMetric(labelValues(address), booleanValue(view.isRunning()));
+        mfs.add(running);
+
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_current_master_epoch",
+                "Current autoscaler master epoch",
+                address,
+                view.getCurrentMasterEpoch());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_next_generation",
+                "Next autoscaler recommendation generation for the current master epoch",
+                address,
+                view.getNextGeneration());
+
+        CounterMetricFamily recommendations =
+                new CounterMetricFamily(
+                        "seatunnel_autoscaler_recommendations_total",
+                        "Autoscaler recommendations published by action",
+                        clusterLabelNames(ADDRESS, "action"));
+        for (ScalingAction action : ScalingAction.values()) {
+            recommendations.addMetric(
+                    labelValues(address, action.name()),
+                    view.getRecommendationCounts().getOrDefault(action, 0L));
+        }
+        mfs.add(recommendations);
+
+        GaugeMetricFamily stabilization =
+                new GaugeMetricFamily(
+                        "seatunnel_autoscaler_stabilization_seconds",
+                        "Configured autoscaler stabilization window in seconds",
+                        clusterLabelNames(ADDRESS, "direction"));
+        stabilization.addMetric(
+                labelValues(address, "scale_out"), view.getScaleOutStabilizationSeconds());
+        stabilization.addMetric(
+                labelValues(address, "scale_in"), view.getScaleInStabilizationSeconds());
+        mfs.add(stabilization);
+    }
+
+    private void collectSnapshot(
+            List<MetricFamilySamples> mfs, String address, AutoscalerMetricsSnapshot snapshot) {
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_current_workers",
+                "Current worker count observed by the autoscaler",
+                address,
+                snapshot.getCurrentWorkers());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_assigned_slots",
+                "Assigned slot count observed by the autoscaler",
+                address,
+                snapshot.getAssignedSlots());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_unassigned_slots",
+                "Unassigned slot count observed by the autoscaler",
+                address,
+                snapshot.getUnassignedSlots());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_pending_jobs",
+                "Pending job count observed by the autoscaler",
+                address,
+                snapshot.getPendingJobCount());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_oldest_pending_job_duration_ms",
+                "Oldest pending job duration observed by the autoscaler",
+                address,
+                snapshot.getOldestPendingDurationMillis());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_resource_shortages",
+                "Resource shortage events observed by the autoscaler since the previous evaluation",
+                address,
+                snapshot.getResourceShortageCount());
+        CounterMetricFamily shortageTotals =
+                new CounterMetricFamily(
+                        "seatunnel_autoscaler_resource_shortages_total",
+                        "Cumulative resource shortage events observed by the autoscaler",
+                        clusterLabelNames(ADDRESS, "strategy"));
+        shortageTotals.addMetric(labelValues(address, "WAIT"), snapshot.getWaitShortageCount());
+        shortageTotals.addMetric(labelValues(address, "REJECT"), snapshot.getRejectShortageCount());
+        mfs.add(shortageTotals);
+
+        collectMetricValue(
+                mfs,
+                "seatunnel_autoscaler_input_cpu_utilization",
+                "Cluster CPU utilization observed by the autoscaler",
+                address,
+                snapshot.getCpu());
+        collectMetricValue(
+                mfs,
+                "seatunnel_autoscaler_input_jvm_memory_utilization",
+                "Cluster JVM memory utilization observed by the autoscaler",
+                address,
+                snapshot.getJvmMemory());
+        collectSlotUtilization(
+                mfs,
+                "seatunnel_autoscaler_input_slot_utilization",
+                "Fixed slot utilization observed by the autoscaler",
+                address,
+                snapshot.getFixedSlotUtilization());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_metrics_valid",
+                "Whether autoscaler worker metrics are complete and valid for scale-in",
+                address,
+                booleanValue(snapshot.isScaleInMetricsValid()));
+
+        GaugeMetricFamily sampleCounts =
+                new GaugeMetricFamily(
+                        "seatunnel_autoscaler_worker_samples",
+                        "Worker metrics sample count observed by the autoscaler",
+                        clusterLabelNames(ADDRESS, STATUS));
+        sampleCounts.addMetric(labelValues(address, "total"), snapshot.getTotalWorkerSamples());
+        sampleCounts.addMetric(labelValues(address, "valid"), snapshot.getValidWorkerSamples());
+        sampleCounts.addMetric(labelValues(address, "missing"), snapshot.getMissingWorkerSamples());
+        sampleCounts.addMetric(labelValues(address, "stale"), snapshot.getStaleWorkerSamples());
+        sampleCounts.addMetric(labelValues(address, "future"), snapshot.getFutureWorkerSamples());
+        mfs.add(sampleCounts);
+    }
+
+    private void collectRecommendation(
+            List<MetricFamilySamples> mfs, String address, ScalingRecommendation recommendation) {
+        GaugeMetricFamily workers =
+                new GaugeMetricFamily(
+                        "seatunnel_autoscaler_recommended_workers",
+                        "Latest worker count recommended by the autoscaler",
+                        clusterLabelNames(ADDRESS, "action", "recommendation_only"));
+        workers.addMetric(
+                labelValues(
+                        address,
+                        recommendation.getAction().name(),
+                        Boolean.toString(recommendation.isRecommendationOnly())),
+                recommendation.getRecommendedWorkers());
+        mfs.add(workers);
+
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_recommended_delta",
+                "Latest recommended worker delta computed by the autoscaler",
+                address,
+                recommendation.getRecommendedWorkers() - recommendation.getCurrentWorkers());
+        addGauge(
+                mfs,
+                "seatunnel_autoscaler_recommendation_generation",
+                "Latest autoscaler recommendation generation for the current master epoch",
+                address,
+                recommendation.getGeneration());
+
+        GaugeMetricFamily info =
+                new GaugeMetricFamily(
+                        "seatunnel_autoscaler_info",
+                        "Current autoscaler recommendation information",
+                        clusterLabelNames(ADDRESS, "slot_mode", "action"));
+        info.addMetric(
+                labelValues(
+                        address,
+                        recommendation.getSnapshot().getSlotMode().name(),
+                        recommendation.getAction().name()),
+                1.0d);
+        mfs.add(info);
+    }
+
+    private void collectMetricValue(
+            List<MetricFamilySamples> mfs,
+            String name,
+            String help,
+            String address,
+            MetricValue value) {
+        GaugeMetricFamily metricFamily =
+                new GaugeMetricFamily(name, help, clusterLabelNames(ADDRESS, STATUS));
+        metricFamily.addMetric(
+                labelValues(address, value.getStatus().name()),
+                value.isValid() ? value.getValue() : Double.NaN);
+        mfs.add(metricFamily);
+    }
+
+    private void collectSlotUtilization(
+            List<MetricFamilySamples> mfs,
+            String name,
+            String help,
+            String address,
+            MetricValue value) {
+        if (value.getStatus() != MetricStatus.VALID) {
+            return;
+        }
+        GaugeMetricFamily metricFamily =
+                new GaugeMetricFamily(name, help, clusterLabelNames(ADDRESS, STATUS));
+        metricFamily.addMetric(labelValues(address, value.getStatus().name()), value.getValue());
+        mfs.add(metricFamily);
+    }
+
+    private void addGauge(
+            List<MetricFamilySamples> mfs, String name, String help, String address, double value) {
+        GaugeMetricFamily metricFamily =
+                new GaugeMetricFamily(name, help, clusterLabelNames(ADDRESS));
+        metricFamily.addMetric(labelValues(address), value);
+        mfs.add(metricFamily);
+    }
+
+    private double booleanValue(boolean value) {
+        return value ? 1.0d : 0.0d;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/CoordinatorServiceTest.java
@@ -36,6 +36,9 @@ import org.apache.seatunnel.engine.core.job.JobDAGInfo;
 import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
 import org.apache.seatunnel.engine.core.job.JobInfo;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
+import org.apache.seatunnel.engine.server.autoscale.AutoscalerView;
+import org.apache.seatunnel.engine.server.autoscale.LatestWorkerSampleStore;
+import org.apache.seatunnel.engine.server.autoscale.ResourceShortageStats;
 import org.apache.seatunnel.engine.server.common.SeaTunnelEngineContext;
 import org.apache.seatunnel.engine.server.common.statestore.metrics.MetricsSnapshotStateStore;
 import org.apache.seatunnel.engine.server.dag.physical.PhysicalPlan;
@@ -54,7 +57,9 @@ import org.apache.seatunnel.engine.server.metrics.SeaTunnelMetricsContext;
 import org.apache.seatunnel.engine.server.operation.PrintMessageOperation;
 import org.apache.seatunnel.engine.server.operation.ReturnRetryTimesOperation;
 import org.apache.seatunnel.engine.server.operation.SubmitJobOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.ResourceManager;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
 import org.apache.seatunnel.engine.server.task.operation.ReportMetricsOperation;
 import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
 
@@ -65,6 +70,7 @@ import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.Mockito;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.logging.ILogger;
@@ -86,6 +92,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -520,6 +528,95 @@ public class CoordinatorServiceTest {
     }
 
     @Test
+    void testAutoscalerLifecycleFollowsActiveMasterTransitions() throws Exception {
+        AtomicBoolean masterFlag = new AtomicBoolean(false);
+        SeaTunnelServer server = Mockito.mock(SeaTunnelServer.class);
+        Mockito.when(server.isMasterNode()).thenAnswer(invocation -> masterFlag.get());
+
+        EngineConfig engineConfig = new EngineConfig();
+        engineConfig.getAutoscalerConfig().setEnabled(true);
+        engineConfig.getAutoscalerConfig().setEvaluationIntervalSeconds(3600);
+        CoordinatorService coordinatorService = newMockCoordinatorService(server, engineConfig);
+        try {
+            setMockAutoscalerResourceManager(coordinatorService);
+
+            AutoscalerView inactiveView = coordinatorService.getAutoscalerView();
+            Assertions.assertTrue(inactiveView.isEnabled());
+            Assertions.assertFalse(inactiveView.isRunning());
+            Assertions.assertEquals(0L, inactiveView.getCurrentMasterEpoch());
+            Assertions.assertEquals(0L, inactiveView.getNextGeneration());
+            Assertions.assertNull(inactiveView.getLatestRecommendation());
+
+            masterFlag.set(true);
+            invokeCheckNewActiveMaster(coordinatorService);
+            AutoscalerView firstActiveView = awaitAutoscalerPublication(coordinatorService);
+            long firstEpoch = firstActiveView.getCurrentMasterEpoch();
+            Assertions.assertTrue(firstEpoch > 0L);
+            Assertions.assertEquals(1L, firstActiveView.getNextGeneration());
+            Assertions.assertEquals(0L, firstActiveView.getLatestRecommendation().getGeneration());
+
+            invokeCheckNewActiveMaster(coordinatorService);
+            AutoscalerView duplicatePromotionView = coordinatorService.getAutoscalerView();
+            Assertions.assertTrue(duplicatePromotionView.isRunning());
+            Assertions.assertEquals(firstEpoch, duplicatePromotionView.getCurrentMasterEpoch());
+            Assertions.assertEquals(1L, duplicatePromotionView.getNextGeneration());
+
+            masterFlag.set(false);
+            invokeCheckNewActiveMaster(coordinatorService);
+            AutoscalerView demotedView = coordinatorService.getAutoscalerView();
+            Assertions.assertFalse(demotedView.isRunning());
+            Assertions.assertEquals(0L, demotedView.getCurrentMasterEpoch());
+            Assertions.assertEquals(0L, demotedView.getNextGeneration());
+            long lastPublishedGeneration = demotedView.getLatestRecommendation().getGeneration();
+
+            invokeEvaluateAutoscalerSafely(coordinatorService);
+            AutoscalerView afterLateEvaluateView = coordinatorService.getAutoscalerView();
+            Assertions.assertFalse(afterLateEvaluateView.isRunning());
+            Assertions.assertEquals(
+                    lastPublishedGeneration,
+                    afterLateEvaluateView.getLatestRecommendation().getGeneration());
+
+            setMockAutoscalerResourceManager(coordinatorService);
+            masterFlag.set(true);
+            invokeCheckNewActiveMaster(coordinatorService);
+            AutoscalerView repromotedView = awaitAutoscalerPublication(coordinatorService);
+            Assertions.assertTrue(repromotedView.getCurrentMasterEpoch() > firstEpoch);
+            Assertions.assertEquals(1L, repromotedView.getNextGeneration());
+            Assertions.assertEquals(0L, repromotedView.getLatestRecommendation().getGeneration());
+            Assertions.assertEquals(1, repromotedView.getHistory().size());
+        } finally {
+            shutdownCoordinatorIfRunning(coordinatorService);
+        }
+    }
+
+    @Test
+    void testDisabledAutoscalerDoesNotStartLoopOnActiveMaster() throws Exception {
+        AtomicBoolean masterFlag = new AtomicBoolean(true);
+        SeaTunnelServer server = Mockito.mock(SeaTunnelServer.class);
+        Mockito.when(server.isMasterNode()).thenAnswer(invocation -> masterFlag.get());
+
+        CoordinatorService coordinatorService =
+                newMockCoordinatorService(server, new EngineConfig());
+        try {
+            invokeCheckNewActiveMaster(coordinatorService);
+
+            await().atMost(30, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> Assertions.assertTrue(coordinatorService.isCoordinatorActive()));
+            AutoscalerView view = coordinatorService.getAutoscalerView();
+            Assertions.assertFalse(view.isEnabled());
+            Assertions.assertFalse(view.isRunning());
+            Assertions.assertEquals(0L, view.getCurrentMasterEpoch());
+            Assertions.assertEquals(0L, view.getNextGeneration());
+            Assertions.assertNull(view.getLatestRecommendation());
+            Assertions.assertNull(getAutoScaler(coordinatorService));
+            Assertions.assertNull(getAutoscalerScheduler(coordinatorService));
+        } finally {
+            coordinatorService.shutdown();
+        }
+    }
+
+    @Test
     void testPendingJobSchedulerIgnoresJobReservedByPreviousScheduler() throws Exception {
         SeaTunnelServer server = Mockito.mock(SeaTunnelServer.class);
         CoordinatorService coordinatorService = newMockCoordinatorService(server);
@@ -742,10 +839,18 @@ public class CoordinatorServiceTest {
         NodeEngineImpl nodeEngine = Mockito.mock(NodeEngineImpl.class);
         ILogger logger = Mockito.mock(ILogger.class);
         HazelcastInstanceImpl hazelcastInstance = Mockito.mock(HazelcastInstanceImpl.class);
+        FlakeIdGenerator autoscalerEpochGenerator = Mockito.mock(FlakeIdGenerator.class);
+        AtomicLong autoscalerEpoch = new AtomicLong(1000L);
         IMap<Object, Object> map = Mockito.mock(IMap.class);
         Mockito.when(map.entrySet()).thenReturn(Collections.emptySet());
         Mockito.when(nodeEngine.getLogger(Mockito.any(Class.class))).thenReturn(logger);
         Mockito.when(nodeEngine.getHazelcastInstance()).thenReturn(hazelcastInstance);
+        Mockito.when(
+                        hazelcastInstance.getFlakeIdGenerator(
+                                Constant.SEATUNNEL_AUTOSCALER_EPOCH_GENERATOR_NAME))
+                .thenReturn(autoscalerEpochGenerator);
+        Mockito.when(autoscalerEpochGenerator.newId())
+                .thenAnswer(invocation -> autoscalerEpoch.incrementAndGet());
         Mockito.when(hazelcastInstance.getMap(Mockito.anyString())).thenReturn(map);
         SeaTunnelEngineContext engineContext = Mockito.mock(SeaTunnelEngineContext.class);
         Mockito.when(server.getEngineContext()).thenReturn(engineContext);
@@ -1454,6 +1559,46 @@ public class CoordinatorServiceTest {
         Method method = CoordinatorService.class.getDeclaredMethod("checkNewActiveMaster");
         method.setAccessible(true);
         method.invoke(coordinatorService);
+    }
+
+    private void invokeEvaluateAutoscalerSafely(CoordinatorService coordinatorService)
+            throws Exception {
+        Method method = CoordinatorService.class.getDeclaredMethod("evaluateAutoscalerSafely");
+        method.setAccessible(true);
+        method.invoke(coordinatorService);
+    }
+
+    private AutoscalerView awaitAutoscalerPublication(CoordinatorService coordinatorService) {
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () -> {
+                            AutoscalerView view = coordinatorService.getAutoscalerView();
+                            Assertions.assertTrue(view.isRunning());
+                            Assertions.assertTrue(view.getCurrentMasterEpoch() > 0L);
+                            Assertions.assertNotNull(view.getLatestRecommendation());
+                        });
+        return coordinatorService.getAutoscalerView();
+    }
+
+    private ResourceManager setMockAutoscalerResourceManager(
+            CoordinatorService coordinatorService) {
+        ResourceManager resourceManager = Mockito.mock(ResourceManager.class);
+        ConcurrentMap<Address, WorkerProfile> workers = new ConcurrentHashMap<>();
+        Mockito.when(resourceManager.getRegisterWorker()).thenReturn(workers);
+        Mockito.when(resourceManager.getAutoscalerWorkerSampleStore())
+                .thenReturn(new LatestWorkerSampleStore(TimeUnit.SECONDS.toMillis(5)));
+        Mockito.when(resourceManager.getResourceShortageStats())
+                .thenReturn(new ResourceShortageStats());
+        ReflectionUtils.setField(coordinatorService, "resourceManager", resourceManager);
+        return resourceManager;
+    }
+
+    private Object getAutoScaler(CoordinatorService coordinatorService) {
+        return ReflectionUtils.getField(coordinatorService, "autoScaler").orElse(null);
+    }
+
+    private Object getAutoscalerScheduler(CoordinatorService coordinatorService) {
+        return ReflectionUtils.getField(coordinatorService, "autoscalerScheduler").orElse(null);
     }
 
     private void invokeClearCoordinatorService(CoordinatorService coordinatorService)

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoScalerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoScalerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DefaultAutoScalerTest {
+
+    @Test
+    void publishesNoActionUntilScaleOutStabilizesThenClampsTarget() {
+        AutoscalerConfig config = new AutoscalerConfig();
+        config.setScaleOutStabilizationSeconds(300);
+        config.setScaleStep(2);
+        config.setMaxWorkers(4);
+        FakeTimeSource timeSource = new FakeTimeSource(1_000L, 0L);
+        InMemoryAutoscalerStateStore store = new InMemoryAutoscalerStateStore(10);
+        DefaultAutoScaler autoscaler =
+                new DefaultAutoScaler(
+                        7L,
+                        config,
+                        () -> baseSnapshot().currentWorkers(3).cpu(MetricValue.valid(0.9d)).build(),
+                        new HierarchicalAutoscalingPolicy(DefaultAutoScaler.policyConfig(config)),
+                        new StabilizationTracker(300_000_000_000L, 600_000_000_000L),
+                        store,
+                        timeSource);
+
+        autoscaler.evaluateOnce();
+        Assertions.assertEquals(
+                ScalingAction.NO_ACTION,
+                store.view(true, true).getLatestRecommendation().getAction());
+
+        timeSource.nanos = 300_000_000_000L;
+        autoscaler.evaluateOnce();
+
+        ScalingRecommendation recommendation = store.view(true, true).getLatestRecommendation();
+        Assertions.assertEquals(ScalingAction.SCALE_OUT, recommendation.getAction());
+        Assertions.assertEquals(4, recommendation.getRecommendedWorkers());
+        Assertions.assertEquals(7L, recommendation.getMasterEpoch());
+        Assertions.assertEquals(1L, recommendation.getGeneration());
+    }
+
+    @Test
+    void resetClearsGenerationAndStabilization() {
+        AutoscalerConfig config = new AutoscalerConfig();
+        config.setScaleOutStabilizationSeconds(0);
+        FakeTimeSource timeSource = new FakeTimeSource(1_000L, 0L);
+        InMemoryAutoscalerStateStore store = new InMemoryAutoscalerStateStore(10);
+        DefaultAutoScaler autoscaler =
+                new DefaultAutoScaler(
+                        8L,
+                        config,
+                        () -> baseSnapshot().cpu(MetricValue.valid(0.9d)).build(),
+                        new HierarchicalAutoscalingPolicy(DefaultAutoScaler.policyConfig(config)),
+                        new StabilizationTracker(0L, 0L),
+                        store,
+                        timeSource);
+
+        autoscaler.evaluateOnce();
+        autoscaler.reset(9L);
+        autoscaler.evaluateOnce();
+
+        ScalingRecommendation recommendation = store.view(true, true).getLatestRecommendation();
+        Assertions.assertEquals(9L, recommendation.getMasterEpoch());
+        Assertions.assertEquals(0L, recommendation.getGeneration());
+    }
+
+    private AutoscalerMetricsSnapshot.Builder baseSnapshot() {
+        return AutoscalerMetricsSnapshot.builder()
+                .evaluationTimeMillis(1_000L)
+                .currentWorkers(3)
+                .minWorkers(1)
+                .maxWorkers(10)
+                .slotMode(SlotMode.FIXED)
+                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                .cpu(MetricValue.valid(0.1d))
+                .jvmMemory(MetricValue.valid(0.1d))
+                .scaleInMetricsValid(true);
+    }
+
+    private static final class FakeTimeSource implements AutoscalerTimeSource {
+        private long millis;
+        private long nanos;
+
+        private FakeTimeSource(long millis, long nanos) {
+            this.millis = millis;
+            this.nanos = nanos;
+        }
+
+        @Override
+        public long currentTimeMillis() {
+            return millis;
+        }
+
+        @Override
+        public long nanoTime() {
+            return nanos;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoscalerSignalCollectorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/DefaultAutoscalerSignalCollectorTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
+import org.apache.seatunnel.engine.server.resourcemanager.ResourceManager;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.CPU;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.Memory;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.ResourceProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
+import org.apache.seatunnel.engine.server.resourcemanager.worker.WorkerProfile;
+import org.apache.seatunnel.engine.server.telemetry.metrics.entity.RequestSlotOperationStats;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.cluster.Address;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+class DefaultAutoscalerSignalCollectorTest {
+
+    @Test
+    void computesFixedSlotUtilizationAndWorkerSampleSummary() {
+        FakeResourceManager resourceManager = new FakeResourceManager();
+        Address worker = address(5801);
+        resourceManager.workers.put(worker, worker(worker, false, 2, 3));
+        resourceManager.sampleStore.record(
+                new WorkerMetricsSample(worker, 10_000L, 0.4d, 0.6d), 10_000L);
+
+        AutoscalerMetricsSnapshot snapshot = collector(resourceManager).collect();
+
+        Assertions.assertEquals(SlotMode.FIXED, snapshot.getSlotMode());
+        Assertions.assertEquals(MetricStatus.VALID, snapshot.getFixedSlotUtilization().getStatus());
+        Assertions.assertEquals(0.4d, snapshot.getFixedSlotUtilization().getValue(), 0.0001d);
+        Assertions.assertEquals(1, snapshot.getValidWorkerSamples());
+        Assertions.assertTrue(snapshot.isScaleInMetricsValid());
+    }
+
+    @Test
+    void dynamicAndMixedSlotsDoNotExposeNumericSlotUtilization() {
+        FakeResourceManager dynamicResourceManager = new FakeResourceManager();
+        Address worker = address(5801);
+        dynamicResourceManager.workers.put(worker, worker(worker, true, 0, 0));
+
+        AutoscalerMetricsSnapshot dynamicSnapshot = collector(dynamicResourceManager).collect();
+        Assertions.assertEquals(SlotMode.DYNAMIC, dynamicSnapshot.getSlotMode());
+        Assertions.assertEquals(
+                MetricStatus.UNKNOWN, dynamicSnapshot.getFixedSlotUtilization().getStatus());
+
+        FakeResourceManager mixedResourceManager = new FakeResourceManager();
+        Address fixed = address(5802);
+        Address dynamic = address(5803);
+        mixedResourceManager.workers.put(fixed, worker(fixed, false, 1, 1));
+        mixedResourceManager.workers.put(dynamic, worker(dynamic, true, 0, 0));
+
+        AutoscalerMetricsSnapshot mixedSnapshot = collector(mixedResourceManager).collect();
+        Assertions.assertEquals(SlotMode.MIXED, mixedSnapshot.getSlotMode());
+        Assertions.assertEquals(
+                MetricStatus.UNKNOWN, mixedSnapshot.getFixedSlotUtilization().getStatus());
+    }
+
+    @Test
+    void includesShortageDeltaAndPendingFacts() {
+        FakeResourceManager resourceManager = new FakeResourceManager();
+        resourceManager.shortageStats.recordWaitShortage(1, "slot");
+        DefaultAutoscalerSignalCollector collector =
+                new DefaultAutoscalerSignalCollector(
+                        resourceManager, new AutoscalerConfig(), () -> 2, () -> 300L, () -> 1_000L);
+
+        AutoscalerMetricsSnapshot first = collector.collect();
+        AutoscalerMetricsSnapshot second = collector.collect();
+
+        Assertions.assertEquals(1L, first.getResourceShortageCount());
+        Assertions.assertTrue(first.isWaitShortage());
+        Assertions.assertEquals(2, first.getPendingJobCount());
+        Assertions.assertEquals(300L, first.getOldestPendingDurationMillis());
+        Assertions.assertEquals(0L, second.getResourceShortageCount());
+    }
+
+    private DefaultAutoscalerSignalCollector collector(FakeResourceManager resourceManager) {
+        AutoscalerConfig config = new AutoscalerConfig();
+        config.setMetricsFreshnessSeconds(5);
+        return new DefaultAutoscalerSignalCollector(
+                resourceManager, config, () -> 0, () -> 0L, () -> 10_500L);
+    }
+
+    private WorkerProfile worker(
+            Address address, boolean dynamicSlot, int assignedSlots, int unassignedSlots) {
+        WorkerProfile workerProfile = new WorkerProfile(address);
+        workerProfile.setDynamicSlot(dynamicSlot);
+        workerProfile.setAssignedSlots(slots(address, assignedSlots));
+        workerProfile.setUnassignedSlots(slots(address, unassignedSlots));
+        return workerProfile;
+    }
+
+    private SlotProfile[] slots(Address address, int count) {
+        SlotProfile[] slots = new SlotProfile[count];
+        for (int i = 0; i < count; i++) {
+            slots[i] =
+                    new SlotProfile(address, i, new ResourceProfile(CPU.of(0), Memory.of(1)), "s");
+        }
+        return slots;
+    }
+
+    private static Address address(int port) {
+        try {
+            return new Address("127.0.0.1", port);
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static final class FakeResourceManager implements ResourceManager {
+        private final ConcurrentMap<Address, WorkerProfile> workers = new ConcurrentHashMap<>();
+        private final LatestWorkerSampleStore sampleStore = new LatestWorkerSampleStore(5_000L);
+        private final ResourceShortageStats shortageStats = new ResourceShortageStats();
+
+        @Override
+        public void init() {}
+
+        @Override
+        public org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture<SlotProfile>
+                applyResource(
+                        long jobId,
+                        ResourceProfile resourceProfile,
+                        Map<String, String> tagFilter) {
+            return null;
+        }
+
+        @Override
+        public org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture<
+                        java.util.List<SlotProfile>>
+                applyResources(
+                        long jobId,
+                        java.util.List<ResourceProfile> resourceProfile,
+                        Map<String, String> tagFilter) {
+            return null;
+        }
+
+        @Override
+        public org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture<Void>
+                releaseResources(long jobId, java.util.List<SlotProfile> profiles) {
+            return null;
+        }
+
+        @Override
+        public org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture<Void>
+                releaseResource(long jobId, SlotProfile profile) {
+            return null;
+        }
+
+        @Override
+        public boolean slotActiveCheck(SlotProfile profile) {
+            return false;
+        }
+
+        @Override
+        public void heartbeat(WorkerProfile workerProfile) {}
+
+        @Override
+        public void memberRemoved(com.hazelcast.internal.services.MembershipServiceEvent event) {}
+
+        @Override
+        public void close() {}
+
+        @Override
+        public java.util.List<SlotProfile> getUnassignedSlots(Map<String, String> tags) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public java.util.List<SlotProfile> getAssignedSlots(Map<String, String> tags) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public int workerCount(Map<String, String> tags) {
+            return workers.size();
+        }
+
+        @Override
+        public ConcurrentMap<Address, WorkerProfile> getRegisterWorker() {
+            return workers;
+        }
+
+        @Override
+        public RequestSlotOperationStats getRequestSlotOperationStats() {
+            return null;
+        }
+
+        @Override
+        public void reportAutoscalerMetrics(WorkerMetricsSample sample, long receiveTimeMillis) {}
+
+        @Override
+        public LatestWorkerSampleStore getAutoscalerWorkerSampleStore() {
+            return sampleStore;
+        }
+
+        @Override
+        public ResourceShortageStats getResourceShortageStats() {
+            return shortageStats;
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/HierarchicalAutoscalingPolicyTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/HierarchicalAutoscalingPolicyTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HierarchicalAutoscalingPolicyTest {
+
+    private final HierarchicalAutoscalingPolicy policy =
+            new HierarchicalAutoscalingPolicy(
+                    AutoscalerPolicyConfig.builder()
+                            .scaleOutCpuThreshold(0.8d)
+                            .scaleOutJvmMemoryThreshold(0.8d)
+                            .scaleInCpuThreshold(0.3d)
+                            .scaleInJvmMemoryThreshold(0.3d)
+                            .fixedSlotScaleInThreshold(0.3d)
+                            .build());
+
+    @Test
+    void schedulerShortageTriggersScaleOutWithLowUtilization() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .resourceShortageCount(1L)
+                                .waitShortage(true)
+                                .cpu(MetricValue.valid(0.1d))
+                                .jvmMemory(MetricValue.valid(0.1d))
+                                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.SCALE_OUT, evaluation.getAction());
+        Assertions.assertTrue(
+                evaluation.getTriggerReasons().contains("scheduler_resource_shortage"));
+    }
+
+    @Test
+    void highCpuTriggersScaleOutWhenSlotsAreLow() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .cpu(MetricValue.valid(0.8d))
+                                .jvmMemory(MetricValue.valid(0.1d))
+                                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.SCALE_OUT, evaluation.getAction());
+        Assertions.assertTrue(evaluation.getTriggerReasons().contains("cpu_utilization_high"));
+    }
+
+    @Test
+    void highJvmMemoryTriggersScaleOutWhenSlotsAreLow() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .cpu(MetricValue.valid(0.1d))
+                                .jvmMemory(MetricValue.valid(0.81d))
+                                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.SCALE_OUT, evaluation.getAction());
+        Assertions.assertTrue(
+                evaluation.getTriggerReasons().contains("jvm_memory_utilization_high"));
+    }
+
+    @Test
+    void slotPressureAloneDoesNotTriggerScaleOut() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .cpu(MetricValue.valid(0.2d))
+                                .jvmMemory(MetricValue.valid(0.2d))
+                                .fixedSlotUtilization(MetricValue.valid(0.95d))
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.NO_ACTION, evaluation.getAction());
+        Assertions.assertTrue(
+                evaluation.getBlockingReasons().contains("slot_pressure_auxiliary_only"));
+    }
+
+    @Test
+    void dynamicSlotModeHasUnknownSlotPressureAndCanScaleInWhenUtilizationIsLow() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .slotMode(SlotMode.DYNAMIC)
+                                .fixedSlotUtilization(MetricValue.unknown())
+                                .cpu(MetricValue.valid(0.29d))
+                                .jvmMemory(MetricValue.valid(0.29d))
+                                .scaleInMetricsValid(true)
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.SCALE_IN_CANDIDATE, evaluation.getAction());
+    }
+
+    @Test
+    void equalScaleInThresholdDoesNotScaleIn() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .cpu(MetricValue.valid(0.3d))
+                                .jvmMemory(MetricValue.valid(0.29d))
+                                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                                .scaleInMetricsValid(true)
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.NO_ACTION, evaluation.getAction());
+    }
+
+    @Test
+    void invalidCurrentWorkerSampleBlocksScaleIn() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .cpu(MetricValue.valid(0.1d))
+                                .jvmMemory(MetricValue.valid(0.1d))
+                                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                                .missingWorkerSamples(1)
+                                .scaleInMetricsValid(false)
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.SCALE_IN_BLOCKED, evaluation.getAction());
+        Assertions.assertTrue(
+                evaluation.getBlockingReasons().contains("scale_in_metrics_incomplete"));
+    }
+
+    @Test
+    void minWorkerCountBlocksScaleIn() {
+        AutoscaleEvaluation evaluation =
+                policy.evaluate(
+                        baseSnapshot()
+                                .currentWorkers(1)
+                                .minWorkers(1)
+                                .cpu(MetricValue.valid(0.1d))
+                                .jvmMemory(MetricValue.valid(0.1d))
+                                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                                .scaleInMetricsValid(true)
+                                .build());
+
+        Assertions.assertEquals(ScalingAction.NO_ACTION, evaluation.getAction());
+        Assertions.assertTrue(evaluation.getBlockingReasons().contains("min_workers_reached"));
+    }
+
+    private AutoscalerMetricsSnapshot.Builder baseSnapshot() {
+        return AutoscalerMetricsSnapshot.builder()
+                .evaluationTimeMillis(1000L)
+                .currentWorkers(3)
+                .minWorkers(1)
+                .maxWorkers(10)
+                .slotMode(SlotMode.FIXED)
+                .assignedSlots(1)
+                .unassignedSlots(9)
+                .fixedSlotUtilization(MetricValue.valid(0.1d))
+                .cpu(MetricValue.valid(0.5d))
+                .jvmMemory(MetricValue.valid(0.5d))
+                .totalWorkerSamples(3)
+                .validWorkerSamples(3)
+                .missingWorkerSamples(0)
+                .staleWorkerSamples(0)
+                .futureWorkerSamples(0)
+                .pendingJobCount(0)
+                .oldestPendingDurationMillis(0L)
+                .resourceShortageCount(0L)
+                .waitShortage(false)
+                .rejectShortage(false)
+                .scaleInMetricsValid(true);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/InMemoryAutoscalerStateStoreTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/InMemoryAutoscalerStateStoreTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class InMemoryAutoscalerStateStoreTest {
+
+    @Test
+    void storesLatestAndBoundedHistoryWithoutDuplicatingIdentity() {
+        InMemoryAutoscalerStateStore store = new InMemoryAutoscalerStateStore(2);
+        ScalingRecommendation first = recommendation(1L, 0L, ScalingAction.NO_ACTION);
+        ScalingRecommendation second = recommendation(1L, 1L, ScalingAction.SCALE_OUT);
+        ScalingRecommendation third = recommendation(1L, 2L, ScalingAction.SCALE_IN_CANDIDATE);
+
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, store.publish(first));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.DUPLICATE, store.publish(first));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, store.publish(second));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, store.publish(third));
+
+        AutoscalerView view = store.view(true, true);
+        Assertions.assertEquals(third, view.getLatestRecommendation());
+        Assertions.assertEquals(2, view.getHistory().size());
+        Assertions.assertEquals(second, view.getHistory().get(0));
+        Assertions.assertEquals(third, view.getHistory().get(1));
+    }
+
+    @Test
+    void rejectsStalePublication() {
+        InMemoryAutoscalerStateStore store = new InMemoryAutoscalerStateStore(2);
+
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED,
+                store.publish(recommendation(2L, 0L, ScalingAction.NO_ACTION)));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.REJECTED,
+                store.publish(recommendation(1L, 9L, ScalingAction.SCALE_OUT)));
+    }
+
+    private ScalingRecommendation recommendation(
+            long masterEpoch, long generation, ScalingAction action) {
+        return ScalingRecommendation.builder()
+                .masterEpoch(masterEpoch)
+                .generation(generation)
+                .action(action)
+                .currentWorkers(3)
+                .recommendedWorkers(3)
+                .observedAtMillis(100L + generation)
+                .validUntilMillis(200L + generation)
+                .snapshot(AutoscalerMetricsSnapshot.builder().currentWorkers(3).build())
+                .recommendationOnly(true)
+                .build();
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/LatestWorkerSampleStoreTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/LatestWorkerSampleStoreTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.cluster.Address;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+class LatestWorkerSampleStoreTest {
+
+    private static final Address WORKER = address(5801);
+
+    @Test
+    void acceptsLatestValidSample() {
+        LatestWorkerSampleStore store = new LatestWorkerSampleStore(5_000L);
+        WorkerMetricsSample sample = new WorkerMetricsSample(WORKER, 1_000L, 0.5d, 0.6d);
+
+        Assertions.assertTrue(store.record(sample, 1_000L));
+        Optional<WorkerMetricsSample> latest = store.getLatest(WORKER);
+
+        Assertions.assertTrue(latest.isPresent());
+        Assertions.assertEquals(0.5d, latest.get().getCpuUtilization());
+        Assertions.assertEquals(0.6d, latest.get().getJvmMemoryUtilization());
+    }
+
+    @Test
+    void rejectsInvalidSamplesAndKeepsPreviousAcceptedValue() {
+        LatestWorkerSampleStore store = new LatestWorkerSampleStore(5_000L);
+        WorkerMetricsSample sample = new WorkerMetricsSample(WORKER, 1_000L, 0.5d, 0.6d);
+
+        Assertions.assertTrue(store.record(sample, 1_000L));
+        Assertions.assertFalse(
+                store.record(new WorkerMetricsSample(WORKER, 2_000L, Double.NaN, 0.1d), 2_000L));
+        Assertions.assertFalse(
+                store.record(new WorkerMetricsSample(WORKER, 2_000L, 1.1d, 0.1d), 2_000L));
+        Assertions.assertFalse(
+                store.record(new WorkerMetricsSample(WORKER, 2_000L, 0.1d, -0.1d), 2_000L));
+
+        Assertions.assertEquals(sample, store.getLatest(WORKER).get());
+    }
+
+    @Test
+    void rejectsFutureAndOutOfOrderSamples() {
+        LatestWorkerSampleStore store = new LatestWorkerSampleStore(5_000L);
+
+        Assertions.assertFalse(
+                store.record(new WorkerMetricsSample(WORKER, 7_001L, 0.1d, 0.1d), 1_000L));
+        Assertions.assertTrue(
+                store.record(new WorkerMetricsSample(WORKER, 2_000L, 0.2d, 0.2d), 2_000L));
+        Assertions.assertFalse(
+                store.record(new WorkerMetricsSample(WORKER, 1_999L, 0.3d, 0.3d), 3_000L));
+
+        Assertions.assertEquals(2_000L, store.getLatest(WORKER).get().getEventTimeMillis());
+    }
+
+    @Test
+    void removesSamplesForUnregisteredWorkers() {
+        LatestWorkerSampleStore store = new LatestWorkerSampleStore(5_000L);
+        Address other = address(5802);
+
+        store.record(new WorkerMetricsSample(WORKER, 1_000L, 0.5d, 0.6d), 1_000L);
+        store.record(new WorkerMetricsSample(other, 1_000L, 0.2d, 0.3d), 1_000L);
+
+        store.retainWorkers(Collections.singleton(WORKER));
+
+        Assertions.assertTrue(store.getLatest(WORKER).isPresent());
+        Assertions.assertFalse(store.getLatest(other).isPresent());
+    }
+
+    @Test
+    void classifiesSampleFreshnessForRegisteredWorkers() {
+        LatestWorkerSampleStore store = new LatestWorkerSampleStore(5_000L);
+        Address stale = address(5802);
+        Address missing = address(5803);
+        store.record(new WorkerMetricsSample(WORKER, 10_000L, 0.5d, 0.6d), 10_000L);
+        store.record(new WorkerMetricsSample(stale, 1_000L, 0.2d, 0.3d), 1_000L);
+
+        Set<Address> workers = new HashSet<>();
+        workers.add(WORKER);
+        workers.add(stale);
+        workers.add(missing);
+
+        WorkerSampleSummary summary = store.summarize(workers, 10_500L, 5_000L);
+
+        Assertions.assertEquals(3, summary.getTotalSamples());
+        Assertions.assertEquals(1, summary.getValidSamples());
+        Assertions.assertEquals(1, summary.getStaleSamples());
+        Assertions.assertEquals(1, summary.getMissingSamples());
+        Assertions.assertEquals(MetricValue.valid(0.5d).getStatus(), summary.getCpu().getStatus());
+        Assertions.assertFalse(summary.isScaleInMetricsValid());
+    }
+
+    private static Address address(int port) {
+        try {
+            return new Address("127.0.0.1", port);
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/RecommendationFenceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/RecommendationFenceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RecommendationFenceTest {
+
+    @Test
+    void acceptsNewerIdentityAndTreatsDuplicateAsNoop() {
+        RecommendationFence fence = new RecommendationFence();
+
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, fence.tryPublish(1L, 0L));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.DUPLICATE, fence.tryPublish(1L, 0L));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, fence.tryPublish(1L, 1L));
+    }
+
+    @Test
+    void rejectsLowerEpochAndNonIncreasingGeneration() {
+        RecommendationFence fence = new RecommendationFence();
+
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, fence.tryPublish(2L, 3L));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.REJECTED, fence.tryPublish(1L, 100L));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.REJECTED, fence.tryPublish(2L, 2L));
+        Assertions.assertEquals(
+                RecommendationFence.PublicationResult.ACCEPTED, fence.tryPublish(3L, 0L));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/ResourceShortageStatsTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/ResourceShortageStatsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ResourceShortageStatsTest {
+
+    @Test
+    void recordsCumulativeWaitAndRejectShortages() {
+        ResourceShortageStats stats = new ResourceShortageStats();
+
+        stats.recordWaitShortage(3, "cpu=1");
+        stats.recordRejectShortage(1, "slot");
+
+        ResourceShortageSnapshot snapshot = stats.snapshot();
+        Assertions.assertEquals(2L, snapshot.getSequence());
+        Assertions.assertEquals(1L, snapshot.getWaitCount());
+        Assertions.assertEquals(1L, snapshot.getRejectCount());
+        Assertions.assertTrue(snapshot.isLatestReject());
+        Assertions.assertEquals(1, snapshot.getLatestTaskGroupCount());
+        Assertions.assertEquals("slot", snapshot.getLatestResourceShape());
+    }
+
+    @Test
+    void computesDeltaFromPreviousSequence() {
+        ResourceShortageStats stats = new ResourceShortageStats();
+        stats.recordWaitShortage(1, "slot");
+        ResourceShortageSnapshot first = stats.snapshotSince(0L);
+
+        stats.recordWaitShortage(1, "slot");
+        stats.recordRejectShortage(1, "slot");
+        ResourceShortageSnapshot second = stats.snapshotSince(first.getSequence());
+
+        Assertions.assertEquals(1L, first.getShortageCount());
+        Assertions.assertEquals(2L, second.getShortageCount());
+        Assertions.assertTrue(second.isLatestWait());
+        Assertions.assertTrue(second.isLatestReject());
+    }
+
+    @Test
+    void deltaOnlyReportsStrategiesSeenSincePreviousSequence() {
+        ResourceShortageStats stats = new ResourceShortageStats();
+        stats.recordWaitShortage(1, "slot");
+        long previousSequence = stats.snapshot().getSequence();
+
+        stats.recordRejectShortage(1, "slot");
+        ResourceShortageSnapshot snapshot = stats.snapshotSince(previousSequence);
+
+        Assertions.assertFalse(snapshot.isLatestWait());
+        Assertions.assertTrue(snapshot.isLatestReject());
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/StabilizationTrackerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/autoscale/StabilizationTrackerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.autoscale;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+class StabilizationTrackerTest {
+
+    @Test
+    void scaleOutRequiresContinuousMonotonicWindow() {
+        StabilizationTracker tracker =
+                new StabilizationTracker(
+                        TimeUnit.SECONDS.toNanos(300), TimeUnit.SECONDS.toNanos(600));
+
+        Assertions.assertFalse(tracker.isStabilized(ScalingAction.SCALE_OUT, 10L));
+        Assertions.assertFalse(
+                tracker.isStabilized(ScalingAction.SCALE_OUT, 10L + TimeUnit.SECONDS.toNanos(299)));
+        Assertions.assertTrue(
+                tracker.isStabilized(ScalingAction.SCALE_OUT, 10L + TimeUnit.SECONDS.toNanos(300)));
+    }
+
+    @Test
+    void differentActionResetsWindow() {
+        StabilizationTracker tracker =
+                new StabilizationTracker(
+                        TimeUnit.SECONDS.toNanos(300), TimeUnit.SECONDS.toNanos(600));
+
+        tracker.isStabilized(ScalingAction.SCALE_OUT, 10L);
+        Assertions.assertTrue(
+                tracker.isStabilized(ScalingAction.NO_ACTION, 10L + TimeUnit.SECONDS.toNanos(200)));
+        Assertions.assertFalse(
+                tracker.isStabilized(ScalingAction.SCALE_OUT, 10L + TimeUnit.SECONDS.toNanos(400)));
+    }
+
+    @Test
+    void resetClearsContinuity() {
+        StabilizationTracker tracker =
+                new StabilizationTracker(
+                        TimeUnit.SECONDS.toNanos(300), TimeUnit.SECONDS.toNanos(600));
+
+        tracker.isStabilized(ScalingAction.SCALE_IN_CANDIDATE, 10L);
+        tracker.reset();
+
+        Assertions.assertFalse(
+                tracker.isStabilized(
+                        ScalingAction.SCALE_IN_CANDIDATE, 10L + TimeUnit.SECONDS.toNanos(700)));
+    }
+
+    @Test
+    void noActionIsImmediatelyStableAndDoesNotStartScalingWindow() {
+        StabilizationTracker tracker =
+                new StabilizationTracker(
+                        TimeUnit.SECONDS.toNanos(300), TimeUnit.SECONDS.toNanos(600));
+
+        Assertions.assertTrue(tracker.isStabilized(ScalingAction.NO_ACTION, 10L));
+        Assertions.assertFalse(tracker.isStabilized(ScalingAction.SCALE_OUT, 11L));
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHookTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/serializable/ClientToServerOperationDataSerializerHookTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.serializable;
+
+import org.apache.seatunnel.engine.server.operation.GetAutoscalerViewOperation;
+
+import org.junit.jupiter.api.Test;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class ClientToServerOperationDataSerializerHookTest {
+
+    @Test
+    void shouldRegisterGetAutoscalerViewOperation() {
+        IdentifiedDataSerializable serializable =
+                new ClientToServerOperationDataSerializerHook()
+                        .createFactory()
+                        .create(
+                                ClientToServerOperationDataSerializerHook
+                                        .GET_AUTOSCALER_VIEW_OPERATION);
+
+        assertInstanceOf(GetAutoscalerViewOperation.class, serializable);
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/serializable/ResourceDataSerializerHookTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/serializable/ResourceDataSerializerHookTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.engine.server.serializable;
 
 import org.apache.seatunnel.engine.server.resourcemanager.opeartion.GetWorkerResourcesOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ReportAutoscalerMetricsOperation;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,5 +36,15 @@ class ResourceDataSerializerHookTest {
                         .create(ResourceDataSerializerHook.GET_WORKER_RESOURCES_TYPE);
 
         assertInstanceOf(GetWorkerResourcesOperation.class, serializable);
+    }
+
+    @Test
+    void shouldRegisterReportAutoscalerMetricsOperation() {
+        IdentifiedDataSerializable serializable =
+                new ResourceDataSerializerHook()
+                        .createFactory()
+                        .create(ResourceDataSerializerHook.REPORT_AUTOSCALER_METRICS_TYPE);
+
+        assertInstanceOf(ReportAutoscalerMetricsOperation.class, serializable);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/service/slot/DefaultSlotServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/service/slot/DefaultSlotServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.service.slot;
+
+import org.apache.seatunnel.engine.common.config.server.AllocateStrategy;
+import org.apache.seatunnel.engine.common.config.server.AutoscalerConfig;
+import org.apache.seatunnel.engine.common.config.server.SlotServiceConfig;
+import org.apache.seatunnel.engine.server.TaskExecutionService;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.ReportAutoscalerMetricsOperation;
+import org.apache.seatunnel.engine.server.resourcemanager.opeartion.WorkerHeartbeatOperation;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.hazelcast.cluster.Address;
+import com.hazelcast.cluster.impl.MemberImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.InvocationFuture;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.awaitility.Awaitility.await;
+
+class DefaultSlotServiceTest {
+
+    @Test
+    void disabledAutoscalerDoesNotReportAutoscalerMetrics() throws Exception {
+        NodeEngineImpl nodeEngine = Mockito.mock(NodeEngineImpl.class);
+        HazelcastInstance hazelcastInstance = Mockito.mock(HazelcastInstance.class);
+        ClusterService clusterService = Mockito.mock(ClusterService.class);
+        MemberImpl localMember = Mockito.mock(MemberImpl.class);
+        Address localAddress = new Address("127.0.0.1", 5801);
+        Mockito.when(nodeEngine.getHazelcastInstance()).thenReturn(hazelcastInstance);
+        Mockito.when(hazelcastInstance.getName()).thenReturn("default-slot-service-test");
+        Mockito.when(nodeEngine.getClusterService()).thenReturn(clusterService);
+        Mockito.when(clusterService.getThisAddress()).thenReturn(localAddress);
+        Mockito.when(nodeEngine.getThisAddress()).thenReturn(localAddress);
+        Mockito.when(nodeEngine.getLocalMember()).thenReturn(localMember);
+        Mockito.when(localMember.getAttributes()).thenReturn(Collections.emptyMap());
+
+        SlotServiceConfig slotServiceConfig = new SlotServiceConfig();
+        slotServiceConfig.setAllocateStrategy(AllocateStrategy.SYSTEM_LOAD);
+        AutoscalerConfig autoscalerConfig = new AutoscalerConfig();
+        autoscalerConfig.setEnabled(false);
+        CapturingSlotService slotService =
+                new CapturingSlotService(
+                        nodeEngine,
+                        Mockito.mock(TaskExecutionService.class),
+                        slotServiceConfig,
+                        autoscalerConfig);
+        try {
+            slotService.init();
+
+            await().untilAsserted(
+                            () ->
+                                    Assertions.assertTrue(
+                                            slotService.countOperations(
+                                                            WorkerHeartbeatOperation.class)
+                                                    >= 2));
+
+            Assertions.assertEquals(
+                    0,
+                    slotService.countOperations(ReportAutoscalerMetricsOperation.class),
+                    "Disabled autoscaler must not report worker metrics to master");
+        } finally {
+            slotService.close();
+        }
+    }
+
+    private static final class CapturingSlotService extends DefaultSlotService {
+
+        private final List<Operation> operations = new CopyOnWriteArrayList<>();
+        private final InvocationFuture<Object> completedFuture;
+
+        private CapturingSlotService(
+                NodeEngineImpl nodeEngine,
+                TaskExecutionService taskExecutionService,
+                SlotServiceConfig config,
+                AutoscalerConfig autoscalerConfig) {
+            super(nodeEngine, taskExecutionService, config, autoscalerConfig);
+            completedFuture = Mockito.mock(InvocationFuture.class);
+            Mockito.when(completedFuture.join()).thenReturn(null);
+        }
+
+        @Override
+        public <E> InvocationFuture<E> sendToMaster(Operation operation) {
+            operations.add(operation);
+            return (InvocationFuture<E>) completedFuture;
+        }
+
+        @Override
+        public double getCpuPercentage() {
+            return 0.42D;
+        }
+
+        @Override
+        public double getMemPercentage() {
+            return 0.24D;
+        }
+
+        private long countOperations(Class<? extends Operation> operationType) {
+            return operations.stream().filter(operationType::isInstance).count();
+        }
+    }
+}


### PR DESCRIPTION
…d metrics

<!--

Thank you for contributing to SeaTunnel! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

## Contribution Checklist
  - Make sure that the pull request corresponds to a [GITHUB issue](https://github.com/apache/seatunnel/issues).
  - Name the pull request in the form "[Feature] [component] Title of the pull request", where *Feature* can be replaced by `Hotfix`, `Bug`, etc.
  - Minor fixes should be named following this pattern: `[hotfix] [docs] Fix typo in README.md doc`.
-->

### Purpose of this pull request

<!-- Describe the purpose of this pull request. For example: This pull request adds checkstyle plugin.-->
### Purpose

related: #12087, #11663 

This PR implements Phase 1 advisory autoscaling for the Zeta engine.

Phase 1 only evaluates autoscaling signals and publishes recommendations. It does not create or remove workers, drain workers, invoke actuators, rebuild execution graphs, or change running-job parallelism.

### What Changed

- Added Zeta autoscaler configuration, disabled by default.
- Added autoscaling domain models for snapshots, evaluations, recommendations, metric states, slot modes, and scaling actions.
- Added hierarchical Phase 1 policy based on:
- scheduler resource shortages
- worker CPU utilization
- worker JVM memory utilization
- fixed-slot utilization as auxiliary context only
- Added stabilization and recommendation fencing with `masterEpoch` and `generation`.
- Integrated the autoscaler loop with Active Master lifecycle in `CoordinatorService`.
- Added worker metrics reporting and ResourceManager-side sample/shortage tracking.
- Added Hazelcast operations and serialization hooks for autoscaler data exchange.
- Added read-only REST APIs:
  - `/autoscaler/status`
  - `/autoscaler/metrics`
  - `/autoscaler/history`
- Added Prometheus/OpenMetrics exports for autoscaler state, inputs, and recommendations.
- Added English and Chinese docs for autoscaling config, REST APIs, and telemetry.
- Added unit tests for config parsing, policy, stabilization, fencing, state store, sample store, signal collection, and
serialization hooks.

### Safety

- Autoscaling is disabled by default.
- All recommendations are advisory-only.
- Scale-in is exposed only as diagnostic recommendation state.
- No worker capacity mutation or running job rescaling is performed in Phase 1

### Does this PR introduce _any_ user-facing change?

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released SeaTunnel versions or within the unreleased branches such as dev.
If no, write 'No'.
If you are adding/modifying connector documents, please follow our new specifications: https://github.com/apache/seatunnel/issues/4544.
-->

Yes.

- Adds optional Zeta engine Phase 1 autoscaling configuration under `seatunnel.engine.autoscaler`, disabled by default.
- Adds user-facing autoscaler settings for enablement, evaluation interval, metric freshness, stabilization windows, CPU/JVM
memory thresholds, fixed-slot thresholds, worker bounds, scale step, and history size.
- Adds read-only autoscaler REST APIs:
  - `/autoscaler/status`
  - `/autoscaler/metrics`
  - `/autoscaler/history`
- Adds Prometheus/OpenMetrics autoscaler metrics for autoscaler state, input signals, recommendation output, worker sample status, and stabilization windows.
- Adds English and Chinese documentation for the new configuration, REST APIs, and telemetry.

Existing scheduling behavior is unchanged unless autoscaling is explicitly enabled.

### How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If you are adding E2E test cases, maybe refer to https://github.com/apache/seatunnel/blob/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-mysql-e2e/src/test/resources/mysqlcdc_to_mysql.conf, here is a good example.
-->


### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
