### PR TITLE
[Feature][Zeta] Report table-level lineage from the Zeta master

### DIFF
--- a/docs/en/engines/zeta/hybrid-cluster-deployment.md
+++ b/docs/en/engines/zeta/hybrid-cluster-deployment.md
@@ -117,6 +117,28 @@ If the cluster has more than one node, the checkpoint storage must be a distribu
 
 For information about checkpoint storage, you can refer to [Checkpoint Storage](checkpoint-storage.md)
 
+### OpenLineage Lineage Reporting
+
+Table-level OpenLineage reporting is configured at cluster level under `openlineage` in
+`seatunnel.yaml`. It is disabled by default:
+
+```yaml
+seatunnel:
+  engine:
+    openlineage:
+      enabled: true
+      transport: http
+      url: http://lineage.example/api/lineage
+      namespace: seatunnel
+      heartbeat_min_interval_ms: 3600000
+```
+
+The complete option table, environment-variable mapping, Flink configuration, dataset naming, and
+known limitations are documented in [OpenLineage Lineage Reporting](../../introduction/concepts/lineage.md).
+The receiver token must come from `OPENLINEAGE_AUTH_TOKEN` or cluster configuration; a token in a
+job `env {}` block is rejected at startup. Lineage delivery failures never fail the data-processing
+job.
+
 ### 4.4 Expiration Configuration For Historical Jobs
 
 The information of each completed job, such as status, counters, and error logs, is stored in the IMap object. As the number of running jobs increases, the memory usage will increase, and eventually, the memory will overflow. Therefore, you can adjust the `history-job-expire-minutes` parameter to address this issue. The time unit for this parameter is minutes. The default value is 1440 minutes, which is one day.

--- a/docs/en/introduction/concepts/lineage.md
+++ b/docs/en/introduction/concepts/lineage.md
@@ -1,0 +1,112 @@
+---
+title: OpenLineage Lineage Reporting
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# OpenLineage Lineage Reporting
+
+SeaTunnel can emit table-level OpenLineage `RunEvent` records to any OpenLineage-compatible
+receiver. The feature is disabled by default. When it is disabled, SeaTunnel does not create a
+lineage network call or a lineage-specific background thread, and existing job behavior is
+unchanged.
+
+## Configuration
+
+The following options are available in a job `env` block unless noted otherwise.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `openlineage_enabled` | Boolean | `false` | Enables OpenLineage reporting. |
+| `openlineage_transport` | String | `http` | Transport name selected from the `LineageBackend` SPI. |
+| `openlineage_url` | String | None | Base URL of the OpenLineage receiver. Required when reporting is enabled. |
+| `openlineage_namespace` | String | `seatunnel` | OpenLineage job namespace. |
+| `openlineage_auth_token` | String | None | Receiver bearer token. It may come only from an environment variable or cluster configuration. |
+| `openlineage_timeout_ms` | Int | `10000` | Timeout for one send attempt, in milliseconds. |
+| `openlineage_retry_times` | Int | `3` | Number of retries after a failed send. |
+| `openlineage_run_facet` | String | `seatunnel_properties` | Name of the custom run facet. |
+| `openlineage_run_properties` | Map | None | Custom properties copied to the run facet. |
+| `openlineage_heartbeat_min_interval_ms` | Long | `3600000` | Minimum interval between streaming-job heartbeat events, in milliseconds. `0` disables heartbeat reporting. |
+| `openlineage_producer` | String | `https://seatunnel.apache.org/<version>` | OpenLineage producer identifier. The default is derived from the running SeaTunnel version at runtime. |
+
+Values are resolved independently with this precedence:
+
+```text
+job env {} > process environment > cluster configuration > default
+```
+
+The token is the exception to this rule. `openlineage_auth_token` is resolved as
+`OPENLINEAGE_AUTH_TOKEN` > cluster configuration. A token in a job `env {}` block is rejected at
+job startup. This prevents the token from being persisted in job configuration or serialized into
+the Flink JobGraph.
+
+Lineage delivery is unconditionally best effort, and there is deliberately no option to change that.
+A receiver or network failure is contained at the engine integration boundary and reported as a
+warning, so it can never change the outcome of the data-processing job.
+
+### Environment variable names
+
+The environment variable name is the upper-case option name:
+
+| Option | Environment variable |
+| --- | --- |
+| `openlineage_enabled` | `OPENLINEAGE_ENABLED` |
+| `openlineage_transport` | `OPENLINEAGE_TRANSPORT` |
+| `openlineage_url` | `OPENLINEAGE_URL` |
+| `openlineage_namespace` | `OPENLINEAGE_NAMESPACE` |
+| `openlineage_auth_token` | `OPENLINEAGE_AUTH_TOKEN` |
+| `openlineage_timeout_ms` | `OPENLINEAGE_TIMEOUT_MS` |
+| `openlineage_retry_times` | `OPENLINEAGE_RETRY_TIMES` |
+| `openlineage_run_facet` | `OPENLINEAGE_RUN_FACET` |
+| `openlineage_run_properties` | `OPENLINEAGE_RUN_PROPERTIES` |
+| `openlineage_heartbeat_min_interval_ms` | `OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS` |
+| `openlineage_producer` | `OPENLINEAGE_PRODUCER` |
+
+For example, set `OPENLINEAGE_URL` and `OPENLINEAGE_AUTH_TOKEN` through the process or service
+manager environment. Do not put a real token in a job file, repository file, command history, or
+logs.
+
+## Dataset names
+
+Supported connector dataset identities use these canonical forms. For multi-table sources and sinks,
+each configured table is represented separately.
+
+| Connector | Namespace | Name |
+| --- | --- | --- |
+| Paimon | `paimon://<catalog_name>/<database>` | `<table>` |
+| Doris | `mysql://<fe_host>:<query_port>` | `<database>.<table>` |
+| JDBC | `<scheme>://<host>:<port>` | `<database>.<table>` |
+
+For Paimon, `<catalog_name>` comes from the connector's `catalog_name` option and the dataset name is
+the table name only, not `database.table`. Set `catalog_name` explicitly to keep the namespace stable
+across jobs; when it is omitted, no Paimon dataset is emitted. For Doris, `fenodes` normally contains the HTTP Stream Load port; the
+lineage namespace uses the Doris query port instead. The generic `default.default.default` table path
+is not emitted.
+
+A sink that routes rows with a template, such as `table = "${table_name}"`, produces no dataset
+either. The template is substituted per row at write time, so it never names a real table, and
+emitting it verbatim would collapse every template-routed job onto one shared node in the graph. A
+name that merely contains a dollar sign, such as `orders$archive`, is a normal identifier and is
+still emitted.
+
+## Run facet properties
+
+Besides the properties configured through `openlineage_run_properties`, the run facet carries an
+`engine` property naming the execution engine that reported the run. Each engine adds the
+identifiers that make its run findable in that engine's own UI; those are described in the engine
+sections below.

--- a/docs/en/introduction/concepts/lineage.md
+++ b/docs/en/introduction/concepts/lineage.md
@@ -110,3 +110,45 @@ Besides the properties configured through `openlineage_run_properties`, the run 
 `engine` property naming the execution engine that reported the run. Each engine adds the
 identifiers that make its run findable in that engine's own UI; those are described in the engine
 sections below.
+
+## Zeta
+
+### Zeta cluster configuration
+
+Zeta reads cluster-level values from `seatunnel.yaml`:
+
+```yaml
+seatunnel:
+  engine:
+    openlineage:
+      enabled: true
+      transport: http
+      url: http://lineage.example/api/lineage
+      namespace: seatunnel
+      timeout_ms: 10000
+      retry_times: 3
+      run_facet: seatunnel_properties
+      heartbeat_min_interval_ms: 3600000
+      producer: https://seatunnel.apache.org/<version>
+```
+
+The cluster-level `auth_token` value is supported, but should be supplied through the cluster's
+secret-management mechanism. It must not be copied into a job `env` block.
+
+### Events reported by Zeta
+
+Zeta emits `START` when a job enters `RUNNING`, then emits `COMPLETE`, `ABORT`, or `FAIL` for the
+corresponding terminal state. `SAVEPOINT_DONE` is represented as `COMPLETE`, while `UNKNOWABLE` is
+represented as `FAIL`. The run facet carries a `sink_action` property in addition to `engine`.
+
+Zeta reads terminal output metrics from historical job metrics, preferring committed counters and
+falling back to attempted write counters when no positive committed counter is available. The event
+records which of the two was used, so a consumer is never told that attempted rows are committed
+ones.
+
+A job that has not finished reports periodic heartbeat events, so a receiver does not mistake a
+still-running job for one whose producer died. Zeta emits them from its checkpoint completion
+callback, so a Zeta job with checkpointing disabled has no heartbeat. They are throttled by
+`openlineage_heartbeat_min_interval_ms`, and setting it to `0` stops them. A run that does stop
+reporting is subject to the receiver's abandoned-run timeout, and the state inferred that way is
+replaced by a terminal event arriving later.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -31,7 +31,8 @@ const sidebars = {
                     "label": "Concepts",
                     "items": [
                         "introduction/concepts/connector-v2-features",
-                        "introduction/concepts/schema-feature"
+                        "introduction/concepts/schema-feature",
+                        "introduction/concepts/lineage"
                     ]
                 }
             ]

--- a/docs/zh/engines/zeta/hybrid-cluster-deployment.md
+++ b/docs/zh/engines/zeta/hybrid-cluster-deployment.md
@@ -116,6 +116,26 @@ seatunnel:
 
 有关检查点存储的信息，您可以查看 [Checkpoint Storage](checkpoint-storage.md)
 
+### OpenLineage 血缘上报
+
+表级 OpenLineage 上报在 `seatunnel.yaml` 的集群级 `openlineage` 节点下配置，默认关闭：
+
+```yaml
+seatunnel:
+  engine:
+    openlineage:
+      enabled: true
+      transport: http
+      url: http://lineage.example/api/lineage
+      namespace: seatunnel
+      heartbeat_min_interval_ms: 3600000
+```
+
+完整配置表、环境变量映射、Flink 配置、数据集命名和已知限制请查看
+[OpenLineage 血缘上报](../../introduction/concepts/lineage.md)。接收端 token 必须来自
+`OPENLINEAGE_AUTH_TOKEN` 或集群配置；作业 `env {}` 中配置 token 会在启动时被拒绝。
+血缘发送失败始终不会使数据处理作业失败。
+
 ### 4.4 历史作业过期配置
 
 每个完成的作业的信息，如状态、计数器和错误日志，都存储在 IMap 对象中。随着运行作业数量的增加，内存会增加，最终内存将溢出。因此，您可以调整 `history-job-expire-minutes` 参数来解决这个问题。此参数的时间单位是分钟。默认值是 1440 分钟，即一天。

--- a/docs/zh/introduction/concepts/lineage.md
+++ b/docs/zh/introduction/concepts/lineage.md
@@ -101,3 +101,41 @@ Paimon 数据集。Doris 的 `fenodes` 通常是 HTTP Stream Load
 
 除 `openlineage_run_properties` 配置的属性外，run facet 还会携带 `engine` 属性，标明上报该 run
 的执行引擎。各引擎还会补充能在自己 UI 中定位该 run 的标识，见下面各引擎章节。
+
+## Zeta
+
+### Zeta 集群配置
+
+Zeta 从 `seatunnel.yaml` 读取集群级配置：
+
+```yaml
+seatunnel:
+  engine:
+    openlineage:
+      enabled: true
+      transport: http
+      url: http://lineage.example/api/lineage
+      namespace: seatunnel
+      timeout_ms: 10000
+      retry_times: 3
+      run_facet: seatunnel_properties
+      heartbeat_min_interval_ms: 3600000
+      producer: https://seatunnel.apache.org/<version>
+```
+
+集群级 `auth_token` 也受支持，但应通过集群的 secret 管理机制提供，不要复制到作业 `env` 块。
+
+### Zeta 上报的事件
+
+Zeta 在作业进入 `RUNNING` 时发射 `START`，并在终态发射对应的 `COMPLETE`、`ABORT` 或 `FAIL`。
+`SAVEPOINT_DONE` 映射为 `COMPLETE`，`UNKNOWABLE` 映射为 `FAIL`。run facet 除 `engine` 外还携带
+`sink_action` 属性。
+
+Zeta 从历史作业指标读取终态输出统计，优先使用 committed 计数；没有正的 committed 计数时回退到
+attempted 写入计数。事件中会记录实际采用的是哪一种口径，因此消费方不会把 attempted 行数误认为
+committed 行数。
+
+未结束的作业会周期性发送心跳事件，使接收端不会把仍在运行的作业误判为 producer 已死。Zeta 搭在
+checkpoint 完成回调上发送，因此关闭 checkpoint 的 Zeta 作业没有心跳。心跳受
+`openlineage_heartbeat_min_interval_ms` 节流，设置为 `0` 时不再发送。确实停止上报的 run 受接收端
+abandoned-run 超时约束，该推断状态会被之后到达的终态事件覆盖。

--- a/docs/zh/introduction/concepts/lineage.md
+++ b/docs/zh/introduction/concepts/lineage.md
@@ -1,0 +1,103 @@
+---
+title: OpenLineage 血缘上报
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# OpenLineage 血缘上报
+
+SeaTunnel 可以向任意兼容 OpenLineage 的接收端发射表级 `RunEvent` 记录。该能力默认关闭，
+关闭时不会创建血缘网络请求或血缘专用后台线程，现有作业行为保持不变。
+
+## 配置项
+
+除特别说明外，以下配置项可以写在作业的 `env` 块中。
+
+| 配置项 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `openlineage_enabled` | Boolean | `false` | 是否启用 OpenLineage 上报。 |
+| `openlineage_transport` | String | `http` | 传输后端名称，对应 `LineageBackend` SPI。 |
+| `openlineage_url` | String | 无 | OpenLineage 接收端基址。启用上报时必须配置。 |
+| `openlineage_namespace` | String | `seatunnel` | OpenLineage job namespace。 |
+| `openlineage_auth_token` | String | 无 | 接收端 bearer token，只能来自环境变量或集群配置。 |
+| `openlineage_timeout_ms` | Int | `10000` | 单次发送尝试的超时时间，单位为毫秒。 |
+| `openlineage_retry_times` | Int | `3` | 发送失败后的重试次数。 |
+| `openlineage_run_facet` | String | `seatunnel_properties` | 自定义 run facet 的名称。 |
+| `openlineage_run_properties` | Map | 无 | 写入 run facet 的自定义属性。 |
+| `openlineage_heartbeat_min_interval_ms` | Long | `3600000` | 流作业心跳的最小间隔，单位为毫秒。设置为 `0` 表示关闭心跳上报。 |
+| `openlineage_producer` | String | `https://seatunnel.apache.org/<version>` | OpenLineage producer 标识。默认值在运行时根据当前 SeaTunnel 版本生成。 |
+
+每个配置项独立按照以下优先级解析：
+
+```text
+作业 env {} > 进程环境变量 > 集群配置 > 默认值
+```
+
+Token 是例外：`openlineage_auth_token` 按 `OPENLINEAGE_AUTH_TOKEN` > 集群配置解析。作业
+`env {}` 中出现 token 会在启动时直接拒绝。这样可以避免 token 持久化到作业配置，或被序列化到
+Flink JobGraph。
+
+血缘投递无条件是 best-effort，并且刻意不提供改变该行为的配置项。接收端或网络失败会在引擎
+集成边界被捕获并记录 warning，因此不可能改变数据处理作业的结果。
+
+### 环境变量名称
+
+环境变量名称是配置项名称的大写形式：
+
+| 配置项 | 环境变量 |
+| --- | --- |
+| `openlineage_enabled` | `OPENLINEAGE_ENABLED` |
+| `openlineage_transport` | `OPENLINEAGE_TRANSPORT` |
+| `openlineage_url` | `OPENLINEAGE_URL` |
+| `openlineage_namespace` | `OPENLINEAGE_NAMESPACE` |
+| `openlineage_auth_token` | `OPENLINEAGE_AUTH_TOKEN` |
+| `openlineage_timeout_ms` | `OPENLINEAGE_TIMEOUT_MS` |
+| `openlineage_retry_times` | `OPENLINEAGE_RETRY_TIMES` |
+| `openlineage_run_facet` | `OPENLINEAGE_RUN_FACET` |
+| `openlineage_run_properties` | `OPENLINEAGE_RUN_PROPERTIES` |
+| `openlineage_heartbeat_min_interval_ms` | `OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS` |
+| `openlineage_producer` | `OPENLINEAGE_PRODUCER` |
+
+例如，可以通过进程环境或服务管理器注入 `OPENLINEAGE_URL` 和 `OPENLINEAGE_AUTH_TOKEN`。不要把真实
+token 写入作业文件、仓库文件、命令历史或日志。
+
+## 数据集命名
+
+支持的连接器数据集标识采用以下规范形式。多表 source 和 sink 会为每张配置的表分别生成
+数据集标识：
+
+| 连接器 | Namespace | Name |
+| --- | --- | --- |
+| Paimon | `paimon://<catalog_name>/<database>` | `<table>` |
+| Doris | `mysql://<fe_host>:<query_port>` | `<database>.<table>` |
+| JDBC | `<scheme>://<host>:<port>` | `<database>.<table>` |
+
+Paimon 的 `<catalog_name>` 来自连接器的 `catalog_name` 配置，数据集的 name 只有表名，不是
+`database.table`。如果需要生成 Paimon 血缘，应显式设置 `catalog_name`；未设置时不会发射
+Paimon 数据集。Doris 的 `fenodes` 通常是 HTTP Stream Load
+端口，而血缘 namespace 使用 Doris query port。通用的 `default.default.default` 表路径不会
+被发射。
+
+使用模板路由的 sink（例如 `table = "${table_name}"`）同样不会产生数据集。模板在写入时按行替换，
+本身从不指向真实的表；若原样发射，所有使用模板路由的作业会在血缘图上汇聚到同一个节点。仅仅
+包含美元符号的名称（例如 `orders$archive`）是正常标识符，仍会被发射。
+
+## Run facet 属性
+
+除 `openlineage_run_properties` 配置的属性外，run facet 还会携带 `engine` 属性，标明上报该 run
+的执行引擎。各引擎还会补充能在自己 UI 中定位该 run 的标识，见下面各引擎章节。

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
         -->
         <module>seatunnel-config</module>
         <module>seatunnel-common</module>
+        <module>seatunnel-lineage</module>
+        <module>seatunnel-lineage-openlineage</module>
         <module>seatunnel-core</module>
         <module>seatunnel-transforms-v2</module>
         <module>seatunnel-connectors-v2</module>

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
@@ -151,4 +151,78 @@ public class EnvCommonOptions {
                     .noDefaultValue()
                     .withDescription(
                             "The http path of the metadata lake, for example: http://localhost:8090/api/metalakes/laowang_test/catalogs/");
+
+    public static Option<Boolean> OPENLINEAGE_ENABLED =
+            Options.key("openlineage_enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether OpenLineage lineage reporting is enabled.");
+
+    public static Option<String> OPENLINEAGE_TRANSPORT =
+            Options.key("openlineage_transport")
+                    .stringType()
+                    .defaultValue("http")
+                    .withDescription(
+                            "Transport name selected from the LineageBackend service provider interface.");
+
+    public static Option<String> OPENLINEAGE_URL =
+            Options.key("openlineage_url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Base URL of the OpenLineage receiver, for example: http://host:8090/api/lineage");
+
+    public static Option<String> OPENLINEAGE_NAMESPACE =
+            Options.key("openlineage_namespace")
+                    .stringType()
+                    .defaultValue("seatunnel")
+                    .withDescription("OpenLineage job namespace.");
+
+    public static Option<String> OPENLINEAGE_AUTH_TOKEN =
+            Options.key("openlineage_auth_token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Bearer token for the OpenLineage receiver. It may only come from the "
+                                    + "OPENLINEAGE_AUTH_TOKEN environment variable or from cluster configuration; "
+                                    + "declaring it in a job env block is rejected at startup.");
+
+    public static Option<Integer> OPENLINEAGE_TIMEOUT_MS =
+            Options.key("openlineage_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("Timeout of one send attempt, in milliseconds.");
+
+    public static Option<Integer> OPENLINEAGE_RETRY_TIMES =
+            Options.key("openlineage_retry_times")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("Number of retries after a failed send attempt.");
+
+    public static Option<String> OPENLINEAGE_RUN_FACET =
+            Options.key("openlineage_run_facet")
+                    .stringType()
+                    .defaultValue("seatunnel_properties")
+                    .withDescription("Name of the run facet carrying the custom run properties.");
+
+    public static Option<Map<String, String>> OPENLINEAGE_RUN_PROPERTIES =
+            Options.key("openlineage_run_properties")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("Custom properties copied into the run facet.");
+
+    public static Option<Long> OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS =
+            Options.key("openlineage_heartbeat_min_interval_ms")
+                    .longType()
+                    .defaultValue(3600000L)
+                    .withDescription(
+                            "Minimum interval between streaming-job heartbeat events, in milliseconds.");
+
+    public static Option<String> OPENLINEAGE_PRODUCER =
+            Options.key("openlineage_producer")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "OpenLineage producer identifier. When unset it defaults to "
+                                    + "https://seatunnel.apache.org/ followed by the running SeaTunnel version.");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
@@ -50,7 +50,21 @@ public class EnvOptionRule implements Factory {
                         MultiTableCommonOptions.MULTI_TABLE_FAILURE_POLICY,
                         EnvCommonOptions.CUSTOM_PARAMETERS,
                         EnvCommonOptions.NODE_TAG_FILTER,
-                        EnvCommonOptions.SINK_FLUSH_INTERVAL)
+                        EnvCommonOptions.SINK_FLUSH_INTERVAL,
+                        EnvCommonOptions.OPENLINEAGE_ENABLED,
+                        EnvCommonOptions.OPENLINEAGE_TRANSPORT,
+                        EnvCommonOptions.OPENLINEAGE_URL,
+                        EnvCommonOptions.OPENLINEAGE_NAMESPACE,
+                        // OPENLINEAGE_AUTH_TOKEN is deliberately absent: a token in a job env
+                        // block is rejected at parse time so that it is never persisted in job
+                        // configuration or serialized into a Flink JobGraph. Listing it here would
+                        // advertise a setting the job is guaranteed to be rejected for.
+                        EnvCommonOptions.OPENLINEAGE_TIMEOUT_MS,
+                        EnvCommonOptions.OPENLINEAGE_RETRY_TIMES,
+                        EnvCommonOptions.OPENLINEAGE_RUN_FACET,
+                        EnvCommonOptions.OPENLINEAGE_RUN_PROPERTIES,
+                        EnvCommonOptions.OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS,
+                        EnvCommonOptions.OPENLINEAGE_PRODUCER)
                 .build();
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/env/EnvOptionRuleTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/env/EnvOptionRuleTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.api.env;
 
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.EnvCommonOptions;
 import org.apache.seatunnel.api.options.EnvOptionRule;
 
 import org.junit.jupiter.api.Assertions;
