### PR TITLE
[Docs][Connector-V2] Improve Paimon RocketMQ and Pulsar connector docs

### DIFF
--- a/docs/en/connectors/sink/Paimon.md
+++ b/docs/en/connectors/sink/Paimon.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-paimon.md';
 
 > Paimon sink connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Sink connector for Apache Paimon. It supports CDC mode and auto-create table.
@@ -730,6 +736,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### Does Paimon sink support automatic table creation and schema evolution?
+
+Yes. When `paimon.auto-create-table = true` or `schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"`, SeaTunnel automatically initializes the destination Paimon table using upstream table schema and primary key information.
+
+### How does Paimon sink achieve exactly-once writes?
+
+Paimon sink integrates with engine two-phase commit (2PC) checkpoint mechanisms across SeaTunnel Zeta, Flink, and Spark. Data written during a checkpoint interval is committed as a formal Paimon snapshot only after checkpoint barriers are fully acknowledged.
+
+### Which table types (Primary Key vs Append-Only) are supported?
+
+Both table types are supported. If the target table defines primary keys (`paimon.table.primary-keys`), the sink performs upsert/delete operations. If no primary keys are defined, the table operates in append-only mode.
 
 ## Changelog
 

--- a/docs/en/connectors/sink/Pulsar.md
+++ b/docs/en/connectors/sink/Pulsar.md
@@ -263,6 +263,20 @@ sink {
 }
 ```
 
+## FAQ
+
+### How does Pulsar sink achieve exactly-once vs at-least-once delivery?
+
+Configure the `semantics` option: `EXACTLY_ONCE` utilizes Pulsar transaction coordinators to commit messages alongside engine checkpoint barriers, whereas `AT_LEAST_ONCE` relies on producer acknowledgments for higher write throughput.
+
+### Can the Pulsar sink route data to multiple topics dynamically?
+
+Yes. In multi-table synchronization pipelines, omitting a fixed `topic` parameter allows SeaTunnel to dynamically route rows to corresponding Pulsar topics based on the table identifiers carried in each record.
+
+### What serialization formats are supported by Pulsar sink?
+
+The sink supports `json`, `text`, and `avro` serialization formats via the `format` option, enabling seamless integration with downstream systems and schema registries.
+
 ## Changelog
 
 <ChangeLog />

--- a/docs/en/connectors/sink/RocketMQ.md
+++ b/docs/en/connectors/sink/RocketMQ.md
@@ -8,7 +8,7 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 
 - 4.9.0 or newer
 
-## Support These Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -203,6 +203,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### How can message routing and partition keys be configured in RocketMQ sink?
+
+Configure `partition.key.fields` with one or more table field names. The connector calculates a hash of the specified fields to ensure that messages sharing identical key values are always routed to the same RocketMQ message queue.
+
+### How does RocketMQ sink provide exactly-once delivery guarantees?
+
+When `exactly.once = true`, the sink utilizes RocketMQ 2PC transactional messages. Uncommitted messages are prepared during checkpoint execution and committed as visible messages only when the compute engine completes its checkpoint barrier handshake.
+
+### What message serialization formats are supported?
+
+The sink supports `json` and `text` formats. Fields can be formatted into JSON payloads or delimited text rows according to your target consumer requirements.
 
 ## Changelog
 

--- a/docs/en/connectors/source/Paimon.md
+++ b/docs/en/connectors/source/Paimon.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-paimon.md';
 
 > Paimon source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Read data from Apache Paimon.
@@ -298,6 +304,20 @@ source {
    }
 }
 ```
+
+## FAQ
+
+### Which read modes does the Paimon source support?
+
+The SeaTunnel Paimon source supports both batch snapshot queries and streaming changelog consumption. In batch mode, it scans the target table's latest snapshot or a specified snapshot range. In streaming mode, it continuously consumes newly committed changes and splits.
+
+### How do I configure storage and catalog backends for Paimon?
+
+Configure `warehouse` pointing to the storage root (e.g. `hdfs:///paimon/warehouse`, `s3a://bucket/warehouse`, or local path) and set `paimon.catalog.type` (such as `filesystem` or `hive`). Required storage or authentication properties can be provided via `paimon.hadoop.conf`.
+
+### Does Paimon source support column projection?
+
+Yes. The Paimon source reads only the projection fields defined in the SeaTunnel job schema, avoiding unnecessary column deserialization and optimizing read performance on columnar formats like ORC and Parquet.
 
 ## Changelog
 

