### PR TITLE
[Test][Zeta] Add ProtoStuff serializer microbenchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,6 +37,7 @@ on:
           - 'SeaTunnelRowBenchmark'
           - 'IntermediateQueueBenchmark'
           - 'DebeziumJsonFormatBenchmark'
+          - 'ProtoStuffSerializerBenchmark'
           - 'SeaTunnelPipelineBenchmark'
           - 'CheckpointingTimeBenchmark'
           - 'CheckpointStorageBenchmark'

--- a/docs/en/engines/zeta/benchmark.md
+++ b/docs/en/engines/zeta/benchmark.md
@@ -185,7 +185,7 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchma
   -rf json -rff seatunnel-benchmarks/target/protostuff.json
 ```
 
-Measures in-memory `IMapFileData` serialization and deserialization throughput (`ops/ms`) with eight
+Measures in-memory `IMapFileData` serialization and deserialization throughput (`ops/ms`) with four
 threads by default. Both methods exercise shared schema-cache lookup, excluding file I/O and
 Hazelcast scheduling.
 

--- a/docs/en/engines/zeta/benchmark.md
+++ b/docs/en/engines/zeta/benchmark.md
@@ -178,6 +178,39 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
 For a quick functional validation, add `-f 1 -wi 0 -i 1 -r 1s` to shorten the run. A single un-warmed
 sample is not valid performance evidence.
 
+### Run the ProtoStuff Serializer Microbenchmarks
+
+`ProtoStuffSerializerBenchmark` isolates the in-memory serialization and deserialization of one
+`IMapFileData` WAL envelope. Its fixed fixture contains a pre-serialized Long key and a
+1,024-character ASCII String value. Nested key/value conversion, filesystem access, and Hazelcast
+are outside the measured path. Setup prepares the input and initializes the schema; normal
+per-call serializer allocations remain measured.
+
+`IMapFileData` does not use the serializer's wrapper path: both methods call `getSchema` on
+every invocation. The default is eight threads to expose contention on the shared schema cache.
+Scores are throughput in `ops/ms` (higher is better). JVM limits match the pipeline benchmark:
+4 GiB heap, G1, pre-touch, disabled explicit GC, and four visible processors.
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
+  -rf json -rff seatunnel-benchmarks/target/protostuff.json
+```
+
+Thread-local fixtures share the production static schema cache. Compare revisions at the same
+thread count, JDK, hardware, and JMH settings; multi-thread throughput is the total across threads.
+The methods are `serializeWalRecord` and `deserializeWalRecord`. For separate GC or lock profiling:
+
+```bash
+bash tools/benchmarks/profile_benchmarks.sh profile gc \
+  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
+bash tools/benchmarks/profile_benchmarks.sh profile lock \
+  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
+```
+
+Use unprofiled runs for performance comparisons. This measures warm-schema performance, not cold
+initialization or end-to-end recovery. The class can also be selected in the Benchmarks workflow
+without expanding the default `benchmarks_core` suite.
+
 ### Run the Checkpoint Benchmark
 
 ```bash

--- a/docs/en/engines/zeta/benchmark.md
+++ b/docs/en/engines/zeta/benchmark.md
@@ -180,36 +180,14 @@ sample is not valid performance evidence.
 
 ### Run the ProtoStuff Serializer Microbenchmarks
 
-`ProtoStuffSerializerBenchmark` isolates the in-memory serialization and deserialization of one
-`IMapFileData` WAL envelope. Its fixed fixture contains a pre-serialized Long key and a
-1,024-character ASCII String value. Nested key/value conversion, filesystem access, and Hazelcast
-are outside the measured path. Setup prepares the input and initializes the schema; normal
-per-call serializer allocations remain measured.
-
-`IMapFileData` does not use the serializer's wrapper path: both methods call `getSchema` on
-every invocation. The default is eight threads to expose contention on the shared schema cache.
-Scores are throughput in `ops/ms` (higher is better). JVM limits match the pipeline benchmark:
-4 GiB heap, G1, pre-touch, disabled explicit GC, and four visible processors.
-
 ```bash
 java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
   -rf json -rff seatunnel-benchmarks/target/protostuff.json
 ```
 
-Thread-local fixtures share the production static schema cache. Compare revisions at the same
-thread count, JDK, hardware, and JMH settings; multi-thread throughput is the total across threads.
-The methods are `serializeWalRecord` and `deserializeWalRecord`. For separate GC or lock profiling:
-
-```bash
-bash tools/benchmarks/profile_benchmarks.sh profile gc \
-  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
-bash tools/benchmarks/profile_benchmarks.sh profile lock \
-  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
-```
-
-Use unprofiled runs for performance comparisons. This measures warm-schema performance, not cold
-initialization or end-to-end recovery. The class can also be selected in the Benchmarks workflow
-without expanding the default `benchmarks_core` suite.
+Measures in-memory `IMapFileData` serialization and deserialization throughput (`ops/ms`) with eight
+threads by default. Both methods exercise shared schema-cache lookup, excluding file I/O and
+Hazelcast scheduling.
 
 ### Run the Checkpoint Benchmark
 

--- a/docs/zh/engines/zeta/benchmark.md
+++ b/docs/zh/engines/zeta/benchmark.md
@@ -169,6 +169,37 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
 快速功能验证时可以增加 `-f 1 -wi 0 -i 1 -r 1s` 缩短运行时间。没有预热且只有一个样本的
 结果不能用于性能结论。
 
+### 运行 ProtoStuff 序列化微基准
+
+`ProtoStuffSerializerBenchmark` 单独测量一个 `IMapFileData` WAL 外层记录在内存中的序列化和
+反序列化。固定输入包含预先序列化的 Long key 和 1,024 个 ASCII 字符的 String value。
+嵌套 key/value 的转换、文件系统访问和 Hazelcast 不在计时范围内。Setup 准备输入并初始化
+Schema，序列化器每次调用正常产生的内存分配仍计入测量。
+
+`IMapFileData` 不走序列化器的 wrapper 分支：两个被测方法每次调用都会进入 `getSchema`。
+默认使用 8 个线程，以暴露共享 Schema 缓存的锁竞争。
+Score 为吞吐，单位 `ops/ms`，越大越好。JVM 资源限制与 Pipeline 基准一致：4 GiB 堆、
+G1、预触页、禁用显式 GC，以及 4 个可见处理器。
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
+  -rf json -rff seatunnel-benchmarks/target/protostuff.json
+```
+
+各线程独立持有输入，但共享生产序列化器的静态 Schema 缓存。前后版本应使用相同的线程数、
+JDK、机器和 JMH 配置；多线程吞吐是所有线程的总吞吐。两个方法分别是 `serializeWalRecord`
+和 `deserializeWalRecord`。可以单独运行 GC 或 lock 诊断：
+
+```bash
+bash tools/benchmarks/profile_benchmarks.sh profile gc \
+  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
+bash tools/benchmarks/profile_benchmarks.sh profile lock \
+  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
+```
+
+性能对比使用不带 profiler 的结果。这里测量 Schema 缓存预热后的性能，不测首次初始化或
+完整恢复耗时。Benchmarks workflow 中也可以选择该类，不增加默认 `benchmarks_core` 套件的范围。
+
 ### 运行 Checkpoint 基准测试
 
 ```bash

--- a/docs/zh/engines/zeta/benchmark.md
+++ b/docs/zh/engines/zeta/benchmark.md
@@ -176,7 +176,7 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchma
   -rf json -rff seatunnel-benchmarks/target/protostuff.json
 ```
 
