### PR TITLE
[Fix][Zeta] Ignore duplicate schema change checkpoint completion

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -1565,11 +1565,15 @@ public class CheckpointCoordinator {
                     checkpoint.getCheckpointId());
             scheduleTriggerPendingCheckpoint(coordinatorConfig.getCheckpointInterval());
         } else {
-            throw new IllegalStateException(
-                    String.format(
-                            "schema-change-after checkpoint is already completed, "
-                                    + "job id: %s, pipeline id: %s, checkpoint id: %s.",
-                            jobId, pipelineId, checkpoint.getCheckpointId()));
+            // A restored pipeline may re-notify the schema-change-after checkpoint that completed
+            // before the failure. The schema change has already been finalized, so there is
+            // nothing left to schedule and the duplicate notification must not fail the pipeline.
+            LOG.info(
+                    "ignore already completed schema-change-after checkpoint, job id: {}, "
+                            + "pipeline id: {}, checkpoint id: {}.",
+                    jobId,
+                    pipelineId,
+                    checkpoint.getCheckpointId());
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -976,6 +976,47 @@ public class CheckpointCoordinatorTest
         }
     }
 
+    @Test
+    void testDuplicateSchemaChangeAfterCheckpointCompletionIsIgnored() {
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            CheckpointCoordinator coordinator = buildMinimalCoordinator(executorService);
+            CheckpointCoordinator spy = Mockito.spy(coordinator);
+            Mockito.doNothing()
+                    .when(spy)
+                    .scheduleTriggerPendingCheckpoint(
+                            Mockito.any(CheckpointType.class), Mockito.anyLong());
+
+            AtomicBoolean schemaChanging =
+                    (AtomicBoolean)
+                            ReflectionUtils.getField(spy, "schemaChanging")
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "schemaChanging field not found"));
+            schemaChanging.set(true);
+            CompletedCheckpoint checkpoint =
+                    new CompletedCheckpoint(
+                            1L,
+                            1,
+                            1L,
+                            System.currentTimeMillis(),
+                            CheckpointType.SCHEMA_CHANGE_AFTER_POINT_TYPE,
+                            System.currentTimeMillis(),
+                            new HashMap<>(),
+                            new HashMap<>());
+
+            spy.completeSchemaChangeAfterCheckpoint(checkpoint);
+            Assertions.assertDoesNotThrow(
+                    () -> spy.completeSchemaChangeAfterCheckpoint(checkpoint));
+            Mockito.verify(spy, Mockito.times(1))
+                    .scheduleTriggerPendingCheckpoint(
+                            Mockito.eq(CheckpointType.CHECKPOINT_TYPE), Mockito.anyLong());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
     /**
      * Regression: when {@code notifyCompleted()} fails (returns {@code false}), {@code
      * completePendingCheckpoint} must return immediately without decrementing {@code


### PR DESCRIPTION
## Purpose

Fixes #12131 by making schema-change-after checkpoint completion idempotent during pipeline recovery.

A pipeline restored from a checkpoint that had already completed its schema change can receive the same completion notification again. Previously, that notification threw an IllegalStateException and failed the recovered job. The coordinator now logs and ignores the duplicate notification; only the first completion resumes regular checkpoint scheduling.

## Tests

- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests verify`
- `./mvnw -pl seatunnel-engine/seatunnel-engine-server -Dtest=CheckpointCoordinatorTest test` (15 tests passed)

## Scope

This change addresses the Zeta recovery failure in #12131. The Doris stream-load cancellation during tablet-rebuilding DDL remains a separate connector concern.