### PR TITLE
[Improve][Connector-V2] Validate DingTalk required options

### DIFF
--- a/seatunnel-connectors-v2/connector-dingtalk/src/main/java/org/apache/seatunnel/connectors/seatunnel/sink/DingTalkSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-dingtalk/src/main/java/org/apache/seatunnel/connectors/seatunnel/sink/DingTalkSinkFactory.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
 import static org.apache.seatunnel.connectors.seatunnel.config.DingTalkSinkOptions.SECRET;
 import static org.apache.seatunnel.connectors.seatunnel.config.DingTalkSinkOptions.URL;
 
@@ -37,7 +38,10 @@ public class DingTalkSinkFactory implements TableSinkFactory {
 
     @Override
     public OptionRule optionRule() {
-        return OptionRule.builder().required(URL, SECRET).build();
+        return OptionRule.builder()
+                .required(URL, notBlank(URL))
+                .required(SECRET, notBlank(SECRET))
+                .build();
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-dingtalk/src/test/java/org/apache/seatunnel/connectors/seatunnel/DingTalkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-dingtalk/src/test/java/org/apache/seatunnel/connectors/seatunnel/DingTalkFactoryTest.java
@@ -17,15 +17,56 @@
 
 package org.apache.seatunnel.connectors.seatunnel;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.config.DingTalkSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.sink.DingTalkSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class DingTalkFactoryTest {
+
+    private final OptionRule optionRule = new DingTalkSinkFactory().optionRule();
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new DingTalkSinkFactory()).optionRule());
+        Assertions.assertNotNull(optionRule);
+    }
+
+    @Test
+    void testValidRequiredOptions() {
+        Assertions.assertDoesNotThrow(() -> validate(requiredConfig()));
+    }
+
+    @Test
+    void testBlankRequiredOptionsRejected() {
+        Map<String, Object> blankUrlConfig = requiredConfig();
+        blankUrlConfig.put(DingTalkSinkOptions.URL.key(), " ");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(blankUrlConfig));
+
+        Map<String, Object> blankSecretConfig = requiredConfig();
+        blankSecretConfig.put(DingTalkSinkOptions.SECRET.key(), "\t");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(blankSecretConfig));
+    }
+
+    private void validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "DingTalkSink");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private Map<String, Object> requiredConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(
+                DingTalkSinkOptions.URL.key(),
+                "https://oapi.dingtalk.com/robot/send?access_token=test-token");
+        config.put(DingTalkSinkOptions.SECRET.key(), "test-secret");
+        return config;
     }
 }

--- a/seatunnel-connectors-v2/connector-dingtalk/src/test/java/org/apache/seatunnel/connectors/seatunnel/DingTalkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-dingtalk/src/test/java/org/apache/seatunnel/connectors/seatunnel/DingTalkFactoryTest.java
@@ -45,14 +45,21 @@ public class DingTalkFactoryTest {
     }
 
     @Test
-    void testBlankRequiredOptionsRejected() {
-        Map<String, Object> blankUrlConfig = requiredConfig();
-        blankUrlConfig.put(DingTalkSinkOptions.URL.key(), " ");
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(blankUrlConfig));
+    void testEmptyRequiredOptionsRejected() {
+        assertInvalidValue(DingTalkSinkOptions.URL.key(), "");
+        assertInvalidValue(DingTalkSinkOptions.SECRET.key(), "");
+    }
 
-        Map<String, Object> blankSecretConfig = requiredConfig();
-        blankSecretConfig.put(DingTalkSinkOptions.SECRET.key(), "\t");
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(blankSecretConfig));
+    @Test
+    void testWhitespaceOnlyRequiredOptionsRejected() {
+        assertInvalidValue(DingTalkSinkOptions.URL.key(), " ");
+        assertInvalidValue(DingTalkSinkOptions.SECRET.key(), "\t");
+    }
+
+    private void assertInvalidValue(String optionKey, String value) {
+        Map<String, Object> config = requiredConfig();
+        config.put(optionKey, value);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
     }
 
     private void validate(Map<String, Object> config) {


### PR DESCRIPTION
### Purpose of this pull request

Handles the Sink / connector-dingtalk slice of #11007.

This change keeps url and secret required and adds declarative notBlank conditions so invalid empty or whitespace-only values fail during factory configuration validation instead of reaching the writer.

### Does this PR introduce any user-facing change?

Yes. Empty and whitespace-only DingTalk url and secret values are now rejected during configuration validation. Option names and all existing nonblank configurations remain unchanged.

### How was this patch tested?

- Added valid configuration coverage.
- Added empty-value coverage for both url and secret.
- Added whitespace-only coverage for both url and secret.
- DingTalkFactoryTest: 4 tests passed, 0 failures.
- connector-dingtalk verify: passed.
- Spotless formatting: passed.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because no option name, default, or valid configuration changes.
* [x] No incompatible change is introduced.
* [x] Existing connector registration, distribution, CI labels, E2E setup, and plugin configuration are unchanged.