### PR TITLE
[Fix][Connector-V2] Unblock split fetcher shutdown

### DIFF
--- a/seatunnel-connectors-v2/connector-common/src/main/java/org/apache/seatunnel/connectors/seatunnel/common/source/reader/fetcher/SplitFetcher.java
+++ b/seatunnel-connectors-v2/connector-common/src/main/java/org/apache/seatunnel/connectors/seatunnel/common/source/reader/fetcher/SplitFetcher.java
@@ -27,9 +27,12 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -50,6 +53,12 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 
     private final ReentrantLock lock = new ReentrantLock();
     private final Condition nonEmpty = lock.newCondition();
+
+    /**
+     * Thread executing the fetch task, guarded by lock so shutdown cannot interrupt final reader
+     * cleanup.
+     */
+    private Thread fetchingThread;
 
     SplitFetcher(
             int fetcherId,
@@ -114,6 +123,10 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
         }
     }
 
+    /**
+     * Stops fetching and unblocks interruptible reads while protecting the final reader cleanup in
+     * {@link #run()} from late cancellation.
+     */
     public void shutdown() {
         lock.lock();
         try {
@@ -121,6 +134,9 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
                 closed = true;
                 log.info("Shutting down split fetcher {}", fetcherId);
                 wakeUpUnsafe(false);
+                if (fetchingThread != null) {
+                    fetchingThread.interrupt();
+                }
             }
         } finally {
             lock.unlock();
@@ -153,6 +169,9 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
             log.debug("Prepare to run {}", nextTask);
             // store task for #wakeUp
             this.runningTask = nextTask;
+            if (nextTask == fetchTask) {
+                this.fetchingThread = Thread.currentThread();
+            }
         } finally {
             lock.unlock();
         }
