### PR TITLE
[Docs][Connector-V2] Improve RabbitMQ Milvus and Email connector docs

### DIFF
--- a/docs/en/connectors/sink/Email.md
+++ b/docs/en/connectors/sink/Email.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-email.md';
 
 > Email sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Send the received rows as an attachment file to one or more email addresses.
@@ -270,6 +276,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### How does Email sink format outgoing attachments?
+
+The connector buffers rows per table into a delimited CSV attachment file (`email_attachment_name`, default `emailsink.csv`) and attaches it to an email dispatched upon writer close.
+
+### Does Email sink send an email if no rows were received?
+
+No. If a table receives 0 rows, no attachment is generated and no email is sent for that table.
+
+### Can multiple recipients be specified?
+
+Yes. Set `email_to_address` with comma-separated recipient addresses (e.g. `user1@example.com,user2@example.com`).
 
 ## Changelog
 

--- a/docs/en/connectors/sink/Milvus.md
+++ b/docs/en/connectors/sink/Milvus.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-milvus.md';
 
 > Milvus sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 This Milvus sink connector writes data to Milvus or Zilliz Cloud. It can create the target
@@ -405,6 +411,16 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### Does Milvus sink automatically create target collections?
+
+Yes. If the target collection does not exist in Milvus, the sink can automatically create it based on the upstream schema and vector dimension configuration.
+
+### How does upsert work in Milvus sink?
+
+When `enable_upsert` is set to `true`, incoming records with existing primary keys will be updated in Milvus rather than resulting in duplicate key errors.
 
 ## Changelog
 

--- a/docs/en/connectors/sink/Rabbitmq.md
+++ b/docs/en/connectors/sink/Rabbitmq.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-rabbitmq.md';
 
 > RabbitMQ sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Used to write data to RabbitMQ queues.
@@ -199,6 +205,16 @@ sink {
       }
 }
 ```
+
+## FAQ
+
+### Does RabbitMQ sink support routing to specific exchanges and routing keys?
+
+Yes. The sink publishes messages to RabbitMQ by binding to the target queue or routing configuration specified by `queue_name` and optional routing parameters.
+
+### How does RabbitMQ sink handle network reconnects and timeouts?
+
+You can tune client connection resilience using the `rabbitmq.config` block (such as `connection-timeout`, `requested-heartbeat`, and retry intervals) to prevent premature disconnection during transient network blips.
 
 ## Changelog
 

--- a/docs/en/connectors/source/Milvus.md
+++ b/docs/en/connectors/source/Milvus.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-milvus.md';
 
 > Milvus source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 This Milvus source connector reads data from Milvus or Zilliz Cloud. It can read one collection
@@ -225,6 +231,20 @@ sink {
   Console {}
 }
 ```
+
+## FAQ
+
+### Can Milvus source read all collections in a database at once?
+
+Yes. If you omit the `collection` parameter or leave it empty, the Milvus source connector will scan and read all collections in the configured `database`.
+
+### Which vector data types are supported?
+
+The connector supports `FLOAT_VECTOR`, `BINARY_VECTOR`, `FLOAT16_VECTOR`, `BFLOAT16_VECTOR`, and `SPARSE_FLOAT_VECTOR` types, carrying index and partition metadata to downstream connectors.
+
+### How does the source handle gRPC message size or rate limits?
+
+You can tune `batch_size` and `rate_limit` options. If the Milvus cluster enforces rate limits or gRPC message limits, the connector automatically retries with backoff.
 
 ## Changelog
 

--- a/docs/en/connectors/source/Rabbitmq.md
+++ b/docs/en/connectors/source/Rabbitmq.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-rabbitmq.md';
 
 > RabbitMQ source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Used to read data from RabbitMQ queues.
@@ -271,6 +277,21 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### Why must parallelism be set to 1 to achieve exactly-once?
+
+RabbitMQ dispatches messages among multiple active consumers on the same queue in a round-robin manner. When multiple parallel readers consume from the same queue, message ordering and deterministic offset/acknowledgement coordination across distributed workers cannot be guaranteed. Therefore, setting parallelism to 1 is required for deterministic exactly-once delivery.
+
+### What message formats are supported by RabbitMQ source?
+
+RabbitMQ source uses SeaTunnel deserialization schemas (such as JSON, Text, etc.) to deserialize message payloads into SeaTunnel rows according to the configured `schema`.
+
+### How does the source handle unacknowledged messages when a failure occurs?
+
+When a SeaTunnel task fails or crashes, the RabbitMQ connection drops, and RabbitMQ automatically requeues any unacknowledged messages. Upon job restoration from a checkpoint, the reader resumes processing without message loss.
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/zh/connectors/sink/Email.md
+++ b/docs/zh/connectors/sink/Email.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-email.md';
 
 > Email 数据接收器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 将接收到的数据写成附件文件，并发送到一个或多个邮箱地址。
@@ -250,6 +256,20 @@ sink {
   }
 }
 ```
+
+## 常见问题
+
+### Email Sink 如何格式化邮件附件？
+
+连接器会将每张表接收到的数据行缓冲到带分隔符的 CSV 附件文件中（通过 `email_attachment_name` 配置，默认为 `emailsink.csv`），并在 Writer 关闭时将附件随邮件发出。
+
+### 如果没有接收到任何数据行，还会发送邮件吗？
+
+不会。如果某张表没有接收到任何数据行，不会生成附件，也不会为该表发送邮件。
+
+### 是否可以配置多个收件人邮箱？
+
+可以。在 `email_to_address` 中配置多个收件人邮箱，使用英文逗号 `,` 分隔（例如 `user1@example.com,user2@example.com`）。
 
 ## 变更日志
 

--- a/docs/zh/connectors/sink/Milvus.md
+++ b/docs/zh/connectors/sink/Milvus.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-milvus.md';
 
 > Milvus数据接收器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 Milvus 接收器用于把数据写入 Milvus 或 Zilliz Cloud。它可以根据上游
@@ -404,6 +410,16 @@ sink {
   }
 }
 ```
