### PR TITLE
[Improve] Allow committers to bypass dev branch rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,12 +47,20 @@ github:
     squash: true
     merge: false
     rebase: false
-  protected_branches:
-    dev:
-      required_status_checks:
-        strict: true
+  rulesets:
+    - name: dev branch protection
+      type: branch
+      branches:
+        includes:
+          - dev
+        excludes: []
+      bypass_teams:
+        - seatunnel-committers
+      required_status_checks_strict: true
       required_pull_request_reviews:
         dismiss_stale_reviews: true
+        require_last_push_approval: false
+        require_code_owner_reviews: false
         required_approving_review_count: 2
 
 notifications:


### PR DESCRIPTION
## Summary
- migrate the `dev` protection from legacy `protected_branches` to an ASF GitHub ruleset
- grant the `seatunnel-committers` team bypass access, allowing committers to override the branch rules when necessary
- preserve the existing two-approval and stale-review dismissal requirements for non-bypass actors

## Verification
- parsed `.asf.yaml` with Ruby YAML
- `git diff --check`
- `./mvnw spotless:apply`
- `./mvnw -q -DskipTests -pl '!seatunnel-engine/seatunnel-engine-ui' verify`\n\n## Compatibility\n- No runtime, API, connector, or user-facing configuration changes.\n- The legacy branch-protection declaration is replaced because it cannot express bypass actors; the ruleset retains the previous review policy and branch-update strictness.