### PR TITLE
[Improve][Connector-V2] Add nonblank validation for required Slack options

### DIFF
--- a/seatunnel-connectors-v2/connector-slack/src/main/java/org/apache/seatunnel/connectors/seatunnel/slack/sink/SlackSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-slack/src/main/java/org/apache/seatunnel/connectors/seatunnel/slack/sink/SlackSinkFactory.java
@@ -26,6 +26,8 @@ import org.apache.seatunnel.connectors.seatunnel.slack.config.SlackSinkOptions;
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+
 @AutoService(Factory.class)
 public class SlackSinkFactory implements TableSinkFactory {
     @Override
@@ -36,10 +38,9 @@ public class SlackSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(
-                        SlackSinkOptions.WEBHOOKS_URL,
-                        SlackSinkOptions.OAUTH_TOKEN,
-                        SlackSinkOptions.SLACK_CHANNEL)
+                .required(SlackSinkOptions.WEBHOOKS_URL, notBlank(SlackSinkOptions.WEBHOOKS_URL))
+                .required(SlackSinkOptions.OAUTH_TOKEN, notBlank(SlackSinkOptions.OAUTH_TOKEN))
+                .required(SlackSinkOptions.SLACK_CHANNEL, notBlank(SlackSinkOptions.SLACK_CHANNEL))
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-slack/src/test/java/org/apache/seatunnel/connectors/seatunnel/slack/SlackFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-slack/src/test/java/org/apache/seatunnel/connectors/seatunnel/slack/SlackFactoryTest.java
@@ -17,15 +17,68 @@
 
 package org.apache.seatunnel.connectors.seatunnel.slack;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.seatunnel.slack.sink.SlackSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
 
 class SlackFactoryTest {
 
     @Test
-    void optionRule() {
-        Assertions.assertNotNull((new SlackSinkFactory()).optionRule());
+    void validConfig() {
+        Assertions.assertDoesNotThrow(() -> validate(validOptions()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"webhooks_url", "oauth_token", "slack_channel"})
+    void missingRequiredOption(String key) {
+        Map<String, Object> options = validOptions();
+        options.remove(key);
+        assertInvalid(options, key);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"webhooks_url", "oauth_token", "slack_channel"})
+    void blankRequiredOption(String key) {
+        for (String value : new String[] {"", " ", "\t", "\n", " \t\r\n "}) {
+            Map<String, Object> options = validOptions();
+            options.put(key, value);
+            assertInvalid(options, key);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"webhooks_url", "oauth_token", "slack_channel"})
+    void preserveNonblankValues(String key) {
+        Map<String, Object> options = validOptions();
+        options.put(key, " arbitrary nonblank value ");
+        Assertions.assertDoesNotThrow(() -> validate(options));
+    }
+
+    private void assertInvalid(Map<String, Object> options, String key) {
+        OptionValidationException exception =
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(options));
+        Assertions.assertTrue(exception.getMessage().contains(key));
+    }
+
+    private void validate(Map<String, Object> options) {
+        ConfigValidator.of(ReadonlyConfig.fromMap(options))
+                .validate(new SlackSinkFactory().optionRule());
+    }
+
+    private Map<String, Object> validOptions() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("webhooks_url", "https://hooks.slack.com/services/test/test/test");
+        options.put("oauth_token", "test-oauth-token");
+        options.put("slack_channel", "seatunnel-alerts");
+        return options;
     }
 }

--- a/seatunnel-connectors-v2/connector-slack/src/test/java/org/apache/seatunnel/connectors/seatunnel/slack/sink/SlackFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-slack/src/test/java/org/apache/seatunnel/connectors/seatunnel/slack/sink/SlackFactoryTest.java
@@ -15,20 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.slack;
+package org.apache.seatunnel.connectors.seatunnel.slack.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
-import org.apache.seatunnel.connectors.seatunnel.slack.sink.SlackSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 class SlackFactoryTest {
 
@@ -45,14 +47,24 @@ class SlackFactoryTest {
         assertInvalid(options, key);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"webhooks_url", "oauth_token", "slack_channel"})
-    void blankRequiredOption(String key) {
-        for (String value : new String[] {"", " ", "\t", "\n", " \t\r\n "}) {
-            Map<String, Object> options = validOptions();
-            options.put(key, value);
-            assertInvalid(options, key);
-        }
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("blankRequiredOptions")
+    void blankRequiredOption(String key, String description, String value) {
+        Map<String, Object> options = validOptions();
+        options.put(key, value);
+        assertInvalid(options, key);
+    }
+
+    private static Stream<Arguments> blankRequiredOptions() {
+        return Stream.of("webhooks_url", "oauth_token", "slack_channel")
+                .flatMap(
+                        key ->
+                                Stream.of(
+                                        Arguments.of(key, "empty", ""),
+                                        Arguments.of(key, "space", " "),
+                                        Arguments.of(key, "tab", "\t"),
+                                        Arguments.of(key, "newline", "\n"),
+                                        Arguments.of(key, "mixed whitespace", " \t\r\n ")));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Purpose of this pull request

Related to #11007. Add declarative `Conditions.notBlank()` validation for the three existing required Slack options: `webhooks_url`, `oauth_token`, and `slack_channel`.

This change is limited to `SlackSinkFactory` and focused factory tests. It does not modify the client, writer, or the OAuth token mapping fix in #12171.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, empty or whitespace-only strings passed factory validation. These values are now rejected during configuration validation. All three options remain required, and all nonblank strings remain accepted without additional URL-format or token-prefix constraints.

### How was this patch tested?

Factory tests use `ConfigValidator` without contacting Slack and cover:

- A valid configuration.
- Each required option missing individually.
- Each option set to an empty string, a space, a tab, a newline, or mixed whitespace.
- Each option set to an arbitrary nonblank string with surrounding spaces.
- Validation errors identifying the affected option.

Validated locally on Windows with JDK 17 and the Maven Wrapper using the equivalent `mvnw.cmd` commands:

```text
./mvnw -f seatunnel-connectors-v2/connector-slack/pom.xml spotless:apply
./mvnw -pl seatunnel-connectors-v2/connector-slack -am -Dtest=SlackFactoryTest -Dsurefire.failIfNoSpecifiedTests=false verify
git diff --check
```

A temporary Maven settings file pointed to Maven Central because the local mirror had a certificate mismatch. All 10 test invocations passed with no failures, errors, or skipped tests; the blank-value tests iterate over the inputs listed above. All nine selected reactor modules passed `verify`. Spotless and `git diff --check` passed. No remote Slack integration tests were run.

### Check list

- No new dependencies or binary packages.
- Scope follows the maintainer's factory-validation-and-tests guidance; the behavior change is described above. Documentation is unchanged.
- No new connector, plugin mapping, distribution configuration, or CI label changes.