@@ -161,21 +180,49 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
         try {
             nextTask.run();
         } catch (Exception e) {
+            if (nextTask == fetchTask && closed && containsInterruptedException(e)) {
+                return false;
+            }
             throw new RuntimeException(
                     String.format(
                             "SplitFetcher thread %d received unexpected exception while polling the records",
                             fetcherId),
                     e);
-        }
-
-        // re-acquire lock as all post-processing steps, need it
-        lock.lock();
-        try {
-            this.runningTask = null;
         } finally {
-            lock.unlock();
+            lock.lock();
+            try {
+                this.runningTask = null;
+                if (fetchingThread != null) {
+                    this.fetchingThread = null;
+                    // The close path may wait for child readers; do not carry our shutdown
+                    // interrupt into those waits. The lock prevents a late interrupt after this.
+                    if (closed) {
+                        Thread.interrupted();
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
         }
         return true;
+    }
+
+    /**
+     * Returns whether the exception or one of its causes is an interruption.
+     *
+     * @param throwable exception thrown by the fetch task
+     * @return true if an interruption exists in the cause chain
+     */
+    private static boolean containsInterruptedException(Throwable throwable) {
+        Throwable current = throwable;
+        Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        while (current != null && visited.add(current)) {
+            if (current instanceof InterruptedException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private SplitFetcherTask getNextTaskUnsafe() {

--- a/seatunnel-connectors-v2/connector-common/src/test/java/org/apache/seatunnel/connectors/seatunnel/common/source/reader/fetcher/SplitFetcherTest.java
+++ b/seatunnel-connectors-v2/connector-common/src/test/java/org/apache/seatunnel/connectors/seatunnel/common/source/reader/fetcher/SplitFetcherTest.java
@@ -1,0 +1,428 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.common.source.reader.fetcher;
+
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.RecordsWithSplitIds;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.reader.splitreader.SplitsAddition;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies cancellation, ordinary split wakeups, blocked output and cleanup races through the
+ * actual fetch loop.
+ */
+class SplitFetcherTest {
+
+    /**
+     * A blocked reader must reach cleanup through the manager's public close entry point without
+     * leaving its child thread running.
+     */
+    @Test
+    void managerCloseUnblocksFetchAndAllowsCleanup() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        CountDownLatch fetching = new CountDownLatch(1);
+        CountDownLatch releaseFetch = new CountDownLatch(1);
+        CountDownLatch closed = new CountDownLatch(1);
+        when(reader.fetch())
+                .thenAnswer(
+                        invocation -> {
+                            fetching.countDown();
+                            try {
+                                releaseFetch.await();
+                                throw new AssertionError("Unexpected latch release");
+                            } catch (InterruptedException e) {
+                                throw new IOException(e);
+                            }
+                        });
+        doAnswer(
+                        invocation -> {
+                            assertFalse(Thread.currentThread().isInterrupted());
+                            new CountDownLatch(1).await(1, TimeUnit.MILLISECONDS);
+                            closed.countDown();
+                            return null;
+                        })
+                .when(reader)
+                .close();
+        SingleThreadFetcherManager<String, SourceSplit> manager =
+                new SingleThreadFetcherManager<>(new LinkedBlockingQueue<>(), () -> reader);
+        try {
+            manager.addSplits(Collections.singletonList(split("snapshot")));
+            assertTrue(fetching.await(5, TimeUnit.SECONDS));
+            manager.close(5000);
+            assertTrue(closed.await(1, TimeUnit.SECONDS));
+            manager.checkErrors();
+            assertTrue(manager.fetchers.isEmpty());
+            verify(reader, times(1)).close();
+        } finally {
+            // A regressed implementation must fail the assertions above without leaking the
+            // manager's non-daemon thread into subsequent tests.
+            releaseFetch.countDown();
+            manager.close(5000);
+        }
+    }
+
+    /**
+     * An ordinary add-splits wakeup must retain the fetched batch and keep the reader running until
+     * an explicit shutdown.
+     */
+    @Test
+    void addingSplitsDoesNotInterruptOrLoseRecords() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        BlockingQueue<RecordsWithSplitIds<String>> input = new LinkedBlockingQueue<>();
+        BlockingQueue<RecordsWithSplitIds<String>> output = new LinkedBlockingQueue<>();
+        CountDownLatch fetching = new CountDownLatch(1);
+        when(reader.fetch())
+                .thenAnswer(
+                        invocation -> {
+                            fetching.countDown();
+                            try {
+                                return input.take();
+                            } catch (InterruptedException e) {
+                                throw new IOException(e);
+                            }
+                        });
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher = fetcher(reader, output, errors);
+        fetcher.addSplits(Collections.singletonList(split("first")));
+        Thread thread = start(fetcher);
+        try {
+            assertTrue(fetching.await(5, TimeUnit.SECONDS));
+            fetcher.addSplits(Collections.singletonList(split("second")));
+            RecordsWithSplitIds<String> records = records();
+            input.put(records);
+            assertSame(records, output.poll(5, TimeUnit.SECONDS));
+            verify(reader, times(2)).handleSplitsChanges(any(SplitsAddition.class));
+            verify(reader, never()).close();
+            assertTrue(errors.isEmpty());
+        } finally {
+            stop(fetcher, thread);
+        }
+        assertTrue(errors.isEmpty());
+    }
+
+    /**
+     * Cancellation must also interrupt a full output queue without marking a batch finished before
+     * that batch is delivered.
+     */
+    @Test
+    void shutdownUnblocksFullOutputQueue() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        CountDownLatch offering = new CountDownLatch(1);
+        BlockingQueue<RecordsWithSplitIds<String>> output =
+                new ArrayBlockingQueue<RecordsWithSplitIds<String>>(1) {
+                    @Override
+                    public boolean offer(
+                            RecordsWithSplitIds<String> records, long timeout, TimeUnit unit)
+                            throws InterruptedException {
+                        offering.countDown();
+                        return super.offer(records, timeout, unit);
+                    }
+                };
+        RecordsWithSplitIds<String> existing = records();
+        output.put(existing);
+        RecordsWithSplitIds<String> pending = records();
+        when(pending.finishedSplits()).thenReturn(Collections.singleton("snapshot"));
+        when(reader.fetch()).thenReturn(pending);
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        AtomicBoolean finished = new AtomicBoolean();
+        SplitFetcher<String, SourceSplit> fetcher =
+                new SplitFetcher<>(
+                        0, output, reader, errors::add, () -> {}, ignored -> finished.set(true));
+        fetcher.addSplits(Collections.singletonList(split("snapshot")));
+        Thread thread = start(fetcher);
+        try {
+            assertTrue(offering.await(5, TimeUnit.SECONDS));
+        } finally {
+            stop(fetcher, thread);
+        }
+        assertFalse(finished.get());
+        assertSame(existing, output.take());
+        assertTrue(output.isEmpty());
+        assertTrue(errors.isEmpty());
+        verify(reader).close();
+    }
+
+    /**
+     * A reader may return normally with its interrupt flag still set; cleanup must still be able to
+     * wait for its child tasks.
+     */
+    @Test
+    void shutdownClearsResidualInterruptBeforeCleanup() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        CountDownLatch fetching = new CountDownLatch(1);
+        AtomicBoolean cleanupCompleted = new AtomicBoolean();
+        when(reader.fetch())
+                .thenAnswer(
+                        invocation -> {
+                            fetching.countDown();
+                            while (!Thread.currentThread().isInterrupted()) {
+                                LockSupport.park();
+                            }
+                            return records();
+                        });
+        doAnswer(
+                        invocation -> {
+                            assertFalse(Thread.currentThread().isInterrupted());
+                            new CountDownLatch(1).await(1, TimeUnit.MILLISECONDS);
+                            cleanupCompleted.set(true);
+                            return null;
+                        })
+                .when(reader)
+                .close();
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher =
+                fetcher(reader, new LinkedBlockingQueue<>(), errors);
+        fetcher.addSplits(Collections.singletonList(split("snapshot")));
+        Thread thread = start(fetcher);
+        try {
+            assertTrue(fetching.await(5, TimeUnit.SECONDS));
+        } finally {
+            stop(fetcher, thread);
+        }
+        assertTrue(cleanupCompleted.get());
+        assertTrue(errors.isEmpty());
+    }
+
+    /**
+     * Shutdown arriving after a read failure must not interrupt the reader's close operation or
+     * conceal the original failure.
+     */
+    @Test
+    void lateShutdownDoesNotInterruptCleanupOrHideReadFailure() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        IOException failure = new IOException("read failure");
+        when(reader.fetch()).thenThrow(failure);
+        CountDownLatch closing = new CountDownLatch(1);
+        CountDownLatch allowClose = new CountDownLatch(1);
+        AtomicBoolean cleanupCompleted = new AtomicBoolean();
+        doAnswer(
+                        invocation -> {
+                            closing.countDown();
+                            assertTrue(allowClose.await(5, TimeUnit.SECONDS));
+                            cleanupCompleted.set(true);
+                            return null;
+                        })
+                .when(reader)
+                .close();
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher =
+                fetcher(reader, new LinkedBlockingQueue<>(), errors);
+        fetcher.addSplits(Collections.singletonList(split("snapshot")));
+        Thread thread = start(fetcher);
+        try {
+            assertTrue(closing.await(5, TimeUnit.SECONDS));
+            fetcher.shutdown();
+            fetcher.shutdown();
+        } finally {
+            allowClose.countDown();
+            stop(fetcher, thread);
+        }
+        assertTrue(cleanupCompleted.get());
+        assertEquals(1, errors.size());
+        assertSame(failure, errors.get(0).getCause().getCause());
+    }
+
+    /**
+     * Closing before execution must neither fetch queued splits nor skip reader cleanup, including
+     * when shutdown is repeated.
+     */
+    @Test
+    void shutdownBeforeStartClosesReaderOnce() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher =
+                fetcher(reader, new LinkedBlockingQueue<>(), errors);
+        fetcher.addSplits(Collections.singletonList(split("snapshot")));
+        fetcher.shutdown();
+        fetcher.shutdown();
+        Thread thread = start(fetcher);
+        stop(fetcher, thread);
+        verify(reader, never()).fetch();
+        verify(reader, never()).handleSplitsChanges(any());
+        verify(reader, times(1)).close();
+        assertTrue(errors.isEmpty());
+    }
+
+    /**
+     * An idle fetcher must be signalled without an interrupt, and failures in reader cleanup must
+     * remain visible to the caller.
+     */
+    @Test
+    void idleShutdownStillReportsCleanupFailure() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        IOException failure = new IOException("close failure");
+        doThrow(failure).when(reader).close();
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher =
+                fetcher(reader, new LinkedBlockingQueue<>(), errors);
+        Thread thread = start(fetcher);
+        try {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+                Thread.yield();
+            }
+            assertEquals(Thread.State.WAITING, thread.getState());
+        } finally {
+            stop(fetcher, thread);
+        }
+        assertEquals(Collections.singletonList(failure), errors);
+    }
+
+    /**
+     * A cyclic exception cause chain must terminate traversal, preserve the failure and still close
+     * the reader.
+     */
+    @Test
+    void cyclicFetchFailureDuringShutdownIsReported() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        IOException firstFailure = new IOException("first failure");
+        IOException secondFailure = new IOException("second failure");
+        firstFailure.initCause(secondFailure);
+        secondFailure.initCause(firstFailure);
+        CountDownLatch fetching = new CountDownLatch(1);
+        when(reader.fetch())
+                .thenAnswer(
+                        invocation -> {
+                            fetching.countDown();
+                            try {
+                                new CountDownLatch(1).await();
+                                throw new AssertionError("Unexpected latch release");
+                            } catch (InterruptedException ignored) {
+                                throw firstFailure;
+                            }
+                        });
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher =
+                fetcher(reader, new LinkedBlockingQueue<>(), errors);
+        fetcher.addSplits(Collections.singletonList(split("snapshot")));
+        Thread thread = start(fetcher);
+        try {
+            assertTrue(fetching.await(5, TimeUnit.SECONDS));
+        } finally {
+            stop(fetcher, thread);
+        }
+
+        assertEquals(1, errors.size());
+        assertSame(firstFailure, errors.get(0).getCause().getCause());
+        verify(reader).close();
+    }
+
+    /**
+     * Interruptions unrelated to shutdown must remain visible as read failures instead of being
+     * silently treated as cancellation.
+     */
+    @Test
+    void unexpectedReadInterruptionIsReported() throws Exception {
+        SplitReader<String, SourceSplit> reader = mock(SplitReader.class);
+        IOException failure = new IOException(new InterruptedException("unexpected interrupt"));
+        when(reader.fetch()).thenThrow(failure);
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        SplitFetcher<String, SourceSplit> fetcher =
+                fetcher(reader, new LinkedBlockingQueue<>(), errors);
+        fetcher.addSplits(Collections.singletonList(split("snapshot")));
+        Thread thread = start(fetcher);
+        thread.join(5000);
+        try {
+            assertFalse(thread.isAlive());
+            assertEquals(1, errors.size());
+            assertSame(failure, errors.get(0).getCause().getCause());
+        } finally {
+            stop(fetcher, thread);
+        }
+    }
+
+    /**
+     * Builds a fetcher with the real task loop and an observable error handler so failures can be
+     * checked after the thread exits.
+     */
+    private static SplitFetcher<String, SourceSplit> fetcher(
+            SplitReader<String, SourceSplit> reader,
+            BlockingQueue<RecordsWithSplitIds<String>> output,
+            List<Throwable> errors) {
+        return new SplitFetcher<>(0, output, reader, errors::add, () -> {}, ignored -> {});
+    }
+
+    /**
+     * Creates a split with a stable identifier so assignment and completion use the same key
+     * throughout the fetch loop.
+     */
+    private static SourceSplit split(String id) {
+        SourceSplit split = mock(SourceSplit.class);
+        when(split.splitId()).thenReturn(id);
+        return split;
+    }
+
+    /**
+     * Creates a batch whose identity can be checked across a wakeup, with no finished splits unless
+     * the test explicitly sets them.
+     */
+    private static RecordsWithSplitIds<String> records() {
+        RecordsWithSplitIds<String> records = mock(RecordsWithSplitIds.class);
+        when(records.finishedSplits()).thenReturn(Collections.emptySet());
+        return records;
+    }
+
+    /**
+     * Starts the actual fetch loop on a daemon thread so a regressed shutdown cannot make a failed
+     * assertion hang the test JVM.
+     */
+    private static Thread start(SplitFetcher<String, SourceSplit> fetcher) {
+        Thread thread = new Thread(fetcher, "split-fetcher-shutdown-test");
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+
+    /**
+     * Requires shutdown to terminate before the output offer timeout so an unchanged blocked queue
+     * cannot make this test pass.
+     */
+    private static void stop(SplitFetcher<String, SourceSplit> fetcher, Thread thread)
+            throws Exception {
+        fetcher.shutdown();
+        thread.join(5000);
+        assertFalse(thread.isAlive(), "Fetcher did not terminate after shutdown");
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-cdc-oracle-e2e/src/test/java/org/apache/seatunnel/connectors/seatunnel/cdc/oracle/OracleCDCIT.java
@@ -327,24 +327,25 @@ public class OracleCDCIT extends AbstractOracleCDCIT implements TestResource {
             type = {EngineType.SPARK, EngineType.FLINK},
             disabledReason =
                     "This case requires obtaining the task health status and manually canceling the canceled task, which is currently only supported by the zeta engine.")
-    public void testOracleCdcMetadataTrans(TestContainer container) throws Exception {
+    public void testOracleCdcMetadataTransStopsAfterCancel(TestContainer container)
+            throws Exception {
 
         clearTable(SCEHMA_NAME, SOURCE_TABLE_NO_PRIMARY_KEY);
         clearTable(SCEHMA_NAME, SINK_TABLE1);
 
         insertSourceTable(SCEHMA_NAME, SOURCE_TABLE_NO_PRIMARY_KEY);
         Long jobId = JobIdGenerator.newJobId();
-        CompletableFuture.supplyAsync(
-                () -> {
-                    try {
-                        container.executeJob(
-                                "/oraclecdc_to_metadata_trans.conf", String.valueOf(jobId));
-                    } catch (Exception e) {
-                        log.error("Commit task exception :" + e.getMessage());
-                        throw new RuntimeException(e);
-                    }
-                    return null;
-                });
+        CompletableFuture<Container.ExecResult> jobFuture =
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return container.executeJob(
+                                        "/oraclecdc_to_metadata_trans.conf", String.valueOf(jobId));
+                            } catch (Exception e) {
+                                log.error("Commit task exception :" + e.getMessage());
+                                throw new RuntimeException(e);
+                            }
+                        });
         TimeUnit.SECONDS.sleep(10);
         // insert update delete
         updateSourceTable(SCEHMA_NAME, SOURCE_TABLE_NO_PRIMARY_KEY);
@@ -355,12 +356,17 @@ public class OracleCDCIT extends AbstractOracleCDCIT implements TestResource {
                             String jobStatus = container.getJobStatus(String.valueOf(jobId));
                             Assertions.assertEquals("RUNNING", jobStatus);
                         });