-默认使用 8 个线程，测量 `IMapFileData` 的内存序列化和反序列化吞吐（`ops/ms`）。
+默认使用 4 个线程，测量 `IMapFileData` 的内存序列化和反序列化吞吐（`ops/ms`）。
 两个方法均覆盖共享 Schema 缓存的查询路径，不包含文件 I/O 和 Hazelcast 调度。
 
 ### 运行 Checkpoint 基准测试

--- a/docs/zh/engines/zeta/benchmark.md
+++ b/docs/zh/engines/zeta/benchmark.md
@@ -171,34 +171,13 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
 
 ### 运行 ProtoStuff 序列化微基准
 
-`ProtoStuffSerializerBenchmark` 单独测量一个 `IMapFileData` WAL 外层记录在内存中的序列化和
-反序列化。固定输入包含预先序列化的 Long key 和 1,024 个 ASCII 字符的 String value。
-嵌套 key/value 的转换、文件系统访问和 Hazelcast 不在计时范围内。Setup 准备输入并初始化
-Schema，序列化器每次调用正常产生的内存分配仍计入测量。
-
-`IMapFileData` 不走序列化器的 wrapper 分支：两个被测方法每次调用都会进入 `getSchema`。
-默认使用 8 个线程，以暴露共享 Schema 缓存的锁竞争。
-Score 为吞吐，单位 `ops/ms`，越大越好。JVM 资源限制与 Pipeline 基准一致：4 GiB 堆、
-G1、预触页、禁用显式 GC，以及 4 个可见处理器。
-
 ```bash
 java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
   -rf json -rff seatunnel-benchmarks/target/protostuff.json
 ```
 
