### PR TITLE
[Improve][Connector-V2] Validate Typesense connection options

### DIFF
--- a/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseSinkFactory.java
@@ -43,8 +43,7 @@ public class TypesenseSinkFactory implements TableSinkFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .required(
-                        TypesenseSinkOptions.HOSTS,
-                        Conditions.notEmpty(TypesenseSinkOptions.HOSTS))
+                        TypesenseSinkOptions.HOSTS, Conditions.notEmpty(TypesenseSinkOptions.HOSTS))
                 .required(
                         TypesenseSinkOptions.COLLECTION,
                         Conditions.notBlank(TypesenseSinkOptions.COLLECTION))

--- a/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseSinkFactory.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.connectors.seatunnel.typesense.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -43,10 +44,15 @@ public class TypesenseSinkFactory implements TableSinkFactory {
         return OptionRule.builder()
                 .required(
                         TypesenseSinkOptions.HOSTS,
+                        Conditions.notEmpty(TypesenseSinkOptions.HOSTS))
+                .required(
                         TypesenseSinkOptions.COLLECTION,
+                        Conditions.notBlank(TypesenseSinkOptions.COLLECTION))
+                .required(
                         TypesenseSinkOptions.APIKEY,
-                        TypesenseSinkOptions.SCHEMA_SAVE_MODE,
-                        TypesenseSinkOptions.DATA_SAVE_MODE)
+                        Conditions.notBlank(TypesenseSinkOptions.APIKEY))
+                .required(
+                        TypesenseSinkOptions.SCHEMA_SAVE_MODE, TypesenseSinkOptions.DATA_SAVE_MODE)
                 .optional(TypesenseSinkOptions.PRIMARY_KEYS)
                 .optional(TypesenseSinkOptions.KEY_DELIMITER)
                 .optional(TypesenseSinkOptions.MAX_BATCH_SIZE)