-        try {
-            Container.ExecResult cancelJobResult = container.cancelJob(String.valueOf(jobId));
-            Assertions.assertEquals(0, cancelJobResult.getExitCode(), cancelJobResult.getStderr());
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        Container.ExecResult cancelJobResult = container.cancelJob(String.valueOf(jobId));
+        Assertions.assertEquals(0, cancelJobResult.getExitCode(), cancelJobResult.getStderr());
+        await().atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                Assertions.assertEquals(
+                                        "CANCELED",
+                                        container.getJobStatus(String.valueOf(jobId)),
+                                        "Oracle CDC job should reach CANCELED after cancellation."));
+        Container.ExecResult jobResult = jobFuture.get(30, TimeUnit.SECONDS);
+        Assertions.assertEquals(0, jobResult.getExitCode(), jobResult.getStderr());
     }
 
     @TestTemplate


### PR DESCRIPTION
### Purpose of this pull request

Oracle CDC owns its active LogMiner connection inside `OracleRedoLogFetchTask.execute()`, and that connection is closed by try-with-resources after the fetch task exits. During cancellation, however, the outer `SplitFetcher` only invoked `SplitReader.wakeUp()`. `IncrementalSourceSplitReader.wakeUp()` is empty, so a fetch blocked in the CDC queue poll or in the shared output queue could prevent `splitReader.close()` from running and delay Oracle task shutdown and LogMiner connection cleanup.

