### PR TITLE
[Fix][Connector-V2][Jdbc] Support MySQL fulltext index creation

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MySqlCatalog.java
@@ -73,6 +73,9 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
     public static final String TABLE_OPTION_ENGINE = "engine";
     public static final String TABLE_OPTION_CHARSET = "charset";
     public static final String TABLE_OPTION_COLLATE = "collate";
+    static final String TABLE_OPTION_INDEX_TYPE_PREFIX = "mysql.index.type.";
+    static final String TABLE_OPTION_INDEX_COLUMN_SUB_PART_PREFIX =
+            "mysql.index.column.sub_part.";
 
     private MySqlVersion version;
     private MySqlTypeConverter typeConverter;
@@ -186,7 +189,17 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
         CatalogTable catalogTable = super.getTable(tablePath);
         readAndFillTableMetaOptions(
                 tablePath.getDatabaseName(), tablePath.getTableName(), catalogTable.getOptions());
+        readAndFillIndexOptions(
+                tablePath.getDatabaseName(), tablePath.getTableName(), catalogTable.getOptions());
         return catalogTable;
+    }
+
+    static String indexTypeOptionKey(String indexName) {
+        return TABLE_OPTION_INDEX_TYPE_PREFIX + indexName;
+    }
+
+    static String indexColumnSubPartOptionKey(String indexName, int ordinalPosition) {
+        return TABLE_OPTION_INDEX_COLUMN_SUB_PART_PREFIX + indexName + "." + ordinalPosition;
     }
 
     private void readAndFillTableMetaOptions(
@@ -210,6 +223,46 @@ public class MySqlCatalog extends AbstractJdbcCatalog {
         } catch (SQLException e) {
             log.warn(
                     "Failed to read table metadata from information_schema for {}.{}: {}",
+                    database,
+                    tableName,
+                    e.getMessage());
+        }
+    }
+
+    private void readAndFillIndexOptions(
+            String database, String tableName, Map<String, String> options) {
+        String url = getUrlFromDatabaseName(database);
+        String sql =
+                "SELECT INDEX_NAME, SEQ_IN_INDEX, INDEX_TYPE, SUB_PART "
+                        + "FROM INFORMATION_SCHEMA.STATISTICS "
+                        + "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND INDEX_NAME <> 'PRIMARY'";
+        try (PreparedStatement ps = getConnection(url).prepareStatement(sql)) {
+            ps.setString(1, database);
+            ps.setString(2, tableName);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String indexName = rs.getString("INDEX_NAME");
+                    if (StringUtils.isBlank(indexName)) {
+                        continue;
+                    }
+                    String indexType = rs.getString("INDEX_TYPE");
+                    if (StringUtils.isNotBlank(indexType)) {
+                        options.put(
+                                indexTypeOptionKey(indexName),
+                                indexType.trim().toUpperCase(Locale.ROOT));
+                    }
+                    Object subPart = rs.getObject("SUB_PART");
+                    if (subPart != null) {
+                        options.put(
+                                indexColumnSubPartOptionKey(
+                                        indexName, rs.getInt("SEQ_IN_INDEX")),
+                                String.valueOf(subPart));
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            log.warn(
+                    "Failed to read index metadata from information_schema for {}.{}: {}",
                     database,
                     tableName,
                     e.getMessage());

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilder.java
@@ -38,6 +38,7 @@ import com.mysql.cj.MysqlType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -58,6 +59,8 @@ public class MysqlCreateTableSqlBuilder {
     private PrimaryKey primaryKey;
 
     private List<ConstraintKey> constraintKeys;
+
+    private Map<String, String> tableOptions;
 
     private String fieldIde;
 
@@ -90,6 +93,7 @@ public class MysqlCreateTableSqlBuilder {
                 .collate(catalogTable.getOptions().get(MySqlCatalog.TABLE_OPTION_COLLATE))
                 .primaryKey(tableSchema.getPrimaryKey())
                 .constraintKeys(tableSchema.getConstraintKeys())
+                .tableOptions(catalogTable.getOptions())
                 .addColumn(tableSchema.getColumns())
                 .fieldIde(catalogTable.getOptions().get("fieldIde"));
     }
@@ -112,6 +116,11 @@ public class MysqlCreateTableSqlBuilder {
 
     public MysqlCreateTableSqlBuilder constraintKeys(List<ConstraintKey> constraintKeys) {
         this.constraintKeys = constraintKeys;
+        return this;
+    }
+
+    public MysqlCreateTableSqlBuilder tableOptions(Map<String, String> tableOptions) {
+        this.tableOptions = tableOptions;
         return this;
     }
 
@@ -231,36 +240,20 @@ public class MysqlCreateTableSqlBuilder {
     private String buildConstraintKeySql(
             ConstraintKey constraintKey, Map<String, String> columnTypeMap) {
         ConstraintKey.ConstraintType constraintType = constraintKey.getConstraintType();
-        String indexColumns =
-                constraintKey.getColumnNames().stream()
-                        .map(
-                                constraintKeyColumn -> {
-                                    String columnName = constraintKeyColumn.getColumnName();
-                                    boolean withLength = false;
-                                    if (columnTypeMap.containsKey(columnName)) {
-                                        String columnType = columnTypeMap.get(columnName);
-                                        if (columnType.endsWith("BLOB")
-                                                || columnType.endsWith("TEXT")) {
-                                            withLength = true;
-                                        }
-                                    }
-                                    if (constraintKeyColumn.getSortType() == null) {
-                                        return String.format(
-                                                "`%s`%s",
-                                                CatalogUtils.getFieldIde(columnName, fieldIde),
-                                                withLength ? "(255)" : "");
-                                    }
-                                    return String.format(
-                                            "`%s`%s %s",
-                                            CatalogUtils.getFieldIde(columnName, fieldIde),
-                                            withLength ? "(255)" : "",
-                                            constraintKeyColumn.getSortType().name());
-                                })
-                        .collect(Collectors.joining(", "));
+        List<String> indexColumnSqls = new ArrayList<>();
+        for (int i = 0; i < constraintKey.getColumnNames().size(); i++) {
+            indexColumnSqls.add(
+                    buildConstraintKeyColumnSql(
+                            constraintKey,
+                            constraintKey.getColumnNames().get(i),
+                            i + 1,
+                            columnTypeMap));
+        }
+        String indexColumns = String.join(", ", indexColumnSqls);
         String keyName = null;
         switch (constraintType) {
             case INDEX_KEY:
-                keyName = "KEY";
+                keyName = buildMysqlIndexKeyName(constraintKey);
                 break;
             case UNIQUE_KEY:
                 keyName = "UNIQUE KEY";
@@ -280,5 +273,67 @@ public class MysqlCreateTableSqlBuilder {
         }
         return String.format(
                 "%s `%s` (%s)", keyName, constraintKey.getConstraintName(), indexColumns);
+    }
+
+    private String buildConstraintKeyColumnSql(
+            ConstraintKey constraintKey,
+            ConstraintKey.ConstraintKeyColumn constraintKeyColumn,
+            int ordinalPosition,
+            Map<String, String> columnTypeMap) {
+        String columnName = constraintKeyColumn.getColumnName();
+        String indexLength = getMysqlIndexColumnLength(constraintKey, ordinalPosition);
+        boolean fullTextIndex = "FULLTEXT".equals(getMysqlIndexType(constraintKey));
+        if (StringUtils.isBlank(indexLength)
+                && !fullTextIndex
+                && columnTypeMap.containsKey(columnName)) {
+            String columnType = columnTypeMap.get(columnName);
+            String normalizedColumnType = columnType.toUpperCase(Locale.ROOT);
+            if (normalizedColumnType.endsWith("BLOB") || normalizedColumnType.endsWith("TEXT")) {
+                indexLength = "255";
+            }
+        }
+        String lengthClause = StringUtils.isBlank(indexLength) ? "" : "(" + indexLength + ")";
+        if (constraintKeyColumn.getSortType() == null) {
+            return String.format(
+                    "`%s`%s", CatalogUtils.getFieldIde(columnName, fieldIde), lengthClause);
+        }
+        return String.format(
+                "`%s`%s %s",
+                CatalogUtils.getFieldIde(columnName, fieldIde),
+                lengthClause,
+                constraintKeyColumn.getSortType().name());
+    }
+
+    private String buildMysqlIndexKeyName(ConstraintKey constraintKey) {
+        String indexType = getMysqlIndexType(constraintKey);
+        if ("FULLTEXT".equals(indexType)) {
+            return "FULLTEXT KEY";
+        }
+        if ("SPATIAL".equals(indexType)) {
+            return "SPATIAL KEY";
+        }
+        return "KEY";
+    }
+
+    private String getMysqlIndexType(ConstraintKey constraintKey) {
+        if (tableOptions == null) {
+            return null;
+        }
+        String value =
+                tableOptions.get(
+                        MySqlCatalog.indexTypeOptionKey(constraintKey.getConstraintName()));
+        return StringUtils.isBlank(value) ? null : value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String getMysqlIndexColumnLength(ConstraintKey constraintKey, int ordinalPosition) {
+        if (tableOptions == null) {
+            return null;
+        }
+        String value =
+                tableOptions.get(
+                        MySqlCatalog.indexColumnSubPartOptionKey(
+                                constraintKey.getConstraintName(), ordinalPosition));
+        String indexLength = StringUtils.trimToNull(value);
+        return StringUtils.isNumeric(indexLength) ? indexLength : null;
     }
 }

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilder.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilder.java
@@ -282,7 +282,8 @@ public class MysqlCreateTableSqlBuilder {
             Map<String, String> columnTypeMap) {
         String columnName = constraintKeyColumn.getColumnName();
         String indexLength = getMysqlIndexColumnLength(constraintKey, ordinalPosition);
-        boolean fullTextIndex = "FULLTEXT".equals(getMysqlIndexType(constraintKey));
+        String mysqlIndexType = getMysqlIndexType(constraintKey);
+        boolean fullTextIndex = "FULLTEXT".equals(mysqlIndexType);
         if (StringUtils.isBlank(indexLength)
                 && !fullTextIndex
                 && columnTypeMap.containsKey(columnName)) {
@@ -294,6 +295,10 @@ public class MysqlCreateTableSqlBuilder {
         }
         String lengthClause = StringUtils.isBlank(indexLength) ? "" : "(" + indexLength + ")";
         if (constraintKeyColumn.getSortType() == null) {
+            return String.format(
+                    "`%s`%s", CatalogUtils.getFieldIde(columnName, fieldIde), lengthClause);
+        }
+        if (!supportExplicitIndexOrder(mysqlIndexType)) {
             return String.format(
                     "`%s`%s", CatalogUtils.getFieldIde(columnName, fieldIde), lengthClause);
         }
@@ -313,6 +318,12 @@ public class MysqlCreateTableSqlBuilder {
             return "SPATIAL KEY";
         }
         return "KEY";
+    }
+
+    private boolean supportExplicitIndexOrder(String mysqlIndexType) {
+        return !"FULLTEXT".equals(mysqlIndexType)
+                && !"SPATIAL".equals(mysqlIndexType)
+                && !"HASH".equals(mysqlIndexType);
     }
 
     private String getMysqlIndexType(ConstraintKey constraintKey) {

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilderTest.java
@@ -212,13 +212,15 @@ public class MysqlCreateTableSqlBuilderTest {
                                                 "idx_billing_id",
                                                 Lists.newArrayList(
                                                         ConstraintKey.ConstraintKeyColumn.of(
-                                                                "billing_id", null))),
+                                                                "billing_id",
+                                                                ConstraintKey.ColumnSortType.ASC))),
                                         ConstraintKey.of(
                                                 ConstraintKey.ConstraintType.INDEX_KEY,
                                                 "idx_destination",
                                                 Lists.newArrayList(
                                                         ConstraintKey.ConstraintKeyColumn.of(
-                                                                "destination", null)))))
+                                                                "destination",
+                                                                ConstraintKey.ColumnSortType.ASC)))))
                         .build();
         Map<String, String> options = new HashMap<>();
         options.put(MySqlCatalog.indexTypeOptionKey("idx_billing_id"), "FULLTEXT");