--- a/docs/en/connectors/source/Pulsar.md
+++ b/docs/en/connectors/source/Pulsar.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-pulsar.md';
 
 > Apache Pulsar source connector
 
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## Description
 
 Source connector for Apache Pulsar.
@@ -385,6 +391,20 @@ source {
   }
 }
 ```
+
+## FAQ
+
+### How does Pulsar source handle partitioned topics and dynamic partition discovery?
+
+When subscribing to partitioned topics or topic patterns (`topic-pattern`), SeaTunnel automatically discovers partitions and dynamically assigns topic splits across reader subtasks. You can tune `topic-discovery.interval` to control how frequently new partitions are detected.
+
+### Which cursor reset strategies and subscription modes are supported?
+
+The source supports `EARLIEST` and `LATEST` startup modes through `cursor.startup.mode`. Consumers join the subscription with configurable subscription types (e.g. `Failover` or `Exclusive`), and SeaTunnel checkpoints message IDs to ensure reliable playback on failure.
+
+### How do I configure authentication for secure Pulsar clusters?
+
+Configure `auth.plugin-class` (e.g. `org.apache.pulsar.client.impl.auth.AuthenticationToken`) and provide required credentials or token values via `auth.params`. TLS connections are enabled by providing `pulsar+ssl://` service URLs.
 
 ## Changelog
 

--- a/docs/en/connectors/source/RocketMQ.md
+++ b/docs/en/connectors/source/RocketMQ.md
@@ -8,7 +8,7 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 
 - 4.9.0 or newer
 
-## Support These Engines
+## Support Those Engines
 
 > Spark<br/>
 > Flink<br/>
@@ -282,6 +282,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### How does RocketMQ source handle multi-topic reads with different schemas?
+
+Use the `tables_configs` configuration array. Each item defines its own `topics`, `schema`, `format`, and optional `tags`, allowing SeaTunnel to deserialize messages from distinct topics into independent table structures.
+
+### Which starting offset modes are supported?
+
+RocketMQ source supports starting from earliest offsets (`CONSUME_FROM_FIRST_OFFSET`), latest offsets (`CONSUME_FROM_LAST_OFFSET`), or timestamp-based offsets (`CONSUME_FROM_TIMESTAMP`) using the `start.mode` parameter.
+
+### How is fault tolerance achieved during job failover?
+
+SeaTunnel checkpoints consumer queue offsets at regular intervals. In case of node or task failure, the source automatically rolls back to the last committed checkpoint offsets to guarantee message delivery integrity.
 
 ## Changelog
 

--- a/docs/zh/connectors/sink/Paimon.md
+++ b/docs/zh/connectors/sink/Paimon.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-paimon.md';
 
 > Paimon 数据连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 Apache Paimon数据连接器。支持cdc写以及自动建表。
@@ -655,6 +661,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### Paimon Sink 连接器是否支持自动建表？
+
+支持。当配置 `paimon.auto-create-table = true` 或 `schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"` 时，SeaTunnel 会自动根据上游传递的元数据信息初始化目标 Paimon 表（包含主键与分区配置）。
+
+### Paimon Sink 如何保证精确一次（Exactly-Once）写入？
+
+Paimon Sink 深度集成了 SeaTunnel Zeta、Flink 以及 Spark 的两阶段提交（2PC）检查点机制。在一个 Checkpoint 周期内写入的数据，会在 Checkpoint 屏障对齐并确认成功后作为快照正式提交。
+
+### Paimon Sink 支持哪些表模式（主键表与追加表）？
+
+两种表模式均受支持。若目标表配置了主键（`paimon.table.primary-keys`），Sink 将按主键执行 Upsert/Delete 逻辑；若未声明主键，则以 Append-Only 追加模式写入。
 
 ## 变更日志
 