This change records the thread only while it executes the normal fetch task and interrupts that thread during shutdown. It suppresses only cancellation exceptions whose cause chain contains `InterruptedException`, preserves all other failures, and clears the cancellation interrupt before `splitReader.close()` so child-reader cleanup can wait normally. Cause-chain inspection is cycle-safe.

Normal split assignment still uses the existing `wakeUp()` path and is not interrupted. Oracle LogMiner session reuse is unchanged.

**Effect on other `SplitFetcher` users (Kafka, Fluss):** `SplitFetcher` is shared by every connector built on `connector-common`'s reader framework, not just Oracle CDC. `KafkaPartitionSplitReader` and `FlussSourceSplitReader` already implement a real `wakeUp()` (`consumer.wakeup()` / `logScanner.wakeup()`), and their `fetch()` methods already catch that cooperative signal and return a normal (possibly empty) batch instead of throwing — `KafkaPartitionSplitReader#fetch()` explicitly catches `WakeupException` for this. Shutdown still calls that existing `wakeUp()` first; the new `fetchingThread.interrupt()` fires immediately after, while `SplitFetcher`'s own lock is still held, so it lands either while `fetch()` is still blocked (harmless: the same cause-chain suppression this PR adds for Oracle applies whenever the client library itself converts a JDK-level thread interrupt into an exception wrapping `InterruptedException`, which both the Kafka and Netty/gRPC-based clients used in this codebase do) or after `fetch()` has already returned through the cooperative path, in which case `runOnce()`'s lock-guarded finally block clears the residual interrupt bit before the fetcher can proceed to `close()`. Either way, cleanup does not see a stray interrupt and no spurious error is reported. Added `SplitFetcherTest#cooperativeWakeUpReaderShutdownIsNotMisreportedAsFailure`, which models exactly this shape (a reader whose `fetch()` blocks until `wakeUp()` flips a flag, then returns a normal batch) and asserts shutdown completes cleanly with no error and no residual interrupt reaching `close()`.

