### PR TITLE
[Fix][Connector-V2] Use OAuth token for Slack messages

### DIFF
--- a/seatunnel-connectors-v2/connector-slack/src/main/java/org/apache/seatunnel/connectors/seatunnel/slack/client/SlackClient.java
+++ b/seatunnel-connectors-v2/connector-slack/src/main/java/org/apache/seatunnel/connectors/seatunnel/slack/client/SlackClient.java
@@ -89,6 +89,15 @@ public class SlackClient {
         return publishMessageSuccess;
     }
 
+    /**
+     * Builds a chat.postMessage request authenticated with the configured OAuth token, not the
+     * channel name.
+     *
+     * @param oauthToken OAuth token used to authenticate the request
+     * @param channelId resolved ID of the destination channel
+     * @param text message text to publish
+     * @return the request with authentication and message fields populated
+     */
     static ChatPostMessageRequest createMessageRequest(
             String oauthToken, String channelId, String text) {
         return ChatPostMessageRequest.builder()

--- a/seatunnel-connectors-v2/connector-slack/src/main/java/org/apache/seatunnel/connectors/seatunnel/slack/client/SlackClient.java
+++ b/seatunnel-connectors-v2/connector-slack/src/main/java/org/apache/seatunnel/connectors/seatunnel/slack/client/SlackClient.java
@@ -25,6 +25,7 @@ import org.apache.seatunnel.connectors.seatunnel.slack.exception.SlackConnectorE
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.methods.response.conversations.ConversationsListResponse;
 import com.slack.api.model.Conversation;
@@ -80,17 +81,21 @@ public class SlackClient {
         try {
             ChatPostMessageResponse chatPostMessageResponse =
                     methodsClient.chatPostMessage(
-                            r ->
-                                    r
-                                            // The Token used to initialize app
-                                            .token(pluginConfig.get(SLACK_CHANNEL))
-                                            .channel(channelId)
-                                            .text(text));
+                            createMessageRequest(pluginConfig.get(OAUTH_TOKEN), channelId, text));
             publishMessageSuccess = chatPostMessageResponse.isOk();
         } catch (IOException | SlackApiException e) {
             log.error("error: {}", ExceptionUtils.getMessage(e));
         }
         return publishMessageSuccess;
+    }
+
+    static ChatPostMessageRequest createMessageRequest(
+            String oauthToken, String channelId, String text) {
+        return ChatPostMessageRequest.builder()
+                .token(oauthToken)
+                .channel(channelId)
+                .text(text)
+                .build();
     }
 
     /** Close Conversion */

--- a/seatunnel-connectors-v2/connector-slack/src/test/java/org/apache/seatunnel/connectors/seatunnel/slack/client/SlackClientTest.java
+++ b/seatunnel-connectors-v2/connector-slack/src/test/java/org/apache/seatunnel/connectors/seatunnel/slack/client/SlackClientTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.slack.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+
+class SlackClientTest {
+
+    @Test
+    void testCreateMessageRequestUsesOAuthToken() {
+        ChatPostMessageRequest request =
+                SlackClient.createMessageRequest(
+                        "xoxb-test-token", "resolved-channel-id", "test-message");
+
+        Assertions.assertEquals("xoxb-test-token", request.getToken());
+        Assertions.assertEquals("resolved-channel-id", request.getChannel());
+        Assertions.assertEquals("test-message", request.getText());
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes #12093.

SlackClient.publishMessage previously supplied the configured Slack channel name as the chat.postMessage authentication token. This change maps oauth_token, the resolved channel ID, and message text to their correct SDK request fields.

### Does this PR introduce any user-facing change?

Yes. Slack sink message publishing now authenticates with the configured oauth_token instead of incorrectly using slack_channel as the token. Existing option names and channel lookup behavior are unchanged.

### How was this patch tested?

- Added SlackClientTest to verify OAuth token, resolved channel ID, and text mapping without a live Slack workspace.
- connector-slack tests: 2 passed, 0 failures.
- connector-slack verify: passed.
- Spotless formatting: passed.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation is not required because no configuration option or usage changes.
* [x] No incompatible change is introduced.
* [x] Existing connector registration, distribution, CI labels, E2E setup, and plugin configuration are unchanged.