### PR TITLE
[Test][Transform-V2] Cover the MOD divisor type contract and its overflow bounds

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/NumericFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/NumericFunction.java
@@ -221,6 +221,9 @@ public class NumericFunction {
                     CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION, "Mod by zero");
         }
         BigDecimal[] res = leftBD.divideAndRemainder(rightBD);
+        // The result keeps the type of the divisor, which is what ZetaSQLType declares for MOD.
+        // No range check is needed for the narrow types: divideAndRemainder guarantees that
+        // |remainder| < |divisor|, so the remainder always fits the divisor's type.
         if (rightValue instanceof Byte) {
             return res[1].byteValue();
         }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/NumericFunctionTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/NumericFunctionTest.java
@@ -185,4 +185,34 @@ public class NumericFunctionTest {
                                 new BigDecimal("12345678901234567890.987654321"),
                                 new BigDecimal("1"))));
     }
+
+    /**
+     * ZetaSQLType derives the MOD result type from the divisor, so the planner and the runtime have
+     * to agree that a TINYINT or SMALLINT divisor yields that same type.
+     */
+    @Test
+    public void testModSupportsTinyIntAndSmallIntDivisors() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"int_v", "tiny_v", "small_v"},
+                        new SeaTunnelDataType[] {
+                            BasicType.INT_TYPE, BasicType.BYTE_TYPE, BasicType.SHORT_TYPE
+                        });
+        SeaTunnelRow inputRow = new SeaTunnelRow(new Object[] {17, (byte) 5, (short) 7});
+
+        SQLEngine sqlEngine = SQLEngineFactory.getSQLEngine(SQLEngineFactory.EngineType.ZETA);
+        sqlEngine.init(
+                "test",
+                null,
+                rowType,
+                "select MOD(int_v, tiny_v) as tiny_mod, MOD(int_v, small_v) as small_mod from test");
+
+        SeaTunnelRowType outRowType = sqlEngine.typeMapping(null);
+        Assertions.assertEquals(BasicType.BYTE_TYPE, outRowType.getFieldType(0));
+        Assertions.assertEquals(BasicType.SHORT_TYPE, outRowType.getFieldType(1));
+
+        SeaTunnelRow outRow = sqlEngine.transformBySQL(inputRow, outRowType).get(0);
+        Assertions.assertEquals((byte) 2, outRow.getField(0));
+        Assertions.assertEquals((short) 3, outRow.getField(1));
+    }
 }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/NumericFunctionTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/zeta/functions/NumericFunctionTest.java
@@ -145,6 +145,23 @@ public class NumericFunctionTest {
         Assertions.assertEquals(1, NumericFunction.mod(Arrays.asList(5, 2)));
         Assertions.assertEquals(1L, NumericFunction.mod(Arrays.asList(5L, 2L)));
 
+        // A TINYINT or SMALLINT divisor has to carry its own type into the result, which is what
+        // ZetaSQLType declares for MOD (added with #12215).
+        Object byteResult = NumericFunction.mod(Arrays.asList(5, (byte) 2));
+        Assertions.assertEquals(Byte.class, byteResult.getClass());
+        Assertions.assertEquals((byte) 1, byteResult);
+
+        Object shortResult = NumericFunction.mod(Arrays.asList(5, (short) 2));
+        Assertions.assertEquals(Short.class, shortResult.getClass());
+        Assertions.assertEquals((short) 1, shortResult);
+
+        // The remainder is always smaller in magnitude than the divisor, so even the widest
+        // possible divisor of each type cannot overflow the result. These are the inputs that
+        // would fail first if that reasoning were wrong.
+        Assertions.assertEquals((byte) 44, NumericFunction.mod(Arrays.asList(300, Byte.MIN_VALUE)));
+        Assertions.assertEquals(
+                (short) 1696, NumericFunction.mod(Arrays.asList(100000, Short.MIN_VALUE)));
+
         Float floatResult = (Float) NumericFunction.mod(Arrays.asList(5.5f, 2.0f));
         Assertions.assertEquals(1.5f, floatResult);
 


### PR DESCRIPTION
### Purpose of this pull request

Follow-up to #12215, which closed #12179.

This PR originally carried the same two-branch fix. #12215 landed that first, so the fix is dropped here and only the coverage that #12215 did not include remains. The production change is now a comment.

@DanielLeens compared the two PRs on #12215 and identified three gaps. @SEZ9 then reviewed the result and found that two of the three were closed less tightly than they looked. All of it is addressed here.

**The planner side is asserted, deliberately in its own test.** The defect was a disagreement between `ZetaSQLType`, which derives the `MOD` result type from the divisor, and the runtime dispatch, which handled only some of those types. `SQLNumericFunctionsTest.testModWithTinyIntAndSmallIntDivisors` from #12215 asserts the returned values, which would still pass if `typeMapping` stopped declaring `TINYINT`. `zeta/NumericFunctionTest.testModDeclaresTheDivisorTypeForTinyIntAndSmallInt` asserts that `typeMapping()` declares `BYTE_TYPE` and `SHORT_TYPE`, and nothing else. The value and runtime-class half is carried by `functions/NumericFunctionTest.testModForDifferentResultTypes` and by the #12215 sibling test, which the Javadoc names. The two halves are split on purpose: @SEZ9 pointed out that asserting the values here as well only duplicated the sibling, and folding the planner check into that sibling would collide with #12364, which is open against the same file.

**The true remainder boundaries are covered.** An earlier revision used `MOD(300, Byte.MIN_VALUE)` and `MOD(100000, Short.MIN_VALUE)` on the grounds that those are the widest divisors. @SEZ9 showed that this misses the point: the results are 44 and 1696, far inside byte and short range, so they never approach the bound the comment describes. What bounds the result is the remainder, not the divisor, and `divideAndRemainder` gives `|remainder| <= |divisor| - 1`. The extremes are therefore `MOD(±127, Byte.MIN_VALUE)` and `MOD(±32767, Short.MIN_VALUE)`, which are now asserted and which also give the narrow types their first negative-dividend coverage.

**The reasoning is recorded at the call site, including what it does not promise.** `divideAndRemainder` bounds the remainder below the divisor in magnitude, so the result is always within the divisor's range. The comment originally said it "always fits", which conflated range with precision: a FLOAT, DOUBLE or DECIMAL dividend keeps its fractional part and `byteValue()` truncates it, so `MOD(5.5, (byte) 2)` is 1 and not 1.5. The comment now says both, and says the truncation is deliberate so nobody "fixes" it into rounding or a wider return type.

### Does this PR introduce _any_ user-facing change?

No. Tests and one comment. `NumericFunction.java` is byte-identical to `dev` once comments are stripped.

### How was this patch tested?

The runtime-side test fails against the dispatch chain with #12215's two branches removed and passes with them. The planner-side test does not depend on those branches at all, by design, so it is unaffected by that mutation.

The boundary assertions were checked against the failure @SEZ9 described rather than accepted on reasoning. Adding his exact guard, `abs(remainder) >= Byte.MAX_VALUE`, to the byte branch:

```
old assertions + guard  -> all 29 tests pass   (the gap he identified)
new assertions + guard  -> fails               (the gap closed)
```

Mutating the narrowing to round instead of truncate fails the new `MOD(5.5d, (byte) 2)` assertion.

Full module on current `dev`:

```
./mvnw -pl seatunnel-transforms-v2 -Dskip.spotless=true test
Tests run: 1158, Failures: 0, Errors: 0, Skipped: 0
```

`./mvnw -pl seatunnel-transforms-v2 spotless:check` passes.
