### PR TITLE
[Improve][Connector-V2] Validate OpenMLDB SQL

### DIFF
--- a/docs/en/connectors/source/OpenMldb.md
+++ b/docs/en/connectors/source/OpenMldb.md
@@ -64,6 +64,8 @@ When it is `true`, configure `zk_host` and `zk_path`.
 
 ### sql [string]
 
+The required `sql` must not be empty or whitespace-only in either standalone or cluster mode.
+
 The SQL statement to execute against OpenMLDB. The result set columns become the schema of the
 emitted SeaTunnel rows.
 

--- a/docs/zh/connectors/source/OpenMldb.md
+++ b/docs/zh/connectors/source/OpenMldb.md
@@ -62,6 +62,8 @@ OpenMLDB 类型会按照所配置 `sql` 语句的结果集映射为 SeaTunnel �
 
 ### sql [string]
 
+无论使用单机模式还是集群模式，必填项 `sql` 都不能为空字符串或仅包含空白字符。
+
 针对 OpenMLDB 执行的 SQL 语句，结果集的列会成为连接器输出行的字段。
 
 ### database [string]

--- a/seatunnel-connectors-v2/connector-openmldb/src/main/java/org/apache/seatunnel/connectors/seatunnel/openmldb/source/OpenMldbSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-openmldb/src/main/java/org/apache/seatunnel/connectors/seatunnel/openmldb/source/OpenMldbSourceFactory.java
@@ -31,6 +31,8 @@ import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+
 @AutoService(Factory.class)
 public class OpenMldbSourceFactory implements TableSourceFactory {
     @Override
@@ -42,7 +44,7 @@ public class OpenMldbSourceFactory implements TableSourceFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .required(OpenMldbSourceOptions.CLUSTER_MODE)
-                .required(OpenMldbSourceOptions.SQL)
+                .required(OpenMldbSourceOptions.SQL, notBlank(OpenMldbSourceOptions.SQL))
                 .required(OpenMldbSourceOptions.DATABASE)
                 .optional(OpenMldbSourceOptions.SESSION_TIMEOUT)
                 .optional(OpenMldbSourceOptions.REQUEST_TIMEOUT)

--- a/seatunnel-connectors-v2/connector-openmldb/src/test/java/org/apache/seatunnel/connectors/seatunnel/openmldb/OpenMldbFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-openmldb/src/test/java/org/apache/seatunnel/connectors/seatunnel/openmldb/OpenMldbFactoryTest.java
@@ -17,12 +17,84 @@
 
 package org.apache.seatunnel.connectors.seatunnel.openmldb;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.seatunnel.openmldb.source.OpenMldbSourceFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
 
 class OpenMldbFactoryTest {
+
+    private final OptionRule optionRule = new OpenMldbSourceFactory().optionRule();
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testNonblankSqlAccepted(boolean clusterMode) {
+        for (String sql :
+                new String[] {
+                    "select * from test_table", " select * from test_table ", "not parsed here"
+                }) {
+            Map<String, Object> config = requiredConfig(clusterMode);
+            config.put("sql", sql);
+            Assertions.assertDoesNotThrow(() -> validate(config));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testMissingSqlRejected(boolean clusterMode) {
+        Map<String, Object> config = requiredConfig(clusterMode);
+        config.remove("sql");
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testEmptySqlRejected(boolean clusterMode) {
+        assertInvalidSql(clusterMode, "");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void testWhitespaceOnlySqlRejected(boolean clusterMode) {
+        assertInvalidSql(clusterMode, " ");
+        assertInvalidSql(clusterMode, "\t\r\n");
+    }
+
+    private void assertInvalidSql(boolean clusterMode, String sql) {
+        Map<String, Object> config = requiredConfig(clusterMode);
+        config.put("sql", sql);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+    }
+
+    private void validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "OpenMldb");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private Map<String, Object> requiredConfig(boolean clusterMode) {
+        Map<String, Object> config = new HashMap<>();
+        config.put("cluster_mode", clusterMode);
+        config.put("database", "test_db");
+        config.put("sql", "select * from test_table");
+        if (clusterMode) {
+            config.put("zk_host", "localhost:2181");
+            config.put("zk_path", "/openmldb");
+        } else {
+            config.put("host", "localhost");
+            config.put("port", 6527);
+        }
+        return config;
+    }
 
     @Test
     void optionRule() {


### PR DESCRIPTION
### Purpose of this pull request

Implements the approved OpenMLDB slice of #11007.

Adds only a declarative nonblank constraint to required `sql`. Existing cluster-mode conditional rules, endpoints, ZooKeeper, database, SDK, and runtime behavior remain unchanged.

### Does this PR introduce any user-facing change?

Empty and whitespace-only SQL values are rejected during factory configuration validation. Missing values remain rejected. English and Chinese connector documentation now states the nonblank requirement. No option names, defaults, dependencies, or connector registration changes.

### How was this patch tested?

- JDK 11: repository-wide `mvn spotless:apply` passed.
- `mvn -o -q -pl seatunnel-connectors-v2/connector-openmldb verify` passed, including 9 factory test executions.
- Coverage: valid, missing, empty, spaces, and tab/newline-only SQL in both standalone and cluster modes. Nonblank unparsed SQL is accepted, proving no SQL syntax validation is added.
- Tests use ConfigValidator and factory optionRule without remote services.
- `git diff --check` passed.
- Full-repository skip-tests verification was attempted, but no completion result was captured before the session interruption; it is not claimed as passed.

### Check list

- [x] Focused positive and negative tests added.
- [x] English and Chinese documentation updated.
- No new binaries, dependencies, configuration names, or defaults.
- Existing connector only: distribution, plugin registration, and E2E configuration unchanged.