-各线程独立持有输入，但共享生产序列化器的静态 Schema 缓存。前后版本应使用相同的线程数、
-JDK、机器和 JMH 配置；多线程吞吐是所有线程的总吞吐。两个方法分别是 `serializeWalRecord`
-和 `deserializeWalRecord`。可以单独运行 GC 或 lock 诊断：
-
-```bash
-bash tools/benchmarks/profile_benchmarks.sh profile gc \
-  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
-bash tools/benchmarks/profile_benchmarks.sh profile lock \
-  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
-```
-
-性能对比使用不带 profiler 的结果。这里测量 Schema 缓存预热后的性能，不测首次初始化或
-完整恢复耗时。Benchmarks workflow 中也可以选择该类，不增加默认 `benchmarks_core` 套件的范围。
+默认使用 8 个线程，测量 `IMapFileData` 的内存序列化和反序列化吞吐（`ops/ms`）。
+两个方法均覆盖共享 Schema 缓存的查询路径，不包含文件 I/O 和 Hazelcast 调度。
 
 ### 运行 Checkpoint 基准测试
 

--- a/seatunnel-benchmarks/README.md
+++ b/seatunnel-benchmarks/README.md
@@ -49,6 +49,40 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
   -rff seatunnel-benchmarks/target/benchmark-result.json
 ```
 
+## Run ProtoStuff serialization microbenchmarks
+
+`ProtoStuffSerializerBenchmark` measures one `IMapFileData` envelope per operation, with a
+pre-serialized Long key and a fixed 1,024-character ASCII String value. It does not measure nested
+key/value conversion, disk I/O, Hazelcast, or cluster startup. Setup prepares the input and warms
+the schema cache; the measured calls retain normal serializer allocations.
+
+The envelope is not a `SerializerDeserializerWrapper`: both measured methods call `getSchema`
+on every invocation. Eight threads are used by default to expose contention on the shared cache.
+Scores are throughput in `ops/ms` (higher is better), with a fixed 4 GiB heap, G1, pre-touch,
+disabled explicit GC, and four JVM-visible processors, matching the pipeline benchmark's JVM limits.
+
+Run both methods with the default eight threads (the static schema cache is shared):
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
+  -rf json -rff seatunnel-benchmarks/target/protostuff.json
+```
+
+For allocation or lock diagnostics, select one method with the existing profiling script:
+
+```bash
+bash tools/benchmarks/profile_benchmarks.sh profile gc \
+  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
+bash tools/benchmarks/profile_benchmarks.sh profile lock \
+  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
+```
+
+Compare revisions using the same JDK, hardware, thread count, and JMH settings. Multi-thread
+throughput is the total across threads. Run performance comparisons without profilers and collect
+profiles separately. This is a warm-cache microbenchmark, not a cold schema
+initialization or end-to-end WAL recovery benchmark. The Benchmarks workflow also exposes this
+class; it is not added to the default `benchmarks_core` suite.
+
 ## Run Zeta full-pipeline benchmarks
 
 ```bash

--- a/seatunnel-benchmarks/README.md
+++ b/seatunnel-benchmarks/README.md
@@ -41,6 +41,12 @@ Run only the `SeaTunnelRow` benchmarks:
 java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark
 ```
 
