### PR TITLE
[Fix][Connector-V2][JDBC] Use range fallback when approximate row count is unavailable

### DIFF
--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/DynamicChunkSplitter.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/DynamicChunkSplitter.java
@@ -425,6 +425,17 @@ public class DynamicChunkSplitter extends ChunkSplitter {
                 sampleShardingAllow);
 
         long approximateRowCnt = queryApproximateRowCnt(table);
+        if (approximateRowCnt <= 0) {
+            // Some JDBC dialects return zero or negative estimates when table statistics are
+            // stale or unavailable. In that case, split by the measured key range instead of
+            // issuing per-chunk boundary probes.
+            log.info(
+                    "The approximate row count of table {} is {}, use range chunk fallback.",
+                    tablePath,
+                    approximateRowCnt);
+            return splitEvenlySizedChunksByRange(
+                    tablePath, min, max, chunkSize, sampleShardingThreshold);
+        }
         double distributionFactor =
                 calculateDistributionFactor(tablePath, min, max, approximateRowCnt);
 
@@ -627,6 +638,109 @@ public class DynamicChunkSplitter extends ChunkSplitter {
         // add the ending split
         splits.add(ChunkRange.of(chunkStart, null));
         return splits;
+    }
+
+    /**
+     * Splits an evenly distributed key range when the approximate row count is unavailable.
+     *
+     * <p>The generated chunk count is proportional to {@code (max - min) / chunkSize}. To keep
+     * sparse ranges bounded, the method returns a single full-table split when the estimated chunk
+     * count exceeds {@code maxChunkCount}, when the range cannot be measured safely, or when chunk
+     * boundaries cannot advance.
+     */
+    @VisibleForTesting
+    static List<ChunkRange> splitEvenlySizedChunksByRange(
+            TablePath tablePath, Object min, Object max, int chunkSize, int maxChunkCount) {
+        checkArgument(chunkSize > 0, "chunkSize must be greater than 0");
+        checkArgument(maxChunkCount > 0, "maxChunkCount must be greater than 0");
+        log.info(
+                "Use evenly-sized range chunk fallback for table {}, the chunk size is {}",
+                tablePath,
+                chunkSize);
+        if (!isRangeChunkFallbackSafe(tablePath, min, max, chunkSize, maxChunkCount)) {
+            return Collections.singletonList(ChunkRange.all());
+        }
+        final List<ChunkRange> splits = new ArrayList<>();
+        Object chunkStart = null;
+        Object chunkEnd;
+        try {
+            chunkEnd = ObjectUtils.plus(min, chunkSize);
+        } catch (ArithmeticException e) {
+            log.info(
+                    "Skip range chunk fallback for table {} because the first chunk boundary overflows: min={}, chunk size={}",
+                    tablePath,
+                    min,
+                    chunkSize,
+                    e);
+            return Collections.singletonList(ChunkRange.all());
+        }
+        if (ObjectUtils.compare(chunkEnd, min) <= 0) {
+            log.info(
+                    "Skip range chunk fallback for table {} because the first chunk boundary does not advance: min={}, chunk end={}, chunk size={}",
+                    tablePath,
+                    min,
+                    chunkEnd,
+                    chunkSize);
+            return Collections.singletonList(ChunkRange.all());
+        }
+        while (ObjectUtils.compare(chunkEnd, max) <= 0) {
+            splits.add(ChunkRange.of(chunkStart, chunkEnd));
+            chunkStart = chunkEnd;
+            try {
+                Object nextChunkEnd = ObjectUtils.plus(chunkEnd, chunkSize);
+                if (ObjectUtils.compare(nextChunkEnd, chunkEnd) <= 0) {
+                    log.info(
+                            "Stop range chunk fallback for table {} because the chunk boundary does not advance: chunk end={}, next chunk end={}, chunk size={}",
+                            tablePath,
+                            chunkEnd,
+                            nextChunkEnd,
+                            chunkSize);
+                    break;
+                }
+                chunkEnd = nextChunkEnd;
+            } catch (ArithmeticException e) {
+                break;
+            }
+        }
+        splits.add(ChunkRange.of(chunkStart, null));
+        return splits;
+    }
+
+    /**
+     * Checks whether range fallback can produce a bounded number of chunks.
+     *
+     * <p>{@code maxChunkCount} is supplied by {@code split.sample-sharding.threshold}, so the
+     * fallback reuses the same shard-count guard used by sampling. Unsafe math, unsupported numeric
+     * ranges, or oversized sparse ranges force the caller to use one full-table split.
+     */
+    private static boolean isRangeChunkFallbackSafe(
+            TablePath tablePath, Object min, Object max, int chunkSize, int maxChunkCount) {
+        BigDecimal range;
+        try {
+            range = ObjectUtils.minus(max, min);
+        } catch (RuntimeException e) {
+            log.info(
+                    "Skip range chunk fallback for table {} because split key range cannot be measured: min={}, max={}",
+                    tablePath,
+                    min,
+                    max,
+                    e);
+            return false;
+        }
+        if (range.compareTo(BigDecimal.ZERO) <= 0) {
+            return false;
+        }
+        BigDecimal estimatedChunkCount =
+                range.divide(BigDecimal.valueOf(chunkSize), 0, ROUND_CEILING).add(BigDecimal.ONE);
+        if (estimatedChunkCount.compareTo(BigDecimal.valueOf(maxChunkCount)) > 0) {
+            log.info(
+                    "Skip range chunk fallback for table {} because estimated chunk count {} exceeds max chunk count {}",
+                    tablePath,
+                    estimatedChunkCount,
+                    maxChunkCount);
+            return false;
+        }
+        return true;
     }
 
     public static List<ChunkRange> efficientShardingThroughSampling(

--- a/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/ObjectUtils.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/main/java/org/apache/seatunnel/connectors/seatunnel/jdbc/utils/ObjectUtils.java
@@ -26,7 +26,21 @@ public class ObjectUtils {
      * will throw {@link ArithmeticException} if number overflows.
      */
     public static Object plus(Object number, int augend) throws ArithmeticException {
-        if (number instanceof Integer) {
+        if (number instanceof Byte) {
+            // Byte and Short are promoted to int before addition; check their own ranges
+            // before narrowing the result back to the original type.
+            int result = Math.addExact((Byte) number, augend);
+            if (result < Byte.MIN_VALUE || result > Byte.MAX_VALUE) {
+                throw new ArithmeticException("byte overflow");
+            }
+            return (byte) result;
+        } else if (number instanceof Short) {
+            int result = Math.addExact((Short) number, augend);
+            if (result < Short.MIN_VALUE || result > Short.MAX_VALUE) {
+                throw new ArithmeticException("short overflow");
+            }
+            return (short) result;
+        } else if (number instanceof Integer) {
             return Math.addExact((Integer) number, augend);
         } else if (number instanceof Long) {
             return Math.addExact((Long) number, augend);

--- a/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/DynamicChunkSplitterTest.java
+++ b/seatunnel-connectors-v2/connector-jdbc/src/test/java/org/apache/seatunnel/connectors/seatunnel/jdbc/source/DynamicChunkSplitterTest.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.type.BasicType;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcConnectionConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceConfig;
 import org.apache.seatunnel.connectors.seatunnel.jdbc.config.JdbcSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.jdbc.utils.ObjectUtils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -305,6 +306,62 @@ public class DynamicChunkSplitterTest {
         assertTrue(JdbcSourceOptions.ENABLE_CONCURRENT_READ.defaultValue());
     }
 
+    /**
+     * Covers bounded range fallback when the approximate row count is zero or negative. Verifies
+     * integer, short, and byte ranges split correctly, oversized ranges collapse to one chunk,
+     * unsafe numeric ranges collapse to one chunk, and bad arguments throw.
+     */
+    @Test
+    public void testSplitEvenlySizedChunksByRangeWhenApproximateRowCountUnavailable() {
+        TablePath tablePath = TablePath.of("db", "xe", "table");
+
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(tablePath, 1, 5, 2, 10),
+                Arrays.asList(
+                        DynamicChunkSplitter.ChunkRange.of(null, 3),
+                        DynamicChunkSplitter.ChunkRange.of(3, 5),
+                        DynamicChunkSplitter.ChunkRange.of(5, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(
+                        tablePath, (short) 1, (short) 5, 2, 10),
+                Arrays.asList(
+                        DynamicChunkSplitter.ChunkRange.of(null, (short) 3),
+                        DynamicChunkSplitter.ChunkRange.of((short) 3, (short) 5),
+                        DynamicChunkSplitter.ChunkRange.of((short) 5, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(
+                        tablePath, (byte) 1, (byte) 5, 2, 10),
+                Arrays.asList(
+                        DynamicChunkSplitter.ChunkRange.of(null, (byte) 3),
+                        DynamicChunkSplitter.ChunkRange.of((byte) 3, (byte) 5),
+                        DynamicChunkSplitter.ChunkRange.of((byte) 5, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(tablePath, 1, 100, 2, 10),
+                Arrays.asList(DynamicChunkSplitter.ChunkRange.of(null, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(
+                        tablePath, (short) 1, (short) 5, 100000, 10),
+                Arrays.asList(DynamicChunkSplitter.ChunkRange.of(null, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(
+                        tablePath, (byte) 1, (byte) 5, 100000, 10),
+                Arrays.asList(DynamicChunkSplitter.ChunkRange.of(null, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(
+                        tablePath, 1.0E20D, 1.0E20D + 1.0E10D, 1, 10),
+                Arrays.asList(DynamicChunkSplitter.ChunkRange.of(null, null)));
+        check(
+                DynamicChunkSplitter.splitEvenlySizedChunksByRange(
+                        tablePath, Double.NaN, 5.0D, 2, 10),
+                Arrays.asList(DynamicChunkSplitter.ChunkRange.of(null, null)));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> DynamicChunkSplitter.splitEvenlySizedChunksByRange(tablePath, 1, 5, 0, 10));
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> DynamicChunkSplitter.splitEvenlySizedChunksByRange(tablePath, 1, 5, 2, 0));
+    }
+
     private void check(
             List<DynamicChunkSplitter.ChunkRange> a, List<DynamicChunkSplitter.ChunkRange> b) {
         checkRule(b);
@@ -325,7 +382,8 @@ public class DynamicChunkSplitterTest {
             }
             if (i > 0 && i < a.size() - 1) {
                 // current chunk end should be greater than current chunk start
-                assertTrue((int) a.get(i).getChunkEnd() > (int) a.get(i).getChunkStart());
+                assertTrue(
+                        ObjectUtils.compare(a.get(i).getChunkEnd(), a.get(i).getChunkStart()) > 0);
             }
         }
     }


### PR DESCRIPTION
## Purpose

Some JDBC dialects return a zero or negative estimate from `queryApproximateRowCnt`:

- AnalyticDB MySQL external tables, which do not have accurate table statistics.
- MySQL tables whose `information_schema` statistics have not been updated.
- PostgreSQL tables that have never been `ANALYZE`d.

With `approximateRowCnt <= 0` the previous code path went through the uneven-distribution branch and `splitUnevenlySizedChunks`, which issues one extra boundary query per chunk. For large uneven tables this is slow and produces a noisy split log.

This change adds a bounded range-based split that uses the measured `min` / `max` of the split key directly, falling back to a single full-table split when the range is unsafe to measure or would produce too many chunks.

## Changes

- `DynamicChunkSplitter`:
  - When `queryApproximateRowCnt` returns `0` or a negative value, call the new `splitEvenlySizedChunksByRange` instead of the uneven-distribution path.
  - `splitEvenlySizedChunksByRange` generates chunks of `chunkSize` keys anchored at the measured `min`, stopping when the next boundary would exceed `max`, the chunk boundary stops advancing, or arithmetic overflows.
  - `isRangeChunkFallbackSafe` caps the estimated chunk count at the existing `split.sample-sharding.threshold` and refuses to fall back when `min`, `max` is an unsupported numeric pair (for example `NaN`).
- `ObjectUtils#plus`: handle `Byte` and `Short` operands with `Math.addExact` and an explicit range check, so the new fallback works for all numeric split key types supported by `ObjectUtils#minus`.
- `DynamicChunkSplitterTest`: use `ObjectUtils.compare` in the chunk ordering check, since the new test exercises `Byte` and `Short` ranges; add `testSplitEvenlySizedChunksByRangeWhenApproximateRowCountUnavailable` covering the happy path, oversized sparse ranges, unsafe numeric ranges, and the chunkSize / maxChunkCount argument validation.

## Validation

```
./mvnw -pl seatunnel-connectors-v2/connector-jdbc \
  -Dtest=DynamicChunkSplitterTest \
  -Dcheckstyle.skip -Dspotless.check.skip test
```

Result: `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`

## Impact

- Behavior change: when `approximateRowCnt <= 0` for a numeric split key, the source now uses a single range-based split plan rather than N boundary probes. Read SQL is unchanged; only the number and shape of splits differ. Tables with valid row count estimates are unaffected.
- No new public API, no configuration change. The existing `split.sample-sharding.threshold` knob is reused as the chunk-count cap.