--- a/docs/zh/connectors/sink/Pulsar.md
+++ b/docs/zh/connectors/sink/Pulsar.md
@@ -262,6 +262,20 @@ sink {
 }
 ```
 
+## FAQ
+
+### Pulsar Sink 如何实现精确一次（Exactly-Once）与至少一次（At-Least-Once）写入？
+
+通过 `semantics` 参数进行配置：`EXACTLY_ONCE` 利用 Pulsar 事务协调器将数据写入与计算引擎 Checkpoint 屏障紧密绑定并协同提交；`AT_LEAST_ONCE` 则依赖 Producer 确认应答，具备更高的吞吐写入表现。
+
+### Pulsar Sink 是否支持动态多表/多 Topic 路由？
+
+支持。在整库或多表同步场景下，若未指定全局固定的单个 `topic`，SeaTunnel 将根据每条数据记录携带的表标识自动动态路由至对应的 Pulsar Topic。
+
+### 支持向 Pulsar 写入哪些数据序列化格式？
+
+Pulsar Sink 支持通过 `format` 参数指定 `json`、`text` 以及 `avro` 格式，方便与下游消费者或 Schema Registry 系统无缝对接。
+
 ## 变更日志
 
 <ChangeLog />

--- a/docs/zh/connectors/sink/RocketMQ.md
+++ b/docs/zh/connectors/sink/RocketMQ.md
@@ -8,7 +8,7 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 
 - 4.9.0 或更新版本
 
-## 支持的引擎
+## 引擎支持
 
 > Spark<br/>
 > Flink<br/>
@@ -200,6 +200,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### RocketMQ Sink 如何配置消息路由与分区键？
+
+可以通过配置 `partition.key.fields` 声明一个或多个数据列作为分区键。连接器将对指定字段值进行 Hash 计算，确保具有相同 Key 值的消息始终投递至 RocketMQ 的同一个消息队列。
+
+### RocketMQ Sink 如何提供精确一次（Exactly-Once）投递保证？
+
+当设置 `exactly.once = true` 时，Sink 将启用 RocketMQ 两阶段事务消息机制。在 Checkpoint 执行过程中发送半消息（Half Message），待计算引擎 Checkpoint 确认成功后再正式提交该批消息供下游消费。
+
+### 支持哪些消息体序列化格式？
+
+支持 `json` 和 `text` 格式。系统可将每行结构化数据解析为标准 JSON 对象或按指定分隔符拼接为纯文本字符串写入 RocketMQ。
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Paimon.md
+++ b/docs/zh/connectors/source/Paimon.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-paimon.md';
 
 > Paimon 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 用于从 `Apache Paimon` 读取数据
@@ -304,6 +310,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### Paimon 源连接器支持哪些读取模式？
+
+SeaTunnel Paimon 源连接器支持批处理快照读取与流式 changelog 消费。在批处理模式下，可扫描指定或最新快照；在流式模式下，持续监听并拉取新提交的增量数据变更。
+
+### 如何配置 Paimon 的存储路径与 Catalog？
+
+通过 `warehouse` 配置底层存储根路径（如 `hdfs:///paimon/warehouse`、`s3a://bucket/warehouse` 或本地路径），并通过 `paimon.catalog.type` 指定 Catalog 类型（如 `filesystem`、`hive` 等）。相关的存储认证参数可统一在 `paimon.hadoop.conf` 中声明。
+
+### Paimon 源连接器是否支持列投影？
+
+支持。Paimon 源连接器仅读取上游作业 Schema 中声明的目标字段，对底层 ORC 或 Parquet 等列式存储格式避免冗余数据反序列化，从而提升查询性能。
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/Pulsar.md
+++ b/docs/zh/connectors/source/Pulsar.md
@@ -4,6 +4,12 @@ import ChangeLog from '../changelog/connector-pulsar.md';
 
 > Apache Pulsar 源连接器
 
+## 引擎支持
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
 ## 描述
 
 Apache Pulsar 的源连接器。