+Run only the `ProtoStuffSerializer` benchmarks:
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark
+```
+
 Write JSON results:
 
 ```bash
@@ -48,17 +54,6 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
   -rf json \
   -rff seatunnel-benchmarks/target/benchmark-result.json
 ```
-
-## Run ProtoStuff serialization microbenchmarks
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
-  -rf json -rff seatunnel-benchmarks/target/protostuff.json
-```
-
-Measures in-memory `IMapFileData` serialization and deserialization throughput (`ops/ms`) with eight
-threads by default. Both methods exercise shared schema-cache lookup, excluding file I/O and
-Hazelcast scheduling.
 
 ## Run Zeta full-pipeline benchmarks
 

--- a/seatunnel-benchmarks/README.md
+++ b/seatunnel-benchmarks/README.md
@@ -51,37 +51,14 @@ java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
 
 ## Run ProtoStuff serialization microbenchmarks
 
-`ProtoStuffSerializerBenchmark` measures one `IMapFileData` envelope per operation, with a
-pre-serialized Long key and a fixed 1,024-character ASCII String value. It does not measure nested
-key/value conversion, disk I/O, Hazelcast, or cluster startup. Setup prepares the input and warms
-the schema cache; the measured calls retain normal serializer allocations.
-
-The envelope is not a `SerializerDeserializerWrapper`: both measured methods call `getSchema`
-on every invocation. Eight threads are used by default to expose contention on the shared cache.
-Scores are throughput in `ops/ms` (higher is better), with a fixed 4 GiB heap, G1, pre-touch,
-disabled explicit GC, and four JVM-visible processors, matching the pipeline benchmark's JVM limits.
-
-Run both methods with the default eight threads (the static schema cache is shared):
-
 ```bash
 java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
   -rf json -rff seatunnel-benchmarks/target/protostuff.json
 ```
 
-For allocation or lock diagnostics, select one method with the existing profiling script:
-
-```bash
-bash tools/benchmarks/profile_benchmarks.sh profile gc \
-  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
-bash tools/benchmarks/profile_benchmarks.sh profile lock \
-  --benchmark 'ProtoStuffSerializerBenchmark.deserializeWalRecord$' -- -t 8
-```
-
-Compare revisions using the same JDK, hardware, thread count, and JMH settings. Multi-thread
-throughput is the total across threads. Run performance comparisons without profilers and collect
-profiles separately. This is a warm-cache microbenchmark, not a cold schema
-initialization or end-to-end WAL recovery benchmark. The Benchmarks workflow also exposes this
-class; it is not added to the default `benchmarks_core` suite.
+Measures in-memory `IMapFileData` serialization and deserialization throughput (`ops/ms`) with eight
+threads by default. Both methods exercise shared schema-cache lookup, excluding file I/O and
+Hazelcast scheduling.
 
 ## Run Zeta full-pipeline benchmarks
 

--- a/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmark.java
+++ b/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmark.java
@@ -35,12 +35,12 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>One operation encodes or decodes one IMapFileData envelope, not its nested key/value objects.
  * No filesystem, Hazelcast, or Zeta runtime is started. Thread-local fixtures share the production
- * serializer's static schema cache, so JMH {@code -t 1} and {@code -t 8} can exercise the same
- * cache-hit path without sharing mutable input objects. Eight threads are used by default to expose
- * contention on the shared cache. IMapFileData is not a serializer wrapper type: both measured
- * methods call getSchema on every invocation, even after setup initializes the schema.
+ * serializer's static schema cache without sharing mutable input objects. Four threads are used by
+ * default to exercise concurrent lookup on the standard four-vCPU runner. IMapFileData is not a
+ * serializer wrapper type: both measured methods call getSchema on every invocation, even after
+ * setup initializes the schema.
  */
