### PR TITLE
[Improve][Zeta] Reduce lock contention in ProtoStuff schema lookup

### DIFF
--- a/seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf/src/main/java/org/apache/seatunnel/engine/serializer/protobuf/ProtoStuffSerializer.java
+++ b/seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf/src/main/java/org/apache/seatunnel/engine/serializer/protobuf/ProtoStuffSerializer.java
@@ -53,7 +53,7 @@ public class ProtoStuffSerializer implements Serializer {
 
     @SuppressWarnings("unchecked")
     private static <T> Schema<T> getSchema(Class<T> clazz) {
-        // Avoid computeIfAbsent's cache-hit locking on Java 8.
+        // Return cached schemas directly, using computeIfAbsent only on cache misses.
         Schema<?> schema = SCHEMA_CACHE.get(clazz);
         if (schema == null) {
             return (Schema<T>) SCHEMA_CACHE.computeIfAbsent(clazz, RuntimeSchema::createFrom);

--- a/seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf/src/main/java/org/apache/seatunnel/engine/serializer/protobuf/ProtoStuffSerializer.java
+++ b/seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf/src/main/java/org/apache/seatunnel/engine/serializer/protobuf/ProtoStuffSerializer.java
@@ -46,10 +46,19 @@ public class ProtoStuffSerializer implements Serializer {
     /** At the moment it looks like we only have one Schema. */
     private static final Map<Class<?>, Schema<?>> SCHEMA_CACHE = new ConcurrentHashMap<>();
 
+    static {
+        // Configure null preservation once, before creating the first runtime schema.
+        System.setProperty("protostuff.runtime.preserve_null_elements", "true");
+    }
+
     @SuppressWarnings("unchecked")
     private static <T> Schema<T> getSchema(Class<T> clazz) {
-        System.setProperty("protostuff.runtime.preserve_null_elements", "true");
-        return (Schema<T>) SCHEMA_CACHE.computeIfAbsent(clazz, RuntimeSchema::createFrom);
+        // Avoid computeIfAbsent's cache-hit locking on Java 8.
+        Schema<?> schema = SCHEMA_CACHE.get(clazz);
+        if (schema == null) {
+            return (Schema<T>) SCHEMA_CACHE.computeIfAbsent(clazz, RuntimeSchema::createFrom);
+        }
+        return (Schema<T>) schema;
     }
 
     private static final Set<Class<?>> WRAPPERS = new HashSet<>();

--- a/seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf/src/test/java/org/apache/seatunnel/engine/serializer/protobuf/ProtoStuffSerializerTest.java
+++ b/seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf/src/test/java/org/apache/seatunnel/engine/serializer/protobuf/ProtoStuffSerializerTest.java
@@ -23,7 +23,63 @@ package org.apache.seatunnel.engine.serializer.protobuf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 public class ProtoStuffSerializerTest {
+
+    @Test
+    public void testConcurrentSchemaInitializationAndReuse() throws Exception {
+        int threads = 8;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        ProtoStuffSerializer serializer = new ProtoStuffSerializer();
+        List<Future<?>> results = new ArrayList<>();
+        try {
+            for (int thread = 0; thread < threads; thread++) {
+                final int id = thread;
+                results.add(
+                        executor.submit(
+                                () -> {
+                                    ready.countDown();
+                                    Assertions.assertTrue(start.await(30, TimeUnit.SECONDS));
+                                    for (int iteration = 0; iteration < 100; iteration++) {
+                                        ConcurrentPayload input = new ConcurrentPayload();
+                                        input.id = id;
+                                        input.values = Arrays.asList("before", null, "after");
+                                        ConcurrentPayload output =
+                                                serializer.deserialize(
+                                                        serializer.serialize(input),
+                                                        ConcurrentPayload.class);
+                                        Assertions.assertEquals(input.id, output.id);
+                                        Assertions.assertEquals(input.values, output.values);
+                                    }
+                                    return null;
+                                }));
+            }
+            Assertions.assertTrue(ready.await(30, TimeUnit.SECONDS));
+            start.countDown();
+            for (Future<?> result : results) {
+                result.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            Assertions.assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+        }
+    }
+
+    public static class ConcurrentPayload {
+        public int id;
+        public List<String> values;
+    }
 
     @Test
     public void testProtoStuffSerializerForArrayType() {


### PR DESCRIPTION
### Purpose of this pull request

Reduce lock contention in `ProtoStuffSerializer` schema lookup during concurrent serialization and deserialization.

- Set `protostuff.runtime.preserve_null_elements` once during class initialization, before the first runtime schema is created, instead of updating the global system properties on every schema lookup.
- Use `SCHEMA_CACHE.get()` for cache hits, avoiding the cache-hit locking in Java 8's `ConcurrentHashMap.computeIfAbsent()`.
- Retain `computeIfAbsent()` for cache misses so schema creation and publication remain atomic.

This change is limited to schema lookup; it does not change WAL recovery logic.

### Does this PR introduce _any_ user-facing change?

No. Public APIs, serialized data format and null-element preservation are unchanged.

### How was this patch tested?

- `./mvnw spotless:apply` — passed.
- Java 8: `./mvnw -pl seatunnel-engine/seatunnel-engine-serializer/serializer-protobuf -am -Dtest=ProtoStuffSerializerTest -Dsurefire.failIfNoSpecifiedTests=false test` — passed (3 tests).
- Added concurrent first-use and cache-reuse coverage with eight threads, including round trips of payloads containing null list elements. Existing array/null-element tests also pass.

### Before optimization:  / Wall / Lock evidence

1. wall:
 
<img width="6000" height="1898" alt="image" src="https://github.com/user-attachments/assets/871901e1-b1ed-458d-b270-7c1e4dd575da" />

2. lock:

- all:

<img width="5954" height="1364" alt="image" src="https://github.com/user-attachments/assets/f8a9ae7b-f354-4ebe-bc84-12eb099e2c02" />

- sigle sample

<img width="5962" height="1336" alt="image" src="https://github.com/user-attachments/assets/26c85ab8-9e30-4e6b-8db3-5042c92bf7d8" />


### After optimization: No schema-lookup lock contention observed
 
  The lock profile no longer shows contention through `ProtoStuffSerializer.getSchema()`. Remaining lock events originate from other code paths.

- all:

<img width="5986" height="1840" alt="image" src="https://github.com/user-attachments/assets/55623ccc-38ce-40a0-81f3-304e484d4ab4" />


-  sigle sample

<img width="5964" height="1274" alt="image" src="https://github.com/user-attachments/assets/6d2972c6-cbbf-4e85-b36b-e584a55575fa" />


### After optimization: Lock evidence — target contention no longer observed

1. lock:

- all:

<img width="5988" height="1504" alt="image" src="https://github.com/user-attachments/assets/c8f5d93a-b235-4ab2-a42e-e9b1fbc109f2" />


- sigle sample

<img width="5994" height="878" alt="image" src="https://github.com/user-attachments/assets/12e5d3f9-29c9-4ed4-87ec-6e4c27f5d10e" />



### Check list

- No new dependencies or binary packages.
- No configuration, public API or serialized-format changes requiring migration documentation.
