### PR TITLE
[Fix][Connector-V2][JDBC][DB2] Read default values as strings in catalog

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/db2/DB2Catalog.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/db2/DB2Catalog.java
@@ -140,7 +140,7 @@ public class DB2Catalog extends AbstractJdbcCatalog {
                         .precision(length)
                         .scale(scale)
                         .nullable(nullable)
-                        .defaultValue(resultSet.getObject("DEFAULT_VALUE"))
+                        .defaultValue(resultSet.getString("DEFAULT_VALUE"))
                         .comment(resultSet.getString("COMMENT"))
                         .build();
         return DB2TypeConverter.INSTANCE.convert(typeDefine);

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/db2/DB2CatalogTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/catalog/db2/DB2CatalogTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.jdbc.catalog.db2;
 
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.Column;
 import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
 import org.apache.seatunnel.api.table.catalog.PrimaryKey;
 import org.apache.seatunnel.api.table.catalog.TableIdentifier;
@@ -29,9 +30,16 @@ import org.apache.seatunnel.common.utils.JdbcUrlUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DB2CatalogTest {
 
@@ -75,5 +83,32 @@ public class DB2CatalogTest {
                 "CREATE TABLE \"E2E\".\"SINK\" (\"C_INT\" INT NOT NULL, "
                         + "\"C_INTEGER\" INT, PRIMARY KEY (\"C_INT\"))",
                 createTableSql);
+    }
+
+    @Test
+    void testBuildColumnReadsDefaultValueAsString() throws SQLException {
+        DB2Catalog catalog =
+                new DB2Catalog(
+                        "db2",
+                        "db2inst1",
+                        "123456",
+                        JdbcUrlUtil.getUrlInfo("jdbc:db2://127.0.0.1:50000/E2E"),
+                        "E2E",
+                        null);
+
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("COLUMN_NAME")).thenReturn("C_VARCHAR");
+        when(resultSet.getString("DATA_TYPE")).thenReturn("VARCHAR");
+        when(resultSet.getLong("LENGTH")).thenReturn(20L);
+        when(resultSet.getInt("SCALE")).thenReturn(0);
+        when(resultSet.getString("NULLS")).thenReturn("Y");
+        when(resultSet.getString("DEFAULT_VALUE")).thenReturn("'abc'");
+        when(resultSet.getString("COMMENT")).thenReturn("comment");
+
+        Column column = catalog.buildColumn(resultSet);
+
+        Assertions.assertEquals("'abc'", column.getDefaultValue());
+        verify(resultSet).getString("DEFAULT_VALUE");
+        verify(resultSet, never()).getObject("DEFAULT_VALUE");
     }
 }


### PR DESCRIPTION
## Purpose

This PR fixes a runtime serialization failure observed when DB2 catalog metadata containing a non-null column default value is loaded into a SeaTunnel job.

The DB2 catalog previously read the column default value via `ResultSet#getObject`, which on IBM DB2 JDBC driver returns driver-specific objects such as `com.ibm.db2.jcc.am.c9`. These objects are stored in `Column.defaultValue` and later fail Hazelcast serialization of `SourceAction`, throwing:

```
java.io.NotSerializableException: com.ibm.db2.jcc.am.c9
```

The fix switches the default value lookup to `ResultSet#getString` so the value is stored as a plain `String`. The string form is what downstream catalog/JSON paths already expect, and it can be safely serialized, deserialized, and used for schema inference.

## Changes

- `DB2Catalog#buildColumn`: read `DEFAULT_VALUE` via `ResultSet#getString` instead of `ResultSet#getObject`.
- `DB2CatalogTest`: add `testBuildColumnReadsDefaultValueAsString` that mocks the result set and verifies
  - `getString("DEFAULT_VALUE")` is called,
  - `getObject("DEFAULT_VALUE")` is never called,
  - the produced `Column#getDefaultValue()` equals the string returned by the driver.

## Validation

- `./mvnw -pl seatunnel-connectors-v2/connector-jdbc -Dtest=DB2CatalogTest test -Dcheckstyle.skip -Dspotless.check.skip`
- `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`

## Impact

- Behavior change: the value stored in `Column.defaultValue` is now a string (or `null`) for DB2 catalog introspection. For sinks that re-emit the default value back to the database, the existing string-based handling already covers this. Other JDBC catalogs are unaffected.
- No new public API, no configuration change.