-@Threads(8)
+@Threads(4)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(

--- a/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmark.java
+++ b/seatunnel-benchmarks/src/main/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmark.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.benchmark;
+
+import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
+import org.apache.seatunnel.engine.serializer.protobuf.ProtoStuffSerializer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Pure in-memory microbenchmarks for the steady-state ProtoStuff WAL record codec.
+ *
+ * <p>One operation encodes or decodes one IMapFileData envelope, not its nested key/value objects.
+ * No filesystem, Hazelcast, or Zeta runtime is started. Thread-local fixtures share the production
+ * serializer's static schema cache, so JMH {@code -t 1} and {@code -t 8} can exercise the same
+ * cache-hit path without sharing mutable input objects. Eight threads are used by default to expose
+ * contention on the shared cache. IMapFileData is not a serializer wrapper type: both measured
+ * methods call getSchema on every invocation, even after setup initializes the schema.
+ */
+@Threads(8)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(
+        value = 3,
+        jvmArgsAppend = {
+            "-Xms4g",
+            "-Xmx4g",
+            "-XX:+UseG1GC",
+            "-XX:+AlwaysPreTouch",
+            "-XX:+DisableExplicitGC",
+            "-XX:ActiveProcessorCount=4",
+            "-Djava.net.preferIPv4Stack=true"
+        })
+public class ProtoStuffSerializerBenchmark extends BenchmarkBase {
+
+    private ProtoStuffSerializer serializer;
+    private IMapFileData record;
+    private byte[] serializedRecord;
+
+    /** Prepare a fixed WAL record and initialize its schema outside the measured methods. */
+    @Setup
+    public void setUp() {
+        serializer = new ProtoStuffSerializer();
+        char[] payload = new char[1024];
+        for (int index = 0; index < payload.length; index++) {
+            payload[index] = (char) ('a' + index % 26);
+        }
+        record =
+                IMapFileData.builder()
+                        .deleted(false)
+                        .key(serializer.serialize(1001L))
+                        .keyClassName(Long.class.getName())
+                        .value(serializer.serialize(new String(payload)))
+                        .valueClassName(String.class.getName())
+                        .timestamp(1_700_000_000_000L)
+                        .build();
+        serializedRecord = serializer.serialize(record);
+        if (!record.equals(serializer.deserialize(serializedRecord, IMapFileData.class))) {
+            throw new IllegalStateException("ProtoStuff WAL record fixture failed to round-trip");
+        }
+    }
+
+    /** Encode one WAL envelope, including the serializer's normal buffer/output allocations. */
+    @Benchmark
+    public byte[] serializeWalRecord() {
+        return serializer.serialize(record);
+    }
+
+    /** Decode one prepared WAL envelope into a newly allocated object. */
+    @Benchmark
+    public IMapFileData deserializeWalRecord() {
+        return serializer.deserialize(serializedRecord, IMapFileData.class);
+    }
+}

--- a/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmarkTest.java
+++ b/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmarkTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.benchmark;
+
+import org.apache.seatunnel.engine.imap.storage.file.bean.IMapFileData;
+import org.apache.seatunnel.engine.serializer.protobuf.ProtoStuffSerializer;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class ProtoStuffSerializerBenchmarkTest {
+
+    @Test
+    void shouldExerciseConcurrentSchemaLookupByDefault() {
+        assertEquals(8, ProtoStuffSerializerBenchmark.class.getAnnotation(Threads.class).value());
+        assertArrayEquals(
+                new Mode[] {Mode.Throughput},
+                ProtoStuffSerializerBenchmark.class.getAnnotation(BenchmarkMode.class).value());
+        assertEquals(
+                TimeUnit.MILLISECONDS,
+                ProtoStuffSerializerBenchmark.class.getAnnotation(OutputTimeUnit.class).value());
+        Fork fork = ProtoStuffSerializerBenchmark.class.getAnnotation(Fork.class);
+        assertEquals(3, fork.value());
+        assertArrayEquals(
+                SeaTunnelPipelineBenchmark.class.getAnnotation(Fork.class).jvmArgsAppend(),
+                fork.jvmArgsAppend());
+    }
+
+    @Test
+    void shouldRoundTripTheWalEnvelopeAndItsPreparedPayload() {
+        ProtoStuffSerializerBenchmark benchmark = new ProtoStuffSerializerBenchmark();
+        benchmark.setUp();
+        ProtoStuffSerializer serializer = new ProtoStuffSerializer();
+
+        IMapFileData record = benchmark.deserializeWalRecord();
+        assertFalse(record.isDeleted());
+        assertEquals(Long.class.getName(), record.getKeyClassName());
+        assertEquals(String.class.getName(), record.getValueClassName());
+        assertEquals(1_700_000_000_000L, record.getTimestamp());
+        assertEquals(Long.valueOf(1001L), serializer.deserialize(record.getKey(), Long.class));
+        String payload = serializer.deserialize(record.getValue(), String.class);
+        assertEquals(1024, payload.length());
+        for (int index = 0; index < payload.length(); index++) {
+            assertEquals((char) ('a' + index % 26), payload.charAt(index));
+        }
+        for (int iteration = 0; iteration < 10; iteration++) {
+            IMapFileData decoded =
+                    serializer.deserialize(benchmark.serializeWalRecord(), IMapFileData.class);
+            assertEquals(record, decoded);
+            assertEquals(record, benchmark.deserializeWalRecord());
+        }
+    }
+
+    @Test
+    void shouldReturnFreshResultsWithoutMutatingTheReusableInputs() {
+        ProtoStuffSerializerBenchmark benchmark = new ProtoStuffSerializerBenchmark();
+        benchmark.setUp();
+
+        byte[] expectedBytes = benchmark.serializeWalRecord();
+        byte[] output = benchmark.serializeWalRecord();
+        assertNotSame(expectedBytes, output);
+        output[0] ^= 1;
+        assertArrayEquals(expectedBytes, benchmark.serializeWalRecord());
+
+        IMapFileData expected = benchmark.deserializeWalRecord();
+        IMapFileData decoded = benchmark.deserializeWalRecord();
+        assertNotSame(expected, decoded);
+        decoded.getKey()[0] ^= 1;
+        decoded.getValue()[0] ^= 1;
+        decoded.setTimestamp(0);
+        assertEquals(expected, benchmark.deserializeWalRecord());
+        assertArrayEquals(expectedBytes, benchmark.serializeWalRecord());
+    }
+}

--- a/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmarkTest.java
+++ b/seatunnel-benchmarks/src/test/java/org/apache/seatunnel/benchmark/ProtoStuffSerializerBenchmarkTest.java
@@ -38,7 +38,7 @@ class ProtoStuffSerializerBenchmarkTest {
 
     @Test
     void shouldExerciseConcurrentSchemaLookupByDefault() {
-        assertEquals(8, ProtoStuffSerializerBenchmark.class.getAnnotation(Threads.class).value());
+        assertEquals(4, ProtoStuffSerializerBenchmark.class.getAnnotation(Threads.class).value());
         assertArrayEquals(
                 new Mode[] {Mode.Throughput},
                 ProtoStuffSerializerBenchmark.class.getAnnotation(BenchmarkMode.class).value());


### PR DESCRIPTION
### Purpose of this pull request

Add a focused JMH microbenchmark for concurrent `ProtoStuffSerializer` serialization and deserialization, so future changes to this shared serialization path can be compared using a repeatable workload and the existing benchmark reports.

#### Background

While investigating `IMapWalStorageBenchmark.recoverAll`, lock profiles identified contention in `ProtoStuffSerializer.getSchema()`. The measured stacks included repeatedly setting `protostuff.runtime.preserve_null_elements` and accessing the schema cache through `ConcurrentHashMap.computeIfAbsent`. The related optimization is described in https://github.com/apache/seatunnel/pull/12176.

The serializer is used by the engine's file-backed IMap storage and checkpoint-related code. WAL writing serializes keys, values, and the outer `IMapFileData` record; recovery deserializes those records and their contents. Repeated schema lookup is therefore part of actual storage processing, rather than an isolated utility call used only during startup.

The existing WAL benchmark is useful for evaluating overall recovery, but its result also includes file enumeration, filesystem access, record processing, and Hazelcast scheduling. These costs can make it difficult to isolate the effect of a serializer change. A smaller in-memory benchmark complements that coverage: it measures the serializer directly, while the existing WAL benchmark can show how much of an improvement carries through to recovery.

This PR establishes that measurement baseline. It does not change the production serializer, include the optimization from PR #12176, or claim a measured speedup.

#### What is measured

- `ProtoStuffSerializerBenchmark.serializeWalRecord`: serialize one `IMapFileData` record.
- `ProtoStuffSerializerBenchmark.deserializeWalRecord`: deserialize one prepared record.
- One fixed fixture containing a pre-serialized Long key and a 1,024-character ASCII String value. Nested key/value preparation is performed in trial setup, not inside the measured methods.
- `IMapFileData` is **not** a `SerializerDeserializerWrapper` type. Both measured methods enter the production `getSchema()` path on every invocation, including after the schema has been initialized.
- Four JMH workers by default. Each worker has its own input fixture, while the production static schema cache remains shared. This exercises the concurrent path involved in the related optimization without introducing an executor, filesystem, or running Hazelcast/Zeta cluster into the benchmark.
- Schema initialization and fixture validation occur in setup. Normal serializer buffer, output-array, and deserialized-object allocations remain part of the measured operation.

The benchmark uses throughput in `ops/ms`, three forks, and the existing warmup/measurement defaults. Its JVM resource settings match the pipeline benchmark: a fixed 4 GiB heap, G1, pre-touch, disabled explicit GC, and four JVM-visible processors.

#### Reporting and future comparisons

The benchmark emits standard JMH results and reuses the unchanged `save_jmh_result.py` and `regression_report.py` pipeline. Markdown reports retain the existing **Score / Error / CV / Unit** columns and calculations. CPU, wall-clock, lock, and GC diagnostics can use the existing profiling script with an exact method selector.

The class is added to the manual Benchmarks workflow selector, with English/Chinese documentation and local commands. It is not added to `benchmarks_core`, so the default scheduled suite is not expanded.

For subsequent optimizations, the same benchmark can run against both revisions with equivalent JDK, hardware, thread count, payload, and JVM/JMH settings. Throughput and allocation evidence can then be considered alongside the existing end-to-end WAL measurements.

### Does this PR introduce _any_ user-facing change?

Adds a developer-facing benchmark, a manual workflow selection, and documentation. No production behavior, configuration, API, or serialized format changes. No new dependencies are introduced.

### How was this patch tested?

- Module Spotless formatting and `git diff --check` passed.
- Java 8 benchmark unit tests: **3 passed**, covering the JMH configuration, fixture round-trip correctness, repeated calls, and independent outputs without input mutation.
- Existing reporting tests: **17 passed**. Reporting scripts were not modified.
- The benchmark reactor package build passed with `-Dskip.ui=true`, after the unrelated UI `npm install` step failed in the local environment.
- The four-thread benchmark-module rebuild, Spotless formatting, and its three tests passed on Java 8.
- Before changing the default to four threads, a full local Java 8 throughput run completed: both methods, 8 threads, 3 forks, 3 warmup and 5 measurement iterations per fork, 10 seconds each, without a profiler. Each method produced 15 measurement samples. The unchanged repository reporting scripts successfully generated the Markdown Score / Error / CV report. This validates the benchmark/reporting path, not a speedup; the local baseline showed substantial variability.
- `verify` was not run.

Build and test:

```sh
./mvnw -Pbenchmark -pl seatunnel-benchmarks -am -Dskip.ui=true \
  -Dtest=ProtoStuffSerializerBenchmarkTest -Dsurefire.failIfNoSpecifiedTests=false package
```

Run the complete microbenchmark:

```sh
java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
  -f 3 -wi 3 -i 5 -w 10s -r 10s -rf json \
  -rff seatunnel-benchmarks/target/protostuff.json
```

### Check list

- [x] No new dependencies or binary packages.
- [x] Updated the benchmark README and English/Chinese benchmark guides.
- [x] No incompatible production changes; migration documentation is not needed.
- [x] No connector changes; connector registration and E2E checklist items do not apply.
