### PR TITLE
[Improve][Zeta] Replace ordinal job status range checks

### DIFF
--- a/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/test/java/org/apache/seatunnel/engine/common/job/JobStatusTest.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.engine.common.job;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,5 +37,25 @@ public class JobStatusTest {
         } finally {
             Locale.setDefault(originalLocale);
         }
+    }
+
+    @Test
+    void testOrdinalOrderIsStableForInternalRpcCompatibility() {
+        assertEquals(
+                Arrays.asList(
+                        JobStatus.INITIALIZING,
+                        JobStatus.CREATED,
+                        JobStatus.PENDING,
+                        JobStatus.SCHEDULED,
+                        JobStatus.RUNNING,
+                        JobStatus.FAILING,
+                        JobStatus.FAILED,
+                        JobStatus.DOING_SAVEPOINT,
+                        JobStatus.SAVEPOINT_DONE,
+                        JobStatus.CANCELING,
+                        JobStatus.CANCELED,
+                        JobStatus.FINISHED,
+                        JobStatus.UNKNOWABLE),
+                Arrays.asList(JobStatus.values()));
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
@@ -39,15 +39,20 @@ import com.hazelcast.map.IMap;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 public class PhysicalPlan {
+
+    private static final Set<JobStatus> NOT_STARTED_STATUSES =
+            EnumSet.of(JobStatus.INITIALIZING, JobStatus.CREATED, JobStatus.PENDING);
 
     private final List<SubPlan> pipelineList;
 
@@ -204,7 +209,7 @@ public class PhysicalPlan {
             return;
         }
 
-        if (((JobStatus) runningJobStateIMap.get(jobId)).ordinal() <= JobStatus.PENDING.ordinal()) {
+        if (NOT_STARTED_STATUSES.contains(runningJobStateIMap.get(jobId))) {
             // Tasks with the status 'INITIALIZING', 'CREATED', 'PENDING' need to be set directly to
             // the 'CANCELLED' state because it has not yet started running
             updateJobState(JobStatus.CANCELED);
@@ -251,7 +256,7 @@ public class PhysicalPlan {
             return;
         }
 
-        if (jobStatus.ordinal() <= JobStatus.PENDING.ordinal()) {
+        if (NOT_STARTED_STATUSES.contains(jobStatus)) {
             // Tasks with the status 'INITIALIZING', 'CREATED', 'PENDING' need to be set directly to
             // the 'CANCELLED' state because it has not yet started running
             updateJobState(JobStatus.CANCELED);


### PR DESCRIPTION
## Motivation
SeaTunnel internal RPC transports `JobStatus.ordinal()`, while `PhysicalPlan` also uses ordinal ranges to decide whether a job has started. Adding or reordering an enum value can therefore silently change cancellation/stop behavior.

## Changes
- Replace the two `ordinal() <= PENDING.ordinal()` checks in `PhysicalPlan` with an explicit `INITIALIZING`/`CREATED`/`PENDING` state set.
- Add a `JobStatusTest` guard that pins the current ordinal table used by internal RPC compatibility.
- Keep the RPC wire format and behavior for existing states unchanged.

## Verification
- `git diff --check` passed.
- Spotless passed.
- Focused `JobStatusTest`: 2 tests, 0 failures.
- The server module is not executed here; the current `origin/dev` checkout has unrelated `JettyService` references to missing `HttpConfig` methods.

Fixes #12124