+
+## 常见问题
+
+### Milvus Sink 是否支持自动创建目标集合？
+
+支持。如果 Milvus 中目标集合尚不存在，Sink 可以根据上游表结构及向量维度信息自动创建目标集合。
+
+### Milvus Sink 的 Upsert 功能如何工作？
+
+当 `enable_upsert` 设置为 `true` 时，若主键已存在，新数据将更新（覆盖）旧数据，避免主键冲突。
 
 ## 变更日志
 

--- a/docs/zh/connectors/sink/Rabbitmq.md
+++ b/docs/zh/connectors/sink/Rabbitmq.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-rabbitmq.md';
 
 > RabbitMQ Sink 连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于将数据写入 RabbitMQ 队列。
@@ -199,6 +205,16 @@ sink {
       }
 }
 ```
+
+## 常见问题
+
+### RabbitMQ Sink 支持路由到指定的 Exchange 和 Routing Key 吗？
+
+支持。Sink 会根据配置的 `queue_name` 及路由参数将消息发布到 RabbitMQ 目标队列或路由规则中。
+
+### RabbitMQ Sink 如何处理网络重连和超时？
+
+可以通过 `rabbitmq.config` 配置块调优客户端连接参数（如 `connection-timeout`、`requested-heartbeat` 等），以应对网络短暂抖动并提高连接稳定性。
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Milvus.md
+++ b/docs/zh/connectors/source/Milvus.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-milvus.md';
 
 > Milvus 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 Milvus 源连接器用于从 Milvus 或 Zilliz Cloud 读取数据。它可以读取一个集合，
@@ -229,6 +235,20 @@ sink {
   Console {}
 }
 ```
+
+## 常见问题
+
+### Milvus Source 能否一次性读取数据库中的所有 Collection？
+
+可以。如果省略 `collection` 参数或将其留空，Milvus 源连接器将读取配置的 `database` 下的所有集合。
+
+### 支持哪些向量数据类型？
+
+连接器支持 `FLOAT_VECTOR`、`BINARY_VECTOR`、`FLOAT16_VECTOR`、`BFLOAT16_VECTOR` 以及 `SPARSE_FLOAT_VECTOR`，并可将分区与索引元数据透传给下游连接器。
+
+### Source 如何处理 gRPC 消息限制或限流错误？
+
+可以通过调整 `batch_size` 和 `rate_limit` 参数来控制读取吞吐。当遇到集群限流或 gRPC 限制时，连接器内置了自动重试与退避机制。
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Rabbitmq.md
+++ b/docs/zh/connectors/source/Rabbitmq.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-rabbitmq.md';
 
 > RabbitMQ 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于从 RabbitMQ 队列读取数据。
@@ -268,6 +274,20 @@ sink {
   }
 }
 ```
+
+## 常见问题
+
+### 为什么实现精确一次必须将并行度设置为 1？
+
+RabbitMQ 会在同一个队列的多个活跃消费者之间以轮询方式分发消息。当多个并行 Reader 同时消费同一个队列时，无法保证消息顺序以及分布式 Worker 之间确定性的 offset/ack 协同。因此，必须将并行度设置为 1 才能实现精确一次。
+
+### RabbitMQ Source 支持哪些消息格式？
+
+RabbitMQ Source 结合 SeaTunnel 反序列化 Schema（如 JSON、Text 等），根据配置的 `schema` 将消息体反序列化为 SeaTunnel 行数据。
+
+### 任务发生故障时未确认的消息如何处理？
+
+当 SeaTunnel 任务失败或异常退出时，与 RabbitMQ 的连接会断开，RabbitMQ 会自动将所有未确认（unacknowledged）的消息重新入队（requeue）。在任务从检查点恢复后，Reader 可以重新处理这些消息，避免数据丢失。
 
 ## 变更日志
 


### PR DESCRIPTION
### Purpose of this pull request

This pull request improves connector documentation for **RabbitMQ** (Source & Sink), **Milvus** (Source & Sink), and **Email** (Sink) in accordance with connector documentation specifications (#4544).

Specifically, it addresses:
1. Adding missing `## Support Those Engines` (in `docs/en/...`) and `## 引擎支持` (in `docs/zh/...`) covering Spark, Flink, and SeaTunnel Zeta across all 10 connector documents.
2. Adding practical FAQs to clarify common configuration questions:
   - **RabbitMQ Source:** Explains the parallelism = 1 constraint for exactly-once, supported payload formats, and reconnection requeue semantics.
   - **RabbitMQ Sink:** Explains exchange/routing key behavior and `rabbitmq.config` timeout/heartbeat tuning.
   - **Milvus Source:** Explains database-wide collection scanning, supported vector data types (`FLOAT_VECTOR`, `BINARY_VECTOR`, `SPARSE_FLOAT_VECTOR`, etc.), and gRPC rate limit retries.
   - **Milvus Sink:** Explains automated collection creation from upstream schema and upsert behavior.
   - **Email Sink:** Clarifies attachment formatting (`emailsink.csv`), behavior on empty tables (no email sent), and multiple recipient syntax.

Fixes #12154 

### Does this PR introduce _any_ user-facing change?

Yes. It improves official SeaTunnel documentation across English and Chinese connector doc pages.

### How was this patch tested?

Rendered and validated markdown syntax and formatting across all 10 modified files in `docs/en/connectors/` and `docs/zh/connectors/`.

### Check list

* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