@@ -240,10 +242,11 @@ public class MysqlCreateTableSqlBuilderTest {
                 createTableSql.contains("FULLTEXT KEY `idx_billing_id` (`billing_id`)"),
                 createTableSql);
         Assertions.assertTrue(
-                createTableSql.contains("KEY `idx_destination` (`destination`(64))"),
+                createTableSql.contains("KEY `idx_destination` (`destination`(64) ASC)"),
                 createTableSql);
         Assertions.assertFalse(
                 createTableSql.contains("KEY `idx_billing_id` (`billing_id`)"), createTableSql);
+        Assertions.assertFalse(createTableSql.contains("`billing_id` ASC"), createTableSql);
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilderTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/mysql/MysqlCreateTableSqlBuilderTest.java
@@ -183,6 +183,70 @@ public class MysqlCreateTableSqlBuilderTest {
     }
 
     @Test
+    public void testBuildCreateTableSqlWithMysqlFulltextAndPrefixIndexes() {
+        TablePath tablePath = TablePath.of("test_db", "test_table");
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .column(PhysicalColumn.of("id", BasicType.LONG_TYPE, 0, false, null, "id"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "billing_id",
+                                        BasicType.STRING_TYPE,
+                                        1024,
+                                        true,
+                                        null,
+                                        "billing_id"))
+                        .column(
+                                PhysicalColumn.of(
+                                        "destination",
+                                        BasicType.STRING_TYPE,
+                                        128,
+                                        true,
+                                        null,
+                                        "destination"))
+                        .primaryKey(PrimaryKey.of("id", Lists.newArrayList("id")))
+                        .constraintKey(
+                                Arrays.asList(
+                                        ConstraintKey.of(
+                                                ConstraintKey.ConstraintType.INDEX_KEY,
+                                                "idx_billing_id",
+                                                Lists.newArrayList(
+                                                        ConstraintKey.ConstraintKeyColumn.of(
+                                                                "billing_id", null))),
+                                        ConstraintKey.of(
+                                                ConstraintKey.ConstraintType.INDEX_KEY,
+                                                "idx_destination",
+                                                Lists.newArrayList(
+                                                        ConstraintKey.ConstraintKeyColumn.of(
+                                                                "destination", null)))))
+                        .build();
+        Map<String, String> options = new HashMap<>();
+        options.put(MySqlCatalog.indexTypeOptionKey("idx_billing_id"), "FULLTEXT");
+        options.put(MySqlCatalog.indexColumnSubPartOptionKey("idx_destination", 1), "64");
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        TableIdentifier.of("test_catalog", "test_db", "test_table"),
+                        tableSchema,
+                        options,
+                        Collections.emptyList(),
+                        "table with fulltext index");
+
+        String createTableSql =
+                MysqlCreateTableSqlBuilder.builder(
+                                tablePath, catalogTable, MySqlTypeConverter.DEFAULT_INSTANCE, true)
+                        .build(DatabaseIdentifier.MYSQL);
+
+        Assertions.assertTrue(
+                createTableSql.contains("FULLTEXT KEY `idx_billing_id` (`billing_id`)"),
+                createTableSql);
+        Assertions.assertTrue(
+                createTableSql.contains("KEY `idx_destination` (`destination`(64))"),
+                createTableSql);
+        Assertions.assertFalse(
+                createTableSql.contains("KEY `idx_billing_id` (`billing_id`)"), createTableSql);
+    }
+
+    @Test
     public void testColumnSinkType() {
         MysqlCreateTableSqlBuilder sqlBuilder = mock(MysqlCreateTableSqlBuilder.class);
 


### PR DESCRIPTION
﻿### Purpose of this pull request

This pull request preserves MySQL native index metadata when reading tables through the JDBC catalog and uses it while generating MySQL `CREATE TABLE` SQL. A source `FULLTEXT` index on a long `VARCHAR` column is now recreated as `FULLTEXT KEY` instead of being downgraded to a normal B-tree `KEY`.

It also omits explicit column order for MySQL `FULLTEXT`, `SPATIAL`, and `HASH` indexes, because MySQL rejects DDL such as `FULLTEXT KEY ... (column ASC)` with `Incorrect usage of spatial/fulltext/hash index and explicit index order`. Prefix index lengths from `SUB_PART` are still preserved for normal indexes when available.

### Does this PR introduce _any_ user-facing change?

Yes. When JDBC sink auto-creates a MySQL table from MySQL catalog metadata with `create_index = true`, MySQL `FULLTEXT` indexes are generated as valid `FULLTEXT KEY` DDL without explicit `ASC`/`DESC` column order. This avoids failures such as `Specified key was too long; max key length is 3072 bytes` and `Incorrect usage of spatial/fulltext/hash index and explicit index order` when a long `VARCHAR` source column has a valid fulltext index.

### How was this patch tested?

Added `MysqlCreateTableSqlBuilderTest#testBuildCreateTableSqlWithMysqlFulltextAndPrefixIndexes` to verify that:

- MySQL fulltext index metadata is rendered as `FULLTEXT KEY`.
- Explicit index order from catalog metadata is omitted for fulltext indexes.
- Prefix length and explicit order are retained for a normal B-tree index.

Local verification:

- `git diff --check apache/dev...HEAD` passed.
- `mvn -pl seatunnel-connectors-v2/connector-jdbc -DskipITs -Dtest=MysqlCreateTableSqlBuilderTest test` was attempted locally, but local verification could not complete reliably in this environment.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