--- a/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/source/TypesenseSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/main/java/org/apache/seatunnel/connectors/seatunnel/typesense/source/TypesenseSourceFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.typesense.source;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
@@ -43,7 +44,12 @@ public class TypesenseSourceFactory implements TableSourceFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(TypesenseSourceOptions.HOSTS, TypesenseSourceOptions.APIKEY)
+                .required(
+                        TypesenseSourceOptions.HOSTS,
+                        Conditions.notEmpty(TypesenseSourceOptions.HOSTS))
+                .required(
+                        TypesenseSourceOptions.APIKEY,
+                        Conditions.notBlank(TypesenseSourceOptions.APIKEY))
                 .optional(TypesenseSourceOptions.PROTOCOL)
                 .optional(TypesenseSourceOptions.QUERY)
                 .optional(TypesenseSourceOptions.QUERY_BATCH_SIZE)

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -108,8 +108,7 @@ class TypesenseFactoryTest {
 
     private void assertInvalid(Map<String, Object> config, OptionRule optionRule) {
         Assertions.assertThrows(
-                OptionValidationException.class,
-                () -> validate(config, optionRule, "Typesense"));
+                OptionValidationException.class, () -> validate(config, optionRule, "Typesense"));
     }
 
     private void validate(Map<String, Object> config, OptionRule optionRule, String name) {

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -46,13 +46,15 @@ class TypesenseFactoryTest {
 
     @Test
     void testValidSourceConfiguration() {
-        Assertions.assertDoesNotThrow(\n                () -> validate(sourceConfig(), sourceOptionRule, "TypesenseSource"));
+        Assertions.assertDoesNotThrow(
+                () -> validate(sourceConfig(), sourceOptionRule, "TypesenseSource"));
     }
 
     @Test
     void testInvalidSourceConnectionOptions() {
         assertMissingRejected(sourceConfig(), TypesenseSourceOptions.HOSTS.key(), sourceOptionRule);
-        assertMissingRejected(\n                sourceConfig(), TypesenseSourceOptions.APIKEY.key(), sourceOptionRule);
+        assertMissingRejected(
+                sourceConfig(), TypesenseSourceOptions.APIKEY.key(), sourceOptionRule);
 
         Map<String, Object> emptyHosts = sourceConfig();
         emptyHosts.put(TypesenseSourceOptions.HOSTS.key(), Collections.emptyList());
@@ -66,7 +68,8 @@ class TypesenseFactoryTest {
 
     @Test
     void testValidSinkConfiguration() {
-        Assertions.assertDoesNotThrow(\n                () -> validate(sinkConfig(), sinkOptionRule, "TypesenseSink"));
+        Assertions.assertDoesNotThrow(
+                () -> validate(sinkConfig(), sinkOptionRule, "TypesenseSink"));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -46,13 +46,13 @@ class TypesenseFactoryTest {
 
     @Test
     void testValidSourceConfiguration() {
-        Assertions.assertDoesNotThrow(() -> validate(sourceConfig(), sourceOptionRule, "TypesenseSource"));
+        Assertions.assertDoesNotThrow(\n                () -> validate(sourceConfig(), sourceOptionRule, "TypesenseSource"));
     }
 
     @Test
     void testInvalidSourceConnectionOptions() {
         assertMissingRejected(sourceConfig(), TypesenseSourceOptions.HOSTS.key(), sourceOptionRule);
-        assertMissingRejected(sourceConfig(), TypesenseSourceOptions.APIKEY.key(), sourceOptionRule);
+        assertMissingRejected(\n                sourceConfig(), TypesenseSourceOptions.APIKEY.key(), sourceOptionRule);
 
         Map<String, Object> emptyHosts = sourceConfig();
         emptyHosts.put(TypesenseSourceOptions.HOSTS.key(), Collections.emptyList());
@@ -66,7 +66,7 @@ class TypesenseFactoryTest {
 
     @Test
     void testValidSinkConfiguration() {
-        Assertions.assertDoesNotThrow(() -> validate(sinkConfig(), sinkOptionRule, "TypesenseSink"));
+        Assertions.assertDoesNotThrow(\n                () -> validate(sinkConfig(), sinkOptionRule, "TypesenseSink"));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -119,7 +119,7 @@ class TypesenseFactoryTest {
 
     private Map<String, Object> sourceConfig() {
         Map<String, Object> config = new HashMap<>();
-        config.put(TypesenseSourceOptions.HOSTS.key(), List.of("localhost:8108"));
+        config.put(TypesenseSourceOptions.HOSTS.key(), Collections.singletonList("localhost:8108"));
         config.put(TypesenseSourceOptions.APIKEY.key(), "source-api-key");
         return config;
     }

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -17,16 +17,116 @@
 
 package org.apache.seatunnel.connectors.seatunnel.typesense.sink;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.typesense.config.TypesenseSinkOptions;
+import org.apache.seatunnel.connectors.seatunnel.typesense.config.TypesenseSourceOptions;
 import org.apache.seatunnel.connectors.seatunnel.typesense.source.TypesenseSourceFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TypesenseFactoryTest {
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class TypesenseFactoryTest {
+
+    private final OptionRule sourceOptionRule = new TypesenseSourceFactory().optionRule();
+    private final OptionRule sinkOptionRule = new TypesenseSinkFactory().optionRule();
 
     @Test
     void optionRule() {
-        Assertions.assertNotNull((new TypesenseSourceFactory()).optionRule());
-        Assertions.assertNotNull((new TypesenseSinkFactory()).optionRule());
+        Assertions.assertNotNull(sourceOptionRule);
+        Assertions.assertNotNull(sinkOptionRule);
+    }
+
+    @Test
+    void testValidSourceConfiguration() {
+        Assertions.assertDoesNotThrow(() -> validate(sourceConfig(), sourceOptionRule, "TypesenseSource"));
+    }
+
+    @Test
+    void testInvalidSourceConnectionOptions() {
+        assertMissingRejected(sourceConfig(), TypesenseSourceOptions.HOSTS.key(), sourceOptionRule);
+        assertMissingRejected(sourceConfig(), TypesenseSourceOptions.APIKEY.key(), sourceOptionRule);
+
+        Map<String, Object> emptyHosts = sourceConfig();
+        emptyHosts.put(TypesenseSourceOptions.HOSTS.key(), Collections.emptyList());
+        assertInvalid(emptyHosts, sourceOptionRule);
+
+        assertStringValueRejected(
+                sourceConfig(), TypesenseSourceOptions.APIKEY.key(), "", sourceOptionRule);
+        assertStringValueRejected(
+                sourceConfig(), TypesenseSourceOptions.APIKEY.key(), "   \t", sourceOptionRule);
+    }
+
+    @Test
+    void testValidSinkConfiguration() {
+        Assertions.assertDoesNotThrow(() -> validate(sinkConfig(), sinkOptionRule, "TypesenseSink"));
+    }
+
+    @Test
+    void testInvalidSinkConnectionOptions() {
+        assertMissingRejected(sinkConfig(), TypesenseSinkOptions.HOSTS.key(), sinkOptionRule);
+        assertMissingRejected(sinkConfig(), TypesenseSinkOptions.COLLECTION.key(), sinkOptionRule);
+        assertMissingRejected(sinkConfig(), TypesenseSinkOptions.APIKEY.key(), sinkOptionRule);
+
+        Map<String, Object> emptyHosts = sinkConfig();
+        emptyHosts.put(TypesenseSinkOptions.HOSTS.key(), Collections.emptyList());
+        assertInvalid(emptyHosts, sinkOptionRule);
+
+        for (String key :
+                new String[] {
+                    TypesenseSinkOptions.COLLECTION.key(), TypesenseSinkOptions.APIKEY.key()
+                }) {
+            assertStringValueRejected(sinkConfig(), key, "", sinkOptionRule);
+            assertStringValueRejected(sinkConfig(), key, "   \t", sinkOptionRule);
+        }
+    }
+
+    private void assertMissingRejected(
+            Map<String, Object> config, String key, OptionRule optionRule) {
+        config.remove(key);
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> validate(config, optionRule, "Typesense"),
+                key);
+    }
+
+    private void assertStringValueRejected(
+            Map<String, Object> config, String key, String value, OptionRule optionRule) {
+        config.put(key, value);
+        assertInvalid(config, optionRule);
+    }
+
+    private void assertInvalid(Map<String, Object> config, OptionRule optionRule) {
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () -> validate(config, optionRule, "Typesense"));
+    }
+
+    private void validate(Map<String, Object> config, OptionRule optionRule, String name) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, name);
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private Map<String, Object> sourceConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(TypesenseSourceOptions.HOSTS.key(), List.of("localhost:8108"));
+        config.put(TypesenseSourceOptions.APIKEY.key(), "source-api-key");
+        return config;
+    }
+
+    private Map<String, Object> sinkConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(TypesenseSinkOptions.HOSTS.key(), List.of("localhost:8108"));
+        config.put(TypesenseSinkOptions.COLLECTION.key(), "collection");
+        config.put(TypesenseSinkOptions.APIKEY.key(), "sink-api-key");
+        return config;
     }
 }

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 class TypesenseFactoryTest {

--- a/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-typesense/src/test/java/org/apache/seatunnel/connectors/seatunnel/typesense/sink/TypesenseFactoryTest.java
@@ -126,7 +126,7 @@ class TypesenseFactoryTest {
 
     private Map<String, Object> sinkConfig() {
         Map<String, Object> config = new HashMap<>();
-        config.put(TypesenseSinkOptions.HOSTS.key(), List.of("localhost:8108"));
+        config.put(TypesenseSinkOptions.HOSTS.key(), Collections.singletonList("localhost:8108"));
         config.put(TypesenseSinkOptions.COLLECTION.key(), "collection");
         config.put(TypesenseSinkOptions.APIKEY.key(), "sink-api-key");
         return config;


### PR DESCRIPTION
### Purpose of this pull request

Related to #11007.

This PR implements the accepted connector-typesense source-and-sink factory-validation slice.

### What changed

- Preserve the existing source and sink required/optional structure.
- Add `Conditions.notEmpty(...)` validation for required `hosts`.
- Add `Conditions.notBlank(...)` validation for required string connection options:
  - source: `api_key`
  - sink: `api_key`, `collection`
- Leave enum-valued `schema_save_mode` and `data_save_mode` unchanged.
- Replace the placeholder factory test with focused source and sink validation coverage.
- Preserve option names, defaults, and all existing valid nonblank configurations.
- Do not modify the catalog factory, client construction, network behavior, remote Typesense validation, or schema/data-dependent checks.

### Does this PR introduce _any_ user-facing change?

Yes.

Invalid empty connection configurations are now rejected during connector option validation instead of reaching the Typesense client/runtime path.

Existing valid nonblank configurations and save-mode behavior are unchanged.

### How was this patch tested?

Focused `ConfigValidator` coverage was added for both source and sink configurations, including:

- valid configurations;
- missing required connection options;
- empty `hosts`;
- empty required string values;
- whitespace-only required string values.

Repository CI will run the connector test suite for this PR.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature.
* [ ] If necessary, please update `incompatible-changes.md`.