@@ -28,5 +29,11 @@ public class EnvOptionRuleTest {
     public void testGetEnvOptionRules() throws Exception {
         OptionRule envOptionRules = new EnvOptionRule().optionRule();
         Assertions.assertNotNull(envOptionRules);
+        Assertions.assertTrue(
+                envOptionRules.getOptionalOptions().contains(EnvCommonOptions.OPENLINEAGE_ENABLED));
+        Assertions.assertTrue(
+                envOptionRules
+                        .getOptionalOptions()
+                        .contains(EnvCommonOptions.OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS));
     }
 }

--- a/seatunnel-dist/release-docs/LICENSE
+++ b/seatunnel-dist/release-docs/LICENSE
@@ -343,6 +343,7 @@ The text of each license is the standard Apache 2.0 license.
       (Apache-2.0) hugegraph-common (org.apache.hugegraph:hugegraph-common:1.5.0 - https://github.com/apache/incubator-hugegraph-commons/tree/master/hugegraph-common)
       (Apache-2.0) jnats (io.nats:jnats:2.24.0 - https://github.com/nats-io/nats.java)
       (Apache-2.0) jspecify (org.jspecify:jspecify:1.0.0 - https://github.com/jspecify/jspecify)
+      (Apache-2.0) openlineage-java (io.openlineage:openlineage-java:1.29.0 - https://github.com/OpenLineage/OpenLineage)
 
 
 ========================================================================

--- a/seatunnel-engine/seatunnel-engine-common/pom.xml
+++ b/seatunnel-engine/seatunnel-engine-common/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>seatunnel-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/EngineConfig.java
@@ -133,6 +133,8 @@ public class EngineConfig {
 
     private MetadataConfig metadataConfig = ServerConfigOptions.METADATA.defaultValue();
 
+    private Map<String, Object> lineageOptions = Collections.emptyMap();
+
     public void setBackupCount(int newBackupCount) {
         checkBackupCount(newBackupCount, 0);
         this.backupCount = newBackupCount;

--- a/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
+++ b/seatunnel-engine/seatunnel-engine-common/src/main/java/org/apache/seatunnel/engine/common/config/YamlSeaTunnelDomConfigProcessor.java
@@ -48,6 +48,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -330,6 +331,10 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
                 engineConfig.setHttpConfig(parseHttpConfig(node));
             } else if (ServerConfigOptions.METADATA.key().equals(name)) {
                 engineConfig.setMetadataConfig(parseMetadataConfigConfig(node));
+            } else if ("openlineage".equals(name)) {
+                Map<String, Object> lineageOptions =
+                        Collections.singletonMap("openlineage", parseLineageOptions(node));
+                engineConfig.setLineageOptions(lineageOptions);
             } else if (ServerConfigOptions.MasterServerConfigOptions.COORDINATOR_SERVICE
                     .key()
                     .equals(name)) {
@@ -685,5 +690,18 @@ public class YamlSeaTunnelDomConfigProcessor extends AbstractDomConfigProcessor 
             }
         }
         return metadataConfig;
+    }
+
+    private Map<String, Object> parseLineageOptions(Node lineageNode) {
+        Map<String, Object> options = new LinkedHashMap<>();
+        for (Node node : childElements(lineageNode)) {
+            Iterable<Node> children = childElements(node);
+            options.put(
+                    cleanNodeName(node),
+                    children.iterator().hasNext()
+                            ? parseLineageOptions(node)
+                            : getTextContent(node));
+        }
+        return options;
     }
 }

--- a/seatunnel-engine/seatunnel-engine-core/pom.xml
+++ b/seatunnel-engine/seatunnel-engine-core/pom.xml
@@ -53,6 +53,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
             <artifactId>seatunnel-config-sql</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/dag/actions/SinkAction.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/dag/actions/SinkAction.java
@@ -19,16 +19,21 @@ package org.apache.seatunnel.engine.core.dag.actions;
 
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.engine.core.job.ConnectorJarIdentifier;
+import org.apache.seatunnel.lineage.LineageDataset;
 
 import lombok.NonNull;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 public class SinkAction<IN, StateT, CommitInfoT, AggregatedCommitInfoT> extends AbstractAction {
+    private static final long serialVersionUID = -8715419530793414312L;
+
     private final SeaTunnelSink<IN, StateT, CommitInfoT, AggregatedCommitInfoT> sink;
+    private List<LineageDataset> lineageDatasets = Collections.emptyList();
 
     public SinkAction(
             long id,
@@ -63,6 +68,30 @@ public class SinkAction<IN, StateT, CommitInfoT, AggregatedCommitInfoT> extends 
 
     public SeaTunnelSink<IN, StateT, CommitInfoT, AggregatedCommitInfoT> getSink() {
         return sink;
+    }
+
+    /**
+     * Returns the datasets written by this sink.
+     *
+     * <p>Legacy serialized actions do not contain this field, so the getter normalizes the missing
+     * value to an empty list.
+     *
+     * @return configured sink datasets, or an empty list for legacy actions
+     */
+    public List<LineageDataset> getLineageDatasets() {
+        return lineageDatasets == null ? Collections.emptyList() : lineageDatasets;
+    }
+
+    /**
+     * Sets the datasets written by this sink.
+     *
+     * @param lineageDatasets sink datasets; {@code null} means no datasets
+     */
+    public void setLineageDatasets(List<LineageDataset> lineageDatasets) {
+        this.lineageDatasets =
+                lineageDatasets == null
+                        ? Collections.emptyList()
+                        : new ArrayList<>(lineageDatasets);
     }
 
     @Override

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/dag/actions/SourceAction.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/dag/actions/SourceAction.java
@@ -22,11 +22,15 @@ import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
 import org.apache.seatunnel.engine.core.job.ConnectorJarIdentifier;
+import org.apache.seatunnel.lineage.LineageDataset;
 
 import lombok.NonNull;
 
 import java.io.Serializable;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class SourceAction<T, SplitT extends SourceSplit, StateT extends Serializable>
@@ -34,6 +38,7 @@ public class SourceAction<T, SplitT extends SourceSplit, StateT extends Serializ
 
     private static final long serialVersionUID = -4104531889750766731L;
     private final SeaTunnelSource<T, SplitT, StateT> source;
+    private List<LineageDataset> lineageDatasets = Collections.emptyList();
 
     public SourceAction(
             long id,
@@ -47,5 +52,29 @@ public class SourceAction<T, SplitT extends SourceSplit, StateT extends Serializ
 
     public SeaTunnelSource<T, SplitT, StateT> getSource() {
         return source;
+    }
+
+    /**
+     * Returns the datasets read by this source.
+     *
+     * <p>Legacy serialized actions do not contain this field, so the getter normalizes the missing
+     * value to an empty list.
+     *
+     * @return configured source datasets, or an empty list for legacy actions
+     */
+    public List<LineageDataset> getLineageDatasets() {
+        return lineageDatasets == null ? Collections.emptyList() : lineageDatasets;
+    }
+
+    /**
+     * Sets the datasets read by this source.
+     *
+     * @param lineageDatasets source datasets; {@code null} means no datasets
+     */
+    public void setLineageDatasets(List<LineageDataset> lineageDatasets) {
+        this.lineageDatasets =
+                lineageDatasets == null
+                        ? Collections.emptyList()
+                        : new ArrayList<>(lineageDatasets);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/main/java/org/apache/seatunnel/engine/core/parse/MultipleTableJobConfigParser.java
@@ -72,6 +72,8 @@ import org.apache.seatunnel.engine.core.dag.actions.SourceAction;
 import org.apache.seatunnel.engine.core.dag.actions.TransformAction;
 import org.apache.seatunnel.engine.core.job.ConnectorJarIdentifier;
 import org.apache.seatunnel.engine.core.job.JobPipelineCheckpointData;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDatasetFactory;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSinkPluginDiscovery;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelSourcePluginDiscovery;
 import org.apache.seatunnel.plugin.discovery.seatunnel.SeaTunnelTransformPluginDiscovery;
@@ -208,6 +210,7 @@ public class MultipleTableJobConfigParser {
         this.isStartWithSavePoint = isStartWithSavePoint;
         this.seaTunnelJobConfig = handleDataSource(seaTunnelJobConfig, metaDataConfig);
         this.envOptions = ReadonlyConfig.fromConfig(seaTunnelJobConfig.getConfig("env"));
+        LineageConfig.rejectJobAuthToken(this.envOptions.getSourceMap());
         this.pipelineCheckpoints = pipelineCheckpoints;
         this.metaDataConfig = metaDataConfig;
         ConfigValidator.of(this.envOptions).validate(new EnvOptionRule().optionRule());
@@ -429,6 +432,13 @@ public class MultipleTableJobConfigParser {
         FactoryUtil.ensureJobModeMatch(jobConfig.getJobContext(), source);
         SourceAction<Object, SourceSplit, Serializable> action =
                 new SourceAction<>(id, actionName, tuple2._1(), factoryUrls, new HashSet<>());
+        // Deliberately not guarded by openlineage_enabled: this parser also runs in
+        // ClientJobExecutionEnvironment, where the server-side seatunnel.yaml is not readable, so a
+        // guard here would silently disable lineage for jobs enabled only at cluster level. The
+        // extraction is a pure map lookup that yields an empty list for unsupported connectors.
+        action.setLineageDatasets(
+                LineageDatasetFactory.fromConnectorOptions(
+                        factoryId, readonlyConfig.getSourceMap()));
         action.setParallelism(parallelism);
         for (CatalogTable catalogTable : tuple2._2()) {
             actions.add(new Tuple2<>(catalogTable, action));
@@ -756,6 +766,11 @@ public class MultipleTableJobConfigParser {
                         sink,
                         jars,
                         new HashSet<>());
+        multiTableAction.setLineageDatasets(
+                sinkActions.stream()
+                        .flatMap(action -> action.getLineageDatasets().stream())
+                        .distinct()
+                        .collect(Collectors.toList()));
         multiTableAction.setParallelism(sinkActions.get(0).getParallelism());
         return Optional.of(multiTableAction);
     }
@@ -838,6 +853,10 @@ public class MultipleTableJobConfigParser {
                         factoryUrls,
                         connectorJarIdentifiers,
                         actionConfig);
+        // See the note on the source action: the guard cannot live here, only in the JobMaster.
+        sinkAction.setLineageDatasets(
+                LineageDatasetFactory.fromConnectorOptions(
+                        factoryId, readonlyConfig.getSourceMap()));
         try {
             if (!isStartWithSavePoint) {
                 handleSaveMode(sink);

--- a/seatunnel-engine/seatunnel-engine-core/src/test/java/org/apache/seatunnel/engine/core/dag/actions/SourceSinkActionCompatibilityTest.java
+++ b/seatunnel-engine/seatunnel-engine-core/src/test/java/org/apache/seatunnel/engine/core/dag/actions/SourceSinkActionCompatibilityTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.core.dag.actions;
+
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.engine.core.job.ConnectorJarIdentifier;
+import org.apache.seatunnel.lineage.LineageDataset;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ObjectStreamClass;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+
+class SourceSinkActionCompatibilityTest {
+
+    /**
+     * Pins the identifiers a savepoint written by an earlier release is deserialized under.
+     *
+     * <p>Both classes gained a {@code lineageDatasets} field. Neither declared a {@code
+     * serialVersionUID} before that, so both ran on the identifier Java computes from the class
+     * structure, and adding a field changes that computed value. The literals here are the computed
+     * values from before the field was added, so declaring them keeps an older stream loadable; the
+     * stream's missing field is covered by {@link
+     * #shouldReturnEmptyLineageDatasetsWhenLegacyStreamHasNoField}.
+     *
+     * <p>What this asserts is that the declared identifiers are still these values, which is what a
+     * later structural change would silently break. It cannot re-derive them: the class they came
+     * from no longer exists in this build, so their provenance is the paragraph above and not an
+     * assertion.
+     */
+    @Test
+    void shouldKeepStableSerialVersionUids() {
+        Assertions.assertEquals(
+                -4104531889750766731L,
+                ObjectStreamClass.lookup(SourceAction.class).getSerialVersionUID());
+        Assertions.assertEquals(
+                -8715419530793414312L,
+                ObjectStreamClass.lookup(SinkAction.class).getSerialVersionUID());
+    }
+
+    @Test
+    void shouldReturnEmptyLineageDatasetsWhenLegacyStreamHasNoField() throws Exception {
+        SourceAction<Object, SourceSplit, Serializable> sourceAction =
+                new SourceAction<>(
+                        1L,
+                        "source",
+                        mock(SeaTunnelSource.class),
+                        emptyJarUrls(),
+                        emptyJarIdentifiers());
+        SinkAction<Object, Serializable, Serializable, Serializable> sinkAction =
+                new SinkAction<>(
+                        2L,
+                        "sink",
+                        mock(SeaTunnelSink.class),
+                        emptyJarUrls(),
+                        emptyJarIdentifiers());
+
+        setLineageDatasets(sourceAction, null);
+        setLineageDatasets(sinkAction, null);
+
+        Assertions.assertEquals(Collections.emptyList(), sourceAction.getLineageDatasets());
+        Assertions.assertEquals(Collections.emptyList(), sinkAction.getLineageDatasets());
+    }
+
+    @Test
+    void shouldCopyConfiguredLineageDatasets() {
+        SourceAction<Object, SourceSplit, Serializable> sourceAction =
+                new SourceAction<>(
+                        1L,
+                        "source",
+                        mock(SeaTunnelSource.class),
+                        emptyJarUrls(),
+                        emptyJarIdentifiers());
+        List<LineageDataset> configured =
+                Collections.singletonList(LineageDataset.of("mysql://host:3306", "db.table"));
+
+        sourceAction.setLineageDatasets(configured);
+
+        Assertions.assertEquals(configured, sourceAction.getLineageDatasets());
+        Assertions.assertNotSame(configured, sourceAction.getLineageDatasets());
+    }
+
+    private static void setLineageDatasets(Object action, List<LineageDataset> datasets)
+            throws Exception {
+        Field field = action.getClass().getDeclaredField("lineageDatasets");
+        field.setAccessible(true);
+        field.set(action, datasets);
+    }
+
+    private static Set<URL> emptyJarUrls() {
+        return Collections.emptySet();
+    }
+
+    private static Set<ConnectorJarIdentifier> emptyJarIdentifiers() {
+        return Collections.emptySet();
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/pom.xml
+++ b/seatunnel-engine/seatunnel-engine-server/pom.xml
@@ -42,6 +42,17 @@
             <artifactId>seatunnel-engine-ui</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--
+            Runtime only: the backend is discovered through the LineageBackend service loader, so
+            no engine class links against it. Compile scope would put openlineage-java and its
+            unshaded Jackson on every master and worker for a feature that is off by default.
+        -->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage-openlineage</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
             <artifactId>checkpoint-storage-hdfs</artifactId>

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -1375,6 +1375,10 @@ public class CheckpointCoordinator {
             pendingCheckpoint.abortCheckpointTimeoutFutureWhenIsCompleted();
         }
         pendingCounter.decrementAndGet();
+        // Reported only after the completed checkpoint has been booked and its timeout future
+        // disarmed: anything that delays this point delays disarming, and the timeout would then
+        // expire a checkpoint that actually succeeded.
+        checkpointManager.reportLineageHeartbeat();
 
         if (isCompleted()) {
             cleanPendingCheckpoint(CheckpointCloseReason.CHECKPOINT_COORDINATOR_COMPLETED);

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManager.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManager.java
@@ -227,6 +227,11 @@ public class CheckpointManager {
         }
     }
 
+    /** Reports a completed-checkpoint lineage heartbeat through the owning job master. */
+    public void reportLineageHeartbeat() {
+        jobMaster.reportLineageHeartbeat();
+    }
+
     protected void handleCheckpointError(int pipelineId, boolean neverRestore) {
         jobMaster.handleCheckpointError(pipelineId, neverRestore);
     }

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/dag/physical/PhysicalPlan.java
@@ -33,6 +33,7 @@ import org.apache.seatunnel.engine.core.job.PipelineExecutionState;
 import org.apache.seatunnel.engine.core.job.PipelineStatus;
 import org.apache.seatunnel.engine.server.execution.TaskGroupLocation;
 import org.apache.seatunnel.engine.server.master.JobMaster;
+import org.apache.seatunnel.engine.server.master.ZetaLineageReporter;
 import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
 
 import com.hazelcast.map.IMap;
@@ -435,6 +436,11 @@ public class PhysicalPlan {
             }
         } catch (Exception e) {
             log.warn("Failed to report job {} state event", jobId, e);
+        }
+        try {
+            ZetaLineageReporter.reportJobState(jobMaster, jobStatus);
+        } catch (Throwable e) {
+            log.warn("Failed to report lineage for job {}", jobId, e);
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/JobMaster.java
@@ -88,6 +88,7 @@ import org.apache.seatunnel.engine.server.resourcemanager.resource.SlotProfile;
 import org.apache.seatunnel.engine.server.task.operation.CleanTaskGroupContextOperation;
 import org.apache.seatunnel.engine.server.task.operation.GetTaskGroupMetricsOperation;
 import org.apache.seatunnel.engine.server.utils.NodeEngineUtil;
+import org.apache.seatunnel.lineage.LineageConfig;
 
 import com.hazelcast.cluster.Address;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -102,13 +103,16 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import java.net.URL;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -117,6 +121,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -151,6 +156,8 @@ public class JobMaster {
 
     private long initializationTimestamp;
 
+    private boolean restart;
+
     private LogicalDag logicalDag;
 
     private volatile JobDAGInfo jobDAGInfo;
@@ -177,6 +184,19 @@ public class JobMaster {
     private Map<Integer, CheckpointPlan> checkpointPlanMap;
 
     private final Map<Integer, List<SlotProfile>> releasedSlotWhenTaskGroupFinished;
+
+    private final AtomicLong lineageHeartbeatTime = new AtomicLong();
+
+    /** Resolved once on first use; see {@link #resolveLineageConfig()}. */
+    private volatile LineageConfig lineageConfig;
+
+    /** Lineage emissions waiting to be sent; see {@link #submitLineageEmission(Runnable)}. */
+    private final Deque<Runnable> lineageEmissions = new ArrayDeque<>();
+
+    private final Object lineageEmissionLock = new Object();
+
+    /** Whether a drain task is already running. Guarded by {@code lineageEmissionLock}. */
+    private boolean drainingLineageEmissions;
 
     private final IMap<Long, JobInfo> runningJobInfoIMap;
 
@@ -229,6 +249,7 @@ public class JobMaster {
 
     public synchronized void init(long initializationTimestamp, boolean restart) throws Exception {
         this.initializationTimestamp = initializationTimestamp;
+        this.restart = restart;
         jobImmutableInformation =
                 nodeEngine.getSerializationService().toObject(jobImmutableInformationData);
         jobCheckpointConfig =
@@ -1007,6 +1028,170 @@ public class JobMaster {
 
     public CheckpointManager getCheckpointManager() {
         return checkpointManager;
+    }
+
+    /**
+     * Returns the restored logical DAG used to build this job's physical execution plan.
+     *
+     * @return logical DAG, or {@code null} before job initialization
+     */
+    public LogicalDag getLogicalDag() {
+        return logicalDag;
+    }
+
+    /**
+     * Returns the history service used to read terminal job metrics.
+     *
+     * @return job history service
+     */
+    public JobHistoryService getJobHistoryService() {
+        return jobHistoryService;
+    }
+
+    /**
+     * Resolves job lineage settings from the job, environment, and cluster configuration.
+     *
+     * <p>A local or test-created {@code JobMaster} can have no engine configuration. In that case
+     * the cluster layer is treated as empty and the lineage defaults remain disabled.
+     *
+     * <p>The result is cached because this is reached from the checkpoint completion callback,
+     * where resolving repeats several map probes and allocations per option for what is a constant:
+     * none of the three layers change over a job master's lifetime. Two callers racing the first
+     * resolution both get an equivalent configuration, so no locking is needed.
+     *
+     * @return resolved lineage configuration
+     */
+    public LineageConfig resolveLineageConfig() {
+        LineageConfig resolved = lineageConfig;
+        if (resolved != null) {
+            return resolved;
+        }
+        Map<String, Object> clusterOptions =
+                engineConfig == null || engineConfig.getLineageOptions() == null
+                        ? Collections.emptyMap()
+                        : engineConfig.getLineageOptions();
+        resolved =
+                LineageConfig.resolve(
+                        jobImmutableInformation.getJobConfig().getEnvOptions(),
+                        clusterOptions,
+                        System.getenv());
+        lineageConfig = resolved;
+        return resolved;
+    }
+
+    /**
+     * Returns the lineage attempt discriminator for this job master lifecycle.
+     *
+     * <p>Fresh submissions retain the original run identity. Engine restarts and savepoint or
+     * checkpoint restores receive distinct prefixes, so each lifecycle is represented as a separate
+     * OpenLineage run.
+     *
+     * <p>The discriminator is derived from {@code initializationTimestamp} rather than from a
+     * random value on purpose: the run ID must stay recomputable from job facts alone, so that an
+     * operator can derive it offline and query the receiver for that run. A random attempt would
+     * make the run ID observable only in the emitted events themselves.
+     *
+     * @return attempt discriminator, or {@code null} for a fresh submission
+     */
+    public String getLineageAttempt() {
+        if (restart) {
+            return "restart-" + initializationTimestamp;
+        }
+        if (jobImmutableInformation != null && jobImmutableInformation.isRestoreJob()) {
+            return "restore-"
+                    + jobImmutableInformation.getRestoreMode().name().toLowerCase(Locale.ROOT)
+                    + "-"
+                    + initializationTimestamp;
+        }
+        return null;
+    }
+
+    /** Reports a checkpoint-triggered lineage heartbeat for a streaming pipeline. */
+    public void reportLineageHeartbeat() {
+        ZetaLineageReporter.reportHeartbeat(this);
+    }
+
+    /**
+     * Returns the current cumulative metrics collected from active task groups for lineage
+     * heartbeats.
+     *
+     * <p>Terminal events use the finished history copy because task groups may already have been
+     * cleaned up. Heartbeats are emitted while the task groups are active and therefore read the
+     * current counters.
+     *
+     * @return current cumulative job metrics
+     */
+    public JobMetrics getCurrentJobMetricsForLineage() {
+        return JobMetricsUtil.toJobMetrics(getCurrJobMetrics());
+    }
+
+    /** Returns the job-wide timestamp of the last emitted lineage heartbeat. */
+    AtomicLong getLineageHeartbeatTime() {
+        return lineageHeartbeatTime;
+    }
+
+    /**
+     * Runs a lineage emission off the calling thread.
+     *
+     * <p>Emission performs a blocking HTTP request whose worst case is {@code timeoutMs} times one
+     * more than {@code retryTimes}. Its two call sites are a completed checkpoint and a job state
+     * transition, both of which hold engine state that must not wait on an unreachable lineage
+     * receiver, so the send is handed to the coordinator executor instead.
+     *
+     * <p>Emissions are queued and drained by a single task rather than submitted independently
+     * because OpenLineage runs are ordered: a COMPLETE that overtakes its own START, or a heartbeat
+     * that overtakes a COMPLETE, leaves the receiver holding the wrong final state for the run. The
+     * queue keeps one job's events in submission order without serializing different jobs against
+     * each other, and occupies at most one executor thread per job.
+     *
+     * @param emission the emission to run; a failure it raises is logged rather than propagated, so
+     *     the next queued emission still runs
+     */
+    public void submitLineageEmission(Runnable emission) {
+        synchronized (lineageEmissionLock) {
+            lineageEmissions.add(emission);
+            if (drainingLineageEmissions) {
+                return;
+            }
+            drainingLineageEmissions = true;
+        }
+        try {
+            executorService.execute(this::drainLineageEmissions);
+        } catch (RejectedExecutionException rejected) {
+            int dropped;
+            synchronized (lineageEmissionLock) {
+                dropped = lineageEmissions.size();
+                lineageEmissions.clear();
+                drainingLineageEmissions = false;
+            }
+            // Dropped events have to be visible: reporting is enabled, so silence here is
+            // indistinguishable from a job that simply produced no lineage.
+            LOGGER.warning(
+                    "Dropped "
+                            + dropped
+                            + " lineage event(s) for job "
+                            + jobId
+                            + ": the coordinator executor is no longer accepting work");
+        }
+    }
+
+    /** Sends queued lineage emissions in order until the queue is empty. */
+    private void drainLineageEmissions() {
+        while (true) {
+            Runnable emission;
+            synchronized (lineageEmissionLock) {
+                emission = lineageEmissions.poll();
+                if (emission == null) {
+                    drainingLineageEmissions = false;
+                    return;
+                }
+            }
+            try {
+                emission.run();
+            } catch (Throwable error) {
+                LOGGER.warning("Failed to emit a lineage event for job " + jobId, error);
+            }
+        }
     }
 
     public PassiveCompletableFuture<JobResult> getJobMasterCompleteFuture() {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/ZetaLineageReporter.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/master/ZetaLineageReporter.java
@@ -1,0 +1,426 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master;
+
+import org.apache.seatunnel.api.common.metrics.JobMetrics;
+import org.apache.seatunnel.api.common.metrics.Measurement;
+import org.apache.seatunnel.api.common.metrics.MetricNames;
+import org.apache.seatunnel.api.sink.multitablesink.MultiTableSink;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.dag.actions.Action;
+import org.apache.seatunnel.engine.core.dag.actions.SinkAction;
+import org.apache.seatunnel.engine.core.dag.actions.SourceAction;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalDag;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalEdge;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalVertex;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+import org.apache.seatunnel.lineage.LineageRunIds;
+import org.apache.seatunnel.lineage.LineageRuntime;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/** Builds Zeta lineage events from the restored logical DAG and job metrics. */
+public final class ZetaLineageReporter {
+    private static final ILogger LOGGER = Logger.getLogger(ZetaLineageReporter.class);
+
+    private ZetaLineageReporter() {}
+
+    /**
+     * Reports a Zeta job lifecycle event when the job enters a lineage-relevant state.
+     *
+     * <p>The events are built on the calling thread so that they describe the job as it was at the
+     * transition, but they are sent through {@link JobMaster#submitLineageEmission(Runnable)}: this
+     * method runs inside {@code PhysicalPlan.updateJobState}, which holds the plan monitor, and a
+     * blocking send would hold it for the lifetime of the HTTP request.
+     *
+     * @param jobMaster job master that owns the logical DAG and job configuration
+     * @param status current job status
+     */
+    public static void reportJobState(JobMaster jobMaster, JobStatus status) {
+        if (status != JobStatus.RUNNING && !status.isEndState()) {
+            return;
+        }
+        LineageConfig config = jobMaster.resolveLineageConfig();
+        if (!config.enabled()) {
+            return;
+        }
+        LineageEventType eventType = eventType(status);
+        List<LineageEvent> events = events(jobMaster, config, eventType);
+        if (events.isEmpty()) {
+            return;
+        }
+        jobMaster.submitLineageEmission(() -> emit(config, events));
+    }
+
+    /**
+     * Reports a throttled lineage heartbeat after a completed streaming checkpoint.
+     *
+     * <p>Everything past the throttle runs off the calling thread. The caller is the checkpoint
+     * coordinator finishing a checkpoint, and both halves of the work block: collecting the current
+     * metrics issues an RPC to every worker, and sending performs an HTTP request. Doing either on
+     * the coordinator thread lets an unreachable lineage receiver stall checkpointing.
+     *
+     * <p>A non-positive interval disables the heartbeat, which is what the option means on Flink
+     * too. Without this the comparison below would read every completed checkpoint as overdue and
+     * report on each one, so the value that turns heartbeats off on one engine would produce the
+     * heaviest possible reporting on the other.
+     *
+     * @param jobMaster job master that owns the pipeline
+     */
+    public static void reportHeartbeat(JobMaster jobMaster) {
+        try {
+            LineageConfig config = jobMaster.resolveLineageConfig();
+            if (!config.enabled()
+                    || config.heartbeatMinIntervalMs() <= 0
+                    || jobMaster.getJobStatus().isEndState()) {
+                return;
+            }
+            if (jobMaster.getJobImmutableInformation().getJobConfig().getJobContext().getJobMode()
+                    != JobMode.STREAMING) {
+                return;
+            }
+            if (!shouldReportHeartbeat(jobMaster, config.heartbeatMinIntervalMs())) {
+                return;
+            }
+            jobMaster.submitLineageEmission(
+                    () -> {
+                        try {
+                            // Checked again here, not only above: the job can reach an end state
+                            // between the check above and this submission, and the terminal event
+                            // is submitted from the plan thread. Without this, a heartbeat that
+                            // lost that race is drained after the terminal event and leaves the
+                            // run marked running forever, which is what the heartbeat exists to
+                            // prevent.
+                            if (jobMaster.getJobStatus().isEndState()) {
+                                return;
+                            }
+                            emit(config, events(jobMaster, config, LineageEventType.RUNNING));
+                        } catch (Throwable error) {
+                            LOGGER.warning("Failed to emit Zeta lineage heartbeat", error);
+                        }
+                    });
+        } catch (Throwable error) {
+            LOGGER.warning("Failed to emit Zeta lineage heartbeat", error);
+        }
+    }
+
+    private static boolean shouldReportHeartbeat(JobMaster jobMaster, long minimumIntervalMs) {
+        // Checkpoint callbacks are per pipeline, but lineage heartbeat expiry is job-wide, so a
+        // single timestamp covers every pipeline of the job.
+        AtomicLong lastTime = jobMaster.getLineageHeartbeatTime();
+        long now = System.currentTimeMillis();
+        while (true) {
+            long previous = lastTime.get();
+            if (previous != 0 && now - previous < minimumIntervalMs) {
+                return false;
+            }
+            if (lastTime.compareAndSet(previous, now)) {
+                return true;
+            }
+        }
+    }
+
+    private static List<LineageEvent> events(
+            JobMaster jobMaster, LineageConfig config, LineageEventType eventType) {
+        LogicalDag logicalDag = jobMaster.getLogicalDag();
+        if (logicalDag == null) {
+            return Collections.emptyList();
+        }
+        // Only a run that is still producing, or one that finished, carries meaningful counts: an
+        // aborted or failed run's metrics describe work that was rolled back.
+        boolean includeStatistics =
+                eventType == LineageEventType.COMPLETE || eventType == LineageEventType.RUNNING;
+        JobMetrics metrics = includeStatistics ? outputMetrics(jobMaster, eventType) : null;
+        Map<Long, List<Long>> upstreamsByVertex = upstreamIndex(logicalDag);
+        List<LineageEvent> events = new ArrayList<>();
+        int sinkCount = 0;
+        for (LogicalVertex vertex : logicalDag.getLogicalVertexMap().values()) {
+            Action action = vertex.getAction();
+            if (!(action instanceof SinkAction)) {
+                continue;
+            }
+            SinkAction<?, ?, ?, ?> sinkAction = (SinkAction<?, ?, ?, ?>) action;
+            sinkCount++;
+            List<LineageDataset> inputs =
+                    sourceDatasets(logicalDag, upstreamsByVertex, vertex.getVertexId());
+            List<LineageDataset> outputs = sinkDatasets(sinkAction);
+            LineageOutputStatistics statistics =
+                    includeStatistics
+                            ? outputStatistics(metrics, sinkAction, outputs.size())
+                            : null;
+            for (LineageDataset output : outputs) {
+                LineageDataset eventOutput = output;
+                if (statistics != null) {
+                    eventOutput = output.withOutputStatistics(statistics);
+                }
+                Map<String, Object> properties = new HashMap<>(config.runProperties());
+                properties.put("engine", "zeta");
+                properties.put("sink_action", sinkAction.getName());
+                events.add(
+                        LineageEvent.builder()
+                                .runId(
+                                        LineageRunIds.forJob(
+                                                jobMaster.getJobId(),
+                                                output.namespace(),
+                                                output.name(),
+                                                jobMaster.getLineageAttempt()))
+                                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                                .eventType(eventType)
+                                .jobNamespace(config.namespace())
+                                .jobName(
+                                        jobMaster
+                                                .getJobImmutableInformation()
+                                                .getJobConfig()
+                                                .getName())
+                                .producer(config.producer())
+                                .runFacet(config.runFacet())
+                                .runProperties(properties)
+                                .inputs(inputs)
+                                .outputs(Collections.singletonList(eventOutput))
+                                .build());
+            }
+        }
+        if (events.isEmpty()) {
+            // Reporting is enabled, so producing nothing is a result the operator needs to see;
+            // otherwise a job with unsupported or unidentifiable sinks looks identical to a
+            // working one that simply has no lineage yet.
+            LOGGER.info(
+                    "No lineage events built for job "
+                            + jobMaster.getJobId()
+                            + ": "
+                            + logicalDag.getLogicalVertexMap().size()
+                            + " vertices, "
+                            + sinkCount
+                            + " sink actions, none of which resolved to a supported dataset");
+        }
+        return events;
+    }
+
+    private static void emit(LineageConfig config, List<LineageEvent> events) {
+        try {
+            for (LineageEvent event : events) {
+                LineageRuntime.emit(config, event);
+            }
+        } catch (Throwable error) {
+            LOGGER.warning("Failed to emit Zeta lineage event", error);
+        }
+    }
+
+    private static LineageEventType eventType(JobStatus status) {
+        switch (status) {
+            case FINISHED:
+            case SAVEPOINT_DONE:
+                return LineageEventType.COMPLETE;
+            case CANCELED:
+                return LineageEventType.ABORT;
+            case FAILED:
+            case UNKNOWABLE:
+                return LineageEventType.FAIL;
+            case RUNNING:
+                return LineageEventType.START;
+            default:
+                throw new IllegalArgumentException("Unsupported lineage job status: " + status);
+        }
+    }
+
+    /** Indexes the DAG edges by target vertex so a backwards walk does not rescan them. */
+    private static Map<Long, List<Long>> upstreamIndex(LogicalDag logicalDag) {
+        Map<Long, List<Long>> upstreamsByVertex = new HashMap<>();
+        for (LogicalEdge edge : logicalDag.getEdges()) {
+            if (edge.getTargetVertexId() == null || edge.getInputVertexId() == null) {
+                continue;
+            }
+            upstreamsByVertex
+                    .computeIfAbsent(edge.getTargetVertexId(), ignored -> new ArrayList<>())
+                    .add(edge.getInputVertexId());
+        }
+        return upstreamsByVertex;
+    }
+
+    /**
+     * Walks the logical DAG backwards from a sink vertex and collects the datasets of every source
+     * reachable from it.
+     *
+     * <p>The traversal deliberately uses {@link LogicalDag#getEdges()} rather than {@link
+     * Action#getUpstream()}. {@code AbstractAction.upstreams} is {@code transient}, so after the
+     * logical DAG is deserialized on the master the accessor returns {@code null} even though its
+     * declaration is annotated {@code @NonNull} — the annotation is documentation, not a runtime
+     * check. Edges survive because {@code LogicalDag} serializes them explicitly, carrying vertex
+     * IDs rather than vertex objects to avoid a serialization cycle.
+     *
+     * @param logicalDag restored logical DAG
+     * @param upstreamsByVertex edge index built once per event set by {@link #upstreamIndex}
+     * @param sinkVertexId vertex ID of the sink to walk back from
+     * @return datasets of all reachable sources, without duplicates
+     */
+    private static List<LineageDataset> sourceDatasets(
+            LogicalDag logicalDag, Map<Long, List<Long>> upstreamsByVertex, Long sinkVertexId) {
+        if (sinkVertexId == null) {
+            return Collections.emptyList();
+        }
+        Set<LineageDataset> datasets = new LinkedHashSet<>();
+        Set<Long> visited = new HashSet<>();
+        Deque<Long> pending = new ArrayDeque<>();
+        pending.add(sinkVertexId);
+        while (!pending.isEmpty()) {
+            Long vertexId = pending.poll();
+            if (!visited.add(vertexId)) {
+                continue;
+            }
+            LogicalVertex vertex = logicalDag.getLogicalVertexMap().get(vertexId);
+            if (vertex != null && vertex.getAction() instanceof SourceAction) {
+                datasets.addAll(((SourceAction<?, ?, ?>) vertex.getAction()).getLineageDatasets());
+                continue;
+            }
+            List<Long> upstreams = upstreamsByVertex.get(vertexId);
+            if (upstreams != null) {
+                pending.addAll(upstreams);
+            }
+        }
+        return new ArrayList<>(datasets);
+    }
+
+    /**
+     * Returns the datasets this sink writes to.
+     *
+     * <p>The datasets come from the connector options, which name the write target directly. They
+     * are deliberately not cross-checked against {@link MultiTableSink#getSinks()}: that map is
+     * keyed by the <em>upstream</em> table identity feeding each writer, not by the table being
+     * written. For a job such as {@code FakeSource -> Paimon} the key is the source's {@code
+     * plugin_output} while the target is the configured {@code database.table}, so filtering on it
+     * discards every dataset and the job reports no lineage at all.
+     */
+    private static List<LineageDataset> sinkDatasets(SinkAction<?, ?, ?, ?> action) {
+        List<LineageDataset> configured = action.getLineageDatasets();
+        if (configured.isEmpty()) {
+            LOGGER.info(
+                    "Sink action "
+                            + action.getName()
+                            + " has no lineage datasets; its connector options did not identify a"
+                            + " supported table");
+        }
+        return configured;
+    }
+
+    private static JobMetrics outputMetrics(JobMaster jobMaster, LineageEventType eventType) {
+        if (eventType == LineageEventType.RUNNING) {
+            return jobMaster.getCurrentJobMetricsForLineage();
+        }
+        return jobMaster.getJobHistoryService().getJobMetrics(jobMaster.getJobId());
+    }
+
+    private static LineageOutputStatistics outputStatistics(
+            JobMetrics metrics, SinkAction<?, ?, ?, ?> sinkAction, int outputCount) {
+        List<TablePath> tablePaths = metricTablePaths(sinkAction);
+        Long committedCount =
+                metricValue(metrics, MetricNames.SINK_COMMITTED_COUNT, outputCount, tablePaths);
+        Long committedBytes =
+                metricValue(metrics, MetricNames.SINK_COMMITTED_BYTES, outputCount, tablePaths);
+        if (committedCount != null && committedCount > 0) {
+            return new LineageOutputStatistics(committedCount, committedBytes, "committed");
+        }
+        Long writeCount =
+                metricValue(metrics, MetricNames.SINK_WRITE_COUNT, outputCount, tablePaths);
+        Long writeBytes =
+                metricValue(metrics, MetricNames.SINK_WRITE_BYTES, outputCount, tablePaths);
+        if (writeCount != null && writeCount > 0) {
+            return new LineageOutputStatistics(writeCount, writeBytes, "attempted");
+        }
+        return null;
+    }
+
+    private static List<TablePath> metricTablePaths(SinkAction<?, ?, ?, ?> action) {
+        if (action.getSink() instanceof MultiTableSink) {
+            return ((MultiTableSink) action.getSink())
+                    .getSinks().keySet().stream().collect(Collectors.toList());
+        }
+        if (action.getConfig() != null) {
+            return Collections.singletonList(action.getConfig().getTablePath());
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Reads one counter for a sink output.
+     *
+     * <p>Sink metrics are suffixed with the <em>upstream</em> table identity, while {@code output}
+     * names the write target, so the two cannot be matched by name. When the sink writes a single
+     * target every upstream slice belongs to it and the slices are summed; otherwise the mapping is
+     * ambiguous and the statistic is omitted rather than guessed, because a plausible-looking wrong
+     * row count is worse on a lineage graph than a missing one.
+     *
+     * @param outputCount number of datasets this sink writes to
+     */
+    private static Long metricValue(
+            JobMetrics metrics, String metricName, int outputCount, List<TablePath> tablePaths) {
+        if (outputCount > 1) {
+            return null;
+        }
+        long total = 0;
+        boolean found = false;
+        for (TablePath tablePath : tablePaths) {
+            Long value = sum(metrics, metricName + "#" + tablePath.getFullName());
+            if (value != null) {
+                total += value;
+                found = true;
+            }
+        }
+        if (found) {
+            return total;
+        }
+        return sum(metrics, metricName);
+    }
+
+    private static Long sum(JobMetrics metrics, String metricName) {
+        List<Measurement> measurements = metrics.get(metricName);
+        if (measurements.isEmpty()) {
+            return null;
+        }
+        long total = 0;
+        boolean hasNumber = false;
+        for (Measurement measurement : measurements) {
+            if (measurement.value() instanceof Number) {
+                total += ((Number) measurement.value()).longValue();
+                hasNumber = true;
+            }
+        }
+        return hasNumber ? total : null;
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinatorTest.java
@@ -1066,6 +1066,50 @@ public class CheckpointCoordinatorTest
         }
     }
 
+    /** Regression: a successfully notified checkpoint must trigger the lineage heartbeat hook. */
+    @Test
+    void testCompletePendingCheckpointReportsLineageHeartbeat() {
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            CheckpointCoordinator coordinator = buildMinimalCoordinator(executorService);
+            CheckpointCoordinator spy = Mockito.spy(coordinator);
+            Mockito.doReturn(true).when(spy).notifyCompleted(Mockito.any());
+
+            CompletedCheckpoint completedCheckpoint =
+                    new CompletedCheckpoint(
+                            1L,
+                            1,
+                            1L,
+                            System.currentTimeMillis(),
+                            CheckpointType.CHECKPOINT_TYPE,
+                            System.currentTimeMillis(),
+                            new HashMap<>(),
+                            new HashMap<>());
+
+            AtomicInteger pendingCounter =
+                    (AtomicInteger)
+                            ReflectionUtils.getField(spy, "pendingCounter")
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "pendingCounter field not found"));
+            pendingCounter.set(1);
+
+            Assertions.assertDoesNotThrow(() -> spy.completePendingCheckpoint(completedCheckpoint));
+
+            CheckpointManager checkpointManager =
+                    (CheckpointManager)
+                            ReflectionUtils.getField(spy, "checkpointManager")
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "checkpointManager field not found"));
+            Mockito.verify(checkpointManager).reportLineageHeartbeat();
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
     /**
      * Regression: when {@code notifyCompleted()} fails inside {@code allTaskReady()}, the method
      * must return immediately and must NOT schedule the next checkpoint trigger.

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/LineageOptionParityTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/LineageOptionParityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.options.EnvCommonOptions;
+import org.apache.seatunnel.lineage.LineageConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Binds the two declarations of the lineage option contract to each other.
+ *
+ * <p>{@code seatunnel-lineage} carries no dependencies so that it can be shaded into a Flink {@code
+ * lib} directory, which means it cannot use {@link Option}. Every key and default therefore exists
+ * twice: as an {@code Option} that {@code EnvOptionRule} validates a job against, and as a constant
+ * that {@link LineageConfig} resolves the running job with. Nothing links them at compile time, so
+ * a change to one silently produces a job that is validated against one default and runs with
+ * another. These assertions are that link.
+ */
+class LineageOptionParityTest {
+
+    @Test
+    void optionKeysMatchTheResolverConstants() {
+        assertKey(EnvCommonOptions.OPENLINEAGE_ENABLED, LineageConfig.ENABLED);
+        assertKey(EnvCommonOptions.OPENLINEAGE_TRANSPORT, LineageConfig.TRANSPORT);
+        assertKey(EnvCommonOptions.OPENLINEAGE_URL, LineageConfig.URL);
+        assertKey(EnvCommonOptions.OPENLINEAGE_NAMESPACE, LineageConfig.NAMESPACE);
+        assertKey(EnvCommonOptions.OPENLINEAGE_AUTH_TOKEN, LineageConfig.AUTH_TOKEN);
+        assertKey(EnvCommonOptions.OPENLINEAGE_TIMEOUT_MS, LineageConfig.TIMEOUT_MS);
+        assertKey(EnvCommonOptions.OPENLINEAGE_RETRY_TIMES, LineageConfig.RETRY_TIMES);
+        assertKey(EnvCommonOptions.OPENLINEAGE_RUN_FACET, LineageConfig.RUN_FACET);
+        assertKey(EnvCommonOptions.OPENLINEAGE_RUN_PROPERTIES, LineageConfig.RUN_PROPERTIES);
+        assertKey(
+                EnvCommonOptions.OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS,
+                LineageConfig.HEARTBEAT_MIN_INTERVAL_MS);
+        assertKey(EnvCommonOptions.OPENLINEAGE_PRODUCER, LineageConfig.PRODUCER);
+    }
+
+    @Test
+    void optionDefaultsMatchTheResolverDefaults() {
+        LineageConfig defaults = LineageConfig.defaults();
+
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_ENABLED.defaultValue(), defaults.enabled());
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_TRANSPORT.defaultValue(),
+                LineageConfig.DEFAULT_TRANSPORT);
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_NAMESPACE.defaultValue(),
+                LineageConfig.DEFAULT_NAMESPACE);
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_RUN_FACET.defaultValue(),
+                LineageConfig.DEFAULT_RUN_FACET);
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_TIMEOUT_MS.defaultValue().intValue(),
+                LineageConfig.DEFAULT_TIMEOUT_MS);
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_RETRY_TIMES.defaultValue().intValue(),
+                LineageConfig.DEFAULT_RETRY_TIMES);
+        Assertions.assertEquals(
+                EnvCommonOptions.OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS.defaultValue().longValue(),
+                LineageConfig.DEFAULT_HEARTBEAT_MIN_INTERVAL_MS);
+    }
+
+    private static void assertKey(Option<?> option, String resolverKey) {
+        Assertions.assertEquals(
+                option.key(),
+                resolverKey,
+                "the declared option and the resolver constant must name the same setting");
+    }
+}

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/ZetaLineageReporterTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/master/ZetaLineageReporterTest.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.master;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.common.metrics.JobMetrics;
+import org.apache.seatunnel.api.common.metrics.Measurement;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.engine.common.config.JobConfig;
+import org.apache.seatunnel.engine.common.job.JobStatus;
+import org.apache.seatunnel.engine.core.dag.actions.SinkAction;
+import org.apache.seatunnel.engine.core.dag.actions.SourceAction;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalDag;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalEdge;
+import org.apache.seatunnel.engine.core.dag.logical.LogicalVertex;
+import org.apache.seatunnel.engine.core.job.JobImmutableInformation;
+import org.apache.seatunnel.engine.core.job.RestoreMode;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEventType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class ZetaLineageReporterTest {
+
+    @Test
+    void shouldUseDistinctAttemptsForRestartAndCheckpointRestores() throws Exception {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        setField(jobMaster, "initializationTimestamp", 42L);
+
+        JobImmutableInformation savepointInfo = mock(JobImmutableInformation.class);
+        doReturn(true).when(savepointInfo).isRestoreJob();
+        doReturn(RestoreMode.SAVEPOINT).when(savepointInfo).getRestoreMode();
+        setField(jobMaster, "jobImmutableInformation", savepointInfo);
+        setField(jobMaster, "restart", false);
+        String savepointAttempt = jobMaster.getLineageAttempt();
+
+        JobImmutableInformation checkpointInfo = mock(JobImmutableInformation.class);
+        doReturn(true).when(checkpointInfo).isRestoreJob();
+        doReturn(RestoreMode.CHECKPOINT).when(checkpointInfo).getRestoreMode();
+        setField(jobMaster, "jobImmutableInformation", checkpointInfo);
+        String checkpointAttempt = jobMaster.getLineageAttempt();
+
+        setField(jobMaster, "restart", true);
+        String restartAttempt = jobMaster.getLineageAttempt();
+
+        Assertions.assertNotNull(savepointAttempt);
+        Assertions.assertNotNull(checkpointAttempt);
+        Assertions.assertNotNull(restartAttempt);
+        Assertions.assertNotEquals(savepointAttempt, checkpointAttempt);
+        Assertions.assertNotEquals(savepointAttempt, restartAttempt);
+        Assertions.assertNotEquals(checkpointAttempt, restartAttempt);
+    }
+
+    /**
+     * The restart attempt must be a pure function of the initialization timestamp so that a run ID
+     * can be recomputed offline from job facts. A random discriminator would satisfy uniqueness but
+     * would make the run ID unrecoverable outside the emitted events.
+     */
+    @Test
+    void shouldDeriveRecomputableRestartAttemptFromInitializationTimestamp() throws Exception {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        setField(jobMaster, "restart", true);
+
+        setField(jobMaster, "initializationTimestamp", 42L);
+        String firstAttempt = jobMaster.getLineageAttempt();
+        String recomputedAttempt = jobMaster.getLineageAttempt();
+
+        setField(jobMaster, "initializationTimestamp", 43L);
+        String laterAttempt = jobMaster.getLineageAttempt();
+
+        Assertions.assertEquals("restart-42", firstAttempt);
+        Assertions.assertEquals(firstAttempt, recomputedAttempt);
+        Assertions.assertEquals("restart-43", laterAttempt);
+        Assertions.assertNotEquals(firstAttempt, laterAttempt);
+    }
+
+    @Test
+    void shouldResolveDisabledConfigWhenEngineConfigIsAbsent() throws Exception {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        JobImmutableInformation jobInformation = mock(JobImmutableInformation.class);
+        doReturn(new JobConfig()).when(jobInformation).getJobConfig();
+        setField(jobMaster, "jobImmutableInformation", jobInformation);
+
+        LineageConfig config = Assertions.assertDoesNotThrow(jobMaster::resolveLineageConfig);
+
+        Assertions.assertFalse(config.enabled());
+        // Reached from the checkpoint completion callback, where none of the three configuration
+        // layers can have changed since the first resolution.
+        Assertions.assertSame(
+                config, jobMaster.resolveLineageConfig(), "the resolved config must be reused");
+    }
+
+    @Test
+    void shouldUseCurrentMetricsForHeartbeatAndHistoryForTerminalEvent() throws Exception {
+        JobMetrics history = metrics("history");
+        JobMetrics current = metrics("current");
+
+        Assertions.assertSame(
+                current,
+                invokeOutputMetrics(
+                        mockCurrentMetricsJobMaster(current), LineageEventType.RUNNING));
+        Assertions.assertSame(
+                history,
+                invokeOutputMetrics(
+                        mockHistoryMetricsJobMaster(history), LineageEventType.COMPLETE));
+    }
+
+    @Test
+    void shouldCollectCurrentMetricsWithoutPersistingOrCleaning() {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        doReturn(Collections.emptyList()).when(jobMaster).getCurrJobMetrics();
+
+        JobMetrics current = jobMaster.getCurrentJobMetricsForLineage();
+
+        Assertions.assertTrue(current.metrics().isEmpty());
+        verify(jobMaster).getCurrJobMetrics();
+        verify(jobMaster, never()).savePipelineMetricsToHistory(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void shouldThrottleHeartbeatsAcrossPipelinesForOneJob() throws Exception {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        doReturn(new AtomicLong()).when(jobMaster).getLineageHeartbeatTime();
+
+        Assertions.assertTrue(invokeShouldReportHeartbeat(jobMaster, Long.MAX_VALUE));
+        Assertions.assertFalse(invokeShouldReportHeartbeat(jobMaster, Long.MAX_VALUE));
+    }
+
+    /**
+     * A non-positive interval disables the heartbeat, matching what the option means on Flink. Zeta
+     * reports from the checkpoint completion callback, so reading zero as "always overdue" would
+     * turn the value that switches heartbeats off into one metrics RPC and one HTTP request per
+     * completed checkpoint.
+     */
+    @Test
+    void shouldNotReportHeartbeatsWhenTheIntervalDisablesThem() {
+        JobMaster disabled = streamingJobMaster(0L);
+
+        ZetaLineageReporter.reportHeartbeat(disabled);
+
+        verify(disabled, never()).submitLineageEmission(any());
+
+        // The same wiring with a usable interval must report, so the assertion above cannot pass
+        // merely because the mock never reached the throttle.
+        JobMaster reporting = streamingJobMaster(1L);
+
+        ZetaLineageReporter.reportHeartbeat(reporting);
+
+        verify(reporting).submitLineageEmission(any());
+    }
+
+    /**
+     * The heartbeat leaves the checkpoint thread through a queue, while the terminal event is
+     * submitted from the plan thread. A heartbeat that passed its own end-state check just before
+     * the job finished would otherwise be drained after the terminal event and leave the run marked
+     * running forever.
+     */
+    @Test
+    void shouldDropAHeartbeatThatLostTheRaceWithTheTerminalEvent() {
+        JobMaster jobMaster = streamingJobMaster(1L);
+        ArgumentCaptor<Runnable> emission = ArgumentCaptor.forClass(Runnable.class);
+
+        ZetaLineageReporter.reportHeartbeat(jobMaster);
+        verify(jobMaster).submitLineageEmission(emission.capture());
+
+        // The plan thread reached the end state after the heartbeat passed its own check.
+        doReturn(JobStatus.FINISHED).when(jobMaster).getJobStatus();
+        emission.getValue().run();
+        verify(jobMaster, never()).getLogicalDag();
+
+        // The same queued emission on a job that is still running does build its events, so the
+        // assertion above cannot pass merely because the emission does nothing.
+        doReturn(JobStatus.RUNNING).when(jobMaster).getJobStatus();
+        emission.getValue().run();
+        verify(jobMaster).getLogicalDag();
+    }
+
+    /**
+     * A running streaming job master whose lineage is enabled with the given heartbeat interval.
+     */
+    private static JobMaster streamingJobMaster(long heartbeatIntervalMs) {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        Map<String, Object> options = new HashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.HEARTBEAT_MIN_INTERVAL_MS, heartbeatIntervalMs);
+        doReturn(LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap()))
+                .when(jobMaster)
+                .resolveLineageConfig();
+        doReturn(JobStatus.RUNNING).when(jobMaster).getJobStatus();
+
+        JobConfig jobConfig = new JobConfig();
+        jobConfig.setJobContext(new JobContext().setJobMode(JobMode.STREAMING));
+        JobImmutableInformation information = mock(JobImmutableInformation.class);
+        doReturn(jobConfig).when(information).getJobConfig();
+        doReturn(information).when(jobMaster).getJobImmutableInformation();
+
+        doReturn(new AtomicLong()).when(jobMaster).getLineageHeartbeatTime();
+        doNothing().when(jobMaster).submitLineageEmission(any());
+        return jobMaster;
+    }
+
+    /**
+     * Emission blocks on an HTTP request whose worst case is the configured timeout times one more
+     * than the retry count. Its callers hold a completed checkpoint and the physical plan monitor,
+     * so the send has to leave the calling thread; it must still reach the receiver in submission
+     * order, because a COMPLETE that overtakes its own START leaves the run in the wrong state.
+     */
+    @Test
+    void shouldRunLineageEmissionsOffTheCallerThreadInSubmissionOrder() throws Exception {
+        JobMaster jobMaster = mock(JobMaster.class, CALLS_REAL_METHODS);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        setField(jobMaster, "executorService", executor);
+        setField(jobMaster, "lineageEmissions", new ArrayDeque<Runnable>());
+        setField(jobMaster, "lineageEmissionLock", new Object());
+        try {
+            List<String> emitted = Collections.synchronizedList(new ArrayList<>());
+            CountDownLatch releaseFirst = new CountDownLatch(1);
+            CountDownLatch lastEmitted = new CountDownLatch(1);
+
+            jobMaster.submitLineageEmission(
+                    () -> {
+                        awaitQuietly(releaseFirst);
+                        emitted.add("first");
+                    });
+            // A failing emission must not break the chain for the events queued behind it.
+            jobMaster.submitLineageEmission(
+                    () -> {
+                        throw new IllegalStateException("receiver rejected the event");
+                    });
+            jobMaster.submitLineageEmission(
+                    () -> {
+                        emitted.add("third");
+                        lastEmitted.countDown();
+                    });
+
+            Assertions.assertTrue(
+                    emitted.isEmpty(), "the calling thread must not run the emission itself");
+            releaseFirst.countDown();
+            Assertions.assertTrue(
+                    lastEmitted.await(30, TimeUnit.SECONDS), "queued emissions must still run");
+            Assertions.assertEquals(Arrays.asList("first", "third"), emitted);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await(30, TimeUnit.SECONDS);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Regression for a failure that only appears once the logical DAG has crossed a serialization
+     * boundary: {@code AbstractAction.upstreams} is {@code transient}, so on the master it is null
+     * and walking {@code Action.getUpstream()} throws. The traversal must go through the DAG edges,
+     * which are serialized as vertex IDs, so this test clears the action upstreams to reproduce the
+     * deserialized shape rather than the freshly built one.
+     */
+    @Test
+    void shouldWalkSourcesThroughDagEdgesWhenActionUpstreamsAreLost() throws Exception {
+        LineageDataset sourceDataset = LineageDataset.of("mysql://host:3306", "db.src");
+
+        SourceAction<?, ?, ?> sourceAction =
+                new SourceAction<>(
+                        1L,
+                        "source",
+                        mock(SeaTunnelSource.class),
+                        new HashSet<>(),
+                        new HashSet<>());
+        sourceAction.setLineageDatasets(Collections.singletonList(sourceDataset));
+        SinkAction<?, ?, ?, ?> sinkAction =
+                new SinkAction<>(
+                        3L, "sink", mock(SeaTunnelSink.class), new HashSet<>(), new HashSet<>());
+
+        LogicalVertex sourceVertex = new LogicalVertex(1L, sourceAction, 1);
+        LogicalVertex transformVertex =
+                new LogicalVertex(
+                        2L, mock(org.apache.seatunnel.engine.core.dag.actions.Action.class), 1);
+        LogicalVertex sinkVertex = new LogicalVertex(3L, sinkAction, 1);
+
+        LogicalDag dag = new LogicalDag();
+        dag.addLogicalVertex(sourceVertex);
+        dag.addLogicalVertex(transformVertex);
+        dag.addLogicalVertex(sinkVertex);
+        dag.addEdge(new LogicalEdge(1L, 2L));
+        dag.addEdge(new LogicalEdge(2L, 3L));
+
+        // Reproduce the deserialized state: the transient upstream links are gone.
+        clearUpstreams(sourceAction);
+        clearUpstreams(sinkAction);
+
+        List<LineageDataset> inputs = invokeSourceDatasets(dag, 3L);
+
+        Assertions.assertEquals(
+                Collections.singletonList(sourceDataset),
+                inputs,
+                "the source must be reached through the transform via DAG edges");
+        Assertions.assertEquals(
+                Collections.emptyList(),
+                invokeSourceDatasets(dag, 99L),
+                "an unknown vertex yields no inputs rather than failing");
+        Assertions.assertEquals(
+                Collections.emptyList(),
+                invokeSourceDatasets(dag, null),
+                "a missing vertex id yields no inputs rather than failing");
+    }
+
+    private static void clearUpstreams(Object action) throws Exception {
+        Class<?> type = action.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField("upstreams");
+                field.setAccessible(true);
+                field.set(action, null);
+                return;
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+        throw new IllegalStateException("upstreams field not found");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<LineageDataset> invokeSourceDatasets(LogicalDag dag, Long sinkVertexId)
+            throws Exception {
+        Method method =
+                ZetaLineageReporter.class.getDeclaredMethod(
+                        "sourceDatasets", LogicalDag.class, Map.class, Long.class);
+        method.setAccessible(true);
+        Method index =
+                ZetaLineageReporter.class.getDeclaredMethod("upstreamIndex", LogicalDag.class);
+        index.setAccessible(true);
+        return (List<LineageDataset>)
+                method.invoke(null, dag, index.invoke(null, dag), sinkVertexId);
+    }
+
+    private static JobMetrics invokeOutputMetrics(JobMaster jobMaster, LineageEventType eventType)
+            throws Exception {
+        Method method =
+                ZetaLineageReporter.class.getDeclaredMethod(
+                        "outputMetrics", JobMaster.class, LineageEventType.class);
+        method.setAccessible(true);
+        return (JobMetrics) method.invoke(null, jobMaster, eventType);
+    }
+
+    private static JobMaster mockCurrentMetricsJobMaster(JobMetrics current) {
+        JobMaster jobMaster = mock(JobMaster.class);
+        doReturn(current).when(jobMaster).getCurrentJobMetricsForLineage();
+        return jobMaster;
+    }
+
+    private static JobMaster mockHistoryMetricsJobMaster(JobMetrics history) {
+        JobMaster jobMaster = mock(JobMaster.class);
+        JobHistoryService historyService = mock(JobHistoryService.class);
+        doReturn(historyService).when(jobMaster).getJobHistoryService();
+        doReturn(1L).when(jobMaster).getJobId();
+        doReturn(history).when(historyService).getJobMetrics(1L);
+        return jobMaster;
+    }
+
+    private static boolean invokeShouldReportHeartbeat(JobMaster jobMaster, long minimumIntervalMs)
+            throws Exception {
+        Method method =
+                ZetaLineageReporter.class.getDeclaredMethod(
+                        "shouldReportHeartbeat", JobMaster.class, long.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, jobMaster, minimumIntervalMs);
+    }
+
+    private static JobMetrics metrics(String value) {
+        Map<String, List<Measurement>> values = new HashMap<>();
+        values.put(
+                "marker",
+                Collections.singletonList(
+                        Measurement.of("marker", value, 1L, Collections.emptyMap())));
+        return JobMetrics.of(values);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = JobMaster.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/seatunnel-lineage-openlineage/pom.xml
+++ b/seatunnel-lineage-openlineage/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-lineage-openlineage</artifactId>
+    <name>SeaTunnel : OpenLineage Backend</name>
+
+    <properties>
+        <openlineage.version>1.29.0</openlineage.version>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpcore.version>4.4.16</httpcore.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.openlineage</groupId>
+            <artifactId>openlineage-java</artifactId>
+            <version>${openlineage.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents.client5</groupId>
+                    <artifactId>httpclient5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <!-- Declared so that this module resolves the same httpcore the rest of the
+             distribution already ships, instead of the older one httpclient depends on. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackend.java
+++ b/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackend.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/** HTTP LineageBackend using the project's fixed Apache HttpClient 4.x transport. */
+public final class OpenLineageBackend implements LineageBackend {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenLineageBackend.class);
+
+    /**
+     * Returns the transport name used to select this backend through the lineage SPI.
+     *
+     * @return the HTTP transport name
+     */
+    @Override
+    public String getName() {
+        return "http";
+    }
+
+    /**
+     * Sends one event using HTTP on a best-effort basis.
+     *
+     * <p>Failures are logged and ignored. Lineage delivery must never change the outcome of the
+     * data-processing job, so this behaviour is not configurable.
+     *
+     * @param config immutable lineage configuration
+     * @param event event to send
+     */
+    @Override
+    public void emit(LineageConfig config, LineageEvent event) {
+        if (!config.enabled()) {
+            return;
+        }
+        String payload;
+        try {
+            payload = OpenLineageEventConverter.toJson(event);
+        } catch (Throwable failure) {
+            LOGGER.warn("Failed to render an OpenLineage event as JSON", failure);
+            return;
+        }
+        try {
+            sendWithRetry(config, payload);
+        } catch (IllegalArgumentException configurationError) {
+            // Reported apart from a delivery failure because it names the option to correct rather
+            // than a receiver to investigate. The failure's own message is deliberately left out:
+            // a malformed endpoint is reported by quoting it in full, credentials included, which
+            // is exactly what endpointSummary exists to keep out of the log.
+            LOGGER.warn(
+                    "Failed to send OpenLineage event: {} is missing or is not a usable endpoint"
+                            + " ({})",
+                    LineageConfig.URL,
+                    endpointSummary(config.url()));
+        } catch (Throwable failure) {
+            // The message carries what the run actually needs: the HTTP status of a rejected
+            // request, the TLS or connection failure behind an unreachable one. The cause is
+            // passed as well so the stack survives; without both, every failure is logged as an
+            // indistinguishable IOException.
+            LOGGER.warn(
+                    "Failed to send OpenLineage event to endpoint {} after {} attempt(s): {}",
+                    endpointSummary(config.url()),
+                    config.retryTimes() + 1,
+                    failure.toString(),
+                    failure);
+        }
+    }
+
+    private void sendWithRetry(LineageConfig config, String payload) throws Exception {
+        Exception failure = null;
+        for (int attempt = 0; attempt <= config.retryTimes(); attempt++) {
+            try {
+                sendOnce(config, payload);
+                return;
+            } catch (IllegalArgumentException configurationError) {
+                // A missing or malformed endpoint fails identically on every attempt, so retrying
+                // only multiplies the sleep by the retry count on every event of the job.
+                throw configurationError;
+            } catch (Exception e) {
+                failure = e;
+                if (attempt < config.retryTimes()) {
+                    try {
+                        Thread.sleep(Math.min(100L, 10L * (attempt + 1)));
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw interrupted;
+                    }
+                }
+            }
+        }
+        throw failure;
+    }
+
+    private static String endpointSummary(String endpoint) {
+        if (endpoint == null || endpoint.trim().isEmpty()) {
+            return "<missing>";
+        }
+        try {
+            URI uri = new URI(endpoint);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) {
+                return "<invalid>";
+            }
+            return uri.getPort() < 0
+                    ? scheme + "://" + host
+                    : scheme + "://" + host + ":" + uri.getPort();
+        } catch (URISyntaxException e) {
+            return "<invalid>";
+        }
+    }
+
+    private void sendOnce(LineageConfig config, String payload) throws IOException {
+        if (config.url() == null || config.url().trim().isEmpty()) {
+            throw new IllegalArgumentException("openlineage_url must be configured when enabled");
+        }
+        RequestConfig requestConfig =
+                RequestConfig.custom()
+                        .setConnectTimeout(config.timeoutMs())
+                        .setConnectionRequestTimeout(config.timeoutMs())
+                        .setSocketTimeout(config.timeoutMs())
+                        .build();
+        HttpPost post = new HttpPost(config.url());
+        post.setConfig(requestConfig);
+        post.setHeader("Content-Type", ContentType.APPLICATION_JSON.getMimeType());
+        if (config.authToken() != null) {
+            post.setHeader("Authorization", "Bearer " + config.authToken());
+        }
+        post.setEntity(new StringEntity(payload, ContentType.APPLICATION_JSON));
+        try (CloseableHttpResponse response = SharedClient.INSTANCE.execute(post)) {
+            HttpEntity entity = response.getEntity();
+            EntityUtils.consumeQuietly(entity);
+            int status = response.getStatusLine().getStatusCode();
+            if (status < HttpStatus.SC_OK || status >= HttpStatus.SC_MULTIPLE_CHOICES) {
+                throw new IOException("OpenLineage endpoint returned HTTP " + status);
+            }
+        }
+    }
+
+    /**
+     * Holds the client shared by every send.
+     *
+     * <p>Building one per attempt also builds a connection pool and an SSL context per attempt,
+     * which on the engine paths that emit lineage costs more than the request itself. Timeouts stay
+     * per request through {@link RequestConfig}, so one client can serve every configuration. It is
+     * intentionally never closed: it lives as long as the process that reports lineage.
+     *
+     * <p>The connection limits are set explicitly because the default pool allows two connections
+     * per route, and every lineage event of a process goes to the same receiver, hence the same
+     * route. Sharing a client at that default would let a third concurrent emitter — a Zeta master
+     * running several streaming jobs reports each job's events on its own thread — wait out the
+     * connection-request timeout and fail against a receiver that is perfectly healthy.
+     */
+    private static final class SharedClient {
+        private static final int MAX_CONNECTIONS = 32;
+
+        private static final CloseableHttpClient INSTANCE =
+                HttpClients.custom()
+                        .setMaxConnPerRoute(MAX_CONNECTIONS)
+                        .setMaxConnTotal(MAX_CONNECTIONS)
+                        .build();
+
+        private SharedClient() {}
+    }
+}

--- a/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageEventConverter.java
+++ b/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageEventConverter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Converts the small SeaTunnel contract into an OpenLineage RunEvent. */
+final class OpenLineageEventConverter {
+    private OpenLineageEventConverter() {}
+
+    static String toJson(LineageEvent event) {
+        OpenLineage openLineage = new OpenLineage(URI.create(event.producer()));
+        OpenLineage.RunFacetsBuilder runFacetsBuilder = openLineage.newRunFacetsBuilder();
+        Map<String, Object> runProperties = new LinkedHashMap<>(event.runProperties());
+        String statisticsSemantics = statisticsSemantics(event.outputs());
+        if (statisticsSemantics != null) {
+            runProperties.put("output_statistics_semantics", statisticsSemantics);
+        }
+        if (!runProperties.isEmpty()) {
+            OpenLineage.DefaultRunFacet facet =
+                    new OpenLineage.DefaultRunFacet(URI.create(event.producer()));
+            facet.getAdditionalProperties().putAll(runProperties);
+            runFacetsBuilder.put(event.runFacet(), facet);
+        }
+
+        OpenLineage.Run run =
+                openLineage
+                        .newRunBuilder()
+                        .runId(event.runId())
+                        .facets(runFacetsBuilder.build())
+                        .build();
+        OpenLineage.Job job =
+                openLineage
+                        .newJobBuilder()
+                        .namespace(event.jobNamespace())
+                        .name(event.jobName())
+                        .build();
+
+        List<OpenLineage.InputDataset> inputs = new ArrayList<>();
+        for (LineageDataset input : event.inputs()) {
+            inputs.add(
+                    openLineage
+                            .newInputDatasetBuilder()
+                            .namespace(input.namespace())
+                            .name(input.name())
+                            .build());
+        }
+
+        List<OpenLineage.OutputDataset> outputs = new ArrayList<>();
+        for (LineageDataset output : event.outputs()) {
+            OpenLineage.OutputDatasetBuilder outputBuilder =
+                    openLineage
+                            .newOutputDatasetBuilder()
+                            .namespace(output.namespace())
+                            .name(output.name());
+            LineageOutputStatistics statistics = output.outputStatistics();
+            if (statistics != null && statistics.hasValue()) {
+                OpenLineage.OutputStatisticsOutputDatasetFacetBuilder statisticsBuilder =
+                        openLineage.newOutputStatisticsOutputDatasetFacetBuilder();
+                if (statistics.rowCount() != null) {
+                    statisticsBuilder.rowCount(statistics.rowCount());
+                }
+                if (statistics.size() != null) {
+                    statisticsBuilder.size(statistics.size());
+                }
+                outputBuilder.outputFacets(
+                        openLineage
+                                .newOutputDatasetOutputFacetsBuilder()
+                                .outputStatistics(statisticsBuilder.build())
+                                .build());
+            }
+            outputs.add(outputBuilder.build());
+        }
+
+        OpenLineage.RunEvent.EventType eventType =
+                OpenLineage.RunEvent.EventType.valueOf(event.eventType().name());
+        OpenLineage.RunEvent runEvent =
+                openLineage
+                        .newRunEventBuilder()
+                        .eventTime(event.eventTime())
+                        .eventType(eventType)
+                        .run(run)
+                        .job(job)
+                        .inputs(inputs)
+                        .outputs(outputs)
+                        .build();
+        return OpenLineageClientUtils.toJson(runEvent);
+    }
+
+    private static String statisticsSemantics(List<LineageDataset> outputs) {
+        String semantics = null;
+        for (LineageDataset output : outputs) {
+            LineageOutputStatistics statistics = output.outputStatistics();
+            if (statistics == null || statistics.semantics() == null) {
+                continue;
+            }
+            if (semantics == null) {
+                semantics = statistics.semantics();
+            } else if (!semantics.equals(statistics.semantics())) {
+                return "mixed";
+            }
+        }
+        return semantics;
+    }
+}

--- a/seatunnel-lineage-openlineage/src/main/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
+++ b/seatunnel-lineage-openlineage/src/main/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.seatunnel.lineage.openlineage.OpenLineageBackend

--- a/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/LineageBackendDiscoveryTest.java
+++ b/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/LineageBackendDiscoveryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageBackendLoader;
+import org.apache.seatunnel.lineage.LineageConfig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the packaging contract rather than the logic.
+ *
+ * <p>The reporter reaches its transport through {@link ServiceLoader}. A module that depends only
+ * on the lineage contract compiles and runs, but its shaded jar carries no provider file, so the
+ * backend cannot be resolved and every event is dropped with a warning. That is invisible to any
+ * test that constructs the backend directly, so the lookup is asserted the way production performs
+ * it.
+ */
+class LineageBackendDiscoveryTest {
+
+    @Test
+    void httpBackendIsReachableThroughTheServiceLoader() {
+        boolean found = false;
+        for (LineageBackend backend : ServiceLoader.load(LineageBackend.class)) {
+            if ("http".equals(backend.getName())) {
+                found = true;
+            }
+        }
+        assertTrue(
+                found,
+                "no LineageBackend named 'http' on the classpath: the provider file is missing, "
+                        + "which means a packaging or dependency change dropped "
+                        + "seatunnel-lineage-openlineage");
+    }
+
+    @Test
+    void enabledConfigResolvesTheHttpBackendRatherThanFailing() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.URL, "http://127.0.0.1:1/api/lineage");
+        LineageConfig config =
+                LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+        LineageBackend backend = LineageBackendLoader.load(config);
+
+        assertNotNull(backend);
+        assertTrue(
+                backend instanceof OpenLineageBackend,
+                "the default transport must resolve to the OpenLineage backend, not fail");
+    }
+}

--- a/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackendTest.java
+++ b/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackendTest.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenLineageBackendTest {
+
+    @Test
+    void serializesFacetAndStatisticsAndSendsToken() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext(
+                "/lineage",
+                exchange -> {
+                    body.set(
+                            new String(readAll(exchange.getRequestBody()), StandardCharsets.UTF_8));
+                    authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+                    respond(exchange, 200);
+                });
+        server.start();
+        try {
+            Map<String, Object> environment =
+                    Collections.singletonMap("OPENLINEAGE_AUTH_TOKEN", "test-token");
+            Map<String, Object> options = new HashMap<>();
+            options.put(LineageConfig.ENABLED, true);
+            options.put(
+                    LineageConfig.URL,
+                    "http://localhost:" + server.getAddress().getPort() + "/lineage");
+            LineageConfig config =
+                    LineageConfig.resolve(options, Collections.emptyMap(), environment);
+            UUID runId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+            LineageEvent event =
+                    LineageEvent.builder()
+                            .runId(runId)
+                            .eventTime(ZonedDateTime.of(2026, 9, 1, 1, 2, 3, 0, ZoneOffset.UTC))
+                            .eventType(LineageEventType.COMPLETE)
+                            .jobNamespace("seatunnel")
+                            .jobName("lineage-test")
+                            .producer("https://seatunnel.apache.org/3.0.0-SNAPSHOT")
+                            .runFacet("seatunnel_properties")
+                            .runProperties(Collections.singletonMap("engine", "zeta"))
+                            .inputs(
+                                    Collections.singletonList(
+                                            LineageDataset.of("mysql://host:9030", "db.in")))
+                            .outputs(
+                                    Collections.singletonList(
+                                            LineageDataset.of("mysql://host:9030", "db.out")
+                                                    .withOutputStatistics(
+                                                            new LineageOutputStatistics(
+                                                                    12L, 345L, "committed"))))
+                            .build();
+
+            new OpenLineageBackend().emit(config, event);
+
+            assertTrue(body.get().contains("\"runId\":\"" + runId + "\""));
+            assertTrue(body.get().contains("\"rowCount\":12"));
+            assertTrue(body.get().contains("\"size\":345"));
+            assertTrue(body.get().contains("\"output_statistics_semantics\":\"committed\""));
+            assertFalse(body.get().contains("\"additionalProperties\""));
+            assertEquals("Bearer test-token", authorization.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void disabledBackendDoesNotRequireEndpoint() throws Exception {
+        LineageConfig config = LineageConfig.defaults();
+        new OpenLineageBackend().emit(config, minimalEvent());
+    }
+
+    @Test
+    void exposesHttpTransportThroughPublicApi() {
+        assertEquals("http", new OpenLineageBackend().getName());
+    }
+
+    @Test
+    void isDiscoverableThroughLineageBackendServiceProvider() {
+        assertTrue(
+                StreamSupport.stream(ServiceLoader.load(LineageBackend.class).spliterator(), false)
+                        .anyMatch(backend -> backend.getClass() == OpenLineageBackend.class));
+    }
+
+    @Test
+    void failedSendDoesNotThrowOrLogSensitiveEndpoint() {
+        HttpServer server = null;
+        Logger logger = (Logger) LogManager.getLogger(OpenLineageBackend.class);
+        CapturingAppender appender = new CapturingAppender();
+        Level originalLevel = logger.getLevel();
+        boolean originalAdditive = logger.isAdditive();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
+        logger.setAdditive(false);
+        appender.start();
+        try {
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext("/lineage", exchange -> respond(exchange, 500));
+            server.start();
+
+            String userInfoSecret = "url-password";
+            String querySecret = "query-secret";
+            Map<String, Object> options = new HashMap<>();
+            options.put(LineageConfig.ENABLED, true);
+            options.put(
+                    LineageConfig.URL,
+                    "http://url-user:"
+                            + userInfoSecret
+                            + "@127.0.0.1:"
+                            + server.getAddress().getPort()
+                            + "/lineage?token="
+                            + querySecret);
+            options.put(LineageConfig.RETRY_TIMES, 0);
+            LineageConfig config =
+                    LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+            assertDoesNotThrow(() -> new OpenLineageBackend().emit(config, minimalEvent()));
+
+            String logs =
+                    appender.getEvents().stream()
+                            .map(LogEvent::getMessage)
+                            .map(message -> message.getFormattedMessage())
+                            .collect(Collectors.joining("\n"));
+            assertTrue(logs.contains("http://127.0.0.1:" + server.getAddress().getPort()));
+            assertFalse(logs.contains("url-user"));
+            assertFalse(logs.contains(userInfoSecret));
+            assertFalse(logs.contains(querySecret));
+        } catch (IOException e) {
+            throw new AssertionError("Unable to start test HTTP server", e);
+        } finally {
+            if (server != null) {
+                server.stop(0);
+            }
+            logger.removeAppender(appender);
+            logger.setLevel(originalLevel);
+            logger.setAdditive(originalAdditive);
+            appender.stop();
+        }
+    }
+
+    /**
+     * A rejected request answers with a status code, and that code is the one thing an operator
+     * needs to tell a bad credential from a receiver that is down. It reaches the log only if the
+     * failure's own message is logged.
+     */
+    @Test
+    void reportsWhyASendFailed() {
+        HttpServer server = null;
+        try {
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext("/lineage", exchange -> respond(exchange, 500));
+            server.start();
+
+            Map<String, Object> options = new HashMap<>();
+            options.put(LineageConfig.ENABLED, true);
+            options.put(
+                    LineageConfig.URL,
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/lineage");
+            options.put(LineageConfig.RETRY_TIMES, 0);
+            LineageConfig config =
+                    LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+            String logs =
+                    capturedWarnings(() -> new OpenLineageBackend().emit(config, minimalEvent()));
+
+            assertTrue(logs.contains("HTTP 500"), logs);
+        } catch (IOException e) {
+            throw new AssertionError("Unable to start test HTTP server", e);
+        } finally {
+            if (server != null) {
+                server.stop(0);
+            }
+        }
+    }
+
+    /**
+     * An endpoint that cannot be used fails the same way on every attempt, so retrying it only
+     * multiplies the backoff sleep by the retry count on every event the job reports.
+     */
+    @Test
+    void doesNotRetryAnEndpointThatCannotBeUsed() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.RETRY_TIMES, 5000);
+        LineageConfig config =
+                LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+        long startedAt = System.nanoTime();
+        String logs = capturedWarnings(() -> new OpenLineageBackend().emit(config, minimalEvent()));
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+        // The retried path sleeps up to 100ms per attempt, so 5000 retries cannot fit in here.
+        assertTrue(
+                elapsedMs < 5000,
+                "a configuration error must not be retried, it took " + elapsedMs + "ms");
+        assertTrue(logs.contains(LineageConfig.URL), logs);
+    }
+
+    /** Runs the body with the backend's warnings captured, and returns them joined. */
+    private static String capturedWarnings(Runnable body) {
+        Logger logger = (Logger) LogManager.getLogger(OpenLineageBackend.class);
+        CapturingAppender appender = new CapturingAppender();
+        Level originalLevel = logger.getLevel();
+        boolean originalAdditive = logger.isAdditive();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
+        logger.setAdditive(false);
+        appender.start();
+        try {
+            body.run();
+            return appender.getEvents().stream()
+                    .map(event -> event.getMessage().getFormattedMessage())
+                    .collect(Collectors.joining("\n"));
+        } finally {
+            logger.removeAppender(appender);
+            logger.setLevel(originalLevel);
+            logger.setAdditive(originalAdditive);
+            appender.stop();
+        }
+    }
+
+    private static LineageEvent minimalEvent() {
+        return LineageEvent.builder()
+                .runId(UUID.randomUUID())
+                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .eventType(LineageEventType.START)
+                .jobNamespace("seatunnel")
+                .jobName("lineage-test")
+                .producer("https://seatunnel.apache.org/3.0.0-SNAPSHOT")
+                .inputs(Collections.emptyList())
+                .outputs(Arrays.asList(LineageDataset.of("mysql://host:9030", "db.out")))
+                .build();
+    }
+
+    private static void respond(HttpExchange exchange, int status) throws IOException {
+        exchange.sendResponseHeaders(status, -1);
+        exchange.close();
+    }
+
+    private static byte[] readAll(InputStream input) throws IOException {
+        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = input.read(buffer)) >= 0) {
+            output.write(buffer, 0, length);
+        }
+        return output.toByteArray();
+    }
+
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<LogEvent> events = new ArrayList<>();
+
+        private CapturingAppender() {
+            super("OpenLineageBackendTest", null, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        private List<LogEvent> getEvents() {
+            return events;
+        }
+    }
+}

--- a/seatunnel-lineage/pom.xml
+++ b/seatunnel-lineage/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-lineage</artifactId>
+    <name>SeaTunnel : Lineage Contract</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackend.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackend.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/** A transport-independent extension point for lineage event delivery. */
+public interface LineageBackend {
+
+    /** Returns the name used by {@link LineageConfig#transport()}. */
+    String getName();
+
+    /** Emits one already-built lineage event. */
+    void emit(LineageConfig config, LineageEvent event) throws Exception;
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackendLoader.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackendLoader.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.lang.ref.WeakReference;
+import java.util.ServiceLoader;
+
+/** Loads the backend selected by the immutable lineage configuration. */
+public final class LineageBackendLoader {
+
+    /**
+     * The most recent successful resolution.
+     *
+     * <p>Resolution scans the whole classpath, and every emitted event resolves the backend again.
+     * The two callers that matter are on latency-sensitive engine paths, where that scan is pure
+     * overhead: a process reports lineage through one transport loaded by one class loader, so the
+     * same answer comes back every time. A single entry is enough to remove the repeat scan while
+     * keeping the loader identity part of the answer.
+     */
+    private static volatile Resolution resolution;
+
+    private LineageBackendLoader() {}
+
+    /** Loads the backend whose name matches the configured transport. */
+    public static LineageBackend load(LineageConfig config) {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            loader = LineageBackendLoader.class.getClassLoader();
+        }
+        Resolution cached = resolution;
+        if (cached != null && cached.matches(loader, config.transport())) {
+            return cached.backend;
+        }
+        for (LineageBackend candidate : ServiceLoader.load(LineageBackend.class, loader)) {
+            if (config.transport().equalsIgnoreCase(candidate.getName())) {
+                if (isLoadedWithThisClass(candidate)) {
+                    resolution = new Resolution(loader, config.transport(), candidate);
+                }
+                return candidate;
+            }
+        }
+        throw new IllegalArgumentException(
+                "No LineageBackend is registered for transport " + config.transport());
+    }
+
+    /**
+     * Returns whether caching the backend can extend nothing's lifetime.
+     *
+     * <p>A cached backend keeps its class, and therefore its class loader, reachable from a static
+     * field. That is free when the backend comes from the same place as this class, which is the
+     * case for both deployments that matter: the engine server jar on Zeta, and the shaded artifact
+     * in the Flink cluster's lib/. It is not free when the context class loader resolves a copy
+     * shipped inside a job's own jar, where caching would pin that job's class loader for the life
+     * of the process. Those resolutions are simply not cached, which is the behaviour that existed
+     * before the cache.
+     */
+    private static boolean isLoadedWithThisClass(LineageBackend backend) {
+        return backend.getClass().getClassLoader() == LineageBackendLoader.class.getClassLoader();
+    }
+
+    private static final class Resolution {
+        /**
+         * Weak so that remembering which loader produced this answer cannot, on its own, keep that
+         * loader alive; a collected reference simply misses and the lookup runs again.
+         */
+        private final WeakReference<ClassLoader> loader;
+
+        private final String transport;
+        private final LineageBackend backend;
+
+        private Resolution(ClassLoader loader, String transport, LineageBackend backend) {
+            this.loader = new WeakReference<>(loader);
+            this.transport = transport;
+            this.backend = backend;
+        }
+
+        private boolean matches(ClassLoader candidateLoader, String candidateTransport) {
+            return loader.get() == candidateLoader
+                    && transport.equalsIgnoreCase(candidateTransport);
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageConfig.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageConfig.java
@@ -1,0 +1,606 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Immutable lineage configuration with per-option source precedence. */
+public final class LineageConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final String ENABLED = "openlineage_enabled";
+    public static final String TRANSPORT = "openlineage_transport";
+    public static final String URL = "openlineage_url";
+    public static final String NAMESPACE = "openlineage_namespace";
+    public static final String AUTH_TOKEN = "openlineage_auth_token";
+    public static final String TIMEOUT_MS = "openlineage_timeout_ms";
+    public static final String RETRY_TIMES = "openlineage_retry_times";
+    public static final String RUN_FACET = "openlineage_run_facet";
+    public static final String RUN_PROPERTIES = "openlineage_run_properties";
+    public static final String HEARTBEAT_MIN_INTERVAL_MS = "openlineage_heartbeat_min_interval_ms";
+    public static final String PRODUCER = "openlineage_producer";
+
+    public static final String DEFAULT_TRANSPORT = "http";
+    public static final String DEFAULT_NAMESPACE = "seatunnel";
+    public static final String DEFAULT_RUN_FACET = "seatunnel_properties";
+    public static final int DEFAULT_TIMEOUT_MS = 10000;
+    public static final int DEFAULT_RETRY_TIMES = 3;
+    public static final long DEFAULT_HEARTBEAT_MIN_INTERVAL_MS = 3600000L;
+
+    private final boolean enabled;
+    private final String transport;
+    private final String url;
+    private final String namespace;
+    private final String authToken;
+    private final int timeoutMs;
+    private final int retryTimes;
+    private final String runFacet;
+    private final Map<String, Object> runProperties;
+    private final long heartbeatMinIntervalMs;
+    private final String producer;
+
+    private LineageConfig(
+            boolean enabled,
+            String transport,
+            String url,
+            String namespace,
+            String authToken,
+            int timeoutMs,
+            int retryTimes,
+            String runFacet,
+            Map<String, Object> runProperties,
+            long heartbeatMinIntervalMs,
+            String producer) {
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException(TIMEOUT_MS + " must be greater than zero");
+        }
+        if (retryTimes < 0) {
+            throw new IllegalArgumentException(RETRY_TIMES + " must not be negative");
+        }
+        if (heartbeatMinIntervalMs < 0) {
+            throw new IllegalArgumentException(HEARTBEAT_MIN_INTERVAL_MS + " must not be negative");
+        }
+        this.enabled = enabled;
+        this.transport = LineageValidation.requireText(transport, TRANSPORT);
+        this.url = blankToNull(url);
+        this.namespace = LineageValidation.requireText(namespace, NAMESPACE);
+        this.authToken = blankToNull(authToken);
+        this.timeoutMs = timeoutMs;
+        this.retryTimes = retryTimes;
+        this.runFacet = LineageValidation.requireText(runFacet, RUN_FACET);
+        this.runProperties =
+                Collections.unmodifiableMap(
+                        runProperties == null
+                                ? new LinkedHashMap<>()
+                                : new LinkedHashMap<>(runProperties));
+        this.heartbeatMinIntervalMs = heartbeatMinIntervalMs;
+        this.producer = LineageValidation.requireText(producer, PRODUCER);
+    }
+
+    /** Returns the default configuration with lineage reporting disabled. */
+    public static LineageConfig defaults() {
+        return new LineageConfig(
+                false,
+                DEFAULT_TRANSPORT,
+                null,
+                DEFAULT_NAMESPACE,
+                null,
+                DEFAULT_TIMEOUT_MS,
+                DEFAULT_RETRY_TIMES,
+                DEFAULT_RUN_FACET,
+                Collections.emptyMap(),
+                DEFAULT_HEARTBEAT_MIN_INTERVAL_MS,
+                defaultProducer());
+    }
+
+    /**
+     * Resolves each option independently using job env, process env, cluster config, then defaults.
+     * The token deliberately skips job env and is rejected there instead. String map values accept
+     * the Flink forms {@code key:value,key2:value2} and {@code {key: value, key2: value2}}; an
+     * equals sign is also accepted for compatibility with common environment-variable syntax.
+     */
+    public static LineageConfig resolve(
+            Map<String, ?> jobOptions, Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        rejectJobAuthToken(jobOptions);
+        Map<String, ?> job = nonNull(jobOptions);
+        Map<String, ?> cluster = nonNull(clusterOptions);
+        Map<String, ?> env = nonNull(environment);
+        return new LineageConfig(
+                asBoolean(first(job, env, cluster, ENABLED), false),
+                asString(first(job, env, cluster, TRANSPORT), TRANSPORT, DEFAULT_TRANSPORT),
+                asNullableString(first(job, env, cluster, URL)),
+                asString(first(job, env, cluster, NAMESPACE), NAMESPACE, DEFAULT_NAMESPACE),
+                asToken(env, cluster),
+                asInt(first(job, env, cluster, TIMEOUT_MS), TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+                asInt(first(job, env, cluster, RETRY_TIMES), RETRY_TIMES, DEFAULT_RETRY_TIMES),
+                asString(first(job, env, cluster, RUN_FACET), RUN_FACET, DEFAULT_RUN_FACET),
+                resolveRunProperties(job, env, cluster),
+                asLong(
+                        first(job, env, cluster, HEARTBEAT_MIN_INTERVAL_MS),
+                        HEARTBEAT_MIN_INTERVAL_MS,
+                        DEFAULT_HEARTBEAT_MIN_INTERVAL_MS),
+                asString(first(job, env, cluster, PRODUCER), PRODUCER, defaultProducer()));
+    }
+
+    /**
+     * Resolves only the enabled flag, using the same precedence and key aliases as {@link
+     * #resolve}.
+     *
+     * <p>Callers on the submission path need this before a full resolution is possible, and must
+     * not answer it with their own lookup: a second implementation drifts from the alias rules here
+     * and then disagrees with the configuration the job actually runs with.
+     */
+    public static boolean isEnabled(
+            Map<String, ?> jobOptions, Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        return asBoolean(first(jobOptions, environment, clusterOptions, ENABLED), false);
+    }
+
+    /** Rejects a token in job options because job configuration may be persisted or serialized. */
+    public static void rejectJobAuthToken(Map<String, ?> jobOptions) {
+        if (contains(jobOptions, AUTH_TOKEN)) {
+            throw new IllegalArgumentException(
+                    AUTH_TOKEN
+                            + " is not allowed in job env; use an environment or cluster setting");
+        }
+    }
+
+    /** Resolves a token from process environment first and cluster configuration second. */
+    public static String resolveToken(Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        return asToken(nonNull(environment), nonNull(clusterOptions));
+    }
+
+    /** Returns whether lineage reporting is enabled. */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /** Returns the selected lineage transport name. */
+    public String transport() {
+        return transport;
+    }
+
+    /** Returns the lineage receiver URL, or {@code null} when it is not configured. */
+    public String url() {
+        return url;
+    }
+
+    /** Returns the OpenLineage job namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    /** Returns the resolved authentication token, if any. */
+    public String authToken() {
+        return authToken;
+    }
+
+    /** Returns the per-attempt send timeout in milliseconds. */
+    public int timeoutMs() {
+        return timeoutMs;
+    }
+
+    /** Returns the number of retries after the initial send attempt. */
+    public int retryTimes() {
+        return retryTimes;
+    }
+
+    /** Returns the run facet name used for custom properties. */
+    public String runFacet() {
+        return runFacet;
+    }
+
+    /** Returns immutable custom properties for the run facet. */
+    public Map<String, Object> runProperties() {
+        return runProperties;
+    }
+
+    /** Returns the minimum interval between streaming heartbeat events. */
+    public long heartbeatMinIntervalMs() {
+        return heartbeatMinIntervalMs;
+    }
+
+    /** Returns the producer URI placed in emitted OpenLineage events. */
+    public String producer() {
+        return producer;
+    }
+
+    /** Returns non-secret values suitable for a serialized callback. */
+    public Map<String, Object> toNonSensitiveMap() {
+        Map<String, Object> result = toMap();
+        result.remove(AUTH_TOKEN);
+        return result;
+    }
+
+    /** Returns a copy with a token resolved only on the execution side. */
+    public LineageConfig withAuthToken(String token) {
+        return new LineageConfig(
+                enabled,
+                transport,
+                url,
+                namespace,
+                token,
+                timeoutMs,
+                retryTimes,
+                runFacet,
+                runProperties,
+                heartbeatMinIntervalMs,
+                producer);
+    }
+
+    /** Returns the option map used by the contract tests and serialized callbacks. */
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put(ENABLED, enabled);
+        result.put(TRANSPORT, transport);
+        if (url != null) {
+            result.put(URL, url);
+        }
+        result.put(NAMESPACE, namespace);
+        if (authToken != null) {
+            result.put(AUTH_TOKEN, authToken);
+        }
+        result.put(TIMEOUT_MS, timeoutMs);
+        result.put(RETRY_TIMES, retryTimes);
+        result.put(RUN_FACET, runFacet);
+        if (!runProperties.isEmpty()) {
+            result.put(RUN_PROPERTIES, runProperties);
+        }
+        result.put(HEARTBEAT_MIN_INTERVAL_MS, heartbeatMinIntervalMs);
+        result.put(PRODUCER, producer);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LineageConfig" + toNonSensitiveMap();
+    }
+
+    private static String asToken(Map<String, ?> environment, Map<String, ?> cluster) {
+        Lookup environmentValue = findEnvironment(environment, AUTH_TOKEN);
+        if (environmentValue.present) {
+            return asNullableString(environmentValue);
+        }
+        Lookup clusterValue = find(cluster, AUTH_TOKEN);
+        return clusterValue.present ? asNullableString(clusterValue) : null;
+    }
+
+    private static Lookup first(
+            Map<String, ?> job, Map<String, ?> environment, Map<String, ?> cluster, String key) {
+        Lookup lookup = find(job, key);
+        if (lookup.present) {
+            return lookup;
+        }
+        lookup = findEnvironment(environment, key);
+        if (lookup.present) {
+            return lookup;
+        }
+        lookup = find(cluster, key);
+        return lookup.present ? lookup : Lookup.absent();
+    }
+
+    private static Lookup find(Map<String, ?> values, String key) {
+        if (values == null || values.isEmpty()) {
+            return Lookup.absent();
+        }
+        if (values.containsKey(key)) {
+            return Lookup.of(values.get(key));
+        }
+        String dotted = key.replace('_', '.');
+        if (values.containsKey(dotted)) {
+            return Lookup.of(values.get(dotted));
+        }
+        String prefixed = "openlineage." + key.substring("openlineage_".length());
+        if (values.containsKey(prefixed)) {
+            return Lookup.of(values.get(prefixed));
+        }
+        Object nested = values.get("openlineage");
+        if (nested instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) nested;
+            String suffix = key.substring("openlineage_".length());
+            if (map.containsKey(suffix)) {
+                return Lookup.of(map.get(suffix));
+            }
+            if (map.containsKey(key)) {
+                return Lookup.of(map.get(key));
+            }
+        }
+        return Lookup.absent();
+    }
+
+    private static Lookup findEnvironment(Map<String, ?> values, String key) {
+        if (values == null || values.isEmpty()) {
+            return Lookup.absent();
+        }
+        String environmentKey = key.toUpperCase(Locale.ROOT);
+        return values.containsKey(environmentKey)
+                ? Lookup.of(values.get(environmentKey))
+                : Lookup.absent();
+    }
+
+    private static boolean contains(Map<String, ?> values, String key) {
+        return find(values, key).present;
+    }
+
+    private static Map<String, ?> nonNull(Map<String, ?> values) {
+        return values == null ? Collections.emptyMap() : values;
+    }
+
+    private static boolean asBoolean(Lookup value, boolean fallback) {
+        return value.present && value.value != null
+                ? Boolean.parseBoolean(String.valueOf(value.value))
+                : fallback;
+    }
+
+    private static int asInt(Lookup value, String key, int fallback) {
+        if (!value.present || value.value == null) {
+            return fallback;
+        }
+        String text = String.valueOf(value.value);
+        try {
+            return Integer.parseInt(text.trim());
+        } catch (NumberFormatException error) {
+            throw notANumber(key, text);
+        }
+    }
+
+    private static long asLong(Lookup value, String key, long fallback) {
+        if (!value.present || value.value == null) {
+            return fallback;
+        }
+        String text = String.valueOf(value.value);
+        try {
+            return Long.parseLong(text.trim());
+        } catch (NumberFormatException error) {
+            throw notANumber(key, text);
+        }
+    }
+
+    /**
+     * Names the option a malformed number came from.
+     *
+     * <p>The bare {@code NumberFormatException} says only what the text was. Every caller here
+     * resolves several numeric options at once, and the engines re-resolve the configuration on
+     * every reported event, so an unnamed failure appears repeatedly in a log that never says which
+     * setting to correct.
+     */
+    private static IllegalArgumentException notANumber(String key, String value) {
+        return new IllegalArgumentException(key + " must be a number, but was \"" + value + "\"");
+    }
+
+    private static String asString(Lookup value, String key, String fallback) {
+        return value.present && value.value != null
+                ? LineageValidation.requireText(String.valueOf(value.value), key)
+                : fallback;
+    }
+
+    private static String asNullableString(Lookup value) {
+        return value.present && value.value != null
+                ? blankToNull(String.valueOf(value.value))
+                : null;
+    }
+
+    private static Map<String, Object> resolveRunProperties(
+            Map<String, ?> job, Map<String, ?> environment, Map<String, ?> cluster) {
+        Map<String, Object> properties = runProperties(job, false);
+        if (properties == null) {
+            properties = runProperties(environment, true);
+        }
+        if (properties == null) {
+            properties = runProperties(cluster, false);
+        }
+        return properties == null ? new LinkedHashMap<>() : properties;
+    }
+
+    /** Returns the properties declared by one source, or null when it declares none. */
+    private static Map<String, Object> runProperties(Map<String, ?> values, boolean environment) {
+        Lookup direct =
+                environment
+                        ? findEnvironment(values, RUN_PROPERTIES)
+                        : find(values, RUN_PROPERTIES);
+        if (direct.present) {
+            return asMap(direct);
+        }
+        Map<String, Object> prefixed = prefixedMap(values, RUN_PROPERTIES, environment);
+        return prefixed.isEmpty() ? null : prefixed;
+    }
+
+    private static Map<String, Object> asMap(Lookup value) {
+        if (!value.present || value.value == null) {
+            return new LinkedHashMap<>();
+        }
+        if (value.value instanceof String) {
+            return parseStringMap((String) value.value);
+        }
+        if (!(value.value instanceof Map)) {
+            throw new IllegalArgumentException(
+                    RUN_PROPERTIES + " must be a map or a comma-separated string map");
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        ((Map<?, ?>) value.value).forEach((key, item) -> result.put(String.valueOf(key), item));
+        return result;
+    }
+
+    private static Map<String, Object> prefixedMap(
+            Map<String, ?> values, String key, boolean environment) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (values == null || values.isEmpty()) {
+            return result;
+        }
+        String[] prefixes =
+                environment
+                        ? new String[] {key.toUpperCase(Locale.ROOT) + "_"}
+                        : new String[] {
+                            key + ".", "openlineage.run_properties.", "openlineage.run.properties."
+                        };
+        for (Map.Entry<String, ?> entry : values.entrySet()) {
+            String entryKey = String.valueOf(entry.getKey());
+            for (String prefix : prefixes) {
+                if (entryKey.startsWith(prefix) && entryKey.length() > prefix.length()) {
+                    result.put(entryKey.substring(prefix.length()), entry.getValue());
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, Object> parseStringMap(String rawValue) {
+        String value = rawValue.trim();
+        if (value.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+        if (value.startsWith("{")) {
+            if (!value.endsWith("}")) {
+                throw malformedMap();
+            }
+            value = value.substring(1, value.length() - 1).trim();
+        }
+        if (value.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String entry : splitMapEntries(value)) {
+            int separator = findMapSeparator(entry);
+            if (separator <= 0) {
+                throw malformedMap();
+            }
+            String key = unquote(entry.substring(0, separator).trim());
+            String item = unquote(entry.substring(separator + 1).trim());
+            if (key.isEmpty()) {
+                throw malformedMap();
+            }
+            result.put(key, item);
+        }
+        return result;
+    }
+
+    private static List<String> splitMapEntries(String value) {
+        List<String> entries = new ArrayList<>();
+        int start = 0;
+        int comma;
+        while ((comma = nextUnquoted(value, start, ",")) >= 0) {
+            entries.add(value.substring(start, comma).trim());
+            start = comma + 1;
+        }
+        entries.add(value.substring(start).trim());
+        return entries;
+    }
+
+    private static int findMapSeparator(String value) {
+        return nextUnquoted(value, 0, ":=");
+    }
+
+    /**
+     * Returns the index of the first character of {@code stops} at or after {@code from} that is
+     * not inside a quoted section, or -1 when the value ends first.
+     *
+     * <p>Entry splitting and key/value separation share this scan so that the quoting and escaping
+     * rules cannot drift apart between them.
+     *
+     * @throws IllegalArgumentException when the value ends inside a quote or a trailing escape
+     */
+    private static int nextUnquoted(String value, int from, String stops) {
+        char quote = 0;
+        boolean escaped = false;
+        for (int i = from; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (quote != 0) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == quote) {
+                    quote = 0;
+                }
+            } else if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (stops.indexOf(current) >= 0) {
+                return i;
+            }
+        }
+        if (quote != 0 || escaped) {
+            throw malformedMap();
+        }
+        return -1;
+    }
+
+    private static String unquote(String value) {
+        if (value.length() < 2) {
+            return value;
+        }
+        char first = value.charAt(0);
+        if (first != value.charAt(value.length() - 1) || (first != '\'' && first != '"')) {
+            return value;
+        }
+        String unquoted = value.substring(1, value.length() - 1);
+        return unquoted.replace("\\" + first, String.valueOf(first));
+    }
+
+    private static IllegalArgumentException malformedMap() {
+        return new IllegalArgumentException(
+                RUN_PROPERTIES + " must use key:value pairs separated by commas");
+    }
+
+    /**
+     * Builds the default producer URI from the running SeaTunnel version.
+     *
+     * <p>This is the single source of the producer default. {@code openlineage_producer} is
+     * declared without a default value so that no build-time version string is baked into the
+     * option, which would go stale on the next release. The receiver does not validate {@code
+     * producer}, so a missing version degrades to the bare project URI rather than to a wrong
+     * version.
+     */
+    private static String defaultProducer() {
+        String version = LineageConfig.class.getPackage().getImplementationVersion();
+        if (version == null || version.trim().isEmpty()) {
+            version = System.getProperty("seatunnel.version", "");
+        }
+        return version.trim().isEmpty()
+                ? "https://seatunnel.apache.org/"
+                : "https://seatunnel.apache.org/" + version.trim();
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.trim().isEmpty() ? null : value;
+    }
+
+    private static final class Lookup {
+        private final boolean present;
+        private final Object value;
+
+        private Lookup(boolean present, Object value) {
+            this.present = present;
+            this.value = value;
+        }
+
+        private static Lookup of(Object value) {
+            return new Lookup(true, value);
+        }
+
+        private static Lookup absent() {
+            return new Lookup(false, null);
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDataset.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDataset.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** A dataset identity with optional output statistics. */
+public final class LineageDataset implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String namespace;
+    private final String name;
+    private final LineageOutputStatistics outputStatistics;
+
+    private LineageDataset(
+            String namespace, String name, LineageOutputStatistics outputStatistics) {
+        this.namespace = LineageValidation.requireText(namespace, "namespace");
+        this.name = LineageValidation.requireText(name, "name");
+        this.outputStatistics = outputStatistics;
+    }
+
+    /** Creates a dataset identity. */
+    public static LineageDataset of(String namespace, String name) {
+        return new LineageDataset(namespace, name, null);
+    }
+
+    /** Returns a copy with output statistics attached. */
+    public LineageDataset withOutputStatistics(LineageOutputStatistics statistics) {
+        return new LineageDataset(namespace, name, statistics);
+    }
+
+    /** Returns the dataset namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    /** Returns the canonical dataset name. */
+    public String name() {
+        return name;
+    }
+
+    /** Returns the output statistics, or {@code null} when no statistics were collected. */
+    public LineageOutputStatistics outputStatistics() {
+        return outputStatistics;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof LineageDataset)) {
+            return false;
+        }
+        LineageDataset that = (LineageDataset) other;
+        return namespace.equals(that.namespace) && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, name);
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetFactory.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetFactory.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/** Builds canonical datasets from connector option maps without depending on connector classes. */
+public final class LineageDatasetFactory {
+    private LineageDatasetFactory() {}
+
+    /**
+     * Extracts canonical dataset identities from one connector option map.
+     *
+     * <p>Only connector options that provide a real table identity are returned. Placeholder {@code
+     * default.default.default} paths are excluded.
+     *
+     * @param options connector options, without the enclosing plugin block
+     */
+    public static List<LineageDataset> fromConnectorOptions(Map<String, ?> options) {
+        return fromConnectorOptions(null, options);
+    }
+
+    /**
+     * Extracts canonical dataset identities for a connector whose plugin name is already known.
+     *
+     * <p>The plugin name must be supplied by the caller whenever it has one. SeaTunnel jobs
+     * normally declare a connector as a named block ({@code sink { Paimon { ... } }}), and the
+     * option map for that block does not contain a {@code plugin_name} entry at all, so inferring
+     * the name from the options alone silently yields no lineage for the most common job syntax.
+     *
+     * @param pluginName connector plugin name, or {@code null} to infer it from the options
+     * @param options connector options, without the enclosing plugin block
+     */
+    public static List<LineageDataset> fromConnectorOptions(
+            String pluginName, Map<String, ?> options) {
+        if (options == null || options.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (pluginName == null || pluginName.trim().isEmpty()) {
+            pluginName = string(options, "plugin_name", "plugin-name");
+        }
+        if (pluginName == null) {
+            pluginName = nestedPluginName(options);
+        }
+        if (pluginName == null) {
+            return Collections.emptyList();
+        }
+        if ("paimon".equalsIgnoreCase(pluginName)) {
+            return paimon(options);
+        }
+        if ("doris".equalsIgnoreCase(pluginName)) {
+            return doris(options);
+        }
+        if (isJdbc(pluginName, options)) {
+            return jdbc(options);
+        }
+        return Collections.emptyList();
+    }
+
+    private static List<LineageDataset> paimon(Map<String, ?> options) {
+        String catalog = string(options, "catalog_name", "catalog-name");
+        if (catalog == null || catalog.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return datasets(
+                options,
+                reference ->
+                        LineageDatasetNaming.paimon(catalog, reference.database, reference.table));
+    }
+
+    private static List<LineageDataset> doris(Map<String, ?> options) {
+        String host = firstHost(string(options, "fenodes", "fe_nodes", "fe-nodes"));
+        Integer queryPort = integer(options, 9030, "query-port", "query_port", "query.port");
+        if (queryPort == null) {
+            return Collections.emptyList();
+        }
+        return datasets(
+                options,
+                reference ->
+                        LineageDatasetNaming.doris(
+                                host, queryPort, reference.database, reference.table));
+    }
+
+    private static List<LineageDataset> jdbc(Map<String, ?> options) {
+        String url = string(options, "url", "jdbc_url", "jdbc-url");
+        if (url == null || !url.startsWith("jdbc:")) {
+            return Collections.emptyList();
+        }
+        try {
+            URI uri = URI.create(url.substring("jdbc:".length()));
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            int port = uri.getPort();
+            String urlDatabase = trimSlashes(uri.getPath());
+            if (scheme == null || host == null || port <= 0) {
+                return Collections.emptyList();
+            }
+            return datasets(
+                    options,
+                    reference ->
+                            LineageDatasetNaming.jdbc(
+                                    scheme,
+                                    host,
+                                    port,
+                                    reference.database == null ? urlDatabase : reference.database,
+                                    reference.table));
+        } catch (IllegalArgumentException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /** Maps every resolvable table entry of a connector block through one naming rule. */
+    private static List<LineageDataset> datasets(
+            Map<String, ?> options, Function<TableReference, Optional<LineageDataset>> naming) {
+        List<LineageDataset> result = new ArrayList<>();
+        for (Map<String, ?> table : tables(options)) {
+            TableReference reference = tableReference(table);
+            if (reference == null) {
+                continue;
+            }
+            naming.apply(reference).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private static boolean isJdbc(String pluginName, Map<String, ?> options) {
+        return string(options, "url", "jdbc_url", "jdbc-url") != null
+                || pluginName.toLowerCase().contains("jdbc")
+                || pluginName.equalsIgnoreCase("mysql")
+                || pluginName.equalsIgnoreCase("postgresql")
+                || pluginName.equalsIgnoreCase("oracle");
+    }
+
+    private static List<Map<String, ?>> tables(Map<String, ?> options) {
+        Object tableList = first(options, "table_list", "table-list", "tables");
+        if (tableList instanceof List) {
+            List<Map<String, ?>> result = new ArrayList<>();
+            for (Object value : (List<?>) tableList) {
+                if (value instanceof Map) {
+                    result.add((Map<String, ?>) value);
+                }
+            }
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        return Collections.singletonList(options);
+    }
+
+    private static String nestedPluginName(Map<String, ?> options) {
+        for (Map.Entry<String, ?> entry : options.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                String name =
+                        string((Map<String, ?>) entry.getValue(), "plugin_name", "plugin-name");
+                if (name != null) {
+                    return name;
+                }
+                if ("paimon".equalsIgnoreCase(entry.getKey())
+                        || "doris".equalsIgnoreCase(entry.getKey())) {
+                    return entry.getKey();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String firstHost(String value) {
+        if (value == null) {
+            return null;
+        }
+        String first = value.split(",")[0].trim();
+        try {
+            URI uri = URI.create(first.contains("://") ? first : "http://" + first);
+            return uri.getHost() == null ? first.split(":")[0] : uri.getHost();
+        } catch (IllegalArgumentException e) {
+            return first.split(":")[0];
+        }
+    }
+
+    private static Integer integer(Map<String, ?> options, int fallback, String... keys) {
+        Object value = first(options, keys);
+        if (value == null) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static String string(Map<String, ?> options, String... keys) {
+        Object value = first(options, keys);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static Object first(Map<String, ?> options, String... keys) {
+        for (String key : keys) {
+            if (options.containsKey(key)) {
+                return options.get(key);
+            }
+        }
+        return null;
+    }
+
+    private static TableReference tableReference(Map<String, ?> options) {
+        String configuredPath = string(options, "table_path", "table-path", "tablePath");
+        String database = string(options, "database", "database_name");
+        String table = string(options, "table", "table_name");
+        if (configuredPath != null && !configuredPath.trim().isEmpty()) {
+            String tablePath = configuredPath.trim();
+            if (LineageDatasetNaming.isDefaultTablePath(tablePath)) {
+                return null;
+            }
+            String[] parts = tablePath.split("\\.", -1);
+            if (parts.length > 1) {
+                database = parts[0];
+                table = join(parts, 1);
+            } else {
+                table = parts[0];
+            }
+        }
+        return new TableReference(database, table);
+    }
+
+    private static String join(String[] parts, int start) {
+        StringBuilder result = new StringBuilder();
+        for (int i = start; i < parts.length; i++) {
+            if (i > start) {
+                result.append('.');
+            }
+            result.append(parts[i]);
+        }
+        return result.toString();
+    }
+
+    private static String trimSlashes(String value) {
+        if (value == null) {
+            return null;
+        }
+        String result = value;
+        while (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        return result;
+    }
+
+    private static final class TableReference {
+        private final String database;
+        private final String table;
+
+        private TableReference(String database, String table) {
+            this.database = database;
+            this.table = table;
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetNaming.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetNaming.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/** Canonical namespace/name mappings for supported table connectors. */
+public final class LineageDatasetNaming {
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{[^}]*}");
+
+    private static final String DEFAULT_TABLE_PATH = "default.default.default";
+
+    private LineageDatasetNaming() {}
+
+    /**
+     * Creates the Paimon dataset identity {@code paimon://catalog/database} and {@code table}.
+     *
+     * <p>The catalog is required because it is part of the dataset identity.
+     */
+    public static Optional<LineageDataset> paimon(
+            String catalogName, String database, String table) {
+        if (isUnusable(catalogName) || isUnusable(database) || isUnusable(table)) {
+            return Optional.empty();
+        }
+        return Optional.of(LineageDataset.of("paimon://" + catalogName + "/" + database, table));
+    }
+
+    /** Creates the Doris dataset identity using its query port rather than its HTTP port. */
+    public static Optional<LineageDataset> doris(
+            String feHost, int queryPort, String database, String table) {
+        return jdbc("mysql", feHost, queryPort, database, table);
+    }
+
+    /** Creates a JDBC dataset identity from the URL scheme, host, port, database, and table. */
+    public static Optional<LineageDataset> jdbc(
+            String scheme, String host, int port, String database, String table) {
+        if (isUnusable(scheme)
+                || isUnusable(host)
+                || port <= 0
+                || isUnusable(database)
+                || isUnusable(table)) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                LineageDataset.of(scheme + "://" + host + ":" + port, database + "." + table));
+    }
+
+    /** Returns whether a complete table path is the placeholder default path. */
+    public static boolean isDefaultTablePath(String fullName) {
+        return fullName != null && DEFAULT_TABLE_PATH.equals(fullName.trim());
+    }
+
+    /**
+     * Returns whether a name component cannot identify a real object.
+     *
+     * <p>Besides an absent value this covers an unresolved placeholder: a multi-table sink routes
+     * rows with a template such as {@code table = "${table_name}"}, substituted per row at write
+     * time, so it is never a real table. Emitting it verbatim would collapse every
+     * placeholder-routed job onto one shared node in the lineage graph — the same failure mode as
+     * the {@code default.default.default} path, but harder to spot because the node carries a
+     * plausible-looking name.
+     */
+    private static boolean isUnusable(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return true;
+        }
+        return PLACEHOLDER.matcher(value).find();
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEvent.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEvent.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/** Immutable event contract shared by engines and lineage backends. */
+public final class LineageEvent implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final UUID runId;
+    private final ZonedDateTime eventTime;
+    private final LineageEventType eventType;
+    private final String jobNamespace;
+    private final String jobName;
+    private final String producer;
+    private final String runFacet;
+    private final Map<String, Object> runProperties;
+    private final List<LineageDataset> inputs;
+    private final List<LineageDataset> outputs;
+
+    private LineageEvent(Builder builder) {
+        this.runId = require(builder.runId, "runId");
+        this.eventTime = require(builder.eventTime, "eventTime");
+        this.eventType = require(builder.eventType, "eventType");
+        this.jobNamespace = LineageValidation.requireText(builder.jobNamespace, "jobNamespace");
+        this.jobName = LineageValidation.requireText(builder.jobName, "jobName");
+        this.producer = LineageValidation.requireText(builder.producer, "producer");
+        this.runFacet = LineageValidation.requireText(builder.runFacet, "runFacet");
+        this.runProperties =
+                Collections.unmodifiableMap(new LinkedHashMap<>(builder.runProperties));
+        this.inputs = Collections.unmodifiableList(new ArrayList<>(builder.inputs));
+        this.outputs = Collections.unmodifiableList(new ArrayList<>(builder.outputs));
+    }
+
+    /** Returns a builder for an immutable lineage event. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Returns a builder pre-populated with every field of this event. */
+    private Builder toBuilder() {
+        return builder()
+                .runId(runId)
+                .eventTime(eventTime)
+                .eventType(eventType)
+                .jobNamespace(jobNamespace)
+                .jobName(jobName)
+                .producer(producer)
+                .runFacet(runFacet)
+                .runProperties(runProperties)
+                .inputs(inputs)
+                .outputs(outputs);
+    }
+
+    /** Returns a copy with a different lifecycle event type and a fresh event time. */
+    public LineageEvent withEventType(LineageEventType type) {
+        return toBuilder()
+                .eventTime(ZonedDateTime.now(eventTime.getZone()))
+                .eventType(type)
+                .build();
+    }
+
+    /**
+     * Returns a copy with one additional run-facet property.
+     *
+     * <p>Used for identifiers that only become known after the event was built, such as an engine
+     * job identifier assigned at submission time. A {@code null} value leaves the event unchanged
+     * so that callers do not need to branch.
+     *
+     * @param key run-facet property name
+     * @param value run-facet property value; {@code null} is ignored
+     * @return a copy carrying the property, or this event when the value is {@code null}
+     */
+    public LineageEvent withRunProperty(String key, Object value) {
+        if (key == null || key.trim().isEmpty() || value == null) {
+            return this;
+        }
+        Map<String, Object> updatedProperties = new LinkedHashMap<>(runProperties);
+        updatedProperties.put(key, value);
+        return toBuilder().runProperties(updatedProperties).build();
+    }
+
+    /** Returns a copy with the same statistics attached to every output dataset. */
+    public LineageEvent withOutputStatistics(LineageOutputStatistics statistics) {
+        List<LineageDataset> updatedOutputs = new ArrayList<>();
+        for (LineageDataset output : outputs) {
+            updatedOutputs.add(output.withOutputStatistics(statistics));
+        }
+        return toBuilder()
+                .eventTime(ZonedDateTime.now(eventTime.getZone()))
+                .outputs(updatedOutputs)
+                .build();
+    }
+
+    /** Returns the run ID. */
+    public UUID runId() {
+        return runId;
+    }
+
+    /** Returns the timezone-aware event time. */
+    public ZonedDateTime eventTime() {
+        return eventTime;
+    }
+
+    /** Returns the lifecycle event type. */
+    public LineageEventType eventType() {
+        return eventType;
+    }
+
+    /** Returns the OpenLineage job namespace. */
+    public String jobNamespace() {
+        return jobNamespace;
+    }
+
+    /** Returns the OpenLineage job name. */
+    public String jobName() {
+        return jobName;
+    }
+
+    /** Returns the producer URI. */
+    public String producer() {
+        return producer;
+    }
+
+    /** Returns the custom run facet name. */
+    public String runFacet() {
+        return runFacet;
+    }
+
+    /** Returns immutable custom run properties. */
+    public Map<String, Object> runProperties() {
+        return runProperties;
+    }
+
+    /** Returns immutable input datasets. */
+    public List<LineageDataset> inputs() {
+        return inputs;
+    }
+
+    /** Returns immutable output datasets. */
+    public List<LineageDataset> outputs() {
+        return outputs;
+    }
+
+    /** Builder for the immutable lineage event contract. */
+    public static final class Builder {
+        private UUID runId;
+        private ZonedDateTime eventTime;
+        private LineageEventType eventType = LineageEventType.START;
+        private String jobNamespace;
+        private String jobName;
+        private String producer;
+        private String runFacet = LineageConfig.DEFAULT_RUN_FACET;
+        private Map<String, Object> runProperties = new LinkedHashMap<>();
+        private List<LineageDataset> inputs = new ArrayList<>();
+        private List<LineageDataset> outputs = new ArrayList<>();
+
+        /** Sets the run ID. */
+        public Builder runId(UUID value) {
+            this.runId = value;
+            return this;
+        }
+
+        /** Sets the timezone-aware event time. */
+        public Builder eventTime(ZonedDateTime value) {
+            this.eventTime = value;
+            return this;
+        }
+
+        /** Sets the lifecycle event type. */
+        public Builder eventType(LineageEventType value) {
+            this.eventType = value;
+            return this;
+        }
+
+        /** Sets the OpenLineage job namespace. */
+        public Builder jobNamespace(String value) {
+            this.jobNamespace = value;
+            return this;
+        }
+
+        /** Sets the OpenLineage job name. */
+        public Builder jobName(String value) {
+            this.jobName = value;
+            return this;
+        }
+
+        /** Sets the producer URI. */
+        public Builder producer(String value) {
+            this.producer = value;
+            return this;
+        }
+
+        /** Sets the custom run facet name. */
+        public Builder runFacet(String value) {
+            this.runFacet = value;
+            return this;
+        }
+
+        /** Replaces the custom run properties. */
+        public Builder runProperties(Map<String, ?> values) {
+            this.runProperties = new LinkedHashMap<>();
+            if (values != null) {
+                values.forEach((key, value) -> this.runProperties.put(key, value));
+            }
+            return this;
+        }
+
+        /** Replaces the input datasets. */
+        public Builder inputs(List<LineageDataset> values) {
+            this.inputs = values == null ? new ArrayList<>() : new ArrayList<>(values);
+            return this;
+        }
+
+        /** Replaces the output datasets. */
+        public Builder outputs(List<LineageDataset> values) {
+            this.outputs = values == null ? new ArrayList<>() : new ArrayList<>(values);
+            return this;
+        }
+
+        /** Builds the immutable event, validating required fields. */
+        public LineageEvent build() {
+            return new LineageEvent(this);
+        }
+    }
+
+    private static <T> T require(T value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(field + " must not be null");
+        }
+        return value;
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEventType.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEventType.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/** OpenLineage lifecycle meanings used by the contract layer. */
+public enum LineageEventType {
+    START,
+    RUNNING,
+    COMPLETE,
+    ABORT,
+    FAIL
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageOutputStatistics.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageOutputStatistics.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+
+/** Cumulative output counters. A null field is intentionally omitted from JSON. */
+public final class LineageOutputStatistics implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Long rowCount;
+    private final Long size;
+    private final String semantics;
+
+    /** Creates cumulative output statistics with an engine-specific counting semantic. */
+    public LineageOutputStatistics(Long rowCount, Long size, String semantics) {
+        this.rowCount = rowCount;
+        this.size = size;
+        this.semantics = semantics;
+    }
+
+    /** Returns the cumulative output row count, if available. */
+    public Long rowCount() {
+        return rowCount;
+    }
+
+    /** Returns the cumulative output size in bytes, if available. */
+    public Long size() {
+        return size;
+    }
+
+    /** Returns the counting semantic, such as {@code committed} or {@code attempted}. */
+    public String semantics() {
+        return semantics;
+    }
+
+    /** Returns whether at least one numeric statistic is present. */
+    public boolean hasValue() {
+        return rowCount != null || size != null;
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageReportingException.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageReportingException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/** Runtime wrapper used by engine call sites to apply their failure policy. */
+public final class LineageReportingException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /** Creates an exception wrapping a lineage delivery failure. */
+    public LineageReportingException(Throwable cause) {
+        super("Lineage event delivery failed", cause);
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRunIds.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRunIds.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/** Deterministic run identity helpers. */
+public final class LineageRunIds {
+    private static final String PREFIX = "seatunnel-job:";
+
+    private LineageRunIds() {}
+
+    /** Returns a deterministic run ID for a numeric SeaTunnel job ID. */
+    public static UUID forJob(long jobId, String namespace, String name, String attempt) {
+        return forJob(String.valueOf(jobId), namespace, name, attempt);
+    }
+
+    /** Returns a deterministic run ID for a job and dataset identity. */
+    public static UUID forJob(String jobId, String namespace, String name, String attempt) {
+        StringBuilder value =
+                new StringBuilder(PREFIX)
+                        .append(jobId)
+                        .append(':')
+                        .append(namespace)
+                        .append('/')
+                        .append(name);
+        if (attempt != null && !attempt.trim().isEmpty()) {
+            value.append(':').append(attempt);
+        }
+        // The prefix isolates this type-3 UUID namespace from other emitters that use the same
+        // nameUUIDFromBytes algorithm. It must not be removed as redundant.
+        return UUID.nameUUIDFromBytes(value.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRuntime.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRuntime.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/**
+ * The single seam through which every engine emits a lineage event.
+ *
+ * <p>The event carries its own {@link LineageEventType}, so there is deliberately no per-lifecycle
+ * method here: a reporter-style API would need one method per type and would still leave the caller
+ * to route the types it does not cover.
+ */
+public final class LineageRuntime {
+    private LineageRuntime() {}
+
+    /** Emits an event through the configured backend, or returns immediately when disabled. */
+    public static void emit(LineageConfig config, LineageEvent event) {
+        if (!config.enabled()) {
+            return;
+        }
+        try {
+            LineageBackendLoader.load(config).emit(config, event);
+        } catch (Exception e) {
+            throw new LineageReportingException(e);
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageValidation.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageValidation.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/**
+ * Argument checks shared by the lineage contract classes.
+ *
+ * <p>This module carries no dependencies so that it can be shaded into the Flink {@code lib}
+ * directory, which rules out {@code StringUtils} and the usual precondition helpers.
+ */
+final class LineageValidation {
+
+    private LineageValidation() {}
+
+    /** Returns the value, rejecting null and whitespace-only text for a required field. */
+    static String requireText(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageConfigTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageConfigTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageConfigTest {
+
+    @Test
+    void resolvesEachOptionByPriority() {
+        Map<String, Object> job = new HashMap<>();
+        job.put(LineageConfig.ENABLED, true);
+        job.put(LineageConfig.TIMEOUT_MS, 2000);
+        Map<String, Object> cluster = new HashMap<>();
+        cluster.put("openlineage.timeout_ms", 3000);
+        cluster.put("openlineage.namespace", "cluster");
+        Map<String, Object> environment = new HashMap<>();
+        environment.put("OPENLINEAGE_NAMESPACE", "environment");
+
+        LineageConfig config = LineageConfig.resolve(job, cluster, environment);
+
+        assertEquals(true, config.enabled());
+        assertEquals(2000, config.timeoutMs());
+        assertEquals("environment", config.namespace());
+        assertFalse(config.toString().contains("secret"));
+    }
+
+    /**
+     * The producer default must be derived from the running version rather than from a build-time
+     * constant, which would silently keep reporting a stale version after a release. Setting the
+     * version property must therefore change the resolved producer.
+     */
+    @Test
+    void producerDefaultFollowsTheRunningVersion() {
+        String originalVersion = System.getProperty("seatunnel.version");
+        try {
+            System.setProperty("seatunnel.version", "9.9.9");
+            assertEquals("https://seatunnel.apache.org/9.9.9", LineageConfig.defaults().producer());
+
+            System.setProperty("seatunnel.version", "");
+            String withoutVersion = LineageConfig.defaults().producer();
+            assertEquals("https://seatunnel.apache.org/", withoutVersion);
+        } finally {
+            if (originalVersion == null) {
+                System.clearProperty("seatunnel.version");
+            } else {
+                System.setProperty("seatunnel.version", originalVersion);
+            }
+        }
+    }
+
+    @Test
+    void tokenUsesOnlyEnvironmentThenCluster() {
+        Map<String, Object> cluster =
+                Collections.singletonMap("openlineage.auth_token", "cluster-token");
+        Map<String, Object> environment =
+                Collections.singletonMap("OPENLINEAGE_AUTH_TOKEN", "env-token");
+
+        assertEquals("env-token", LineageConfig.resolveToken(cluster, environment));
+        assertEquals("cluster-token", LineageConfig.resolveToken(cluster, Collections.emptyMap()));
+
+        LineageConfig config = LineageConfig.resolve(Collections.emptyMap(), cluster, environment);
+        assertFalse(config.toString().contains("env-token"));
+        assertFalse(config.withAuthToken(null).toMap().containsKey(LineageConfig.AUTH_TOKEN));
+    }
+
+    @Test
+    void rejectsTokenInJobOptions() {
+        Map<String, Object> job =
+                Collections.singletonMap(LineageConfig.AUTH_TOKEN, "not-a-real-token");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LineageConfig.resolve(job, Collections.emptyMap(), Collections.emptyMap()));
+    }
+
+    @Test
+    void parsesStringRunPropertiesWithSourcePriority() {
+        Map<String, Object> cluster = new HashMap<>();
+        cluster.put("openlineage.run_properties", "cluster: value, shared: cluster");
+        Map<String, Object> environment = new HashMap<>();
+        environment.put("OPENLINEAGE_RUN_PROPERTIES", "{environment: value, shared: environment}");
+
+        LineageConfig environmentConfig =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, environment);
+
+        assertEquals("value", environmentConfig.runProperties().get("environment"));
+        assertEquals("environment", environmentConfig.runProperties().get("shared"));
+        assertFalse(environmentConfig.runProperties().containsKey("cluster"));
+
+        LineageConfig clusterConfig =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, Collections.emptyMap());
+        assertEquals("value", clusterConfig.runProperties().get("cluster"));
+        assertEquals("cluster", clusterConfig.runProperties().get("shared"));
+    }
+
+    @Test
+    void parsesPrefixedClusterRunProperties() {
+        Map<String, Object> cluster = new HashMap<>();
+        cluster.put("openlineage.run_properties.owner", "platform");
+        cluster.put("openlineage.run_properties.region", "cn");
+
+        LineageConfig config =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, Collections.emptyMap());
+
+        assertEquals("platform", config.runProperties().get("owner"));
+        assertEquals("cn", config.runProperties().get("region"));
+    }
+
+    /**
+     * The five string options share one validation path, so an unnamed error leaves the operator
+     * guessing which of them was blanked out.
+     */
+    @Test
+    void namesTheBlankOptionItRejects() {
+        Map<String, Object> cluster = Collections.singletonMap(LineageConfig.NAMESPACE, "  ");
+
+        IllegalArgumentException failure =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                LineageConfig.resolve(
+                                        Collections.emptyMap(), cluster, Collections.emptyMap()));
+
+        assertTrue(
+                failure.getMessage().contains(LineageConfig.NAMESPACE),
+                "the error must name the option at fault, was: " + failure.getMessage());
+    }
+
+    @Test
+    void rejectsMalformedStringRunProperties() {
+        Map<String, Object> environment =
+                Collections.singletonMap("OPENLINEAGE_RUN_PROPERTIES", "not-a-map");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        LineageConfig.resolve(
+                                Collections.emptyMap(), Collections.emptyMap(), environment));
+    }
+
+    /**
+     * The separators of the string map form are also legal inside a value: a team name carries a
+     * comma and a URL carries a colon. Quoting is the only way to write either, so the parser must
+     * keep the quoted section intact instead of splitting inside it.
+     */
+    @Test
+    void keepsSeparatorsThatAppearInsideQuotedRunPropertyValues() {
+        Map<String, Object> cluster =
+                Collections.singletonMap(
+                        "openlineage.run_properties",
+                        "owner: \"data, platform\", docs: 'http://wiki/x', plain: value");
+
+        LineageConfig config =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, Collections.emptyMap());
+
+        assertEquals("data, platform", config.runProperties().get("owner"));
+        assertEquals("http://wiki/x", config.runProperties().get("docs"));
+        assertEquals("value", config.runProperties().get("plain"));
+    }
+
+    /**
+     * A duration written the way the rest of SeaTunnel accepts one is the likely mistake here. The
+     * configuration is resolved again on every reported event, so a failure that names only the
+     * text repeats forever in a log that never says which of the numeric options to correct.
+     */
+    @Test
+    void namesTheNumericOptionThatCouldNotBeParsed() {
+        Map<String, Object> job = Collections.singletonMap(LineageConfig.TIMEOUT_MS, "10s");
+
+        IllegalArgumentException failure =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                LineageConfig.resolve(
+                                        job, Collections.emptyMap(), Collections.emptyMap()));
+
+        assertTrue(failure.getMessage().contains(LineageConfig.TIMEOUT_MS), failure.getMessage());
+        assertTrue(failure.getMessage().contains("10s"), failure.getMessage());
+    }
+
+    @Test
+    void namesTheHeartbeatOptionThatCouldNotBeParsed() {
+        Map<String, Object> cluster =
+                Collections.singletonMap("openlineage.heartbeat_min_interval_ms", "1h");
+
+        IllegalArgumentException failure =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                LineageConfig.resolve(
+                                        Collections.emptyMap(), cluster, Collections.emptyMap()));
+
+        assertTrue(
+                failure.getMessage().contains(LineageConfig.HEARTBEAT_MIN_INTERVAL_MS),
+                failure.getMessage());
+    }
+
+    @Test
+    void rejectsRunPropertiesThatEndInsideAQuote() {
+        Map<String, Object> cluster =
+                Collections.singletonMap("openlineage.run_properties", "owner: \"unterminated");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        LineageConfig.resolve(
+                                Collections.emptyMap(), cluster, Collections.emptyMap()));
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetFactoryTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetFactoryTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageDatasetFactoryTest {
+
+    /**
+     * A SeaTunnel job normally declares a connector as a named block, for example {@code sink {
+     * Paimon { ... } }}. The option map for that block carries no {@code plugin_name} entry, so the
+     * caller must pass the plugin name; otherwise the most common job syntax silently produces no
+     * lineage at all.
+     */
+    @Test
+    void usesTheSuppliedPluginNameWhenOptionsDoNotCarryOne() {
+        Map<String, Object> options = paimonOptions();
+
+        assertTrue(
+                LineageDatasetFactory.fromConnectorOptions(options).isEmpty(),
+                "options from a named block cannot identify the connector on their own");
+
+        List<LineageDataset> datasets =
+                LineageDatasetFactory.fromConnectorOptions("Paimon", options);
+
+        assertEquals(1, datasets.size());
+        assertEquals("paimon://paimon_s3/seatunnel_lineage_verify", datasets.get(0).namespace());
+        assertEquals("st_verify_paimon", datasets.get(0).name());
+    }
+
+    @Test
+    void stillReadsThePluginNameFromOptionsWhenPresent() {
+        Map<String, Object> options = paimonOptions();
+        options.put("plugin_name", "Paimon");
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals(1, datasets.size());
+        assertEquals("paimon://paimon_s3/seatunnel_lineage_verify", datasets.get(0).namespace());
+    }
+
+    /**
+     * Paimon's catalog is part of the dataset identity, so an absent catalog must not be guessed.
+     */
+    @Test
+    void emitsNothingForPaimonWithoutAnExplicitCatalog() {
+        Map<String, Object> options = paimonOptions();
+        options.remove("catalog_name");
+
+        assertTrue(LineageDatasetFactory.fromConnectorOptions("Paimon", options).isEmpty());
+    }
+
+    /**
+     * Doris advertises its Stream Load HTTP port in {@code fenodes}, but the lineage namespace must
+     * use the MySQL query port, otherwise the table splits into two nodes in the graph.
+     */
+    @Test
+    void usesTheDorisQueryPortRatherThanTheFenodesPort() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("fenodes", "192.168.10.131:8030");
+        options.put("database", "ds71");
+        options.put("table", "orders");
+
+        List<LineageDataset> datasets =
+                LineageDatasetFactory.fromConnectorOptions("Doris", options);
+
+        assertEquals(1, datasets.size());
+        assertEquals("mysql://192.168.10.131:9030", datasets.get(0).namespace());
+        assertEquals("ds71.orders", datasets.get(0).name());
+    }
+
+    @Test
+    void emitsNothingForAnUnsupportedConnector() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("row.num", 10);
+
+        assertTrue(LineageDatasetFactory.fromConnectorOptions("FakeSource", options).isEmpty());
+    }
+
+    private static Map<String, Object> paimonOptions() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("warehouse", "s3a://lineage-paimon-warehouse/");
+        options.put("catalog_name", "paimon_s3");
+        options.put("database", "seatunnel_lineage_verify");
+        options.put("table", "st_verify_paimon");
+        Map<String, Object> hadoopConf = new LinkedHashMap<>();
+        hadoopConf.put("fs.s3a.endpoint", "http://example.invalid");
+        options.put("paimon.hadoop.conf", hadoopConf);
+        return options;
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetNamingTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetNamingTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageDatasetNamingTest {
+
+    @Test
+    void mapsConnectorOptionsAndKeepsDorisQueryPort() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Doris");
+        options.put("fenodes", "fe.example:8030");
+        options.put("query-port", 9030);
+        options.put("database", "warehouse");
+        options.put("table", "orders");
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals("mysql://fe.example:9030", datasets.get(0).namespace());
+        assertEquals("warehouse.orders", datasets.get(0).name());
+    }
+
+    @Test
+    void usesExplicitPaimonCatalogAndTableList() {
+        Map<String, Object> first = new HashMap<>();
+        first.put("database", "db");
+        first.put("table", "one");
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("catalog_name", "analytics");
+        options.put("table_list", Arrays.asList(first));
+
+        assertEquals(
+                "paimon://analytics/db",
+                LineageDatasetFactory.fromConnectorOptions(options).get(0).namespace());
+    }
+
+    @Test
+    void mapsJdbcSourceTablePath() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Jdbc");
+        options.put("url", "jdbc:mysql://db.example:3306/connection_default");
+        options.put("table_path", "table_database.orders");
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals("mysql://db.example:3306", datasets.get(0).namespace());
+        // table_path wins over the database named in the JDBC URL.
+        assertEquals("table_database.orders", datasets.get(0).name());
+    }
+
+    @Test
+    void skipsDefaultTablePath() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Jdbc");
+        options.put("url", "jdbc:mysql://db.example:3306/warehouse");
+        options.put("table_path", "default.default.default");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    @Test
+    void requiresExplicitPaimonCatalog() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("database", "analytics");
+        options.put("table", "orders");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    /**
+     * Two tables that share a name in different databases must stay distinct nodes on the lineage
+     * graph, so the database has to be part of the dataset identity rather than only of the
+     * namespace.
+     */
+    @Test
+    void keepsSameNamedPaimonTablesInDifferentDatabasesDistinct() {
+        Map<String, Object> first = new HashMap<>();
+        first.put("database", "db_one");
+        first.put("table", "orders");
+        Map<String, Object> second = new HashMap<>();
+        second.put("database", "db_two");
+        second.put("table", "orders");
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("catalog_name", "analytics");
+        options.put("table_list", Arrays.asList(first, second));
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals(2, datasets.size());
+        assertEquals("paimon://analytics/db_one", datasets.get(0).namespace());
+        assertEquals("paimon://analytics/db_two", datasets.get(1).namespace());
+        assertEquals("orders", datasets.get(0).name());
+        assertEquals("orders", datasets.get(1).name());
+        assertNotEquals(datasets.get(0), datasets.get(1));
+    }
+
+    @Test
+    void excludesDefaultTablePathFromEveryConnectorMapping() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Doris");
+        options.put("fenodes", "fe.example:8030");
+        options.put("database", "warehouse");
+        options.put("table", "orders");
+        options.put("table_path", "default.default.default");
+
+        assertTrue(LineageDatasetNaming.isDefaultTablePath("default.default.default"));
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    @Test
+    void ignoresMalformedDorisQueryPort() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Doris");
+        options.put("fenodes", "fe.example:8030");
+        options.put("query-port", "not-a-port");
+        options.put("database", "warehouse");
+        options.put("table", "orders");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    /**
+     * A multi-table sink routes rows with a template that is substituted per row, so the template
+     * itself is never a real table. Emitting it would collapse every placeholder-routed job onto
+     * one shared graph node whose name looks plausible.
+     */
+    @Test
+    void rejectsUnresolvedPlaceholdersInTableIdentity() {
+        assertFalse(LineageDatasetNaming.paimon("catalog", "db", "${table_name}").isPresent());
+        assertFalse(
+                LineageDatasetNaming.paimon("catalog", "${database_name}", "orders").isPresent());
+        assertFalse(LineageDatasetNaming.paimon("${catalog}", "db", "orders").isPresent());
+        assertFalse(
+                LineageDatasetNaming.doris("fe.example", 9030, "db", "${table_name}").isPresent());
+        assertFalse(
+                LineageDatasetNaming.jdbc("mysql", "host", 3306, "db", "${table_name}")
+                        .isPresent());
+
+        // A name that merely contains a dollar sign is a legal identifier and must still pass.
+        assertTrue(LineageDatasetNaming.paimon("catalog", "db", "orders$archive").isPresent());
+    }
+
+    @Test
+    void placeholderRoutedSinkYieldsNoDatasetThroughTheFactory() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("catalog_name", "paimon_s3");
+        options.put("database", "${database_name}");
+        options.put("table", "${table_name}");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageEventTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageEventTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageEventTest {
+
+    @Test
+    void addsRunPropertyWithoutDisturbingTheRestOfTheEvent() {
+        LineageEvent event = event();
+
+        LineageEvent withProperty = event.withRunProperty("flink_job_id", "abc123");
+
+        assertEquals("abc123", withProperty.runProperties().get("flink_job_id"));
+        assertEquals("kept", withProperty.runProperties().get("existing"));
+        assertEquals(event.runId(), withProperty.runId());
+        assertEquals(event.eventType(), withProperty.eventType());
+        assertEquals(event.eventTime(), withProperty.eventTime());
+        assertEquals(event.outputs(), withProperty.outputs());
+
+        // The source event must stay immutable so a shared event can be reused per callback.
+        assertFalse(event.runProperties().containsKey("flink_job_id"));
+    }
+
+    /**
+     * The Flink status hook has no job identifier for a callback that does not carry one, so a null
+     * value must be a no-op rather than something the caller has to branch on. Emitting a null
+     * property would also send a null into the run facet.
+     */
+    @Test
+    void ignoresAbsentRunPropertyValues() {
+        LineageEvent event = event();
+
+        assertSame(event, event.withRunProperty("flink_job_id", null));
+        assertSame(event, event.withRunProperty(null, "abc123"));
+        assertSame(event, event.withRunProperty("  ", "abc123"));
+    }
+
+    @Test
+    void runPropertiesStayImmutable() {
+        LineageEvent event = event().withRunProperty("flink_job_id", "abc123");
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> event.runProperties().put("injected", "value"));
+    }
+
+    @Test
+    void changingEventTypeKeepsRunIdentityAndProperties() {
+        LineageEvent event = event().withRunProperty("flink_job_id", "abc123");
+
+        LineageEvent completed = event.withEventType(LineageEventType.COMPLETE);
+
+        assertEquals(LineageEventType.COMPLETE, completed.eventType());
+        assertEquals(event.runId(), completed.runId());
+        assertEquals("abc123", completed.runProperties().get("flink_job_id"));
+        assertTrue(completed.eventTime().getOffset().equals(ZoneOffset.UTC));
+    }
+
+    private static LineageEvent event() {
+        return LineageEvent.builder()
+                .runId(UUID.nameUUIDFromBytes("seatunnel-job:1".getBytes()))
+                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .eventType(LineageEventType.START)
+                .jobNamespace("seatunnel")
+                .jobName("job")
+                .producer("https://seatunnel.apache.org/")
+                .runFacet(LineageConfig.DEFAULT_RUN_FACET)
+                .runProperties(Collections.singletonMap("existing", "kept"))
+                .outputs(
+                        Collections.singletonList(
+                                LineageDataset.of("mysql://host:3306", "db.orders")))
+                .build();
+    }
+}

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -133,3 +133,4 @@ seatunnel-shade-jetty-9.4.56.v20240826-3.0.0.jar
 seatunnel-shade-scala-compiler-2.12-3.0.0.jar
 seatunnel-shade-calcite-1.38.0-3.0.0.jar
 seatunnel-shade-jackson-yaml-2.15.4-3.0.0.jar
+openlineage-java-1.29.0.jar


### PR DESCRIPTION
> **Stacked on #12208.** This branch is built on top of `feature/openlineage-core` (PR #12208), so until #12208 merges, this diff also shows #12208's changes (the `seatunnel-lineage`/`seatunnel-lineage-openlineage` modules and the new `openlineage_*` options). It will shrink to just the Zeta-specific commits once #12208 merges into `dev`. Please review this PR's own commits (`git log feature/openlineage-core..feature/openlineage-zeta`); #12208's commits are under separate review there.

### Purpose of this pull request

Implements #12205 (part of the umbrella #12207), stacked on #12208. Adds `ZetaLineageReporter` and wires it into `JobMaster`/`PhysicalPlan`/`CheckpointCoordinator` so a Zeta job reports OpenLineage START / throttled RUNNING heartbeat / terminal COMPLETE-FAIL-ABORT events for each of its sinks when `openlineage_enabled = true`.

### Does this PR introduce _any_ user-facing change?

Yes, but opt-in only (`openlineage_enabled`, default `false`, added in #12208). When enabled: one extra outbound HTTP call at job start, one per completed checkpoint (throttled by `openlineage_heartbeat_min_interval_ms`), and one at job end. When disabled (the default for every existing job), no change to job execution, checkpointing, or scheduling.

### How was this patch tested?

- Unit tests: `ZetaLineageReporterTest`, `LineageOptionParityTest` (env-option resolution matches what #12208 defines), `CheckpointCoordinatorTest` (the heartbeat hook doesn't interfere with checkpoint completion), `SourceSinkActionCompatibilityTest` (the actions this PR touches keep a stable `serialVersionUID`).
- End-to-end against a real Gravitino instance, in an isolated standalone SeaTunnel sandbox cluster not shared with any other workload, built from this PR's own code:
  - `FakeSource (10 rows) → Paimon` batch job: Gravitino received one `start` and one `complete` event with `outputStatistics: {rowCount: 10, size: 170}`; the Paimon table's data files (schema/manifest/snapshot/parquet) were inspected directly and match.
  - `FakeSource (10 rows) → Doris` batch job: same event shape and statistics; verified against the actual table with `SELECT COUNT(*)` over the Doris query port — `10`, matching.
  - Both events' facets were checked for the shaded-Jackson corruption issue described in #12208 — clean, properties inlined correctly, no `additionalProperties` wrapping.
- `./mvnw -q -DskipTests verify` across the whole reactor — 470 modules, BUILD SUCCESS. This branch's affected-module unit tests all pass.

### Check list

* [ ] No new JAR
* [x] Documentation updated (`docs/en`, `docs/zh` — Zeta section of the lineage concept page; one line added to the hybrid-cluster-deployment doc)
* [ ] `incompatible-changes.md` — not applicable
* [ ] Connector-specific checklist items — not applicable