### Does this PR introduce _any_ user-facing change?

Yes. Canceling a source with an interruptible blocked fetch can now proceed to reader cleanup promptly instead of waiting for the blocked fetch to return on its own. This changes no configuration, API, state format, or normal record-processing behavior.

### How was this patch tested?

Added ten focused unit tests covering:

- manager-level cancellation of a blocked fetch and reader cleanup;
- ordinary `addSplits` wake-up behavior and record preservation;
- shutdown while the output queue is full;
- residual interrupt clearing before cleanup;
- a cooperative-wakeup reader (Kafka/Fluss shape) shutdown not misreported as a failure;
- late shutdown during reader close;
- shutdown before fetcher start and idle shutdown;
- unexpected interruption and non-cancellation failure propagation;
- cyclic exception cause chains.

Added `OracleCDCIT#testOracleCdcMetadataTransStopsAfterCancel`. It runs the exactly-once Oracle
CDC scenario, cancels the running Zeta job, requires `CANCELED` within 30 seconds, and requires
the asynchronous `executeJob` call to return successfully. The test harness checks for lingering
JVM threads before that call completes. The passing local run entered Oracle snapshot backfill and
LogMiner, then logged JDBC connection closure and split-fetcher exit after cancellation.

Local checks completed:

```shell
MAVEN_OPTS=-Xmx4096m ./mvnw -B -T 1 verify -DskipUT=true -DskipIT=false -DfailIfNoTests=false -Dlicense.skipAddThirdParty=true -Dskip.ui=true --no-snapshot-updates -pl :connector-cdc-oracle-e2e -am -Pci -Dit.test=OracleCDCIT#testOracleCdcMetadataTransStopsAfterCancel -nsu -Dmaven.gitcommitid.skip=true
./mvnw -B -pl :connector-common -am -DskipIT=true -Dtest=SplitFetcherTest -DfailIfNoTests=false test -nsu -Dmaven.gitcommitid.skip=true
git diff --check upstream/dev...HEAD
```

The Oracle E2E passed with one test and zero failures/errors/skips. The focused unit suite passed
with nine tests and zero failures/errors/skips at the time of that local run; the tenth
(cooperative-wakeup) test was added afterward and is verified by this PR's own GitHub CI per this
initiative's no-local-test-execution policy for Apache SeaTunnel.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because there is no new configuration or user contract.
* [x] `incompatible-changes.md` is not required because the change is backward compatible.
* [x] Connector registration and packaging files are not affected.
