### PR TITLE
[Improve][Connector-V2] Validate nonblank DataHub sink options

### DIFF
--- a/seatunnel-connectors-v2/connector-datahub/src/main/java/org/apache/seatunnel/connectors/seatunnel/datahub/sink/DataHubSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-datahub/src/main/java/org/apache/seatunnel/connectors/seatunnel/datahub/sink/DataHubSinkFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.datahub.sink;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.connector.TableSink;
@@ -44,7 +45,11 @@ public class DataHubSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(ENDPOINT, ACCESS_ID, ACCESS_KEY, PROJECT, TOPIC)
+                .required(ENDPOINT, Conditions.notBlank(ENDPOINT))
+                .required(ACCESS_ID, Conditions.notBlank(ACCESS_ID))
+                .required(ACCESS_KEY, Conditions.notBlank(ACCESS_KEY))
+                .required(PROJECT, Conditions.notBlank(PROJECT))
+                .required(TOPIC, Conditions.notBlank(TOPIC))
                 .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .optional(TIMEOUT, RETRY_TIMES)
                 .build();

--- a/seatunnel-connectors-v2/connector-datahub/src/test/java/org/apache/seatunnel/connectors/seatunnel/datahub/DataHubFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-datahub/src/test/java/org/apache/seatunnel/connectors/seatunnel/datahub/DataHubFactoryTest.java
@@ -45,11 +45,12 @@ class DataHubFactoryTest {
     }
 
     @Test
-    void testMissingRequiredOptionRejected() {
-        Map<String, Object> config = validConfig();
-        config.remove(DataHubSinkOptions.ENDPOINT.key());
-
-        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    void testMissingRequiredOptionsRejected() {
+        for (String key : requiredKeys()) {
+            Map<String, Object> config = validConfig();
+            config.remove(key);
+            Assertions.assertThrows(OptionValidationException.class, () -> validate(config), key);
+        }
     }
 
     @Test
@@ -63,19 +64,21 @@ class DataHubFactoryTest {
     }
 
     private void assertInvalidRequiredValue(String value) {
-        DataHubSinkOptions[] options = null;
-        for (String key :
-                new String[] {
-                    DataHubSinkOptions.ENDPOINT.key(),
-                    DataHubSinkOptions.ACCESS_ID.key(),
-                    DataHubSinkOptions.ACCESS_KEY.key(),
-                    DataHubSinkOptions.PROJECT.key(),
-                    DataHubSinkOptions.TOPIC.key()
-                }) {
+        for (String key : requiredKeys()) {
             Map<String, Object> config = validConfig();
             config.put(key, value);
             Assertions.assertThrows(OptionValidationException.class, () -> validate(config), key);
         }
+    }
+
+    private String[] requiredKeys() {
+        return new String[] {
+            DataHubSinkOptions.ENDPOINT.key(),
+            DataHubSinkOptions.ACCESS_ID.key(),
+            DataHubSinkOptions.ACCESS_KEY.key(),
+            DataHubSinkOptions.PROJECT.key(),
+            DataHubSinkOptions.TOPIC.key()
+        };
     }
 
     private void validate(Map<String, Object> config) {

--- a/seatunnel-connectors-v2/connector-datahub/src/test/java/org/apache/seatunnel/connectors/seatunnel/datahub/DataHubFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-datahub/src/test/java/org/apache/seatunnel/connectors/seatunnel/datahub/DataHubFactoryTest.java
@@ -17,15 +17,80 @@
 
 package org.apache.seatunnel.connectors.seatunnel.datahub;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.datahub.config.DataHubSinkOptions;
 import org.apache.seatunnel.connectors.seatunnel.datahub.sink.DataHubSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DataHubFactoryTest {
+import java.util.HashMap;
+import java.util.Map;
+
+class DataHubFactoryTest {
+
+    private final OptionRule optionRule = new DataHubSinkFactory().optionRule();
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new DataHubSinkFactory()).optionRule());
+        Assertions.assertNotNull(optionRule);
+    }
+
+    @Test
+    void testValidRequiredOptions() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testMissingRequiredOptionRejected() {
+        Map<String, Object> config = validConfig();
+        config.remove(DataHubSinkOptions.ENDPOINT.key());
+
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @Test
+    void testEmptyRequiredOptionsRejected() {
+        assertInvalidRequiredValue("");
+    }
+
+    @Test
+    void testWhitespaceOnlyRequiredOptionsRejected() {
+        assertInvalidRequiredValue("   \t");
+    }
+
+    private void assertInvalidRequiredValue(String value) {
+        DataHubSinkOptions[] options = null;
+        for (String key :
+                new String[] {
+                    DataHubSinkOptions.ENDPOINT.key(),
+                    DataHubSinkOptions.ACCESS_ID.key(),
+                    DataHubSinkOptions.ACCESS_KEY.key(),
+                    DataHubSinkOptions.PROJECT.key(),
+                    DataHubSinkOptions.TOPIC.key()
+                }) {
+            Map<String, Object> config = validConfig();
+            config.put(key, value);
+            Assertions.assertThrows(OptionValidationException.class, () -> validate(config), key);
+        }
+    }
+
+    private void validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "DataHubSink");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(DataHubSinkOptions.ENDPOINT.key(), "https://datahub.example.com");
+        config.put(DataHubSinkOptions.ACCESS_ID.key(), "access-id");
+        config.put(DataHubSinkOptions.ACCESS_KEY.key(), "access-key");
+        config.put(DataHubSinkOptions.PROJECT.key(), "project");
+        config.put(DataHubSinkOptions.TOPIC.key(), "topic");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

Related to #11007.

This PR implements the accepted connector-datahub factory-validation slice.

### What changed

- Keep `endpoint`, `accessId`, `accessKey`, `project`, and `topic` required.
- Add declarative `Conditions.notBlank(...)` validation to each required string option.
- Replace the placeholder factory test with focused validation coverage for:
  - valid configuration;
  - missing required options;
  - empty required options;
  - whitespace-only required options.
- Preserve option names and all existing nonblank configurations.
- Leave client construction, timeout/retry semantics, network behavior, and runtime error handling unchanged.

### Does this PR introduce _any_ user-facing change?

Yes.

Empty or whitespace-only values for required DataHub sink connection options are now rejected during connector option validation instead of reaching the DataHub client/runtime path.

Existing nonblank configurations are unchanged.

### How was this patch tested?

Focused `ConfigValidator` tests cover:

- valid configuration;
- missing required options;
- empty required options;
- whitespace-only required options;

for all five required string options.

Repository CI will run the connector test suite for this PR.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature.
* [ ] If necessary, please update `incompatible-changes.md`.