@@ -378,6 +384,20 @@ source {
   }
 }
 ```
+
+## FAQ
+
+### Pulsar 源连接器如何处理分区 Topic 与动态分区发现？
+
+当订阅分区 Topic 或使用正则表达式匹配 Topic 时（`topic-pattern`），SeaTunnel 会自动感知分区信息并将分片均匀分配给并发任务。可通过 `topic-discovery.interval` 调整新分区检测的探测频率。
+
+### 支持哪些消费游标（Cursor）位点恢复与订阅模式？
+
+通过 `cursor.startup.mode` 支持配置为 `EARLIEST`（从最早未消费位点）或 `LATEST`（从最新位点开始消费）。消费者以配置的订阅类型（如 `Failover` 或 `Exclusive`）注册，并在 Checkpoint 时同步保存消息 ID，确保故障时精准回溯。
+
+### 如何在连接受安全防护的 Pulsar 集群时配置身份认证？
+
+可通过 `auth.plugin-class`（如 `org.apache.pulsar.client.impl.auth.AuthenticationToken`）声明认证插件实现类，并在 `auth.params` 中传入对应凭据或 Token。如果启用了 TLS 加密传输，则需将服务地址指定为 `pulsar+ssl://`。
 
 ## 变更日志
 

--- a/docs/zh/connectors/source/RocketMQ.md
+++ b/docs/zh/connectors/source/RocketMQ.md
@@ -8,7 +8,7 @@ import ChangeLog from '../changelog/connector-rocketmq.md';
 
 - 4.9.0 或更新版本
 
-## 支持的引擎
+## 引擎支持
 
 > Spark<br/>
 > Flink<br/>
@@ -276,6 +276,20 @@ sink {
   }
 }
 ```
+
+## FAQ
+
+### RocketMQ 源连接器如何支持多 Topic 不同 Schema 的读取？
+
+可以通过配置 `tables_configs` 数组来实现。每个配置项可独立定义该 Topic 的 `topics`、`schema`、`format` 以及 `tags`，SeaTunnel 将并发消费并独立解析为对应的表数据流。
+
+### RocketMQ 源连接器支持哪些起始消费位点模式？
+
+通过 `start.mode` 参数支持从最早位点（`CONSUME_FROM_FIRST_OFFSET`）、最新位点（`CONSUME_FROM_LAST_OFFSET`）或指定时间戳位点（`CONSUME_FROM_TIMESTAMP`）开始读取数据。
+
+### 作业发生故障恢复时如何保证消费位点一致性？
+
+SeaTunnel 会周期性对消费者队列位点进行 Checkpoint 状态持久化。当任务发生异常或节点故障重启时，源连接器将严格从上一次成功提交的 Checkpoint 位点重新恢复消费。
 
 ## 变更日志
 


### PR DESCRIPTION
### Purpose of this pull request

This pull request improves connector documentation for **Paimon** (Source & Sink), **RocketMQ** (Source & Sink), and **Pulsar** (Source & Sink) in accordance with connector documentation specifications (#4544).

Specifically, it addresses:
1. Adding missing `## Support Those Engines` (in `docs/en/...`) and `## 引擎支持` (in `docs/zh/...`) covering Spark, Flink, and SeaTunnel Zeta across Paimon and Pulsar source docs, and standardizing engine headers across RocketMQ docs.
2. Adding practical FAQs to clarify common production configurations:
   - **Paimon Source:** Clarifies batch snapshot vs streaming changelog modes, catalog/warehouse configuration, and column projection efficiency.
   - **Paimon Sink:** Explains automated table creation from upstream schema, 2PC checkpoint commit mechanism, and primary key (upsert) vs append-only table modes.
   - **RocketMQ Source:** Details multi-table reads with `tables_configs`, starting offset modes (`EARLIEST`/`LATEST`/`TIMESTAMP`), and consumer checkpoint recovery.
   - **RocketMQ Sink:** Explains partition key hashing (`partition.key.fields`), 2PC transactional messages for exactly-once guarantees, and payload formatting.
   - **Pulsar Source:** Covers partitioned topic subscription, partition discovery intervals, consumer cursor recovery, and authentication token setup.
   - **Pulsar Sink:** Explains `EXACTLY_ONCE` vs `AT_LEAST_ONCE` semantics, dynamic multi-table topic routing, and supported serialization formats (`json`, `text`, `avro`).

Fixes #12186 

### Does this PR introduce _any_ user-facing change?

Yes. It improves official SeaTunnel documentation across English and Chinese connector documentation pages.

### How was this patch tested?

Rendered and validated markdown syntax, tables, and headers across all 12 modified files in `docs/en/connectors/` and `docs/zh/connectors/`.

### Check list

* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
