### PR TITLE
[Fix][Connector-V2][JDBC][SapHana] Add NCHAR type support in catalog conversion

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/saphana/SapHanaTypeConverter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/saphana/SapHanaTypeConverter.java
@@ -53,6 +53,7 @@ public class SapHanaTypeConverter implements TypeConverter<BasicTypeDefine> {
 
     // -------------------------string----------------------------
     public static final String HANA_VARCHAR = "VARCHAR";
+    public static final String HANA_NCHAR = "NCHAR";
     public static final String HANA_NVARCHAR = "NVARCHAR";
     public static final String HANA_ALPHANUM = "ALPHANUM";
     public static final String HANA_SHORTTEXT = "SHORTTEXT";
@@ -103,6 +104,7 @@ public class SapHanaTypeConverter implements TypeConverter<BasicTypeDefine> {
                     HANA_BINARY,
                     HANA_VARBINARY,
                     HANA_VARCHAR,
+                    HANA_NCHAR,
                     HANA_NVARCHAR,
                     HANA_ALPHANUM,
                     HANA_SHORTTEXT);
@@ -208,6 +210,7 @@ public class SapHanaTypeConverter implements TypeConverter<BasicTypeDefine> {
                 }
                 break;
             case HANA_NVARCHAR:
+            case HANA_NCHAR:
             case HANA_SHORTTEXT:
                 builder.dataType(BasicType.STRING_TYPE);
                 builder.columnLength(TypeDefineUtils.charTo4ByteLength(typeDefine.getLength()));

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/saphana/SapHanaTypeConverterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/internal/dialect/saphana/SapHanaTypeConverterTest.java
@@ -244,6 +244,20 @@ public class SapHanaTypeConverterTest {
         typeDefine =
                 BasicTypeDefine.builder()
                         .name("test")
+                        .columnType("NCHAR")
+                        .dataType("NCHAR")
+                        .length(1L)
+                        .build();
+        column = SapHanaTypeConverter.INSTANCE.convert(typeDefine);
+
+        Assertions.assertEquals(typeDefine.getName(), column.getName());
+        Assertions.assertEquals(BasicType.STRING_TYPE, column.getDataType());
+        Assertions.assertEquals(4, column.getColumnLength());
+        Assertions.assertEquals(typeDefine.getColumnType(), column.getSourceType());
+
+        typeDefine =
+                BasicTypeDefine.builder()
+                        .name("test")
                         .columnType("ALPHANUM")
                         .dataType("ALPHANUM")
                         .length(1L)


### PR DESCRIPTION
## Purpose

SAP HANA defines NCHAR as a fixed-length Unicode string type, but the SAP HANA type converter had no entry for it. Catalog introspection of a NCHAR column therefore fell into the default branch and failed with `convertToSeaTunnelTypeError` instead of being mapped to a string column.

NCHAR semantics (fixed-length Unicode string) match NVARCHAR for the purposes of the SeaTunnel type system, so this change registers NCHAR in the same case group and lets it round-trip through the existing string conversion path.

## Changes

- `SapHanaTypeConverter`
  - Add `HANA_NCHAR = "NCHAR"` constant alongside the other string types.
  - Add `HANA_NCHAR` to the `shouldAppendLength` list so `appendColumnSizeIfNeed` emits `NCHAR(<length>)` and `removeColumnSizeIfNeed` strips it back to the bare type name.
  - Group `HANA_NCHAR` into the existing `HANA_NVARCHAR` / `HANA_SHORTTEXT` case, which maps it to `STRING_TYPE` with `charTo4ByteLength(length)`.
- `SapHanaTypeConverterTest#testConvertChar`: add a NCHAR conversion case that asserts the column name, data type, four-byte length, and source type are preserved.

## Validation

```
./mvnw -pl seatunnel-connectors-v2/connector-jdbc \
  -Dtest=SapHanaTypeConverterTest#testConvertChar \
  -Dcheckstyle.skip -Dspotless.check.skip test
```

Result: `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`

## Impact

- Behavior change: NCHAR columns now convert to `STRING_TYPE` instead of throwing. Other SAP HANA types, source mapping, and existing round-trips are unchanged.
- No new public API, no configuration change.