### PR TITLE
[Feature][Flink] Report table-level lineage from the Flink starter

### DIFF
--- a/docs/en/introduction/concepts/lineage.md
+++ b/docs/en/introduction/concepts/lineage.md
@@ -110,3 +110,74 @@ Besides the properties configured through `openlineage_run_properties`, the run 
 `engine` property naming the execution engine that reported the run. Each engine adds the
 identifiers that make its run findable in that engine's own UI; those are described in the engine
 sections below.
+## Flink
+
+### Flink cluster configuration
+
+Flink reads cluster-level values with the `openlineage.` prefix. For Flink 1.20 and later, use
+`config.yaml`; the legacy `flink-conf.yaml` name is also supported:
+
+```yaml
+openlineage.enabled: true
+openlineage.transport: http
+openlineage.url: http://lineage.example/api/lineage
+openlineage.namespace: seatunnel
+openlineage.timeout_ms: 10000
+openlineage.retry_times: 3
+openlineage.run_facet: seatunnel_properties
+openlineage.heartbeat_min_interval_ms: 3600000
+openlineage.producer: https://seatunnel.apache.org/<version>
+```
+
+### Installing the lineage artifact on the cluster
+
+The Flink integration ships one deployable artifact, built by the `seatunnel-lineage-flink` module:
+
+```text
+seatunnel-lineage-flink-<version>-shaded.jar
+```
+
+Install it in the JobManager's `$FLINK_HOME/lib` directory and restart the JobManager, because a
+Flink class path is fixed at startup. Deploy exactly one copy, and remove the previous version when
+upgrading: two versions in `lib/` leave the effective class path order undefined.
+
+The artifact relocates Jackson, the OpenLineage model, Apache HttpClient, and the commons-logging
+bridge under `org.apache.seatunnel.lineage.shaded`. That matters because `lib/` is on the parent
+class loader, so anything placed there is visible to every job running on that cluster; relocation
+keeps this artifact from changing which Jackson those jobs see. Do not substitute the SeaTunnel
+starter jar, which carries the same libraries unrelocated.
+
+Keep the same cluster configuration in both configuration-file layouts when an installation supports
+both Flink 1.20+ and legacy deployments.
+
+**A job with lineage enabled fails to submit when the artifact is not installed.** This is
+deliberate — a job that silently loses its lineage is worse than one that refuses to start — and
+the submission error names the missing class and how to resolve it. To submit without installing
+it, set `openlineage_enabled=false`.
+
+### Events reported by Flink
+
+Flink registers the status hook only when the runtime exposes the required API. Flink lineage
+support requires Flink 1.16 or later, which in the SeaTunnel starters means the Flink 1.20 path;
+the Flink 1.13 and 1.15 starters do not register this hook and run the job unchanged.
+
+Exactly one side reports a successful Flink job, so a run never receives two `COMPLETE` events. An
+attached submission reports it from the client, which is the only place the output statistics are
+readable; a detached submission reports it from the JobManager status hook, without statistics.
+`FAIL` and `ABORT` come from the status hook, except for a job that never started: a submission
+that fails — no available slots, a rejected credential, or a JobManager that cannot load the status
+hook — is reported as `FAIL` by the client, because no hook runs for a job the cluster never
+created.
+
+A detached Flink job therefore has no `outputStatistics`, because its client result does not expose
+accumulators. Attached execution emits the available `SinkWriteCount` and `SinkWriteBytes` values,
+with `attempted` semantics.
+
+The run facet carries a `flink_job_id` property in addition to `engine`. The run ID is derived
+before submission, when no Flink job ID exists yet, so `flink_job_id` is what ties a lineage run
+back to the job shown in the Flink UI and REST API.
+
+A job that has not finished reports periodic heartbeat events, so a receiver does not mistake a
+still-running job for one whose producer died. Flink emits them from a scheduled task on the
+JobManager and therefore does not depend on checkpointing. They are throttled by
+`openlineage_heartbeat_min_interval_ms`, and setting it to `0` stops them.

--- a/docs/en/introduction/concepts/lineage.md
+++ b/docs/en/introduction/concepts/lineage.md
@@ -1,0 +1,112 @@
+---
+title: OpenLineage Lineage Reporting
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# OpenLineage Lineage Reporting
+
+SeaTunnel can emit table-level OpenLineage `RunEvent` records to any OpenLineage-compatible
+receiver. The feature is disabled by default. When it is disabled, SeaTunnel does not create a
+lineage network call or a lineage-specific background thread, and existing job behavior is
+unchanged.
+
+## Configuration
+
+The following options are available in a job `env` block unless noted otherwise.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `openlineage_enabled` | Boolean | `false` | Enables OpenLineage reporting. |
+| `openlineage_transport` | String | `http` | Transport name selected from the `LineageBackend` SPI. |
+| `openlineage_url` | String | None | Base URL of the OpenLineage receiver. Required when reporting is enabled. |
+| `openlineage_namespace` | String | `seatunnel` | OpenLineage job namespace. |
+| `openlineage_auth_token` | String | None | Receiver bearer token. It may come only from an environment variable or cluster configuration. |
+| `openlineage_timeout_ms` | Int | `10000` | Timeout for one send attempt, in milliseconds. |
+| `openlineage_retry_times` | Int | `3` | Number of retries after a failed send. |
+| `openlineage_run_facet` | String | `seatunnel_properties` | Name of the custom run facet. |
+| `openlineage_run_properties` | Map | None | Custom properties copied to the run facet. |
+| `openlineage_heartbeat_min_interval_ms` | Long | `3600000` | Minimum interval between streaming-job heartbeat events, in milliseconds. `0` disables heartbeat reporting. |
+| `openlineage_producer` | String | `https://seatunnel.apache.org/<version>` | OpenLineage producer identifier. The default is derived from the running SeaTunnel version at runtime. |
+
+Values are resolved independently with this precedence:
+
+```text
+job env {} > process environment > cluster configuration > default
+```
+
+The token is the exception to this rule. `openlineage_auth_token` is resolved as
+`OPENLINEAGE_AUTH_TOKEN` > cluster configuration. A token in a job `env {}` block is rejected at
+job startup. This prevents the token from being persisted in job configuration or serialized into
+the Flink JobGraph.
+
+Lineage delivery is unconditionally best effort, and there is deliberately no option to change that.
+A receiver or network failure is contained at the engine integration boundary and reported as a
+warning, so it can never change the outcome of the data-processing job.
+
+### Environment variable names
+
+The environment variable name is the upper-case option name:
+
+| Option | Environment variable |
+| --- | --- |
+| `openlineage_enabled` | `OPENLINEAGE_ENABLED` |
+| `openlineage_transport` | `OPENLINEAGE_TRANSPORT` |
+| `openlineage_url` | `OPENLINEAGE_URL` |
+| `openlineage_namespace` | `OPENLINEAGE_NAMESPACE` |
+| `openlineage_auth_token` | `OPENLINEAGE_AUTH_TOKEN` |
+| `openlineage_timeout_ms` | `OPENLINEAGE_TIMEOUT_MS` |
+| `openlineage_retry_times` | `OPENLINEAGE_RETRY_TIMES` |
+| `openlineage_run_facet` | `OPENLINEAGE_RUN_FACET` |
+| `openlineage_run_properties` | `OPENLINEAGE_RUN_PROPERTIES` |
+| `openlineage_heartbeat_min_interval_ms` | `OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS` |
+| `openlineage_producer` | `OPENLINEAGE_PRODUCER` |
+
+For example, set `OPENLINEAGE_URL` and `OPENLINEAGE_AUTH_TOKEN` through the process or service
+manager environment. Do not put a real token in a job file, repository file, command history, or
+logs.
+
+## Dataset names
+
+Supported connector dataset identities use these canonical forms. For multi-table sources and sinks,
+each configured table is represented separately.
+
+| Connector | Namespace | Name |
+| --- | --- | --- |
+| Paimon | `paimon://<catalog_name>/<database>` | `<table>` |
+| Doris | `mysql://<fe_host>:<query_port>` | `<database>.<table>` |
+| JDBC | `<scheme>://<host>:<port>` | `<database>.<table>` |
+
+For Paimon, `<catalog_name>` comes from the connector's `catalog_name` option and the dataset name is
+the table name only, not `database.table`. Set `catalog_name` explicitly to keep the namespace stable
+across jobs; when it is omitted, no Paimon dataset is emitted. For Doris, `fenodes` normally contains the HTTP Stream Load port; the
+lineage namespace uses the Doris query port instead. The generic `default.default.default` table path
+is not emitted.
+
+A sink that routes rows with a template, such as `table = "${table_name}"`, produces no dataset
+either. The template is substituted per row at write time, so it never names a real table, and
+emitting it verbatim would collapse every template-routed job onto one shared node in the graph. A
+name that merely contains a dollar sign, such as `orders$archive`, is a normal identifier and is
+still emitted.
+
+## Run facet properties
+
+Besides the properties configured through `openlineage_run_properties`, the run facet carries an
+`engine` property naming the execution engine that reported the run. Each engine adds the
+identifiers that make its run findable in that engine's own UI; those are described in the engine
+sections below.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -31,7 +31,8 @@ const sidebars = {
                     "label": "Concepts",
                     "items": [
                         "introduction/concepts/connector-v2-features",
-                        "introduction/concepts/schema-feature"
+                        "introduction/concepts/schema-feature",
+                        "introduction/concepts/lineage"
                     ]
                 }
             ]

--- a/docs/zh/introduction/concepts/lineage.md
+++ b/docs/zh/introduction/concepts/lineage.md
@@ -101,3 +101,67 @@ Paimon 数据集。Doris 的 `fenodes` 通常是 HTTP Stream Load
 
 除 `openlineage_run_properties` 配置的属性外，run facet 还会携带 `engine` 属性，标明上报该 run
 的执行引擎。各引擎还会补充能在自己 UI 中定位该 run 的标识，见下面各引擎章节。
+
+## Flink
+
+### Flink 集群配置
+
+Flink 使用 `openlineage.` 前缀读取集群级配置。Flink 1.20 及之后版本使用 `config.yaml`；旧版
+`flink-conf.yaml` 文件名也支持：
+
+```yaml
+openlineage.enabled: true
+openlineage.transport: http
+openlineage.url: http://lineage.example/api/lineage
+openlineage.namespace: seatunnel
+openlineage.timeout_ms: 10000
+openlineage.retry_times: 3
+openlineage.run_facet: seatunnel_properties
+openlineage.heartbeat_min_interval_ms: 3600000
+openlineage.producer: https://seatunnel.apache.org/<version>
+```
+
+### 在集群上安装血缘产物
+
+Flink 侧只有一个可部署产物，由 `seatunnel-lineage-flink` 模块构建：
+
+```text
+seatunnel-lineage-flink-<version>-shaded.jar
+```
+
+把它放进 JobManager 的 `$FLINK_HOME/lib` 目录并重启 JobManager —— Flink 的 classpath 在启动时固定。
+只放一份，升级时先删掉旧版本：`lib/` 里同时存在两个版本会让实际的 classpath 顺序变得不确定。
+
+该产物把 Jackson、OpenLineage 模型、Apache HttpClient 以及 commons-logging 桥接一并 relocate 到
+`org.apache.seatunnel.lineage.shaded` 之下。这一点很关键：`lib/` 位于父 classloader，放进去的类对该
+集群上的**所有**作业可见，relocate 才能保证本产物不会改变那些作业看到的 Jackson 版本。不要用
+SeaTunnel starter jar 代替它 —— 后者携带的是未 relocate 的同名依赖。
+
+如果安装环境同时支持 Flink 1.20+ 和 legacy 部署，应在实际使用的两种配置文件布局中保持相同配置。
+
+**未安装该产物时，开启血缘的作业会提交失败。** 这是刻意的设计——静默丢失血缘比拒绝启动更糟——
+提交错误会指出缺失的类以及解决办法。若要在未安装的情况下提交作业，请设置
+`openlineage_enabled=false`。
+
+### Flink 上报的事件
+
+只有运行时提供所需 API 时，Flink 才会注册状态 hook。Flink 侧血缘需要 Flink 1.16 或更高版本；在
+SeaTunnel starter 中对应 Flink 1.20 路径，Flink 1.13 和 1.15 starter 不注册该 hook，作业行为
+保持不变。
+
+Flink 作业成功结束时只有一侧上报终态事件，因此同一个 run 不会收到两次 `COMPLETE`。attached
+提交由客户端上报，因为只有客户端能读到输出统计；detached 提交由 JobManager 的 status hook
+上报，不带统计信息。`FAIL` 和 `ABORT` 由 status hook 上报，作业根本没有启动的情况除外：提交
+失败时——没有可用 slot、凭据被拒绝，或者 JobManager 无法加载 status hook——由客户端上报
+`FAIL`，因为集群从未创建过这个作业，也就不会有 hook 运行。
+
+因此 Flink detached 作业没有 `outputStatistics`，因为 detached 结果不暴露 accumulators。
+Attached 执行会发射可获得的 `SinkWriteCount` 和 `SinkWriteBytes`，其口径为 `attempted`。
+
+run facet 除 `engine` 外还携带 `flink_job_id` 属性。runId 在作业提交前就已生成，那时还没有
+Flink job ID，因此 `flink_job_id` 是把血缘 run 关联回 Flink UI 与 REST API 中那个作业的唯一
+途径。
+
+未结束的作业会周期性发送心跳事件，使接收端不会把仍在运行的作业误判为 producer 已死。Flink 由
+JobManager 上的定时任务发送，不依赖 checkpoint。心跳受 `openlineage_heartbeat_min_interval_ms`
+节流，设置为 `0` 时不再发送。

--- a/docs/zh/introduction/concepts/lineage.md
+++ b/docs/zh/introduction/concepts/lineage.md
@@ -1,0 +1,103 @@
+---
+title: OpenLineage 血缘上报
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# OpenLineage 血缘上报
+
+SeaTunnel 可以向任意兼容 OpenLineage 的接收端发射表级 `RunEvent` 记录。该能力默认关闭，
+关闭时不会创建血缘网络请求或血缘专用后台线程，现有作业行为保持不变。
+
+## 配置项
+
+除特别说明外，以下配置项可以写在作业的 `env` 块中。
+
+| 配置项 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `openlineage_enabled` | Boolean | `false` | 是否启用 OpenLineage 上报。 |
+| `openlineage_transport` | String | `http` | 传输后端名称，对应 `LineageBackend` SPI。 |
+| `openlineage_url` | String | 无 | OpenLineage 接收端基址。启用上报时必须配置。 |
+| `openlineage_namespace` | String | `seatunnel` | OpenLineage job namespace。 |
+| `openlineage_auth_token` | String | 无 | 接收端 bearer token，只能来自环境变量或集群配置。 |
+| `openlineage_timeout_ms` | Int | `10000` | 单次发送尝试的超时时间，单位为毫秒。 |
+| `openlineage_retry_times` | Int | `3` | 发送失败后的重试次数。 |
+| `openlineage_run_facet` | String | `seatunnel_properties` | 自定义 run facet 的名称。 |
+| `openlineage_run_properties` | Map | 无 | 写入 run facet 的自定义属性。 |
+| `openlineage_heartbeat_min_interval_ms` | Long | `3600000` | 流作业心跳的最小间隔，单位为毫秒。设置为 `0` 表示关闭心跳上报。 |
+| `openlineage_producer` | String | `https://seatunnel.apache.org/<version>` | OpenLineage producer 标识。默认值在运行时根据当前 SeaTunnel 版本生成。 |
+
+每个配置项独立按照以下优先级解析：
+
+```text
+作业 env {} > 进程环境变量 > 集群配置 > 默认值
+```
+
+Token 是例外：`openlineage_auth_token` 按 `OPENLINEAGE_AUTH_TOKEN` > 集群配置解析。作业
+`env {}` 中出现 token 会在启动时直接拒绝。这样可以避免 token 持久化到作业配置，或被序列化到
+Flink JobGraph。
+
+血缘投递无条件是 best-effort，并且刻意不提供改变该行为的配置项。接收端或网络失败会在引擎
+集成边界被捕获并记录 warning，因此不可能改变数据处理作业的结果。
+
+### 环境变量名称
+
+环境变量名称是配置项名称的大写形式：
+
+| 配置项 | 环境变量 |
+| --- | --- |
+| `openlineage_enabled` | `OPENLINEAGE_ENABLED` |
+| `openlineage_transport` | `OPENLINEAGE_TRANSPORT` |
+| `openlineage_url` | `OPENLINEAGE_URL` |
+| `openlineage_namespace` | `OPENLINEAGE_NAMESPACE` |
+| `openlineage_auth_token` | `OPENLINEAGE_AUTH_TOKEN` |
+| `openlineage_timeout_ms` | `OPENLINEAGE_TIMEOUT_MS` |
+| `openlineage_retry_times` | `OPENLINEAGE_RETRY_TIMES` |
+| `openlineage_run_facet` | `OPENLINEAGE_RUN_FACET` |
+| `openlineage_run_properties` | `OPENLINEAGE_RUN_PROPERTIES` |
+| `openlineage_heartbeat_min_interval_ms` | `OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS` |
+| `openlineage_producer` | `OPENLINEAGE_PRODUCER` |
+
+例如，可以通过进程环境或服务管理器注入 `OPENLINEAGE_URL` 和 `OPENLINEAGE_AUTH_TOKEN`。不要把真实
+token 写入作业文件、仓库文件、命令历史或日志。
+
+## 数据集命名
+
+支持的连接器数据集标识采用以下规范形式。多表 source 和 sink 会为每张配置的表分别生成
+数据集标识：
+
+| 连接器 | Namespace | Name |
+| --- | --- | --- |
+| Paimon | `paimon://<catalog_name>/<database>` | `<table>` |
+| Doris | `mysql://<fe_host>:<query_port>` | `<database>.<table>` |
+| JDBC | `<scheme>://<host>:<port>` | `<database>.<table>` |
+
+Paimon 的 `<catalog_name>` 来自连接器的 `catalog_name` 配置，数据集的 name 只有表名，不是
+`database.table`。如果需要生成 Paimon 血缘，应显式设置 `catalog_name`；未设置时不会发射
+Paimon 数据集。Doris 的 `fenodes` 通常是 HTTP Stream Load
+端口，而血缘 namespace 使用 Doris query port。通用的 `default.default.default` 表路径不会
+被发射。
+
+使用模板路由的 sink（例如 `table = "${table_name}"`）同样不会产生数据集。模板在写入时按行替换，
+本身从不指向真实的表；若原样发射，所有使用模板路由的作业会在血缘图上汇聚到同一个节点。仅仅
+包含美元符号的名称（例如 `orders$archive`）是正常标识符，仍会被发射。
+
+## Run facet 属性
+
+除 `openlineage_run_properties` 配置的属性外，run facet 还会携带 `engine` 属性，标明上报该 run
+的执行引擎。各引擎还会补充能在自己 UI 中定位该 run 的标识，见下面各引擎章节。

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
         -->
         <module>seatunnel-config</module>
         <module>seatunnel-common</module>
+        <module>seatunnel-lineage</module>
+        <module>seatunnel-lineage-openlineage</module>
         <module>seatunnel-core</module>
         <module>seatunnel-transforms-v2</module>
         <module>seatunnel-connectors-v2</module>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>seatunnel-common</module>
         <module>seatunnel-lineage</module>
         <module>seatunnel-lineage-openlineage</module>
+        <module>seatunnel-lineage-flink</module>
         <module>seatunnel-core</module>
         <module>seatunnel-transforms-v2</module>
         <module>seatunnel-connectors-v2</module>

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvCommonOptions.java
@@ -151,4 +151,78 @@ public class EnvCommonOptions {
                     .noDefaultValue()
                     .withDescription(
                             "The http path of the metadata lake, for example: http://localhost:8090/api/metalakes/laowang_test/catalogs/");
+
+    public static Option<Boolean> OPENLINEAGE_ENABLED =
+            Options.key("openlineage_enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether OpenLineage lineage reporting is enabled.");
+
+    public static Option<String> OPENLINEAGE_TRANSPORT =
+            Options.key("openlineage_transport")
+                    .stringType()
+                    .defaultValue("http")
+                    .withDescription(
+                            "Transport name selected from the LineageBackend service provider interface.");
+
+    public static Option<String> OPENLINEAGE_URL =
+            Options.key("openlineage_url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Base URL of the OpenLineage receiver, for example: http://host:8090/api/lineage");
+
+    public static Option<String> OPENLINEAGE_NAMESPACE =
+            Options.key("openlineage_namespace")
+                    .stringType()
+                    .defaultValue("seatunnel")
+                    .withDescription("OpenLineage job namespace.");
+
+    public static Option<String> OPENLINEAGE_AUTH_TOKEN =
+            Options.key("openlineage_auth_token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Bearer token for the OpenLineage receiver. It may only come from the "
+                                    + "OPENLINEAGE_AUTH_TOKEN environment variable or from cluster configuration; "
+                                    + "declaring it in a job env block is rejected at startup.");
+
+    public static Option<Integer> OPENLINEAGE_TIMEOUT_MS =
+            Options.key("openlineage_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("Timeout of one send attempt, in milliseconds.");
+
+    public static Option<Integer> OPENLINEAGE_RETRY_TIMES =
+            Options.key("openlineage_retry_times")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("Number of retries after a failed send attempt.");
+
+    public static Option<String> OPENLINEAGE_RUN_FACET =
+            Options.key("openlineage_run_facet")
+                    .stringType()
+                    .defaultValue("seatunnel_properties")
+                    .withDescription("Name of the run facet carrying the custom run properties.");
+
+    public static Option<Map<String, String>> OPENLINEAGE_RUN_PROPERTIES =
+            Options.key("openlineage_run_properties")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("Custom properties copied into the run facet.");
+
+    public static Option<Long> OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS =
+            Options.key("openlineage_heartbeat_min_interval_ms")
+                    .longType()
+                    .defaultValue(3600000L)
+                    .withDescription(
+                            "Minimum interval between streaming-job heartbeat events, in milliseconds.");
+
+    public static Option<String> OPENLINEAGE_PRODUCER =
+            Options.key("openlineage_producer")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "OpenLineage producer identifier. When unset it defaults to "
+                                    + "https://seatunnel.apache.org/ followed by the running SeaTunnel version.");
 }

--- a/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
+++ b/seatunnel-api/src/main/java/org/apache/seatunnel/api/options/EnvOptionRule.java
@@ -50,7 +50,21 @@ public class EnvOptionRule implements Factory {
                         MultiTableCommonOptions.MULTI_TABLE_FAILURE_POLICY,
                         EnvCommonOptions.CUSTOM_PARAMETERS,
                         EnvCommonOptions.NODE_TAG_FILTER,
-                        EnvCommonOptions.SINK_FLUSH_INTERVAL)
+                        EnvCommonOptions.SINK_FLUSH_INTERVAL,
+                        EnvCommonOptions.OPENLINEAGE_ENABLED,
+                        EnvCommonOptions.OPENLINEAGE_TRANSPORT,
+                        EnvCommonOptions.OPENLINEAGE_URL,
+                        EnvCommonOptions.OPENLINEAGE_NAMESPACE,
+                        // OPENLINEAGE_AUTH_TOKEN is deliberately absent: a token in a job env
+                        // block is rejected at parse time so that it is never persisted in job
+                        // configuration or serialized into a Flink JobGraph. Listing it here would
+                        // advertise a setting the job is guaranteed to be rejected for.
+                        EnvCommonOptions.OPENLINEAGE_TIMEOUT_MS,
+                        EnvCommonOptions.OPENLINEAGE_RETRY_TIMES,
+                        EnvCommonOptions.OPENLINEAGE_RUN_FACET,
+                        EnvCommonOptions.OPENLINEAGE_RUN_PROPERTIES,
+                        EnvCommonOptions.OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS,
+                        EnvCommonOptions.OPENLINEAGE_PRODUCER)
                 .build();
     }
 }

--- a/seatunnel-api/src/test/java/org/apache/seatunnel/api/env/EnvOptionRuleTest.java
+++ b/seatunnel-api/src/test/java/org/apache/seatunnel/api/env/EnvOptionRuleTest.java
@@ -18,6 +18,7 @@
 package org.apache.seatunnel.api.env;
 
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.EnvCommonOptions;
 import org.apache.seatunnel.api.options.EnvOptionRule;
 
 import org.junit.jupiter.api.Assertions;
@@ -28,5 +29,11 @@ public class EnvOptionRuleTest {
     public void testGetEnvOptionRules() throws Exception {
         OptionRule envOptionRules = new EnvOptionRule().optionRule();
         Assertions.assertNotNull(envOptionRules);
+        Assertions.assertTrue(
+                envOptionRules.getOptionalOptions().contains(EnvCommonOptions.OPENLINEAGE_ENABLED));
+        Assertions.assertTrue(
+                envOptionRules
+                        .getOptionalOptions()
+                        .contains(EnvCommonOptions.OPENLINEAGE_HEARTBEAT_MIN_INTERVAL_MS));
     }
 }

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/pom.xml
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/pom.xml
@@ -73,5 +73,11 @@
             <scope>${flink.scope}</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageHooks.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageHooks.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.api.common.metrics.MetricNames;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+import org.apache.seatunnel.lineage.LineageRuntime;
+import org.apache.seatunnel.lineage.flink.FlinkClusterOptions;
+import org.apache.seatunnel.lineage.flink.LineageJobStatusHook;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The Flink 1.20 lineage registration, overriding the unsupported one in the common starter.
+ *
+ * <p>This class exists per Flink version rather than in the common starter because {@code
+ * JobStatusHook} is a 1.16+ API: a module compiled against 1.15 can neither name the interface nor
+ * call {@code StreamGraph.registerJobStatusHook}. Only this half is version-specific — event
+ * construction, configuration resolution and the deployment diagnostics stay in {@link
+ * FlinkLineageSupport}.
+ */
+final class FlinkLineageHooks {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlinkLineageHooks.class);
+
+    private FlinkLineageHooks() {}
+
+    /** Returns whether this starter can register a job status hook. */
+    static boolean isSupported() {
+        return true;
+    }
+
+    /**
+     * Registers the JobManager-side status hook and the client-side statistics listener.
+     *
+     * @param streamGraph the graph the hook is attached to
+     * @param environment the environment the result listener is registered on
+     * @param config lineage configuration with the auth token already removed
+     * @param events the start events whose runs the hook closes
+     * @param clientReportsTerminalEvent whether the client reports the successful terminal event
+     * @return whether the hook was registered
+     */
+    static boolean register(
+            StreamGraph streamGraph,
+            StreamExecutionEnvironment environment,
+            LineageConfig config,
+            List<LineageEvent> events,
+            boolean clientReportsTerminalEvent) {
+        streamGraph.registerJobStatusHook(
+                new LineageJobStatusHook(config, events, clientReportsTerminalEvent));
+        try {
+            environment.registerJobListener(new OutputStatisticsListener(config, events));
+        } catch (Throwable error) {
+            LOGGER.warn("Failed to register Flink lineage result listener", error);
+        }
+        return true;
+    }
+
+    /**
+     * Reports the terminal events only the submitting client can report.
+     *
+     * <p>Two of them. The output statistics live in the job accumulators, which only the client can
+     * read, so an attached submission reports the successful terminal event here and the JobManager
+     * hook is told to stay silent so the two cannot race. A submission that fails is the other: no
+     * hook runs for a job that never reached the cluster, so nothing else would close the runs
+     * whose start events have already been sent.
+     */
+    private static final class OutputStatisticsListener implements JobListener {
+        private final LineageConfig config;
+        private final List<LineageEvent> events;
+
+        private OutputStatisticsListener(LineageConfig config, List<LineageEvent> events) {
+            this.config = config;
+            this.events = events;
+        }
+
+        /**
+         * Closes the runs whose start events were already sent when the submission fails.
+         *
+         * <p>The start events describe the job the caller is about to run and are sent before the
+         * graph reaches the cluster, so a submission that never starts would otherwise leave every
+         * one of those runs open on the receiver until its abandoned-run timeout. That is not a
+         * corner case here: a JobManager without {@code seatunnel-lineage-flink} in its {@code
+         * lib/} directory fails the submission by design, and this integration is what makes it
+         * fail.
+         *
+         * <p>Flink calls this with a null client and the failure on that path, which is the first
+         * point at which the client knows the job will not run. A submission whose reply was lost
+         * after the JobManager accepted the job reports FAIL here and is later corrected by the
+         * hook's own terminal event, which the receiver sees last.
+         */
+        @Override
+        public void onJobSubmitted(JobClient jobClient, Throwable throwable) {
+            if (throwable == null) {
+                return;
+            }
+            try {
+                emit(LineageEventType.FAIL, null, null);
+            } catch (Throwable error) {
+                LOGGER.warn("Failed to close the Flink lineage runs of a failed submission", error);
+            }
+        }
+
+        @Override
+        public void onJobExecuted(JobExecutionResult result, Throwable executionError) {
+            try {
+                if (!FlinkLineageSupport.isAttachedJobExecutionResult(result, executionError)) {
+                    return;
+                }
+                Map<String, Object> accumulators = result.getAllAccumulatorResults();
+                Long rowCount = number(accumulators.get(MetricNames.SINK_WRITE_COUNT));
+                Long size = number(accumulators.get(MetricNames.SINK_WRITE_BYTES));
+                LineageOutputStatistics statistics =
+                        positive(rowCount) || positive(size)
+                                ? new LineageOutputStatistics(rowCount, size, "attempted")
+                                : null;
+                String flinkJobId = result.getJobID() == null ? null : result.getJobID().toString();
+                // Emitted even without statistics: an attached submission silences the JobManager
+                // hook, so skipping here would leave the run with no terminal event at all rather
+                // than one that is merely missing its row counts.
+                emit(LineageEventType.COMPLETE, flinkJobId, statistics);
+            } catch (Throwable error) {
+                LOGGER.warn("Failed to emit Flink output statistics", error);
+            }
+        }
+
+        /** Sends one terminal event for every run this listener owns. */
+        private void emit(
+                LineageEventType eventType, String flinkJobId, LineageOutputStatistics statistics) {
+            LineageConfig runtimeConfig =
+                    config.withAuthToken(
+                            LineageConfig.resolveToken(
+                                    FlinkClusterOptions.load(), System.getenv()));
+            for (LineageEvent event : events) {
+                LineageEvent terminal =
+                        statistics == null ? event : event.withOutputStatistics(statistics);
+                LineageRuntime.emit(
+                        runtimeConfig,
+                        terminal.withEventType(eventType)
+                                .withRunProperty(
+                                        LineageJobStatusHook.FLINK_JOB_ID_PROPERTY, flinkJobId));
+            }
+        }
+
+        private static Long number(Object value) {
+            return value instanceof Number ? ((Number) value).longValue() : null;
+        }
+
+        private static boolean positive(Long value) {
+            return value != null && value > 0;
+        }
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageHookNamingTest.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageHookNamingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.lineage.flink.LineageJobStatusHook;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Binds the hook class name that the common starter can only spell as a literal to the real class.
+ *
+ * <p>{@code seatunnel-flink-starter-common} compiles against Flink 1.15 and therefore cannot
+ * resolve {@link LineageJobStatusHook}, which implements a 1.16+ interface. It nevertheless has to
+ * name it: the diagnostic for a JobManager that is missing the lineage jar recognises the failure
+ * by matching this name in a stack trace relayed as text over REST. A rename that left the literal
+ * behind would silently turn that diagnostic off, and the operator would be back to a bare {@code
+ * ClassNotFoundException}. This module can resolve both, so it asserts they agree.
+ */
+class FlinkLineageHookNamingTest {
+
+    @Test
+    void theCommonStarterNamesTheRealHookClass() {
+        Assertions.assertEquals(
+                LineageJobStatusHook.class.getName(),
+                FlinkLineageSupport.HOOK_HANDLER_CLASS,
+                "the missing-deployment diagnostic must name the class the JobManager loads");
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageRegistrationTest.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageRegistrationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.common.metrics.MetricNames;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.flink.LineageJobStatusHook;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.execution.DetachedJobExecutionResult;
+import org.apache.flink.core.execution.JobListener;
+import org.apache.flink.core.execution.JobStatusHook;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.util.OptionalFailure;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Covers the lineage registration path against a Flink runtime that actually has the status-hook
+ * API.
+ *
+ * <p>{@code seatunnel-flink-starter-common} compiles against Flink 1.15, which has no {@code
+ * JobStatusHook}: there {@code FlinkLineageHooks} reports lineage as unsupported, so the same
+ * assertions could only ever be skipped. This module carries the {@code FlinkLineageHooks} that
+ * does the real registration, and is the only place the hook and the result listener are reachable
+ * at all.
+ */
+class FlinkLineageRegistrationTest {
+
+    @BeforeEach
+    void resetBackend() {
+        RecordingLineageBackend.EVENTS.clear();
+    }
+
+    @Test
+    void detectsTheStatusHookApiOnFlink20() {
+        Assertions.assertTrue(FlinkLineageSupport.isSupported());
+    }
+
+    @Test
+    void keepsFlinkCallbacksBestEffortWhenTheLineageBackendFails() throws Exception {
+        StreamExecutionEnvironment environment = environmentWithOneSink();
+        StreamGraph streamGraph = Assertions.assertDoesNotThrow(() -> register(environment));
+
+        Assertions.assertNotNull(streamGraph);
+        Assertions.assertEquals(1, environment.getJobListeners().size());
+        JobListener listener = environment.getJobListeners().get(0);
+        Map<String, OptionalFailure<Object>> accumulatorResults = new HashMap<>();
+        accumulatorResults.put(
+                MetricNames.SINK_WRITE_COUNT, OptionalFailure.of((Object) Long.valueOf(1L)));
+        JobExecutionResult attached = new JobExecutionResult(new JobID(), 1L, accumulatorResults);
+        Assertions.assertDoesNotThrow(() -> listener.onJobExecuted(attached, null));
+        Assertions.assertDoesNotThrow(
+                () -> listener.onJobExecuted(new DetachedJobExecutionResult(new JobID()), null));
+
+        JobStatusHook hook = registeredHook(streamGraph);
+        Assertions.assertDoesNotThrow(() -> hook.onFinished(new JobID()));
+        Assertions.assertDoesNotThrow(
+                () -> hook.onFailed(new JobID(), new IllegalStateException("failed")));
+        Assertions.assertDoesNotThrow(() -> hook.onCanceled(new JobID()));
+    }
+
+    /**
+     * A local environment is an attached submission, so the client reports the successful terminal
+     * event with the output statistics it reads from the accumulators. The hook must be told to
+     * stay out of that event, or the two would race and the statistics-free one could land last.
+     */
+    @Test
+    void handsTheTerminalEventToTheClientForAnAttachedSubmission() throws Exception {
+        StreamGraph streamGraph = register(environmentWithOneSink());
+
+        JobStatusHook hook = registeredHook(streamGraph);
+        Assertions.assertTrue(hook instanceof LineageJobStatusHook);
+        Field field = LineageJobStatusHook.class.getDeclaredField("clientReportsCompletion");
+        field.setAccessible(true);
+        Assertions.assertTrue(
+                field.getBoolean(hook),
+                "an attached submission must leave the successful terminal event to the client");
+    }
+
+    /**
+     * The no-argument {@code getStreamGraph()} clears the environment's transformations, which
+     * would leave the caller with an unrunnable job if registration failed afterwards. Lineage must
+     * be droppable, so the transformations have to survive registration.
+     */
+    @Test
+    void leavesTheEnvironmentRunnableAfterRegistration() throws Exception {
+        StreamExecutionEnvironment environment = environmentWithOneSink();
+
+        Assertions.assertNotNull(register(environment));
+
+        Assertions.assertFalse(
+                environment.getStreamGraph(false).getStreamNodes().isEmpty(),
+                "registration must not consume the transformations the job still needs");
+    }
+
+    private static StreamExecutionEnvironment environmentWithOneSink() {
+        StreamExecutionEnvironment environment =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        environment.fromElements(1).print();
+        return environment;
+    }
+
+    /**
+     * A submission that never produces a running job leaves the start events sent at registration
+     * describing runs that nothing would ever close: no JobManager hook runs for a job that was
+     * never created, so the client is the only side that learns of the failure. The case this
+     * exists for is a JobManager without the lineage artifact in its {@code lib/} directory, which
+     * this integration deliberately fails the submission over.
+     */
+    @Test
+    void closesTheRunsOfASubmissionThatFailed() {
+        StreamExecutionEnvironment environment = environmentWithOneSink();
+
+        Assertions.assertNotNull(register(environment, RecordingLineageBackend.NAME));
+        Assertions.assertEquals(
+                Collections.singletonList(LineageEventType.START),
+                recordedEventTypes(),
+                "the start event is sent before the job is submitted");
+
+        environment.getJobListeners().get(0).onJobSubmitted(null, new IllegalStateException("no"));
+
+        Assertions.assertEquals(
+                Arrays.asList(LineageEventType.START, LineageEventType.FAIL),
+                recordedEventTypes(),
+                "a failed submission must close the runs its start events opened");
+    }
+
+    /** A submitted job is closed by its terminal callback, so nothing may be reported here. */
+    @Test
+    void leavesTheRunsOpenWhenTheSubmissionSucceeds() {
+        StreamExecutionEnvironment environment = environmentWithOneSink();
+        Assertions.assertNotNull(register(environment, RecordingLineageBackend.NAME));
+
+        environment.getJobListeners().get(0).onJobSubmitted(null, null);
+
+        Assertions.assertEquals(
+                Collections.singletonList(LineageEventType.START),
+                recordedEventTypes(),
+                "a successful submission must not close its own runs");
+    }
+
+    private static List<LineageEventType> recordedEventTypes() {
+        List<LineageEventType> types = new ArrayList<>();
+        for (LineageEvent event : RecordingLineageBackend.EVENTS) {
+            types.add(event.eventType());
+        }
+        return types;
+    }
+
+    private static StreamGraph register(StreamExecutionEnvironment environment) {
+        return register(environment, LineageConfig.DEFAULT_TRANSPORT);
+    }
+
+    private static StreamGraph register(StreamExecutionEnvironment environment, String transport) {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.TRANSPORT, transport);
+        options.put(LineageConfig.URL, "http://127.0.0.1:1");
+        options.put(LineageConfig.TIMEOUT_MS, 100);
+        options.put(LineageConfig.RETRY_TIMES, 0);
+        LineageConfig config =
+                FlinkLineageSupport.resolveConfig(
+                        options,
+                        Collections.<String, Object>emptyMap(),
+                        Collections.<String, Object>emptyMap());
+        return FlinkLineageSupport.register(
+                environment,
+                config,
+                new JobContext(),
+                Collections.<LineageDataset>emptyList(),
+                Collections.singletonList(LineageDataset.of("mysql://db", "warehouse.orders")),
+                "lineage-test");
+    }
+
+    private static JobStatusHook registeredHook(StreamGraph streamGraph) {
+        List<JobStatusHook> hooks = streamGraph.getJobStatusHooks();
+        Assertions.assertEquals(1, hooks.size());
+        return hooks.get(0);
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/java/org/apache/seatunnel/core/starter/flink/execution/RecordingLineageBackend.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/java/org/apache/seatunnel/core/starter/flink/execution/RecordingLineageBackend.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Captures the events the registration path emits, so a test can assert which lifecycle events a
+ * submission produced rather than only that nothing was thrown.
+ *
+ * <p>Selected through the {@code LineageBackend} SPI by naming {@link #NAME} as the transport.
+ */
+public final class RecordingLineageBackend implements LineageBackend {
+    static final String NAME = "recording";
+
+    static final List<LineageEvent> EVENTS = new CopyOnWriteArrayList<>();
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void emit(LineageConfig config, LineageEvent event) {
+        EVENTS.add(event);
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-20-starter/src/test/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
@@ -1,0 +1,1 @@
+org.apache.seatunnel.core.starter.flink.execution.RecordingLineageBackend

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/pom.xml
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/pom.xml
@@ -76,6 +76,27 @@
 
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--
+            Carries the job status hook the client serializes into the JobGraph, and transitively the
+            OpenLineage backend. The backend is required at runtime, not just the contract: the
+            reporter resolves it through the LineageBackend service loader, so without it the starter
+            jar carries no provider file and lineage silently reports nothing.
+
+            The same module also produces the shaded artifact that must be installed in the Flink
+            cluster's lib/ directory; see docs/en/introduction/concepts/lineage.md.
+        -->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage-flink</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
             <artifactId>connector-console</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkExecution.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkExecution.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigUtil;
 import org.apache.seatunnel.shade.com.typesafe.config.ConfigValueFactory;
 
 import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.options.EnvCommonOptions;
 import org.apache.seatunnel.common.Constants;
 import org.apache.seatunnel.common.config.Common;
@@ -33,10 +34,14 @@ import org.apache.seatunnel.core.starter.execution.PluginExecuteProcessor;
 import org.apache.seatunnel.core.starter.execution.RuntimeEnvironment;
 import org.apache.seatunnel.core.starter.execution.TaskExecution;
 import org.apache.seatunnel.core.starter.flink.FlinkStarter;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageDatasetFactory;
 import org.apache.seatunnel.translation.flink.metric.FlinkJobMetricsSummary;
 
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +57,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -82,6 +88,10 @@ public class FlinkExecution implements TaskExecution {
     private final PluginExecuteProcessor<DataStreamTableInfo, FlinkRuntimeEnvironment>
             sinkPluginExecuteProcessor;
     private final List<URL> jarPaths;
+    private final JobContext jobContext;
+    private final LineageConfig lineageConfig;
+    private final List<LineageDataset> lineageInputs;
+    private final List<LineageDataset> lineageOutputs;
 
     public FlinkExecution(Config config) {
         try {
@@ -98,10 +108,32 @@ public class FlinkExecution implements TaskExecution {
             throw new SeaTunnelException("load flink starter error.", e);
         }
         Config envConfig = config.getConfig("env");
+        Map<String, Object> envOptions = ReadonlyConfig.fromConfig(envConfig).getSourceMap();
+        LineageConfig.rejectJobAuthToken(envOptions);
+        LineageConfig resolvedLineageConfig = LineageConfig.defaults();
+        List<LineageDataset> resolvedLineageInputs = Collections.emptyList();
+        List<LineageDataset> resolvedLineageOutputs = Collections.emptyList();
+        LineageConfig candidateLineageConfig = FlinkLineageSupport.resolveConfig(envOptions);
+        if (candidateLineageConfig.enabled() && FlinkLineageSupport.isSupported()) {
+            resolvedLineageConfig = candidateLineageConfig;
+            resolvedLineageInputs = collectLineageDatasets(config.getConfigList(Constants.SOURCE));
+            resolvedLineageOutputs = collectLineageDatasets(config.getConfigList(Constants.SINK));
+        } else if (candidateLineageConfig.enabled()) {
+            // Reporting was asked for and will not happen, which the operator cannot otherwise
+            // tell apart from a working setup that has not reported yet.
+            LOGGER.warn(
+                    "Lineage reporting is enabled but this Flink starter does not support it;"
+                            + " the status hook API requires Flink 1.16 or later, so use the"
+                            + " flink-20-starter. No lineage events will be reported for this job.");
+        }
+        this.lineageConfig = resolvedLineageConfig;
+        this.lineageInputs = resolvedLineageInputs;
+        this.lineageOutputs = resolvedLineageOutputs;
         registerPlugin(envConfig);
         JobContext jobContext = new JobContext();
         jobContext.setJobMode(RuntimeEnvironment.getJobMode(config));
         jobContext.setEnableCheckpoint(RuntimeEnvironment.getEnableCheckpoint(config));
+        this.jobContext = jobContext;
 
         this.sourcePluginExecuteProcessor =
                 new SourceExecuteProcessor(
@@ -150,10 +182,24 @@ public class FlinkExecution implements TaskExecution {
         }
         try {
             final long jobStartTime = System.currentTimeMillis();
+            StreamGraph lineageStreamGraph =
+                    lineageConfig.enabled()
+                            ? FlinkLineageSupport.register(
+                                    flinkRuntimeEnvironment.getStreamExecutionEnvironment(),
+                                    lineageConfig,
+                                    jobContext,
+                                    lineageInputs,
+                                    lineageOutputs,
+                                    flinkRuntimeEnvironment.getJobName())
+                            : null;
             JobExecutionResult jobResult =
-                    flinkRuntimeEnvironment
-                            .getStreamExecutionEnvironment()
-                            .execute(flinkRuntimeEnvironment.getJobName());
+                    lineageStreamGraph == null
+                            ? flinkRuntimeEnvironment
+                                    .getStreamExecutionEnvironment()
+                                    .execute(flinkRuntimeEnvironment.getJobName())
+                            : flinkRuntimeEnvironment
+                                    .getStreamExecutionEnvironment()
+                                    .execute(lineageStreamGraph);
             final long jobEndTime = System.currentTimeMillis();
 
             final FlinkJobMetricsSummary jobMetricsSummary =
@@ -165,8 +211,24 @@ public class FlinkExecution implements TaskExecution {
 
             LOGGER.info("Job finished, execution result: \n{}", jobMetricsSummary);
         } catch (Exception e) {
+            String lineageDeploymentHint = FlinkLineageSupport.describeMissingHookClass(e);
+            if (lineageDeploymentHint != null) {
+                throw new TaskExecuteException(lineageDeploymentHint, e);
+            }
             throw new TaskExecuteException("Execute Flink job error", e);
         }
+    }
+
+    private static List<LineageDataset> collectLineageDatasets(
+            List<? extends Config> connectorConfigs) {
+        return connectorConfigs.stream()
+                .map(
+                        config ->
+                                LineageDatasetFactory.fromConnectorOptions(
+                                        ReadonlyConfig.fromConfig(config).getSourceMap()))
+                .flatMap(List::stream)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     private void registerPlugin(Config envConfig) {

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageHooks.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageHooks.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+
+import java.util.List;
+
+/**
+ * The Flink-version-specific half of lineage registration, absent on this starter.
+ *
+ * <p>{@code JobStatusHook} is a 1.16+ API, so the hook can only be built and registered by a
+ * starter that compiles against a Flink new enough to declare it. This module compiles against 1.15
+ * and therefore answers that lineage is unsupported; {@code seatunnel-flink-20-starter} carries a
+ * class of the same name that does the real work, and its copy wins in the shaded starter jar. That
+ * is the same per-version override the starters already use for {@link SinkExecuteProcessor}.
+ *
+ * <p>Keeping the version-specific step behind this seam is what lets {@link FlinkLineageSupport}
+ * and {@link FlinkExecution} stay version-agnostic without reflecting over the hook API.
+ */
+final class FlinkLineageHooks {
+
+    private FlinkLineageHooks() {}
+
+    /** Returns whether this starter can register a job status hook. */
+    static boolean isSupported() {
+        return false;
+    }
+
+    /**
+     * Registers the JobManager-side status hook and the client-side statistics listener.
+     *
+     * @param streamGraph the graph the hook is attached to
+     * @param environment the environment the result listener is registered on
+     * @param config lineage configuration with the auth token already removed
+     * @param events the start events whose runs the hook closes
+     * @param clientReportsTerminalEvent whether the client reports the successful terminal event
+     * @return whether the hook was registered
+     */
+    static boolean register(
+            StreamGraph streamGraph,
+            StreamExecutionEnvironment environment,
+            LineageConfig config,
+            List<LineageEvent> events,
+            boolean clientReportsTerminalEvent) {
+        return false;
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageSupport.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageSupport.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageRunIds;
+import org.apache.seatunnel.lineage.LineageRuntime;
+import org.apache.seatunnel.lineage.flink.FlinkClusterOptions;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The version-agnostic half of the Flink lineage integration.
+ *
+ * <p>Everything here compiles against Flink 1.15. The one step that cannot — building and
+ * registering a {@code JobStatusHook}, which is a 1.16+ API — lives behind {@link
+ * FlinkLineageHooks}, whose per-version copy decides whether lineage is available at all.
+ */
+public final class FlinkLineageSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlinkLineageSupport.class);
+
+    /**
+     * Binary name of the hook implementation the JobManager must be able to load.
+     *
+     * <p>A literal rather than {@code LineageJobStatusHook.class.getName()}: that class implements
+     * a Flink 1.16+ interface, so this module cannot resolve it. {@code FlinkLineageHookNamingTest}
+     * in the 1.20 starter asserts the two still agree.
+     */
+    static final String HOOK_HANDLER_CLASS =
+            "org.apache.seatunnel.lineage.flink.LineageJobStatusHook";
+
+    /** The artifact that carries the hook class into a Flink cluster's lib/ directory. */
+    private static final String HOOK_ARTIFACT = "seatunnel-lineage-flink-<version>-shaded.jar";
+
+    private FlinkLineageSupport() {}
+
+    /**
+     * Returns whether this starter exposes the status-hook API used by lineage.
+     *
+     * <p>The capability check keeps the common starter compatible with Flink 1.13 and 1.15, where
+     * the lineage integration must remain inactive.
+     */
+    public static boolean isSupported() {
+        return FlinkLineageHooks.isSupported();
+    }
+
+    /** Resolves lineage configuration using the Flink cluster configuration and process env. */
+    public static LineageConfig resolveConfig(Map<String, ?> jobOptions) {
+        return resolveConfig(jobOptions, FlinkClusterOptions.load(), System.getenv());
+    }
+
+    /**
+     * Resolves lineage configuration without parsing inactive options.
+     *
+     * <p>The enabled option is checked first with the same job, process-environment, and cluster
+     * precedence as the contract. Invalid non-enabled options therefore do not affect a disabled
+     * job, while a job-level auth token is still rejected.
+     */
+    public static LineageConfig resolveConfig(
+            Map<String, ?> jobOptions, Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        LineageConfig.rejectJobAuthToken(jobOptions);
+        if (!isLineageEnabled(jobOptions, clusterOptions, environment)) {
+            return LineageConfig.defaults();
+        }
+        return LineageConfig.resolve(jobOptions, clusterOptions, environment);
+    }
+
+    /**
+     * Resolves only the lineage enabled flag using job, process-environment, and cluster
+     * precedence.
+     */
+    public static boolean isLineageEnabled(
+            Map<String, ?> jobOptions, Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        return LineageConfig.isEnabled(jobOptions, clusterOptions, environment);
+    }
+
+    /**
+     * Registers the 1.20-only status hook and the attached-mode statistics listener.
+     *
+     * @return the stream graph the caller must submit, or null when lineage was not registered and
+     *     the caller must fall back to its own submission path
+     */
+    public static StreamGraph register(
+            StreamExecutionEnvironment environment,
+            LineageConfig config,
+            JobContext jobContext,
+            List<LineageDataset> inputs,
+            List<LineageDataset> outputs,
+            String jobName) {
+        try {
+            if (config == null || !config.enabled()) {
+                return null;
+            }
+            if (outputs == null || outputs.isEmpty()) {
+                // Reporting is enabled, so producing nothing is a result the operator needs to
+                // see; otherwise a job whose sinks resolved to no dataset looks identical to a
+                // working one that simply has no lineage yet.
+                LOGGER.info(
+                        "No lineage events built for job {}: none of its sinks resolved to a"
+                                + " supported dataset",
+                        jobName);
+                return null;
+            }
+            if (!FlinkLineageHooks.isSupported()) {
+                LOGGER.warn(
+                        "Lineage reporting is enabled but the running Flink version does not"
+                                + " expose the job status hook API, which requires Flink 1.16 or"
+                                + " later. No lineage events will be reported for job {}.",
+                        jobName);
+                return null;
+            }
+            List<LineageEvent> events = createEvents(config, jobContext, inputs, outputs, jobName);
+            try {
+                for (LineageEvent event : events) {
+                    LineageRuntime.emit(config, event);
+                }
+            } catch (Throwable error) {
+                LOGGER.warn("Failed to emit Flink lineage start event", error);
+            }
+
+            // Explicitly non-clearing: the no-argument overload clears the environment's
+            // transformations, so any later failure here would leave the caller's fallback
+            // execute(jobName) with an empty topology instead of a job that simply has no lineage.
+            StreamGraph streamGraph = environment.getStreamGraph(false);
+            streamGraph.setJobName(jobName);
+            boolean clientReportsTerminalEvent = isAttachedSubmission(environment);
+            if (!FlinkLineageHooks.register(
+                    streamGraph,
+                    environment,
+                    config.withAuthToken(null),
+                    events,
+                    clientReportsTerminalEvent)) {
+                return null;
+            }
+            // Stated before submission because the JobManager-side failure that follows a missing
+            // deployment is a bare ClassNotFoundException that never mentions lineage.
+            LOGGER.info(
+                    "Registered the lineage job status hook; the JobManager must be able to load {}"
+                            + " from {} in $FLINK_HOME/lib, otherwise job submission fails",
+                    HOOK_HANDLER_CLASS,
+                    HOOK_ARTIFACT);
+            return streamGraph;
+        } catch (Throwable error) {
+            LOGGER.warn("Failed to register Flink lineage support: {}", error.toString(), error);
+            return null;
+        }
+    }
+
+    /**
+     * Returns whether the submission is attached, and therefore whether the client will report the
+     * terminal event itself.
+     *
+     * <p>This reads the same option Flink itself branches on in {@code
+     * StreamExecutionEnvironment.execute(StreamGraph)}, so the answer cannot disagree with which
+     * callback actually fires. It decides ownership of the terminal event: both the JobManager hook
+     * and the client listener observe the same run, but only the client can read the accumulators
+     * that carry the output statistics, so in attached mode the hook must stay silent rather than
+     * race a second COMPLETE that would overwrite them.
+     *
+     * <p>An unreadable configuration answers {@code false}, which keeps the hook reporting: a
+     * duplicated terminal event is recoverable, a missing one is not.
+     */
+    private static boolean isAttachedSubmission(StreamExecutionEnvironment environment) {
+        try {
+            return Boolean.TRUE.equals(
+                    environment.getConfiguration().get(DeploymentOptions.ATTACHED));
+        } catch (Throwable error) {
+            LOGGER.warn("Unable to determine whether the Flink submission is attached", error);
+            return false;
+        }
+    }
+
+    /**
+     * Explains a job submission that failed because the status hook is missing on the JobManager.
+     *
+     * <p>The hook is a structural field of the JobGraph, not user code, so the JobManager
+     * deserializes it with the system class loader before any user class loader exists. Shipping
+     * the class in the submitted job jar is therefore not enough, and Flink reports only a bare
+     * {@code ClassNotFoundException} from {@code JobSubmitHandler.loadJobGraph}, which does not say
+     * that lineage caused it or how to fix it.
+     *
+     * <p>Failing the submission is intended: a job that silently loses its lineage is worse than
+     * one that refuses to start. This only makes the reason actionable.
+     *
+     * <p>The failure is recognised from the message rather than from the exception type, because
+     * the deployment this exists for is a session cluster submitted over REST: there the
+     * JobManager-side failure never crosses the wire as an exception object. The client sees a
+     * {@code RestClientException} whose message carries the server-side stack trace as text, so a
+     * type check alone would never match. The message must report the hook class as the one that
+     * could not be loaded, so neither an unrelated failure that mentions the class nor an unrelated
+     * missing class in the same trace is misreported as a missing deployment.
+     *
+     * @param failure the exception thrown by job submission
+     * @return an explanatory message, or {@code null} when the failure is unrelated to lineage
+     */
+    public static String describeMissingHookClass(Throwable failure) {
+        for (Throwable current = failure;
+                current != null && current != current.getCause();
+                current = current.getCause()) {
+            String message = current.getMessage();
+            if (message == null || !message.contains(HOOK_HANDLER_CLASS)) {
+                continue;
+            }
+            if (!reportsUnloadableHookClass(current, message)) {
+                continue;
+            }
+            return "Execute Flink job error: lineage reporting is enabled, but the JobManager"
+                    + " cannot load "
+                    + HOOK_HANDLER_CLASS
+                    + ". The job status hook is part of the JobGraph and is deserialized by the"
+                    + " JobManager before the user class loader exists, so shipping it in the"
+                    + " submitted jar is not enough. Install "
+                    + HOOK_ARTIFACT
+                    + " in $FLINK_HOME/lib on the JobManager and restart it, or set"
+                    + " openlineage_enabled=false to submit without lineage.";
+        }
+        return null;
+    }
+
+    /**
+     * Returns whether a link in the cause chain reports that the hook class could not be loaded,
+     * either as the exception type or, for a failure relayed as text across the REST boundary, in
+     * its message.
+     *
+     * <p>A relayed message carries a whole server-side stack trace, which can name several failures
+     * at once. The class-loading failure and the hook class must therefore appear as one {@code
+     * Throwable.toString()} pair rather than merely somewhere in the same text; otherwise a
+     * submission that failed over an unrelated missing class would be reported as a missing lineage
+     * deployment, and the caller replaces the top-level message with that explanation.
+     */
+    private static boolean reportsUnloadableHookClass(Throwable current, String message) {
+        if (current instanceof ClassNotFoundException || current instanceof NoClassDefFoundError) {
+            return true;
+        }
+        String binaryName = HOOK_HANDLER_CLASS;
+        // NoClassDefFoundError names the class in internal form.
+        String internalName = HOOK_HANDLER_CLASS.replace('.', '/');
+        return message.contains(ClassNotFoundException.class.getName() + ": " + binaryName)
+                || message.contains(NoClassDefFoundError.class.getName() + ": " + binaryName)
+                || message.contains(NoClassDefFoundError.class.getName() + ": " + internalName);
+    }
+
+    /** Returns whether a completed result is attached and safe to use for output statistics. */
+    public static boolean isAttachedJobExecutionResult(
+            JobExecutionResult result, Throwable executionError) {
+        try {
+            return executionError == null && result != null && result.isJobExecutionResult();
+        } catch (Throwable error) {
+            LOGGER.warn("Unable to determine whether Flink execution was attached", error);
+            return false;
+        }
+    }
+
+    private static List<LineageEvent> createEvents(
+            LineageConfig config,
+            JobContext jobContext,
+            List<LineageDataset> inputs,
+            List<LineageDataset> outputs,
+            String jobName) {
+        List<LineageEvent> events = new ArrayList<>();
+        for (LineageDataset output : outputs) {
+            Map<String, Object> properties = new LinkedHashMap<>(config.runProperties());
+            properties.put("engine", "flink");
+            events.add(
+                    LineageEvent.builder()
+                            .runId(
+                                    LineageRunIds.forJob(
+                                            jobContext.getJobId(),
+                                            output.namespace(),
+                                            output.name(),
+                                            null))
+                            .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                            .eventType(LineageEventType.START)
+                            .jobNamespace(config.namespace())
+                            .jobName(jobName)
+                            .producer(config.producer())
+                            .runFacet(config.runFacet())
+                            .runProperties(properties)
+                            .inputs(inputs)
+                            .outputs(Collections.singletonList(output))
+                            .build());
+        }
+        return events;
+    }
+}

--- a/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageSupportTest.java
+++ b/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/test/java/org/apache/seatunnel/core/starter/flink/execution/FlinkLineageSupportTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.lineage.LineageConfig;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.execution.DetachedJobExecutionResult;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+class FlinkLineageSupportTest {
+
+    @Test
+    void shouldNotParseInactiveLineageOptions() {
+        Map<String, Object> jobOptions = new LinkedHashMap<>();
+        jobOptions.put(LineageConfig.ENABLED, false);
+        jobOptions.put(LineageConfig.TIMEOUT_MS, "not-a-number");
+
+        LineageConfig config =
+                FlinkLineageSupport.resolveConfig(
+                        jobOptions,
+                        Collections.<String, Object>emptyMap(),
+                        Collections.<String, Object>emptyMap());
+
+        Assertions.assertFalse(config.enabled());
+    }
+
+    @Test
+    void shouldResolveEnablementWithJobEnvironmentClusterPrecedence() {
+        Map<String, Object> clusterOptions = Collections.singletonMap(LineageConfig.ENABLED, true);
+        Map<String, Object> environment = Collections.singletonMap("OPENLINEAGE_ENABLED", false);
+
+        LineageConfig environmentConfig =
+                FlinkLineageSupport.resolveConfig(
+                        Collections.<String, Object>emptyMap(), clusterOptions, environment);
+        Assertions.assertFalse(environmentConfig.enabled());
+
+        Map<String, Object> jobOptions = Collections.singletonMap(LineageConfig.ENABLED, true);
+        LineageConfig jobConfig =
+                FlinkLineageSupport.resolveConfig(jobOptions, clusterOptions, environment);
+        Assertions.assertTrue(jobConfig.enabled());
+
+        Map<String, Object> disabledJobOptions =
+                Collections.singletonMap(LineageConfig.ENABLED, false);
+        Assertions.assertFalse(
+                FlinkLineageSupport.isLineageEnabled(
+                        disabledJobOptions,
+                        clusterOptions,
+                        Collections.singletonMap("OPENLINEAGE_ENABLED", true)));
+    }
+
+    @Test
+    void shouldRejectJobTokenEvenWhenLineageIsDisabled() {
+        Map<String, Object> jobOptions = new LinkedHashMap<>();
+        jobOptions.put(LineageConfig.AUTH_TOKEN, "job-token");
+        jobOptions.put(LineageConfig.ENABLED, false);
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        FlinkLineageSupport.resolveConfig(
+                                jobOptions,
+                                Collections.<String, Object>emptyMap(),
+                                Collections.<String, Object>emptyMap()));
+    }
+
+    /**
+     * This starter compiles against Flink 1.15, which has no {@code JobStatusHook}, so its {@code
+     * FlinkLineageHooks} answers that lineage is unsupported and {@code FlinkExecution} warns
+     * instead of reporting. The 1.20 starter overrides that class and asserts the opposite; the
+     * registration path itself is covered there.
+     */
+    @Test
+    void shouldReportTheStatusHookApiAsUnsupportedOnThisStarter() {
+        Assertions.assertFalse(
+                FlinkLineageSupport.isSupported(),
+                "a starter compiled against Flink 1.15 cannot register a job status hook");
+    }
+
+    @Test
+    void shouldReportStatisticsOnlyForAttachedExecutionResult() {
+        JobExecutionResult attached =
+                new JobExecutionResult(new JobID(), 1L, Collections.emptyMap());
+        DetachedJobExecutionResult detached = new DetachedJobExecutionResult(new JobID());
+
+        Assertions.assertTrue(FlinkLineageSupport.isAttachedJobExecutionResult(attached, null));
+        Assertions.assertFalse(FlinkLineageSupport.isAttachedJobExecutionResult(detached, null));
+        Assertions.assertFalse(
+                FlinkLineageSupport.isAttachedJobExecutionResult(
+                        attached, new IllegalStateException("job failed")));
+        Assertions.assertFalse(FlinkLineageSupport.isAttachedJobExecutionResult(null, null));
+    }
+
+    /**
+     * Reproduces the exception chain a real detached submission produces when the hook class is not
+     * on the JobManager. Flink surfaces only a bare ClassNotFoundException from
+     * JobSubmitHandler.loadJobGraph, which names the class but never mentions lineage or the fix.
+     */
+    @Test
+    void explainsAJobManagerThatCannotLoadTheStatusHook() {
+        String hookClass = FlinkLineageSupport.HOOK_HANDLER_CLASS;
+        Exception submissionFailure =
+                new RuntimeException(
+                        "Failed to submit JobGraph.",
+                        new RuntimeException(
+                                "Failed to deserialize JobGraph.",
+                                new ClassNotFoundException(hookClass)));
+
+        String hint = FlinkLineageSupport.describeMissingHookClass(submissionFailure);
+
+        Assertions.assertNotNull(hint);
+        Assertions.assertTrue(hint.contains("$FLINK_HOME/lib"), "must say where to install it");
+        Assertions.assertTrue(
+                hint.contains("seatunnel-lineage-flink"), "must name the artifact to install");
+        Assertions.assertTrue(
+                hint.contains("openlineage_enabled=false"),
+                "must offer a way to submit without it");
+        Assertions.assertTrue(hint.contains(hookClass), "must name the class Flink could not load");
+    }
+
+    /**
+     * The deployment this hint exists for is a session cluster submitted over REST, where the
+     * JobManager-side failure never crosses the wire as an exception object: the client sees a REST
+     * exception whose message carries the server-side stack trace as text. Matching on the
+     * exception type alone would leave exactly that deployment with the bare submission error.
+     */
+    @Test
+    void explainsAMissingHookRelayedAsTextAcrossTheRestBoundary() {
+        String hookClass = FlinkLineageSupport.HOOK_HANDLER_CLASS;
+        Exception submissionFailure =
+                new RuntimeException(
+                        "Failed to submit job.",
+                        new IllegalStateException(
+                                "[Internal server error., <Exception on server side:"
+                                        + " org.apache.flink.runtime.rest.handler.RestHandlerException:"
+                                        + " Could not deserialize JobGraph."
+                                        + " Caused by: java.lang.ClassNotFoundException: "
+                                        + hookClass
+                                        + ">]"));
+
+        String hint = FlinkLineageSupport.describeMissingHookClass(submissionFailure);
+
+        Assertions.assertNotNull(hint, "a class-loading failure relayed as text must be explained");
+        Assertions.assertTrue(hint.contains("$FLINK_HOME/lib"), "must say where to install it");
+        Assertions.assertTrue(hint.contains(hookClass), "must name the class Flink could not load");
+    }
+
+    @Test
+    void leavesUnrelatedSubmissionFailuresUntouched() {
+        Assertions.assertNull(
+                FlinkLineageSupport.describeMissingHookClass(
+                        new RuntimeException(
+                                "Failed to submit JobGraph.",
+                                new ClassNotFoundException("com.example.SomeConnector"))));
+        Assertions.assertNull(
+                FlinkLineageSupport.describeMissingHookClass(
+                        new IllegalStateException("Recovery is suppressed")));
+        Assertions.assertNull(FlinkLineageSupport.describeMissingHookClass(null));
+        // A relayed trace can name several failures at once. The hook class must be the one that
+        // could not be loaded; a different missing class in the same text is a different problem,
+        // and the caller reports this hint as the top-level failure message.
+        Assertions.assertNull(
+                FlinkLineageSupport.describeMissingHookClass(
+                        new IllegalStateException(
+                                "[Internal server error., <Exception on server side:"
+                                        + " java.lang.ClassNotFoundException:"
+                                        + " com.example.SomeConnector at"
+                                        + " JobSubmitHandler.loadJobGraph; JobGraph hooks: ["
+                                        + FlinkLineageSupport.HOOK_HANDLER_CLASS
+                                        + "]>]")));
+        // Naming the hook class is not enough on its own: only a class-loading failure means the
+        // artifact is missing from the JobManager.
+        Assertions.assertNull(
+                FlinkLineageSupport.describeMissingHookClass(
+                        new IllegalStateException(
+                                "Could not serialize "
+                                        + FlinkLineageSupport.HOOK_HANDLER_CLASS
+                                        + ": java.io.NotSerializableException")));
+    }
+}

--- a/seatunnel-dist/release-docs/LICENSE
+++ b/seatunnel-dist/release-docs/LICENSE
@@ -343,6 +343,7 @@ The text of each license is the standard Apache 2.0 license.
       (Apache-2.0) hugegraph-common (org.apache.hugegraph:hugegraph-common:1.5.0 - https://github.com/apache/incubator-hugegraph-commons/tree/master/hugegraph-common)
       (Apache-2.0) jnats (io.nats:jnats:2.24.0 - https://github.com/nats-io/nats.java)
       (Apache-2.0) jspecify (org.jspecify:jspecify:1.0.0 - https://github.com/jspecify/jspecify)
+      (Apache-2.0) openlineage-java (io.openlineage:openlineage-java:1.29.0 - https://github.com/OpenLineage/OpenLineage)
 
 
 ========================================================================

--- a/seatunnel-lineage-flink/pom.xml
+++ b/seatunnel-lineage-flink/pom.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-lineage-flink</artifactId>
+    <name>SeaTunnel : Lineage Flink Hook</name>
+    <description>The Flink JobStatusHook implementation, plus the shaded artifact that carries it and the
+        lineage backend into a Flink cluster's lib/ directory. The hook is a structural field of the
+        JobGraph, so the JobManager deserializes it with the system class loader before any user
+        class loader exists; it cannot be shipped inside the submitted job jar.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--
+            The backend implementation must travel with the hook: the JobManager resolves it through
+            the LineageBackend service loader while it runs the terminal callbacks, and there is no
+            user class loader there to fall back to.
+        -->
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage-openlineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--
+            Flink provides its own configuration classes and slf4j binding in lib/.
+
+            Compiled against 1.20 because JobStatusHook is a 1.16+ API and this artifact implements
+            it directly. That is not a runtime floor beyond what the hook itself already requires:
+            the artifact is only ever loaded by a JobManager that supports the hook, and the Flink
+            starters below 1.20 never register one.
+        -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.1.20.1.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <!--
+                        The id overrides the shade execution the parent pom manages, which would
+                        otherwise also run here and replace the thin main artifact with an
+                        unrelocated uber-jar. The main artifact must stay thin: it is what the Flink
+                        starter compiles and links against.
+                    -->
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <!--
+                                Attached, so the thin main artifact stays the one the Flink starter
+                                depends on. The shaded classifier is the deployable: it is the only
+                                artifact that belongs in $FLINK_HOME/lib.
+                            -->
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <!--
+                                Flink's lib/ already provides slf4j and a logging implementation.
+                                Only the commons-logging bridge is bundled, and only because Apache
+                                HttpClient calls commons-logging directly: a JobManager's lib/
+                                carries neither it nor the real commons-logging, and without it
+                                HttpClients.createDefault() fails with a NoClassDefFoundError that
+                                the best-effort backend swallows into a warning, so the job succeeds
+                                while its lineage is silently lost. The bridge is relocated below,
+                                which keeps it invisible to the cluster while its output still
+                                reaches Flink's own logs. The real commons-logging stays excluded so
+                                it can never collide with the bridge.
+                            -->
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>commons-logging:*</exclude>
+                                    <exclude>org.apache.flink:*</exclude>
+                                    <exclude>log4j:*</exclude>
+                                    <exclude>org.apache.logging.log4j:*</exclude>
+                                    <exclude>ch.qos.logback:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <!--
+                                Flink's lib/ is on the parent class loader, so every class in this
+                                jar is visible to every job on the cluster. Relocating the third
+                                party implementation keeps that visibility harmless.
+
+                                The lineage contract classes are deliberately NOT relocated: the
+                                client serializes LineageConfig and LineageEvent into the JobGraph
+                                and the JobManager reads them back from this jar, so both sides must
+                                agree on their names. Jackson and the OpenLineage model never appear
+                                in that serialized graph, and they are relocated together in a single
+                                pass so the model's Jackson annotations keep pointing at the Jackson
+                                that reads them.
+                            -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.openlineage</pattern>
+                                    <shadedPattern>org.apache.seatunnel.lineage.shaded.io.openlineage</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.apache.seatunnel.lineage.shaded.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.yaml.snakeyaml</pattern>
+                                    <shadedPattern>org.apache.seatunnel.lineage.shaded.org.yaml.snakeyaml</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>org.apache.seatunnel.lineage.shaded.org.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.logging</pattern>
+                                    <shadedPattern>org.apache.seatunnel.lineage.shaded.org.apache.commons.logging</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.codec</pattern>
+                                    <shadedPattern>org.apache.seatunnel.lineage.shaded.org.apache.commons.codec</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <!-- Keeps the LineageBackend provider file resolvable in lib/. -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/seatunnel-lineage-flink/src/main/java/org/apache/seatunnel/lineage/flink/FlinkClusterOptions.java
+++ b/seatunnel-lineage-flink/src/main/java/org/apache/seatunnel/lineage/flink/FlinkClusterOptions.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.flink;
+
+import org.apache.flink.configuration.GlobalConfiguration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Reads the Flink cluster configuration that lineage options and the receiver token come from. */
+public final class FlinkClusterOptions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlinkClusterOptions.class);
+
+    private FlinkClusterOptions() {}
+
+    /**
+     * Loads the Flink cluster configuration once per JVM.
+     *
+     * <p>{@link GlobalConfiguration#loadConfiguration()} reads {@code config.yaml} (Flink 1.20+) or
+     * {@code flink-conf.yaml} (legacy) from disk. The result cannot change within a process, while
+     * the status hook consults it on every terminal callback, so the read is memoized. The client
+     * and the JobManager memoize their own copies, which is correct because they read their own
+     * configuration directory.
+     */
+    public static Map<String, String> load() {
+        return Holder.OPTIONS;
+    }
+
+    /** Defers the disk read to first use; class initialisation makes it happen exactly once. */
+    private static final class Holder {
+        static final Map<String, String> OPTIONS = read();
+
+        private static Map<String, String> read() {
+            try {
+                return Collections.unmodifiableMap(
+                        new LinkedHashMap<>(GlobalConfiguration.loadConfiguration().toMap()));
+            } catch (Throwable error) {
+                LOGGER.debug("Unable to load Flink cluster configuration for lineage", error);
+                return Collections.emptyMap();
+            }
+        }
+    }
+}

--- a/seatunnel-lineage-flink/src/main/java/org/apache/seatunnel/lineage/flink/LineageJobStatusHook.java
+++ b/seatunnel-lineage-flink/src/main/java/org/apache/seatunnel/lineage/flink/LineageJobStatusHook.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.flink;
+
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageRuntime;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.execution.JobStatusHook;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits the terminal lineage event for a Flink job from the JobManager.
+ *
+ * <p>This class is the reason the lineage artifact has to be installed in the Flink cluster's
+ * {@code lib/} directory. The hook is a structural field of the JobGraph, so the JobManager
+ * deserializes it with the system class loader before any user class loader exists; the class is
+ * not resolvable from the submitted job jar.
+ *
+ * <p>The instance is serialized into the JobGraph, which is written to the BlobServer and to HA
+ * storage. It therefore carries no credential: the caller strips the token, and the token is
+ * resolved again on the JobManager from its own cluster configuration and process environment.
+ */
+public final class LineageJobStatusHook implements JobStatusHook {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LineageJobStatusHook.class);
+
+    /** Run-facet property carrying the Flink job identifier shown in the Flink UI and REST API. */
+    public static final String FLINK_JOB_ID_PROPERTY = "flink_job_id";
+
+    private final LineageConfig config;
+    private final List<LineageEvent> events;
+    private final boolean clientReportsCompletion;
+
+    /**
+     * Cancelled by whichever terminal callback fires. Transient because the hook is serialized into
+     * the JobGraph on the client, where no heartbeat is running; the JobManager starts its own on
+     * {@code onCreated}. Volatile because the callbacks that start and stop it are not guaranteed
+     * to run on one thread.
+     */
+    private transient volatile ScheduledFuture<?> heartbeat;
+
+    /**
+     * Set by the terminal callback before its event is submitted, so a heartbeat that is already
+     * queued cannot report RUNNING after it. Written from the job's state-transition thread and
+     * read from the emitting thread, hence volatile. Transient for the same reason as the
+     * heartbeat: nothing is terminal on the client that serializes this into the JobGraph.
+     */
+    private transient volatile boolean terminal;
+
+    /**
+     * @param config lineage configuration with the auth token already removed
+     * @param events the start events whose runs this hook closes
+     * @param clientReportsCompletion whether the submitting client reports the successful terminal
+     *     event itself, in which case this hook must not send a second one
+     */
+    public LineageJobStatusHook(
+            LineageConfig config, List<LineageEvent> events, boolean clientReportsCompletion) {
+        this.config = config;
+        this.events = new ArrayList<>(events);
+        this.clientReportsCompletion = clientReportsCompletion;
+    }
+
+    @Override
+    public void onCreated(JobID jobId) {
+        guarded(() -> startHeartbeat(jobId(jobId)));
+    }
+
+    @Override
+    public void onFinished(JobID jobId) {
+        guarded(
+                () -> {
+                    stopHeartbeat();
+                    // An attached client emits the successful terminal event with the output
+                    // statistics read from the job accumulators, which are not reachable from here.
+                    // Both events describe the same run, and the later arrival wins on the
+                    // receiver, so exactly one of the two may send it.
+                    if (!clientReportsCompletion) {
+                        submitTerminal(LineageEventType.COMPLETE, jobId(jobId));
+                    }
+                });
+    }
+
+    @Override
+    public void onFailed(JobID jobId, Throwable cause) {
+        guarded(
+                () -> {
+                    stopHeartbeat();
+                    submitTerminal(LineageEventType.FAIL, jobId(jobId));
+                });
+    }
+
+    @Override
+    public void onCanceled(JobID jobId) {
+        guarded(
+                () -> {
+                    stopHeartbeat();
+                    submitTerminal(LineageEventType.ABORT, jobId(jobId));
+                });
+    }
+
+    /**
+     * Runs one callback body, absorbing anything it throws.
+     *
+     * <p>Flink invokes these hooks inline from the job's state transition, so an exception escaping
+     * here would fail a job for a lineage problem. Reporting is best effort by contract.
+     */
+    private static void guarded(Runnable callback) {
+        try {
+            callback.run();
+        } catch (Throwable error) {
+            LOGGER.warn("Failed to handle Flink lineage status callback", error);
+        }
+    }
+
+    /**
+     * Renders the Flink job identifier passed to every {@code JobStatusHook} callback.
+     *
+     * <p>The run ID is derived before submission, when no Flink job ID exists yet, so this is the
+     * only point where the lineage run can be tied back to the job visible in the Flink UI.
+     */
+    private static String jobId(JobID jobId) {
+        return jobId == null ? null : jobId.toString();
+    }
+
+    /**
+     * Starts the periodic RUNNING event that keeps the receiver from treating a still-running job
+     * as abandoned.
+     *
+     * <p>A receiver decides a run was abandoned from how long it has been silent, so a job that
+     * outlives that window without reporting has its lineage dropped from the current graph even
+     * though it is healthy. Zeta reports from its checkpoint completion callback, but Flink offers
+     * the JobManager no periodic callback to hang this on: {@code JobStatusHook} is purely
+     * transitional, and the client's {@code JobListener} is gone once a detached submission
+     * returns. A scheduled task is therefore the only place this can live for a detached job, which
+     * is how streaming jobs are normally submitted.
+     *
+     * <p>Batch jobs are not excluded. The interval is coarse enough that a batch job finishes long
+     * before the first heartbeat, and one that does run for hours needs the heartbeat for the same
+     * reason a streaming job does.
+     *
+     * <p>The first heartbeat is one full interval away because the start event has just refreshed
+     * the run.
+     */
+    private void startHeartbeat(String flinkJobId) {
+        long intervalMs = config.heartbeatMinIntervalMs();
+        if (intervalMs <= 0) {
+            return;
+        }
+        try {
+            heartbeat =
+                    Heartbeats.SCHEDULER.scheduleWithFixedDelay(
+                            () -> emit(LineageEventType.RUNNING, flinkJobId),
+                            intervalMs,
+                            intervalMs,
+                            TimeUnit.MILLISECONDS);
+        } catch (Throwable error) {
+            // A job must not fail because its lineage heartbeat could not be scheduled.
+            LOGGER.warn("Failed to schedule Flink lineage heartbeat", error);
+        }
+    }
+
+    /**
+     * Stops the heartbeat before the terminal event is queued, so no RUNNING can follow it.
+     *
+     * <p>Both steps are non-blocking, which is the point: Flink runs this on the job's own state
+     * transition, and waiting here for an in-flight send would hold that thread for a full retry
+     * cycle per output dataset. Cancelling keeps further heartbeats from being scheduled;
+     * publishing the terminal flag makes a heartbeat that is already queued, or already inside its
+     * loop over the runs, give up rather than report RUNNING after the run has closed.
+     */
+    private void stopHeartbeat() {
+        ScheduledFuture<?> scheduled = heartbeat;
+        if (scheduled != null) {
+            scheduled.cancel(false);
+            heartbeat = null;
+        }
+        terminal = true;
+    }
+
+    /**
+     * Queues the terminal event instead of sending it on the job's state-transition thread.
+     *
+     * <p>A send blocks for the configured timeout on every retry, once per output dataset, so
+     * sending here would hold a JobManager thread for minutes against an unreachable receiver and
+     * make a lineage failure visible as a stalled job. Queueing also keeps the terminal event
+     * behind any heartbeat that is already sending, because the emitting thread runs one task at a
+     * time; see {@link Heartbeats}.
+     */
+    private void submitTerminal(LineageEventType eventType, String flinkJobId) {
+        try {
+            Heartbeats.SCHEDULER.execute(() -> emit(eventType, flinkJobId));
+        } catch (Throwable error) {
+            LOGGER.warn("Failed to submit the terminal Flink lineage event", error);
+        }
+    }
+
+    /**
+     * Holds the one scheduler shared by every job on this JobManager.
+     *
+     * <p>Every lineage send of this JobManager runs here, and a single daemon thread is what orders
+     * them: a terminal event queued while a heartbeat is still sending cannot overtake it, so the
+     * receiver never sees RUNNING after a run has closed. One thread rather than one per job also
+     * bounds what a dead receiver can cost the process, and {@code scheduleWithFixedDelay} lets a
+     * slow send push its own next run back instead of piling up. Daemon so a JobManager shutdown is
+     * never held open by it.
+     */
+    private static final class Heartbeats {
+        /**
+         * How long a shutting-down JobManager waits for queued terminal events.
+         *
+         * <p>Application-mode clusters shut down as soon as the job reaches a terminal state, which
+         * is the same moment the terminal event is queued. Without a wait the run would stay open
+         * on the receiver until its abandoned-run timeout. The wait is short because a reachable
+         * receiver answers in milliseconds and an unreachable one must not delay the shutdown.
+         */
+        private static final long DRAIN_TIMEOUT_MS = 5000;
+
+        static final ScheduledExecutorService SCHEDULER =
+                Executors.newSingleThreadScheduledExecutor(
+                        runnable -> {
+                            Thread thread = new Thread(runnable, "seatunnel-lineage-heartbeat");
+                            thread.setDaemon(true);
+                            return thread;
+                        });
+
+        static {
+            Runtime.getRuntime()
+                    .addShutdownHook(new Thread(Heartbeats::drain, "seatunnel-lineage-drain"));
+        }
+
+        /**
+         * Gives already queued terminal events a bounded chance to leave before the JVM exits.
+         *
+         * <p>{@code shutdown} drops the periodic heartbeats and keeps the queued terminal events,
+         * which is exactly the wanted split.
+         */
+        private static void drain() {
+            SCHEDULER.shutdown();
+            try {
+                if (!SCHEDULER.awaitTermination(DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    SCHEDULER.shutdownNow();
+                }
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                SCHEDULER.shutdownNow();
+            }
+        }
+
+        private Heartbeats() {}
+    }
+
+    /**
+     * Waits until every event queued so far has been sent.
+     *
+     * <p>A test seam. The emitting thread runs one task at a time, so a task queued after the
+     * events under test completes only once they have.
+     *
+     * @return whether the queue drained within the timeout
+     */
+    static boolean awaitPendingEmissions(long timeoutMs) throws InterruptedException {
+        try {
+            Future<?> barrier = Heartbeats.SCHEDULER.submit(() -> {});
+            barrier.get(timeoutMs, TimeUnit.MILLISECONDS);
+            return true;
+        } catch (InterruptedException interrupted) {
+            throw interrupted;
+        } catch (Exception error) {
+            return false;
+        }
+    }
+
+    /**
+     * Sends one lifecycle event for every run this hook owns.
+     *
+     * <p>Runs only on the shared emitting thread, which orders every send of this JobManager
+     * against every other; see {@link Heartbeats}.
+     */
+    private void emit(LineageEventType eventType, String flinkJobId) {
+        try {
+            LineageConfig runtimeConfig =
+                    config.withAuthToken(
+                            LineageConfig.resolveToken(
+                                    FlinkClusterOptions.load(), System.getenv()));
+            for (LineageEvent event : events) {
+                if (eventType == LineageEventType.RUNNING && terminal) {
+                    // The terminal event owns this run from here on. Abandoning the rest of the
+                    // loop is safe: whatever the terminal callback sends covers every run this
+                    // hook owns.
+                    return;
+                }
+                LineageRuntime.emit(
+                        runtimeConfig,
+                        event.withEventType(eventType)
+                                .withRunProperty(FLINK_JOB_ID_PROPERTY, flinkJobId));
+            }
+        } catch (Throwable error) {
+            LOGGER.warn("Failed to emit Flink lineage status event", error);
+        }
+    }
+}

--- a/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/LineageJobStatusHookTest.java
+++ b/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/LineageJobStatusHookTest.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.flink;
+
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+
+import org.apache.flink.api.common.JobID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+class LineageJobStatusHookTest {
+
+    @BeforeEach
+    void resetBackend() throws Exception {
+        // The emitting thread is shared by every hook of the process, so an event still queued by
+        // the previous test would otherwise be recorded into this test's list.
+        LineageJobStatusHook.awaitPendingEmissions(5000);
+        RecordingLineageBackend.reset();
+    }
+
+    /** Waits for the events the terminal callbacks handed to the emitting thread. */
+    private static void awaitEmissions() throws Exception {
+        Assertions.assertTrue(
+                LineageJobStatusHook.awaitPendingEmissions(5000),
+                "the queued lineage events must have been emitted");
+    }
+
+    private static LineageConfig config(String token) {
+        return config(token, null);
+    }
+
+    private static LineageConfig config(String token, Long heartbeatMs) {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.TRANSPORT, RecordingLineageBackend.NAME);
+        options.put(LineageConfig.URL, "http://127.0.0.1:1");
+        if (heartbeatMs != null) {
+            options.put(LineageConfig.HEARTBEAT_MIN_INTERVAL_MS, heartbeatMs);
+        }
+        LineageConfig resolved =
+                LineageConfig.resolve(
+                        options,
+                        Collections.<String, Object>emptyMap(),
+                        Collections.<String, Object>emptyMap());
+        return resolved.withAuthToken(token);
+    }
+
+    private static LineageEvent event() {
+        return LineageEvent.builder()
+                .runId(UUID.randomUUID())
+                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .eventType(LineageEventType.START)
+                .jobNamespace("seatunnel")
+                .jobName("hook-test")
+                .producer("https://seatunnel.apache.org/test")
+                .runFacet("seatunnel_properties")
+                .outputs(Collections.singletonList(LineageDataset.of("mysql://db", "sales.orders")))
+                .build();
+    }
+
+    private static final JobID JOB_1 = JobID.fromHexString("00000000000000000000000000000001");
+    private static final JobID JOB_2 = JobID.fromHexString("00000000000000000000000000000002");
+    private static final JobID JOB_3 = JobID.fromHexString("00000000000000000000000000000003");
+
+    @Test
+    void emitsTheTerminalEventTypeThatMatchesTheCallback() throws Throwable {
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(config(null), Collections.singletonList(event()), false);
+
+        hook.onFinished(JOB_1);
+        hook.onFailed(JOB_2, new IllegalStateException("boom"));
+        hook.onCanceled(JOB_3);
+        awaitEmissions();
+
+        Assertions.assertEquals(3, RecordingLineageBackend.EVENTS.size());
+        Assertions.assertEquals(
+                LineageEventType.COMPLETE, RecordingLineageBackend.EVENTS.get(0).eventType());
+        Assertions.assertEquals(
+                LineageEventType.FAIL, RecordingLineageBackend.EVENTS.get(1).eventType());
+        Assertions.assertEquals(
+                LineageEventType.ABORT, RecordingLineageBackend.EVENTS.get(2).eventType());
+        Assertions.assertEquals(
+                JOB_2.toString(),
+                RecordingLineageBackend.EVENTS
+                        .get(1)
+                        .runProperties()
+                        .get(LineageJobStatusHook.FLINK_JOB_ID_PROPERTY));
+    }
+
+    /**
+     * An attached client reports the successful terminal event itself, carrying the output
+     * statistics this hook cannot read. Only the successful callback is handed over: a failed or
+     * cancelled job resolves the client's result future exceptionally, so the client reports
+     * nothing and the hook stays the only source of those events.
+     */
+    @Test
+    void leavesTheSuccessfulTerminalEventToAnAttachedClient() throws Throwable {
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(config(null), Collections.singletonList(event()), true);
+
+        hook.onFinished(JOB_1);
+        awaitEmissions();
+        Assertions.assertTrue(
+                RecordingLineageBackend.EVENTS.isEmpty(),
+                "the attached client owns the successful terminal event");
+
+        hook.onFailed(JOB_2, new IllegalStateException("boom"));
+        hook.onCanceled(JOB_3);
+        awaitEmissions();
+
+        Assertions.assertEquals(2, RecordingLineageBackend.EVENTS.size());
+        Assertions.assertEquals(
+                LineageEventType.FAIL, RecordingLineageBackend.EVENTS.get(0).eventType());
+        Assertions.assertEquals(
+                LineageEventType.ABORT, RecordingLineageBackend.EVENTS.get(1).eventType());
+    }
+
+    /**
+     * The JobGraph carrying this hook is written to the BlobServer and to HA storage, so the
+     * instance must never hold a receiver credential. The JobManager resolves the token again from
+     * its own configuration and environment.
+     */
+    @Test
+    void survivesTheJobGraphRoundTripWithoutCarryingTheToken() throws Throwable {
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(
+                        config("secret-token").withAuthToken(null),
+                        Collections.singletonList(event()),
+                        false);
+
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(hook);
+        }
+        Assertions.assertFalse(
+                new String(bytes.toByteArray(), "ISO-8859-1").contains("secret-token"),
+                "a serialized hook must not carry the receiver token");
+
+        LineageJobStatusHook restored;
+        try (ObjectInputStream in =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            restored = (LineageJobStatusHook) in.readObject();
+        }
+
+        restored.onFinished(JOB_1);
+        awaitEmissions();
+        Assertions.assertEquals(1, RecordingLineageBackend.EVENTS.size());
+        Assertions.assertEquals(
+                LineageEventType.COMPLETE, RecordingLineageBackend.EVENTS.get(0).eventType());
+        Assertions.assertNull(RecordingLineageBackend.CONFIGS.get(0).authToken());
+    }
+
+    @Test
+    void keepsTheJobRunningWhenTheBackendCannotBeResolved() throws Throwable {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.TRANSPORT, "no-such-transport");
+        options.put(LineageConfig.URL, "http://127.0.0.1:1");
+        LineageConfig broken =
+                LineageConfig.resolve(
+                        options,
+                        Collections.<String, Object>emptyMap(),
+                        Collections.<String, Object>emptyMap());
+
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(broken, Collections.singletonList(event()), false);
+
+        Assertions.assertDoesNotThrow(() -> hook.onFinished(JOB_1));
+        awaitEmissions();
+        Assertions.assertTrue(RecordingLineageBackend.EVENTS.isEmpty());
+    }
+
+    /**
+     * A streaming job never reaches a terminal callback while it is healthy, so without this the
+     * receiver would see nothing after the start event and eventually treat the run as abandoned.
+     */
+    @Test
+    void emitsHeartbeatsWhileTheJobRunsAndStopsAtTheTerminalEvent() throws Throwable {
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(
+                        config(null, 30L), Collections.singletonList(event()), false);
+
+        hook.onCreated(JOB_1);
+
+        long deadlineMs = System.currentTimeMillis() + 5000;
+        while (RecordingLineageBackend.EVENTS.size() < 2
+                && System.currentTimeMillis() < deadlineMs) {
+            Thread.sleep(10);
+        }
+        Assertions.assertTrue(
+                RecordingLineageBackend.EVENTS.size() >= 2,
+                "onCreated must start a repeating heartbeat, saw "
+                        + RecordingLineageBackend.EVENTS.size());
+        for (LineageEvent emitted : RecordingLineageBackend.EVENTS) {
+            Assertions.assertEquals(LineageEventType.RUNNING, emitted.eventType());
+            Assertions.assertEquals(
+                    JOB_1.toString(),
+                    emitted.runProperties().get(LineageJobStatusHook.FLINK_JOB_ID_PROPERTY));
+        }
+
+        hook.onCanceled(JOB_1);
+        awaitEmissions();
+        int afterTerminal = RecordingLineageBackend.EVENTS.size();
+        Assertions.assertEquals(
+                LineageEventType.ABORT,
+                RecordingLineageBackend.EVENTS.get(afterTerminal - 1).eventType());
+
+        // Several heartbeat intervals: a RUNNING arriving after the terminal event would reopen a
+        // run the receiver has already closed.
+        Thread.sleep(300);
+        Assertions.assertEquals(
+                afterTerminal,
+                RecordingLineageBackend.EVENTS.size(),
+                "no heartbeat may follow the terminal event");
+    }
+
+    /** A heartbeat interval of zero disables the heartbeat rather than scheduling a busy loop. */
+    @Test
+    void doesNotScheduleAHeartbeatWhenTheIntervalIsZero() throws Throwable {
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(
+                        config(null, 0L), Collections.singletonList(event()), false);
+
+        hook.onCreated(JOB_1);
+        Thread.sleep(150);
+        awaitEmissions();
+
+        Assertions.assertTrue(
+                RecordingLineageBackend.EVENTS.isEmpty(),
+                "a zero interval must not emit heartbeats");
+    }
+
+    /**
+     * Flink runs the terminal callback inline on the job's own state transition, and one send
+     * blocks for a full retry cycle per output dataset. Handing the event to the emitting thread is
+     * what keeps an unreachable receiver from stalling the job's transition, and that thread sends
+     * one event at a time, so the terminal event still leaves after the RUNNING that was already in
+     * flight rather than being overtaken by it.
+     */
+    @Test
+    void handsTheTerminalEventOffInsteadOfWaitingForTheSend() throws Throwable {
+        RecordingLineageBackend.HEARTBEAT_ENTERED = new CountDownLatch(1);
+        RecordingLineageBackend.HEARTBEAT_RELEASE = new CountDownLatch(1);
+        LineageJobStatusHook hook =
+                new LineageJobStatusHook(
+                        config(null, 20L), Collections.singletonList(event()), false);
+
+        hook.onCreated(JOB_1);
+        Assertions.assertTrue(
+                RecordingLineageBackend.HEARTBEAT_ENTERED.await(5, TimeUnit.SECONDS),
+                "the heartbeat must have started sending");
+
+        long startedAt = System.nanoTime();
+        hook.onCanceled(JOB_1);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+        Assertions.assertTrue(
+                elapsedMs < 1000,
+                "the terminal callback must not wait for a send, it took " + elapsedMs + "ms");
+        Assertions.assertTrue(
+                RecordingLineageBackend.EVENTS.isEmpty(),
+                "nothing can have been sent while the receiver still holds the heartbeat");
+
+        RecordingLineageBackend.HEARTBEAT_RELEASE.countDown();
+        awaitEmissions();
+
+        Assertions.assertEquals(
+                LineageEventType.RUNNING, RecordingLineageBackend.EVENTS.get(0).eventType());
+        Assertions.assertEquals(
+                LineageEventType.ABORT,
+                RecordingLineageBackend.EVENTS
+                        .get(RecordingLineageBackend.EVENTS.size() - 1)
+                        .eventType());
+
+        // Heartbeats scheduled while the terminal event was being sent must find the run closed.
+        int afterTerminal = RecordingLineageBackend.EVENTS.size();
+        Thread.sleep(300);
+        Assertions.assertEquals(
+                afterTerminal,
+                RecordingLineageBackend.EVENTS.size(),
+                "no heartbeat may follow the terminal event");
+    }
+}

--- a/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/RecordingLineageBackend.java
+++ b/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/RecordingLineageBackend.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.flink;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Captures the events a hook emits, so a test can assert on them without a receiver.
+ *
+ * <p>The lists are concurrent because the heartbeat writes from the scheduler thread while the test
+ * asserts from its own.
+ */
+public final class RecordingLineageBackend implements LineageBackend {
+    static final String NAME = "recording";
+
+    static final List<LineageEvent> EVENTS = new CopyOnWriteArrayList<>();
+    static final List<LineageConfig> CONFIGS = new CopyOnWriteArrayList<>();
+
+    /**
+     * Holds a heartbeat inside its send, the way an unreachable receiver does, so a test can assert
+     * on what happens when a terminal event arrives while a RUNNING is still in flight. Counted
+     * down when the send is entered; the send then waits for {@link #HEARTBEAT_RELEASE}.
+     */
+    static volatile CountDownLatch HEARTBEAT_ENTERED;
+
+    static volatile CountDownLatch HEARTBEAT_RELEASE;
+
+    static void reset() {
+        EVENTS.clear();
+        CONFIGS.clear();
+        HEARTBEAT_ENTERED = null;
+        HEARTBEAT_RELEASE = null;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public void emit(LineageConfig config, LineageEvent event) {
+        CountDownLatch release = HEARTBEAT_RELEASE;
+        CountDownLatch entered = HEARTBEAT_ENTERED;
+        if (release != null && entered != null && event.eventType() == LineageEventType.RUNNING) {
+            entered.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+        CONFIGS.add(config);
+        EVENTS.add(event);
+    }
+}

--- a/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/ShadedArtifactDriver.java
+++ b/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/ShadedArtifactDriver.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.flink;
+
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+import org.apache.seatunnel.lineage.LineageRuntime;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Emits one event, run by {@link ShadedArtifactIT} in a JVM whose only class path entries are the
+ * shaded artifact and slf4j-api. It stands in for the JobManager, which has exactly that.
+ */
+public final class ShadedArtifactDriver {
+
+    private ShadedArtifactDriver() {}
+
+    public static void main(String[] args) throws Exception {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.URL, args[0]);
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("engine", "flink");
+        properties.put(LineageJobStatusHook.FLINK_JOB_ID_PROPERTY, "shaded-artifact-it");
+        options.put(LineageConfig.RUN_PROPERTIES, properties);
+
+        LineageConfig config =
+                LineageConfig.resolve(
+                        options,
+                        Collections.<String, Object>emptyMap(),
+                        Collections.<String, Object>emptyMap());
+
+        LineageEvent event =
+                LineageEvent.builder()
+                        .runId(UUID.randomUUID())
+                        .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                        .eventType(LineageEventType.COMPLETE)
+                        .jobNamespace("seatunnel")
+                        .jobName("shaded-artifact-it")
+                        .producer("https://seatunnel.apache.org/shaded-artifact-it")
+                        .runFacet(config.runFacet())
+                        .runProperties(properties)
+                        .inputs(
+                                Collections.singletonList(
+                                        LineageDataset.of("mysql://source:9030", "sales.orders")))
+                        .outputs(
+                                Collections.singletonList(
+                                        LineageDataset.of("mysql://sink:9030", "dw.orders")))
+                        .build()
+                        .withOutputStatistics(new LineageOutputStatistics(7L, 128L, "attempted"));
+
+        LineageRuntime.emit(config, event);
+    }
+}

--- a/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/ShadedArtifactIT.java
+++ b/seatunnel-lineage-flink/src/test/java/org/apache/seatunnel/lineage/flink/ShadedArtifactIT.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.flink;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Sends one event from a JVM that has only the shaded artifact and slf4j-api on its class path, the
+ * way a JobManager runs the status hook.
+ *
+ * <p>This is not a duplicate of the unit tests. Both defects it guards are invisible to them and
+ * silent in production, because the backend contains every failure in a warning and lets the job
+ * succeed without its lineage:
+ *
+ * <ul>
+ *   <li>Relocating Jackson and the OpenLineage model in separate passes, or relocating only one of
+ *       them, breaks the model's {@code @JsonAnyGetter} and nests every facet property under a
+ *       literal {@code additionalProperties} key that the receiver stores verbatim.
+ *   <li>Apache HttpClient calls commons-logging directly. Dropping the bridge from the artifact
+ *       leaves {@code HttpClients.createDefault()} throwing NoClassDefFoundError on a JobManager,
+ *       whose lib/ supplies no commons-logging of its own.
+ * </ul>
+ *
+ * <p>Run with {@code ./mvnw -pl seatunnel-lineage-flink -DskipUT -DskipIT=false verify}.
+ */
+class ShadedArtifactIT {
+
+    @Test
+    void emitsAValidEventWithNothingButTheShadedArtifact() throws Exception {
+        BlockingQueue<String> bodies = new ArrayBlockingQueue<>(4);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v1/lineage", new CapturingHandler(bodies));
+        server.start();
+        String body;
+        try {
+            String endpoint =
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1/lineage";
+            run(endpoint);
+            body = bodies.poll(30, TimeUnit.SECONDS);
+        } finally {
+            server.stop(0);
+        }
+
+        Assertions.assertNotNull(body, "the shaded artifact sent no request");
+        Assertions.assertFalse(
+                body.contains("\"additionalProperties\""),
+                "relocation broke @JsonAnyGetter, so facets are nested: " + body);
+        Assertions.assertTrue(body.contains("\"engine\":\"flink\""), body);
+        Assertions.assertTrue(body.contains("\"flink_job_id\":\"shaded-artifact-it\""), body);
+        Assertions.assertTrue(body.contains("\"rowCount\":7"), body);
+        Assertions.assertTrue(body.contains("\"name\":\"dw.orders\""), body);
+    }
+
+    /** Runs the driver in a JVM that sees only what a JobManager's lib/ would supply. */
+    private static void run(String endpoint) throws Exception {
+        String classPath =
+                new File("target/test-classes").getAbsolutePath()
+                        + File.pathSeparator
+                        + shadedArtifact().getAbsolutePath()
+                        + File.pathSeparator
+                        + jarOf(LoggerFactory.class).getAbsolutePath();
+        ProcessBuilder builder =
+                new ProcessBuilder(
+                        new File(System.getProperty("java.home"), "bin/java").getAbsolutePath(),
+                        "-cp",
+                        classPath,
+                        ShadedArtifactDriver.class.getName(),
+                        endpoint);
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+        String output = read(process.getInputStream());
+        Assertions.assertTrue(
+                process.waitFor(60, TimeUnit.SECONDS), "the driver JVM did not exit: " + output);
+        Assertions.assertEquals(0, process.exitValue(), output);
+    }
+
+    /** Locates the deployable artifact this module attaches during the package phase. */
+    private static File shadedArtifact() {
+        File[] candidates =
+                new File("target")
+                        .listFiles(
+                                (directory, name) ->
+                                        name.startsWith("seatunnel-lineage-flink")
+                                                && name.endsWith("-shaded.jar"));
+        Assertions.assertNotNull(candidates, "target/ does not exist; run the package phase first");
+        Assertions.assertEquals(
+                1,
+                candidates.length,
+                "expected exactly one shaded artifact in target/, found "
+                        + java.util.Arrays.toString(candidates));
+        return candidates[0];
+    }
+
+    private static File jarOf(Class<?> type) throws Exception {
+        return new File(type.getProtectionDomain().getCodeSource().getLocation().toURI());
+    }
+
+    private static String read(InputStream stream) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        for (int read = stream.read(buffer); read > 0; read = stream.read(buffer)) {
+            bytes.write(buffer, 0, read);
+        }
+        return new String(bytes.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    private static final class CapturingHandler implements HttpHandler {
+        private final BlockingQueue<String> bodies;
+
+        private CapturingHandler(BlockingQueue<String> bodies) {
+            this.bodies = bodies;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws java.io.IOException {
+            try {
+                bodies.offer(read(exchange.getRequestBody()));
+            } catch (Exception error) {
+                throw new java.io.IOException(error);
+            }
+            exchange.sendResponseHeaders(201, -1);
+            exchange.close();
+        }
+    }
+}

--- a/seatunnel-lineage-flink/src/test/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
+++ b/seatunnel-lineage-flink/src/test/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
@@ -1,0 +1,1 @@
+org.apache.seatunnel.lineage.flink.RecordingLineageBackend

--- a/seatunnel-lineage-openlineage/pom.xml
+++ b/seatunnel-lineage-openlineage/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-lineage-openlineage</artifactId>
+    <name>SeaTunnel : OpenLineage Backend</name>
+
+    <properties>
+        <openlineage.version>1.29.0</openlineage.version>
+        <httpclient.version>4.5.13</httpclient.version>
+        <httpcore.version>4.4.16</httpcore.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-lineage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.openlineage</groupId>
+            <artifactId>openlineage-java</artifactId>
+            <version>${openlineage.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents.client5</groupId>
+                    <artifactId>httpclient5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.micrometer</groupId>
+                    <artifactId>micrometer-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <!-- Declared so that this module resolves the same httpcore the rest of the
+             distribution already ships, instead of the older one httpclient depends on. -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackend.java
+++ b/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackend.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageEvent;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/** HTTP LineageBackend using the project's fixed Apache HttpClient 4.x transport. */
+public final class OpenLineageBackend implements LineageBackend {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenLineageBackend.class);
+
+    /**
+     * Returns the transport name used to select this backend through the lineage SPI.
+     *
+     * @return the HTTP transport name
+     */
+    @Override
+    public String getName() {
+        return "http";
+    }
+
+    /**
+     * Sends one event using HTTP on a best-effort basis.
+     *
+     * <p>Failures are logged and ignored. Lineage delivery must never change the outcome of the
+     * data-processing job, so this behaviour is not configurable.
+     *
+     * @param config immutable lineage configuration
+     * @param event event to send
+     */
+    @Override
+    public void emit(LineageConfig config, LineageEvent event) {
+        if (!config.enabled()) {
+            return;
+        }
+        String payload;
+        try {
+            payload = OpenLineageEventConverter.toJson(event);
+        } catch (Throwable failure) {
+            LOGGER.warn("Failed to render an OpenLineage event as JSON", failure);
+            return;
+        }
+        try {
+            sendWithRetry(config, payload);
+        } catch (IllegalArgumentException configurationError) {
+            // Reported apart from a delivery failure because it names the option to correct rather
+            // than a receiver to investigate. The failure's own message is deliberately left out:
+            // a malformed endpoint is reported by quoting it in full, credentials included, which
+            // is exactly what endpointSummary exists to keep out of the log.
+            LOGGER.warn(
+                    "Failed to send OpenLineage event: {} is missing or is not a usable endpoint"
+                            + " ({})",
+                    LineageConfig.URL,
+                    endpointSummary(config.url()));
+        } catch (Throwable failure) {
+            // The message carries what the run actually needs: the HTTP status of a rejected
+            // request, the TLS or connection failure behind an unreachable one. The cause is
+            // passed as well so the stack survives; without both, every failure is logged as an
+            // indistinguishable IOException.
+            LOGGER.warn(
+                    "Failed to send OpenLineage event to endpoint {} after {} attempt(s): {}",
+                    endpointSummary(config.url()),
+                    config.retryTimes() + 1,
+                    failure.toString(),
+                    failure);
+        }
+    }
+
+    private void sendWithRetry(LineageConfig config, String payload) throws Exception {
+        Exception failure = null;
+        for (int attempt = 0; attempt <= config.retryTimes(); attempt++) {
+            try {
+                sendOnce(config, payload);
+                return;
+            } catch (IllegalArgumentException configurationError) {
+                // A missing or malformed endpoint fails identically on every attempt, so retrying
+                // only multiplies the sleep by the retry count on every event of the job.
+                throw configurationError;
+            } catch (Exception e) {
+                failure = e;
+                if (attempt < config.retryTimes()) {
+                    try {
+                        Thread.sleep(Math.min(100L, 10L * (attempt + 1)));
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw interrupted;
+                    }
+                }
+            }
+        }
+        throw failure;
+    }
+
+    private static String endpointSummary(String endpoint) {
+        if (endpoint == null || endpoint.trim().isEmpty()) {
+            return "<missing>";
+        }
+        try {
+            URI uri = new URI(endpoint);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) {
+                return "<invalid>";
+            }
+            return uri.getPort() < 0
+                    ? scheme + "://" + host
+                    : scheme + "://" + host + ":" + uri.getPort();
+        } catch (URISyntaxException e) {
+            return "<invalid>";
+        }
+    }
+
+    private void sendOnce(LineageConfig config, String payload) throws IOException {
+        if (config.url() == null || config.url().trim().isEmpty()) {
+            throw new IllegalArgumentException("openlineage_url must be configured when enabled");
+        }
+        RequestConfig requestConfig =
+                RequestConfig.custom()
+                        .setConnectTimeout(config.timeoutMs())
+                        .setConnectionRequestTimeout(config.timeoutMs())
+                        .setSocketTimeout(config.timeoutMs())
+                        .build();
+        HttpPost post = new HttpPost(config.url());
+        post.setConfig(requestConfig);
+        post.setHeader("Content-Type", ContentType.APPLICATION_JSON.getMimeType());
+        if (config.authToken() != null) {
+            post.setHeader("Authorization", "Bearer " + config.authToken());
+        }
+        post.setEntity(new StringEntity(payload, ContentType.APPLICATION_JSON));
+        try (CloseableHttpResponse response = SharedClient.INSTANCE.execute(post)) {
+            HttpEntity entity = response.getEntity();
+            EntityUtils.consumeQuietly(entity);
+            int status = response.getStatusLine().getStatusCode();
+            if (status < HttpStatus.SC_OK || status >= HttpStatus.SC_MULTIPLE_CHOICES) {
+                throw new IOException("OpenLineage endpoint returned HTTP " + status);
+            }
+        }
+    }
+
+    /**
+     * Holds the client shared by every send.
+     *
+     * <p>Building one per attempt also builds a connection pool and an SSL context per attempt,
+     * which on the engine paths that emit lineage costs more than the request itself. Timeouts stay
+     * per request through {@link RequestConfig}, so one client can serve every configuration. It is
+     * intentionally never closed: it lives as long as the process that reports lineage.
+     *
+     * <p>The connection limits are set explicitly because the default pool allows two connections
+     * per route, and every lineage event of a process goes to the same receiver, hence the same
+     * route. Sharing a client at that default would let a third concurrent emitter — a Zeta master
+     * running several streaming jobs reports each job's events on its own thread — wait out the
+     * connection-request timeout and fail against a receiver that is perfectly healthy.
+     */
+    private static final class SharedClient {
+        private static final int MAX_CONNECTIONS = 32;
+
+        private static final CloseableHttpClient INSTANCE =
+                HttpClients.custom()
+                        .setMaxConnPerRoute(MAX_CONNECTIONS)
+                        .setMaxConnTotal(MAX_CONNECTIONS)
+                        .build();
+
+        private SharedClient() {}
+    }
+}

--- a/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageEventConverter.java
+++ b/seatunnel-lineage-openlineage/src/main/java/org/apache/seatunnel/lineage/openlineage/OpenLineageEventConverter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+
+import io.openlineage.client.OpenLineage;
+import io.openlineage.client.OpenLineageClientUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Converts the small SeaTunnel contract into an OpenLineage RunEvent. */
+final class OpenLineageEventConverter {
+    private OpenLineageEventConverter() {}
+
+    static String toJson(LineageEvent event) {
+        OpenLineage openLineage = new OpenLineage(URI.create(event.producer()));
+        OpenLineage.RunFacetsBuilder runFacetsBuilder = openLineage.newRunFacetsBuilder();
+        Map<String, Object> runProperties = new LinkedHashMap<>(event.runProperties());
+        String statisticsSemantics = statisticsSemantics(event.outputs());
+        if (statisticsSemantics != null) {
+            runProperties.put("output_statistics_semantics", statisticsSemantics);
+        }
+        if (!runProperties.isEmpty()) {
+            OpenLineage.DefaultRunFacet facet =
+                    new OpenLineage.DefaultRunFacet(URI.create(event.producer()));
+            facet.getAdditionalProperties().putAll(runProperties);
+            runFacetsBuilder.put(event.runFacet(), facet);
+        }
+
+        OpenLineage.Run run =
+                openLineage
+                        .newRunBuilder()
+                        .runId(event.runId())
+                        .facets(runFacetsBuilder.build())
+                        .build();
+        OpenLineage.Job job =
+                openLineage
+                        .newJobBuilder()
+                        .namespace(event.jobNamespace())
+                        .name(event.jobName())
+                        .build();
+
+        List<OpenLineage.InputDataset> inputs = new ArrayList<>();
+        for (LineageDataset input : event.inputs()) {
+            inputs.add(
+                    openLineage
+                            .newInputDatasetBuilder()
+                            .namespace(input.namespace())
+                            .name(input.name())
+                            .build());
+        }
+
+        List<OpenLineage.OutputDataset> outputs = new ArrayList<>();
+        for (LineageDataset output : event.outputs()) {
+            OpenLineage.OutputDatasetBuilder outputBuilder =
+                    openLineage
+                            .newOutputDatasetBuilder()
+                            .namespace(output.namespace())
+                            .name(output.name());
+            LineageOutputStatistics statistics = output.outputStatistics();
+            if (statistics != null && statistics.hasValue()) {
+                OpenLineage.OutputStatisticsOutputDatasetFacetBuilder statisticsBuilder =
+                        openLineage.newOutputStatisticsOutputDatasetFacetBuilder();
+                if (statistics.rowCount() != null) {
+                    statisticsBuilder.rowCount(statistics.rowCount());
+                }
+                if (statistics.size() != null) {
+                    statisticsBuilder.size(statistics.size());
+                }
+                outputBuilder.outputFacets(
+                        openLineage
+                                .newOutputDatasetOutputFacetsBuilder()
+                                .outputStatistics(statisticsBuilder.build())
+                                .build());
+            }
+            outputs.add(outputBuilder.build());
+        }
+
+        OpenLineage.RunEvent.EventType eventType =
+                OpenLineage.RunEvent.EventType.valueOf(event.eventType().name());
+        OpenLineage.RunEvent runEvent =
+                openLineage
+                        .newRunEventBuilder()
+                        .eventTime(event.eventTime())
+                        .eventType(eventType)
+                        .run(run)
+                        .job(job)
+                        .inputs(inputs)
+                        .outputs(outputs)
+                        .build();
+        return OpenLineageClientUtils.toJson(runEvent);
+    }
+
+    private static String statisticsSemantics(List<LineageDataset> outputs) {
+        String semantics = null;
+        for (LineageDataset output : outputs) {
+            LineageOutputStatistics statistics = output.outputStatistics();
+            if (statistics == null || statistics.semantics() == null) {
+                continue;
+            }
+            if (semantics == null) {
+                semantics = statistics.semantics();
+            } else if (!semantics.equals(statistics.semantics())) {
+                return "mixed";
+            }
+        }
+        return semantics;
+    }
+}

--- a/seatunnel-lineage-openlineage/src/main/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
+++ b/seatunnel-lineage-openlineage/src/main/resources/META-INF/services/org.apache.seatunnel.lineage.LineageBackend
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+org.apache.seatunnel.lineage.openlineage.OpenLineageBackend

--- a/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/LineageBackendDiscoveryTest.java
+++ b/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/LineageBackendDiscoveryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageBackendLoader;
+import org.apache.seatunnel.lineage.LineageConfig;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the packaging contract rather than the logic.
+ *
+ * <p>The reporter reaches its transport through {@link ServiceLoader}. A module that depends only
+ * on the lineage contract compiles and runs, but its shaded jar carries no provider file, so the
+ * backend cannot be resolved and every event is dropped with a warning. That is invisible to any
+ * test that constructs the backend directly, so the lookup is asserted the way production performs
+ * it.
+ */
+class LineageBackendDiscoveryTest {
+
+    @Test
+    void httpBackendIsReachableThroughTheServiceLoader() {
+        boolean found = false;
+        for (LineageBackend backend : ServiceLoader.load(LineageBackend.class)) {
+            if ("http".equals(backend.getName())) {
+                found = true;
+            }
+        }
+        assertTrue(
+                found,
+                "no LineageBackend named 'http' on the classpath: the provider file is missing, "
+                        + "which means a packaging or dependency change dropped "
+                        + "seatunnel-lineage-openlineage");
+    }
+
+    @Test
+    void enabledConfigResolvesTheHttpBackendRatherThanFailing() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.URL, "http://127.0.0.1:1/api/lineage");
+        LineageConfig config =
+                LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+        LineageBackend backend = LineageBackendLoader.load(config);
+
+        assertNotNull(backend);
+        assertTrue(
+                backend instanceof OpenLineageBackend,
+                "the default transport must resolve to the OpenLineage backend, not fail");
+    }
+}

--- a/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackendTest.java
+++ b/seatunnel-lineage-openlineage/src/test/java/org/apache/seatunnel/lineage/openlineage/OpenLineageBackendTest.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage.openlineage;
+
+import org.apache.seatunnel.lineage.LineageBackend;
+import org.apache.seatunnel.lineage.LineageConfig;
+import org.apache.seatunnel.lineage.LineageDataset;
+import org.apache.seatunnel.lineage.LineageEvent;
+import org.apache.seatunnel.lineage.LineageEventType;
+import org.apache.seatunnel.lineage.LineageOutputStatistics;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenLineageBackendTest {
+
+    @Test
+    void serializesFacetAndStatisticsAndSendsToken() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        AtomicReference<String> authorization = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext(
+                "/lineage",
+                exchange -> {
+                    body.set(
+                            new String(readAll(exchange.getRequestBody()), StandardCharsets.UTF_8));
+                    authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+                    respond(exchange, 200);
+                });
+        server.start();
+        try {
+            Map<String, Object> environment =
+                    Collections.singletonMap("OPENLINEAGE_AUTH_TOKEN", "test-token");
+            Map<String, Object> options = new HashMap<>();
+            options.put(LineageConfig.ENABLED, true);
+            options.put(
+                    LineageConfig.URL,
+                    "http://localhost:" + server.getAddress().getPort() + "/lineage");
+            LineageConfig config =
+                    LineageConfig.resolve(options, Collections.emptyMap(), environment);
+            UUID runId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+            LineageEvent event =
+                    LineageEvent.builder()
+                            .runId(runId)
+                            .eventTime(ZonedDateTime.of(2026, 9, 1, 1, 2, 3, 0, ZoneOffset.UTC))
+                            .eventType(LineageEventType.COMPLETE)
+                            .jobNamespace("seatunnel")
+                            .jobName("lineage-test")
+                            .producer("https://seatunnel.apache.org/3.0.0-SNAPSHOT")
+                            .runFacet("seatunnel_properties")
+                            .runProperties(Collections.singletonMap("engine", "zeta"))
+                            .inputs(
+                                    Collections.singletonList(
+                                            LineageDataset.of("mysql://host:9030", "db.in")))
+                            .outputs(
+                                    Collections.singletonList(
+                                            LineageDataset.of("mysql://host:9030", "db.out")
+                                                    .withOutputStatistics(
+                                                            new LineageOutputStatistics(
+                                                                    12L, 345L, "committed"))))
+                            .build();
+
+            new OpenLineageBackend().emit(config, event);
+
+            assertTrue(body.get().contains("\"runId\":\"" + runId + "\""));
+            assertTrue(body.get().contains("\"rowCount\":12"));
+            assertTrue(body.get().contains("\"size\":345"));
+            assertTrue(body.get().contains("\"output_statistics_semantics\":\"committed\""));
+            assertFalse(body.get().contains("\"additionalProperties\""));
+            assertEquals("Bearer test-token", authorization.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void disabledBackendDoesNotRequireEndpoint() throws Exception {
+        LineageConfig config = LineageConfig.defaults();
+        new OpenLineageBackend().emit(config, minimalEvent());
+    }
+
+    @Test
+    void exposesHttpTransportThroughPublicApi() {
+        assertEquals("http", new OpenLineageBackend().getName());
+    }
+
+    @Test
+    void isDiscoverableThroughLineageBackendServiceProvider() {
+        assertTrue(
+                StreamSupport.stream(ServiceLoader.load(LineageBackend.class).spliterator(), false)
+                        .anyMatch(backend -> backend.getClass() == OpenLineageBackend.class));
+    }
+
+    @Test
+    void failedSendDoesNotThrowOrLogSensitiveEndpoint() {
+        HttpServer server = null;
+        Logger logger = (Logger) LogManager.getLogger(OpenLineageBackend.class);
+        CapturingAppender appender = new CapturingAppender();
+        Level originalLevel = logger.getLevel();
+        boolean originalAdditive = logger.isAdditive();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
+        logger.setAdditive(false);
+        appender.start();
+        try {
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext("/lineage", exchange -> respond(exchange, 500));
+            server.start();
+
+            String userInfoSecret = "url-password";
+            String querySecret = "query-secret";
+            Map<String, Object> options = new HashMap<>();
+            options.put(LineageConfig.ENABLED, true);
+            options.put(
+                    LineageConfig.URL,
+                    "http://url-user:"
+                            + userInfoSecret
+                            + "@127.0.0.1:"
+                            + server.getAddress().getPort()
+                            + "/lineage?token="
+                            + querySecret);
+            options.put(LineageConfig.RETRY_TIMES, 0);
+            LineageConfig config =
+                    LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+            assertDoesNotThrow(() -> new OpenLineageBackend().emit(config, minimalEvent()));
+
+            String logs =
+                    appender.getEvents().stream()
+                            .map(LogEvent::getMessage)
+                            .map(message -> message.getFormattedMessage())
+                            .collect(Collectors.joining("\n"));
+            assertTrue(logs.contains("http://127.0.0.1:" + server.getAddress().getPort()));
+            assertFalse(logs.contains("url-user"));
+            assertFalse(logs.contains(userInfoSecret));
+            assertFalse(logs.contains(querySecret));
+        } catch (IOException e) {
+            throw new AssertionError("Unable to start test HTTP server", e);
+        } finally {
+            if (server != null) {
+                server.stop(0);
+            }
+            logger.removeAppender(appender);
+            logger.setLevel(originalLevel);
+            logger.setAdditive(originalAdditive);
+            appender.stop();
+        }
+    }
+
+    /**
+     * A rejected request answers with a status code, and that code is the one thing an operator
+     * needs to tell a bad credential from a receiver that is down. It reaches the log only if the
+     * failure's own message is logged.
+     */
+    @Test
+    void reportsWhyASendFailed() {
+        HttpServer server = null;
+        try {
+            server = HttpServer.create(new InetSocketAddress(0), 0);
+            server.createContext("/lineage", exchange -> respond(exchange, 500));
+            server.start();
+
+            Map<String, Object> options = new HashMap<>();
+            options.put(LineageConfig.ENABLED, true);
+            options.put(
+                    LineageConfig.URL,
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/lineage");
+            options.put(LineageConfig.RETRY_TIMES, 0);
+            LineageConfig config =
+                    LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+            String logs =
+                    capturedWarnings(() -> new OpenLineageBackend().emit(config, minimalEvent()));
+
+            assertTrue(logs.contains("HTTP 500"), logs);
+        } catch (IOException e) {
+            throw new AssertionError("Unable to start test HTTP server", e);
+        } finally {
+            if (server != null) {
+                server.stop(0);
+            }
+        }
+    }
+
+    /**
+     * An endpoint that cannot be used fails the same way on every attempt, so retrying it only
+     * multiplies the backoff sleep by the retry count on every event the job reports.
+     */
+    @Test
+    void doesNotRetryAnEndpointThatCannotBeUsed() {
+        Map<String, Object> options = new HashMap<>();
+        options.put(LineageConfig.ENABLED, true);
+        options.put(LineageConfig.RETRY_TIMES, 5000);
+        LineageConfig config =
+                LineageConfig.resolve(options, Collections.emptyMap(), Collections.emptyMap());
+
+        long startedAt = System.nanoTime();
+        String logs = capturedWarnings(() -> new OpenLineageBackend().emit(config, minimalEvent()));
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt);
+
+        // The retried path sleeps up to 100ms per attempt, so 5000 retries cannot fit in here.
+        assertTrue(
+                elapsedMs < 5000,
+                "a configuration error must not be retried, it took " + elapsedMs + "ms");
+        assertTrue(logs.contains(LineageConfig.URL), logs);
+    }
+
+    /** Runs the body with the backend's warnings captured, and returns them joined. */
+    private static String capturedWarnings(Runnable body) {
+        Logger logger = (Logger) LogManager.getLogger(OpenLineageBackend.class);
+        CapturingAppender appender = new CapturingAppender();
+        Level originalLevel = logger.getLevel();
+        boolean originalAdditive = logger.isAdditive();
+        logger.addAppender(appender);
+        logger.setLevel(Level.WARN);
+        logger.setAdditive(false);
+        appender.start();
+        try {
+            body.run();
+            return appender.getEvents().stream()
+                    .map(event -> event.getMessage().getFormattedMessage())
+                    .collect(Collectors.joining("\n"));
+        } finally {
+            logger.removeAppender(appender);
+            logger.setLevel(originalLevel);
+            logger.setAdditive(originalAdditive);
+            appender.stop();
+        }
+    }
+
+    private static LineageEvent minimalEvent() {
+        return LineageEvent.builder()
+                .runId(UUID.randomUUID())
+                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .eventType(LineageEventType.START)
+                .jobNamespace("seatunnel")
+                .jobName("lineage-test")
+                .producer("https://seatunnel.apache.org/3.0.0-SNAPSHOT")
+                .inputs(Collections.emptyList())
+                .outputs(Arrays.asList(LineageDataset.of("mysql://host:9030", "db.out")))
+                .build();
+    }
+
+    private static void respond(HttpExchange exchange, int status) throws IOException {
+        exchange.sendResponseHeaders(status, -1);
+        exchange.close();
+    }
+
+    private static byte[] readAll(InputStream input) throws IOException {
+        java.io.ByteArrayOutputStream output = new java.io.ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = input.read(buffer)) >= 0) {
+            output.write(buffer, 0, length);
+        }
+        return output.toByteArray();
+    }
+
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<LogEvent> events = new ArrayList<>();
+
+        private CapturingAppender() {
+            super("OpenLineageBackendTest", null, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        private List<LogEvent> getEvents() {
+            return events;
+        }
+    }
+}

--- a/seatunnel-lineage/pom.xml
+++ b/seatunnel-lineage/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>seatunnel-lineage</artifactId>
+    <name>SeaTunnel : Lineage Contract</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackend.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackend.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/** A transport-independent extension point for lineage event delivery. */
+public interface LineageBackend {
+
+    /** Returns the name used by {@link LineageConfig#transport()}. */
+    String getName();
+
+    /** Emits one already-built lineage event. */
+    void emit(LineageConfig config, LineageEvent event) throws Exception;
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackendLoader.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageBackendLoader.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.lang.ref.WeakReference;
+import java.util.ServiceLoader;
+
+/** Loads the backend selected by the immutable lineage configuration. */
+public final class LineageBackendLoader {
+
+    /**
+     * The most recent successful resolution.
+     *
+     * <p>Resolution scans the whole classpath, and every emitted event resolves the backend again.
+     * The two callers that matter are on latency-sensitive engine paths, where that scan is pure
+     * overhead: a process reports lineage through one transport loaded by one class loader, so the
+     * same answer comes back every time. A single entry is enough to remove the repeat scan while
+     * keeping the loader identity part of the answer.
+     */
+    private static volatile Resolution resolution;
+
+    private LineageBackendLoader() {}
+
+    /** Loads the backend whose name matches the configured transport. */
+    public static LineageBackend load(LineageConfig config) {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            loader = LineageBackendLoader.class.getClassLoader();
+        }
+        Resolution cached = resolution;
+        if (cached != null && cached.matches(loader, config.transport())) {
+            return cached.backend;
+        }
+        for (LineageBackend candidate : ServiceLoader.load(LineageBackend.class, loader)) {
+            if (config.transport().equalsIgnoreCase(candidate.getName())) {
+                if (isLoadedWithThisClass(candidate)) {
+                    resolution = new Resolution(loader, config.transport(), candidate);
+                }
+                return candidate;
+            }
+        }
+        throw new IllegalArgumentException(
+                "No LineageBackend is registered for transport " + config.transport());
+    }
+
+    /**
+     * Returns whether caching the backend can extend nothing's lifetime.
+     *
+     * <p>A cached backend keeps its class, and therefore its class loader, reachable from a static
+     * field. That is free when the backend comes from the same place as this class, which is the
+     * case for both deployments that matter: the engine server jar on Zeta, and the shaded artifact
+     * in the Flink cluster's lib/. It is not free when the context class loader resolves a copy
+     * shipped inside a job's own jar, where caching would pin that job's class loader for the life
+     * of the process. Those resolutions are simply not cached, which is the behaviour that existed
+     * before the cache.
+     */
+    private static boolean isLoadedWithThisClass(LineageBackend backend) {
+        return backend.getClass().getClassLoader() == LineageBackendLoader.class.getClassLoader();
+    }
+
+    private static final class Resolution {
+        /**
+         * Weak so that remembering which loader produced this answer cannot, on its own, keep that
+         * loader alive; a collected reference simply misses and the lookup runs again.
+         */
+        private final WeakReference<ClassLoader> loader;
+
+        private final String transport;
+        private final LineageBackend backend;
+
+        private Resolution(ClassLoader loader, String transport, LineageBackend backend) {
+            this.loader = new WeakReference<>(loader);
+            this.transport = transport;
+            this.backend = backend;
+        }
+
+        private boolean matches(ClassLoader candidateLoader, String candidateTransport) {
+            return loader.get() == candidateLoader
+                    && transport.equalsIgnoreCase(candidateTransport);
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageConfig.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageConfig.java
@@ -1,0 +1,606 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Immutable lineage configuration with per-option source precedence. */
+public final class LineageConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public static final String ENABLED = "openlineage_enabled";
+    public static final String TRANSPORT = "openlineage_transport";
+    public static final String URL = "openlineage_url";
+    public static final String NAMESPACE = "openlineage_namespace";
+    public static final String AUTH_TOKEN = "openlineage_auth_token";
+    public static final String TIMEOUT_MS = "openlineage_timeout_ms";
+    public static final String RETRY_TIMES = "openlineage_retry_times";
+    public static final String RUN_FACET = "openlineage_run_facet";
+    public static final String RUN_PROPERTIES = "openlineage_run_properties";
+    public static final String HEARTBEAT_MIN_INTERVAL_MS = "openlineage_heartbeat_min_interval_ms";
+    public static final String PRODUCER = "openlineage_producer";
+
+    public static final String DEFAULT_TRANSPORT = "http";
+    public static final String DEFAULT_NAMESPACE = "seatunnel";
+    public static final String DEFAULT_RUN_FACET = "seatunnel_properties";
+    public static final int DEFAULT_TIMEOUT_MS = 10000;
+    public static final int DEFAULT_RETRY_TIMES = 3;
+    public static final long DEFAULT_HEARTBEAT_MIN_INTERVAL_MS = 3600000L;
+
+    private final boolean enabled;
+    private final String transport;
+    private final String url;
+    private final String namespace;
+    private final String authToken;
+    private final int timeoutMs;
+    private final int retryTimes;
+    private final String runFacet;
+    private final Map<String, Object> runProperties;
+    private final long heartbeatMinIntervalMs;
+    private final String producer;
+
+    private LineageConfig(
+            boolean enabled,
+            String transport,
+            String url,
+            String namespace,
+            String authToken,
+            int timeoutMs,
+            int retryTimes,
+            String runFacet,
+            Map<String, Object> runProperties,
+            long heartbeatMinIntervalMs,
+            String producer) {
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException(TIMEOUT_MS + " must be greater than zero");
+        }
+        if (retryTimes < 0) {
+            throw new IllegalArgumentException(RETRY_TIMES + " must not be negative");
+        }
+        if (heartbeatMinIntervalMs < 0) {
+            throw new IllegalArgumentException(HEARTBEAT_MIN_INTERVAL_MS + " must not be negative");
+        }
+        this.enabled = enabled;
+        this.transport = LineageValidation.requireText(transport, TRANSPORT);
+        this.url = blankToNull(url);
+        this.namespace = LineageValidation.requireText(namespace, NAMESPACE);
+        this.authToken = blankToNull(authToken);
+        this.timeoutMs = timeoutMs;
+        this.retryTimes = retryTimes;
+        this.runFacet = LineageValidation.requireText(runFacet, RUN_FACET);
+        this.runProperties =
+                Collections.unmodifiableMap(
+                        runProperties == null
+                                ? new LinkedHashMap<>()
+                                : new LinkedHashMap<>(runProperties));
+        this.heartbeatMinIntervalMs = heartbeatMinIntervalMs;
+        this.producer = LineageValidation.requireText(producer, PRODUCER);
+    }
+
+    /** Returns the default configuration with lineage reporting disabled. */
+    public static LineageConfig defaults() {
+        return new LineageConfig(
+                false,
+                DEFAULT_TRANSPORT,
+                null,
+                DEFAULT_NAMESPACE,
+                null,
+                DEFAULT_TIMEOUT_MS,
+                DEFAULT_RETRY_TIMES,
+                DEFAULT_RUN_FACET,
+                Collections.emptyMap(),
+                DEFAULT_HEARTBEAT_MIN_INTERVAL_MS,
+                defaultProducer());
+    }
+
+    /**
+     * Resolves each option independently using job env, process env, cluster config, then defaults.
+     * The token deliberately skips job env and is rejected there instead. String map values accept
+     * the Flink forms {@code key:value,key2:value2} and {@code {key: value, key2: value2}}; an
+     * equals sign is also accepted for compatibility with common environment-variable syntax.
+     */
+    public static LineageConfig resolve(
+            Map<String, ?> jobOptions, Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        rejectJobAuthToken(jobOptions);
+        Map<String, ?> job = nonNull(jobOptions);
+        Map<String, ?> cluster = nonNull(clusterOptions);
+        Map<String, ?> env = nonNull(environment);
+        return new LineageConfig(
+                asBoolean(first(job, env, cluster, ENABLED), false),
+                asString(first(job, env, cluster, TRANSPORT), TRANSPORT, DEFAULT_TRANSPORT),
+                asNullableString(first(job, env, cluster, URL)),
+                asString(first(job, env, cluster, NAMESPACE), NAMESPACE, DEFAULT_NAMESPACE),
+                asToken(env, cluster),
+                asInt(first(job, env, cluster, TIMEOUT_MS), TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+                asInt(first(job, env, cluster, RETRY_TIMES), RETRY_TIMES, DEFAULT_RETRY_TIMES),
+                asString(first(job, env, cluster, RUN_FACET), RUN_FACET, DEFAULT_RUN_FACET),
+                resolveRunProperties(job, env, cluster),
+                asLong(
+                        first(job, env, cluster, HEARTBEAT_MIN_INTERVAL_MS),
+                        HEARTBEAT_MIN_INTERVAL_MS,
+                        DEFAULT_HEARTBEAT_MIN_INTERVAL_MS),
+                asString(first(job, env, cluster, PRODUCER), PRODUCER, defaultProducer()));
+    }
+
+    /**
+     * Resolves only the enabled flag, using the same precedence and key aliases as {@link
+     * #resolve}.
+     *
+     * <p>Callers on the submission path need this before a full resolution is possible, and must
+     * not answer it with their own lookup: a second implementation drifts from the alias rules here
+     * and then disagrees with the configuration the job actually runs with.
+     */
+    public static boolean isEnabled(
+            Map<String, ?> jobOptions, Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        return asBoolean(first(jobOptions, environment, clusterOptions, ENABLED), false);
+    }
+
+    /** Rejects a token in job options because job configuration may be persisted or serialized. */
+    public static void rejectJobAuthToken(Map<String, ?> jobOptions) {
+        if (contains(jobOptions, AUTH_TOKEN)) {
+            throw new IllegalArgumentException(
+                    AUTH_TOKEN
+                            + " is not allowed in job env; use an environment or cluster setting");
+        }
+    }
+
+    /** Resolves a token from process environment first and cluster configuration second. */
+    public static String resolveToken(Map<String, ?> clusterOptions, Map<String, ?> environment) {
+        return asToken(nonNull(environment), nonNull(clusterOptions));
+    }
+
+    /** Returns whether lineage reporting is enabled. */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /** Returns the selected lineage transport name. */
+    public String transport() {
+        return transport;
+    }
+
+    /** Returns the lineage receiver URL, or {@code null} when it is not configured. */
+    public String url() {
+        return url;
+    }
+
+    /** Returns the OpenLineage job namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    /** Returns the resolved authentication token, if any. */
+    public String authToken() {
+        return authToken;
+    }
+
+    /** Returns the per-attempt send timeout in milliseconds. */
+    public int timeoutMs() {
+        return timeoutMs;
+    }
+
+    /** Returns the number of retries after the initial send attempt. */
+    public int retryTimes() {
+        return retryTimes;
+    }
+
+    /** Returns the run facet name used for custom properties. */
+    public String runFacet() {
+        return runFacet;
+    }
+
+    /** Returns immutable custom properties for the run facet. */
+    public Map<String, Object> runProperties() {
+        return runProperties;
+    }
+
+    /** Returns the minimum interval between streaming heartbeat events. */
+    public long heartbeatMinIntervalMs() {
+        return heartbeatMinIntervalMs;
+    }
+
+    /** Returns the producer URI placed in emitted OpenLineage events. */
+    public String producer() {
+        return producer;
+    }
+
+    /** Returns non-secret values suitable for a serialized callback. */
+    public Map<String, Object> toNonSensitiveMap() {
+        Map<String, Object> result = toMap();
+        result.remove(AUTH_TOKEN);
+        return result;
+    }
+
+    /** Returns a copy with a token resolved only on the execution side. */
+    public LineageConfig withAuthToken(String token) {
+        return new LineageConfig(
+                enabled,
+                transport,
+                url,
+                namespace,
+                token,
+                timeoutMs,
+                retryTimes,
+                runFacet,
+                runProperties,
+                heartbeatMinIntervalMs,
+                producer);
+    }
+
+    /** Returns the option map used by the contract tests and serialized callbacks. */
+    public Map<String, Object> toMap() {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put(ENABLED, enabled);
+        result.put(TRANSPORT, transport);
+        if (url != null) {
+            result.put(URL, url);
+        }
+        result.put(NAMESPACE, namespace);
+        if (authToken != null) {
+            result.put(AUTH_TOKEN, authToken);
+        }
+        result.put(TIMEOUT_MS, timeoutMs);
+        result.put(RETRY_TIMES, retryTimes);
+        result.put(RUN_FACET, runFacet);
+        if (!runProperties.isEmpty()) {
+            result.put(RUN_PROPERTIES, runProperties);
+        }
+        result.put(HEARTBEAT_MIN_INTERVAL_MS, heartbeatMinIntervalMs);
+        result.put(PRODUCER, producer);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LineageConfig" + toNonSensitiveMap();
+    }
+
+    private static String asToken(Map<String, ?> environment, Map<String, ?> cluster) {
+        Lookup environmentValue = findEnvironment(environment, AUTH_TOKEN);
+        if (environmentValue.present) {
+            return asNullableString(environmentValue);
+        }
+        Lookup clusterValue = find(cluster, AUTH_TOKEN);
+        return clusterValue.present ? asNullableString(clusterValue) : null;
+    }
+
+    private static Lookup first(
+            Map<String, ?> job, Map<String, ?> environment, Map<String, ?> cluster, String key) {
+        Lookup lookup = find(job, key);
+        if (lookup.present) {
+            return lookup;
+        }
+        lookup = findEnvironment(environment, key);
+        if (lookup.present) {
+            return lookup;
+        }
+        lookup = find(cluster, key);
+        return lookup.present ? lookup : Lookup.absent();
+    }
+
+    private static Lookup find(Map<String, ?> values, String key) {
+        if (values == null || values.isEmpty()) {
+            return Lookup.absent();
+        }
+        if (values.containsKey(key)) {
+            return Lookup.of(values.get(key));
+        }
+        String dotted = key.replace('_', '.');
+        if (values.containsKey(dotted)) {
+            return Lookup.of(values.get(dotted));
+        }
+        String prefixed = "openlineage." + key.substring("openlineage_".length());
+        if (values.containsKey(prefixed)) {
+            return Lookup.of(values.get(prefixed));
+        }
+        Object nested = values.get("openlineage");
+        if (nested instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) nested;
+            String suffix = key.substring("openlineage_".length());
+            if (map.containsKey(suffix)) {
+                return Lookup.of(map.get(suffix));
+            }
+            if (map.containsKey(key)) {
+                return Lookup.of(map.get(key));
+            }
+        }
+        return Lookup.absent();
+    }
+
+    private static Lookup findEnvironment(Map<String, ?> values, String key) {
+        if (values == null || values.isEmpty()) {
+            return Lookup.absent();
+        }
+        String environmentKey = key.toUpperCase(Locale.ROOT);
+        return values.containsKey(environmentKey)
+                ? Lookup.of(values.get(environmentKey))
+                : Lookup.absent();
+    }
+
+    private static boolean contains(Map<String, ?> values, String key) {
+        return find(values, key).present;
+    }
+
+    private static Map<String, ?> nonNull(Map<String, ?> values) {
+        return values == null ? Collections.emptyMap() : values;
+    }
+
+    private static boolean asBoolean(Lookup value, boolean fallback) {
+        return value.present && value.value != null
+                ? Boolean.parseBoolean(String.valueOf(value.value))
+                : fallback;
+    }
+
+    private static int asInt(Lookup value, String key, int fallback) {
+        if (!value.present || value.value == null) {
+            return fallback;
+        }
+        String text = String.valueOf(value.value);
+        try {
+            return Integer.parseInt(text.trim());
+        } catch (NumberFormatException error) {
+            throw notANumber(key, text);
+        }
+    }
+
+    private static long asLong(Lookup value, String key, long fallback) {
+        if (!value.present || value.value == null) {
+            return fallback;
+        }
+        String text = String.valueOf(value.value);
+        try {
+            return Long.parseLong(text.trim());
+        } catch (NumberFormatException error) {
+            throw notANumber(key, text);
+        }
+    }
+
+    /**
+     * Names the option a malformed number came from.
+     *
+     * <p>The bare {@code NumberFormatException} says only what the text was. Every caller here
+     * resolves several numeric options at once, and the engines re-resolve the configuration on
+     * every reported event, so an unnamed failure appears repeatedly in a log that never says which
+     * setting to correct.
+     */
+    private static IllegalArgumentException notANumber(String key, String value) {
+        return new IllegalArgumentException(key + " must be a number, but was \"" + value + "\"");
+    }
+
+    private static String asString(Lookup value, String key, String fallback) {
+        return value.present && value.value != null
+                ? LineageValidation.requireText(String.valueOf(value.value), key)
+                : fallback;
+    }
+
+    private static String asNullableString(Lookup value) {
+        return value.present && value.value != null
+                ? blankToNull(String.valueOf(value.value))
+                : null;
+    }
+
+    private static Map<String, Object> resolveRunProperties(
+            Map<String, ?> job, Map<String, ?> environment, Map<String, ?> cluster) {
+        Map<String, Object> properties = runProperties(job, false);
+        if (properties == null) {
+            properties = runProperties(environment, true);
+        }
+        if (properties == null) {
+            properties = runProperties(cluster, false);
+        }
+        return properties == null ? new LinkedHashMap<>() : properties;
+    }
+
+    /** Returns the properties declared by one source, or null when it declares none. */
+    private static Map<String, Object> runProperties(Map<String, ?> values, boolean environment) {
+        Lookup direct =
+                environment
+                        ? findEnvironment(values, RUN_PROPERTIES)
+                        : find(values, RUN_PROPERTIES);
+        if (direct.present) {
+            return asMap(direct);
+        }
+        Map<String, Object> prefixed = prefixedMap(values, RUN_PROPERTIES, environment);
+        return prefixed.isEmpty() ? null : prefixed;
+    }
+
+    private static Map<String, Object> asMap(Lookup value) {
+        if (!value.present || value.value == null) {
+            return new LinkedHashMap<>();
+        }
+        if (value.value instanceof String) {
+            return parseStringMap((String) value.value);
+        }
+        if (!(value.value instanceof Map)) {
+            throw new IllegalArgumentException(
+                    RUN_PROPERTIES + " must be a map or a comma-separated string map");
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        ((Map<?, ?>) value.value).forEach((key, item) -> result.put(String.valueOf(key), item));
+        return result;
+    }
+
+    private static Map<String, Object> prefixedMap(
+            Map<String, ?> values, String key, boolean environment) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        if (values == null || values.isEmpty()) {
+            return result;
+        }
+        String[] prefixes =
+                environment
+                        ? new String[] {key.toUpperCase(Locale.ROOT) + "_"}
+                        : new String[] {
+                            key + ".", "openlineage.run_properties.", "openlineage.run.properties."
+                        };
+        for (Map.Entry<String, ?> entry : values.entrySet()) {
+            String entryKey = String.valueOf(entry.getKey());
+            for (String prefix : prefixes) {
+                if (entryKey.startsWith(prefix) && entryKey.length() > prefix.length()) {
+                    result.put(entryKey.substring(prefix.length()), entry.getValue());
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, Object> parseStringMap(String rawValue) {
+        String value = rawValue.trim();
+        if (value.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+        if (value.startsWith("{")) {
+            if (!value.endsWith("}")) {
+                throw malformedMap();
+            }
+            value = value.substring(1, value.length() - 1).trim();
+        }
+        if (value.isEmpty()) {
+            return new LinkedHashMap<>();
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String entry : splitMapEntries(value)) {
+            int separator = findMapSeparator(entry);
+            if (separator <= 0) {
+                throw malformedMap();
+            }
+            String key = unquote(entry.substring(0, separator).trim());
+            String item = unquote(entry.substring(separator + 1).trim());
+            if (key.isEmpty()) {
+                throw malformedMap();
+            }
+            result.put(key, item);
+        }
+        return result;
+    }
+
+    private static List<String> splitMapEntries(String value) {
+        List<String> entries = new ArrayList<>();
+        int start = 0;
+        int comma;
+        while ((comma = nextUnquoted(value, start, ",")) >= 0) {
+            entries.add(value.substring(start, comma).trim());
+            start = comma + 1;
+        }
+        entries.add(value.substring(start).trim());
+        return entries;
+    }
+
+    private static int findMapSeparator(String value) {
+        return nextUnquoted(value, 0, ":=");
+    }
+
+    /**
+     * Returns the index of the first character of {@code stops} at or after {@code from} that is
+     * not inside a quoted section, or -1 when the value ends first.
+     *
+     * <p>Entry splitting and key/value separation share this scan so that the quoting and escaping
+     * rules cannot drift apart between them.
+     *
+     * @throws IllegalArgumentException when the value ends inside a quote or a trailing escape
+     */
+    private static int nextUnquoted(String value, int from, String stops) {
+        char quote = 0;
+        boolean escaped = false;
+        for (int i = from; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (quote != 0) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == quote) {
+                    quote = 0;
+                }
+            } else if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (stops.indexOf(current) >= 0) {
+                return i;
+            }
+        }
+        if (quote != 0 || escaped) {
+            throw malformedMap();
+        }
+        return -1;
+    }
+
+    private static String unquote(String value) {
+        if (value.length() < 2) {
+            return value;
+        }
+        char first = value.charAt(0);
+        if (first != value.charAt(value.length() - 1) || (first != '\'' && first != '"')) {
+            return value;
+        }
+        String unquoted = value.substring(1, value.length() - 1);
+        return unquoted.replace("\\" + first, String.valueOf(first));
+    }
+
+    private static IllegalArgumentException malformedMap() {
+        return new IllegalArgumentException(
+                RUN_PROPERTIES + " must use key:value pairs separated by commas");
+    }
+
+    /**
+     * Builds the default producer URI from the running SeaTunnel version.
+     *
+     * <p>This is the single source of the producer default. {@code openlineage_producer} is
+     * declared without a default value so that no build-time version string is baked into the
+     * option, which would go stale on the next release. The receiver does not validate {@code
+     * producer}, so a missing version degrades to the bare project URI rather than to a wrong
+     * version.
+     */
+    private static String defaultProducer() {
+        String version = LineageConfig.class.getPackage().getImplementationVersion();
+        if (version == null || version.trim().isEmpty()) {
+            version = System.getProperty("seatunnel.version", "");
+        }
+        return version.trim().isEmpty()
+                ? "https://seatunnel.apache.org/"
+                : "https://seatunnel.apache.org/" + version.trim();
+    }
+
+    private static String blankToNull(String value) {
+        return value == null || value.trim().isEmpty() ? null : value;
+    }
+
+    private static final class Lookup {
+        private final boolean present;
+        private final Object value;
+
+        private Lookup(boolean present, Object value) {
+            this.present = present;
+            this.value = value;
+        }
+
+        private static Lookup of(Object value) {
+            return new Lookup(true, value);
+        }
+
+        private static Lookup absent() {
+            return new Lookup(false, null);
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDataset.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDataset.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** A dataset identity with optional output statistics. */
+public final class LineageDataset implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String namespace;
+    private final String name;
+    private final LineageOutputStatistics outputStatistics;
+
+    private LineageDataset(
+            String namespace, String name, LineageOutputStatistics outputStatistics) {
+        this.namespace = LineageValidation.requireText(namespace, "namespace");
+        this.name = LineageValidation.requireText(name, "name");
+        this.outputStatistics = outputStatistics;
+    }
+
+    /** Creates a dataset identity. */
+    public static LineageDataset of(String namespace, String name) {
+        return new LineageDataset(namespace, name, null);
+    }
+
+    /** Returns a copy with output statistics attached. */
+    public LineageDataset withOutputStatistics(LineageOutputStatistics statistics) {
+        return new LineageDataset(namespace, name, statistics);
+    }
+
+    /** Returns the dataset namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    /** Returns the canonical dataset name. */
+    public String name() {
+        return name;
+    }
+
+    /** Returns the output statistics, or {@code null} when no statistics were collected. */
+    public LineageOutputStatistics outputStatistics() {
+        return outputStatistics;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof LineageDataset)) {
+            return false;
+        }
+        LineageDataset that = (LineageDataset) other;
+        return namespace.equals(that.namespace) && name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespace, name);
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetFactory.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetFactory.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/** Builds canonical datasets from connector option maps without depending on connector classes. */
+public final class LineageDatasetFactory {
+    private LineageDatasetFactory() {}
+
+    /**
+     * Extracts canonical dataset identities from one connector option map.
+     *
+     * <p>Only connector options that provide a real table identity are returned. Placeholder {@code
+     * default.default.default} paths are excluded.
+     *
+     * @param options connector options, without the enclosing plugin block
+     */
+    public static List<LineageDataset> fromConnectorOptions(Map<String, ?> options) {
+        return fromConnectorOptions(null, options);
+    }
+
+    /**
+     * Extracts canonical dataset identities for a connector whose plugin name is already known.
+     *
+     * <p>The plugin name must be supplied by the caller whenever it has one. SeaTunnel jobs
+     * normally declare a connector as a named block ({@code sink { Paimon { ... } }}), and the
+     * option map for that block does not contain a {@code plugin_name} entry at all, so inferring
+     * the name from the options alone silently yields no lineage for the most common job syntax.
+     *
+     * @param pluginName connector plugin name, or {@code null} to infer it from the options
+     * @param options connector options, without the enclosing plugin block
+     */
+    public static List<LineageDataset> fromConnectorOptions(
+            String pluginName, Map<String, ?> options) {
+        if (options == null || options.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (pluginName == null || pluginName.trim().isEmpty()) {
+            pluginName = string(options, "plugin_name", "plugin-name");
+        }
+        if (pluginName == null) {
+            pluginName = nestedPluginName(options);
+        }
+        if (pluginName == null) {
+            return Collections.emptyList();
+        }
+        if ("paimon".equalsIgnoreCase(pluginName)) {
+            return paimon(options);
+        }
+        if ("doris".equalsIgnoreCase(pluginName)) {
+            return doris(options);
+        }
+        if (isJdbc(pluginName, options)) {
+            return jdbc(options);
+        }
+        return Collections.emptyList();
+    }
+
+    private static List<LineageDataset> paimon(Map<String, ?> options) {
+        String catalog = string(options, "catalog_name", "catalog-name");
+        if (catalog == null || catalog.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return datasets(
+                options,
+                reference ->
+                        LineageDatasetNaming.paimon(catalog, reference.database, reference.table));
+    }
+
+    private static List<LineageDataset> doris(Map<String, ?> options) {
+        String host = firstHost(string(options, "fenodes", "fe_nodes", "fe-nodes"));
+        Integer queryPort = integer(options, 9030, "query-port", "query_port", "query.port");
+        if (queryPort == null) {
+            return Collections.emptyList();
+        }
+        return datasets(
+                options,
+                reference ->
+                        LineageDatasetNaming.doris(
+                                host, queryPort, reference.database, reference.table));
+    }
+
+    private static List<LineageDataset> jdbc(Map<String, ?> options) {
+        String url = string(options, "url", "jdbc_url", "jdbc-url");
+        if (url == null || !url.startsWith("jdbc:")) {
+            return Collections.emptyList();
+        }
+        try {
+            URI uri = URI.create(url.substring("jdbc:".length()));
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            int port = uri.getPort();
+            String urlDatabase = trimSlashes(uri.getPath());
+            if (scheme == null || host == null || port <= 0) {
+                return Collections.emptyList();
+            }
+            return datasets(
+                    options,
+                    reference ->
+                            LineageDatasetNaming.jdbc(
+                                    scheme,
+                                    host,
+                                    port,
+                                    reference.database == null ? urlDatabase : reference.database,
+                                    reference.table));
+        } catch (IllegalArgumentException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /** Maps every resolvable table entry of a connector block through one naming rule. */
+    private static List<LineageDataset> datasets(
+            Map<String, ?> options, Function<TableReference, Optional<LineageDataset>> naming) {
+        List<LineageDataset> result = new ArrayList<>();
+        for (Map<String, ?> table : tables(options)) {
+            TableReference reference = tableReference(table);
+            if (reference == null) {
+                continue;
+            }
+            naming.apply(reference).ifPresent(result::add);
+        }
+        return result;
+    }
+
+    private static boolean isJdbc(String pluginName, Map<String, ?> options) {
+        return string(options, "url", "jdbc_url", "jdbc-url") != null
+                || pluginName.toLowerCase().contains("jdbc")
+                || pluginName.equalsIgnoreCase("mysql")
+                || pluginName.equalsIgnoreCase("postgresql")
+                || pluginName.equalsIgnoreCase("oracle");
+    }
+
+    private static List<Map<String, ?>> tables(Map<String, ?> options) {
+        Object tableList = first(options, "table_list", "table-list", "tables");
+        if (tableList instanceof List) {
+            List<Map<String, ?>> result = new ArrayList<>();
+            for (Object value : (List<?>) tableList) {
+                if (value instanceof Map) {
+                    result.add((Map<String, ?>) value);
+                }
+            }
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        return Collections.singletonList(options);
+    }
+
+    private static String nestedPluginName(Map<String, ?> options) {
+        for (Map.Entry<String, ?> entry : options.entrySet()) {
+            if (entry.getValue() instanceof Map) {
+                String name =
+                        string((Map<String, ?>) entry.getValue(), "plugin_name", "plugin-name");
+                if (name != null) {
+                    return name;
+                }
+                if ("paimon".equalsIgnoreCase(entry.getKey())
+                        || "doris".equalsIgnoreCase(entry.getKey())) {
+                    return entry.getKey();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String firstHost(String value) {
+        if (value == null) {
+            return null;
+        }
+        String first = value.split(",")[0].trim();
+        try {
+            URI uri = URI.create(first.contains("://") ? first : "http://" + first);
+            return uri.getHost() == null ? first.split(":")[0] : uri.getHost();
+        } catch (IllegalArgumentException e) {
+            return first.split(":")[0];
+        }
+    }
+
+    private static Integer integer(Map<String, ?> options, int fallback, String... keys) {
+        Object value = first(options, keys);
+        if (value == null) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static String string(Map<String, ?> options, String... keys) {
+        Object value = first(options, keys);
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static Object first(Map<String, ?> options, String... keys) {
+        for (String key : keys) {
+            if (options.containsKey(key)) {
+                return options.get(key);
+            }
+        }
+        return null;
+    }
+
+    private static TableReference tableReference(Map<String, ?> options) {
+        String configuredPath = string(options, "table_path", "table-path", "tablePath");
+        String database = string(options, "database", "database_name");
+        String table = string(options, "table", "table_name");
+        if (configuredPath != null && !configuredPath.trim().isEmpty()) {
+            String tablePath = configuredPath.trim();
+            if (LineageDatasetNaming.isDefaultTablePath(tablePath)) {
+                return null;
+            }
+            String[] parts = tablePath.split("\\.", -1);
+            if (parts.length > 1) {
+                database = parts[0];
+                table = join(parts, 1);
+            } else {
+                table = parts[0];
+            }
+        }
+        return new TableReference(database, table);
+    }
+
+    private static String join(String[] parts, int start) {
+        StringBuilder result = new StringBuilder();
+        for (int i = start; i < parts.length; i++) {
+            if (i > start) {
+                result.append('.');
+            }
+            result.append(parts[i]);
+        }
+        return result.toString();
+    }
+
+    private static String trimSlashes(String value) {
+        if (value == null) {
+            return null;
+        }
+        String result = value;
+        while (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        return result;
+    }
+
+    private static final class TableReference {
+        private final String database;
+        private final String table;
+
+        private TableReference(String database, String table) {
+            this.database = database;
+            this.table = table;
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetNaming.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageDatasetNaming.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/** Canonical namespace/name mappings for supported table connectors. */
+public final class LineageDatasetNaming {
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{[^}]*}");
+
+    private static final String DEFAULT_TABLE_PATH = "default.default.default";
+
+    private LineageDatasetNaming() {}
+
+    /**
+     * Creates the Paimon dataset identity {@code paimon://catalog/database} and {@code table}.
+     *
+     * <p>The catalog is required because it is part of the dataset identity.
+     */
+    public static Optional<LineageDataset> paimon(
+            String catalogName, String database, String table) {
+        if (isUnusable(catalogName) || isUnusable(database) || isUnusable(table)) {
+            return Optional.empty();
+        }
+        return Optional.of(LineageDataset.of("paimon://" + catalogName + "/" + database, table));
+    }
+
+    /** Creates the Doris dataset identity using its query port rather than its HTTP port. */
+    public static Optional<LineageDataset> doris(
+            String feHost, int queryPort, String database, String table) {
+        return jdbc("mysql", feHost, queryPort, database, table);
+    }
+
+    /** Creates a JDBC dataset identity from the URL scheme, host, port, database, and table. */
+    public static Optional<LineageDataset> jdbc(
+            String scheme, String host, int port, String database, String table) {
+        if (isUnusable(scheme)
+                || isUnusable(host)
+                || port <= 0
+                || isUnusable(database)
+                || isUnusable(table)) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                LineageDataset.of(scheme + "://" + host + ":" + port, database + "." + table));
+    }
+
+    /** Returns whether a complete table path is the placeholder default path. */
+    public static boolean isDefaultTablePath(String fullName) {
+        return fullName != null && DEFAULT_TABLE_PATH.equals(fullName.trim());
+    }
+
+    /**
+     * Returns whether a name component cannot identify a real object.
+     *
+     * <p>Besides an absent value this covers an unresolved placeholder: a multi-table sink routes
+     * rows with a template such as {@code table = "${table_name}"}, substituted per row at write
+     * time, so it is never a real table. Emitting it verbatim would collapse every
+     * placeholder-routed job onto one shared node in the lineage graph — the same failure mode as
+     * the {@code default.default.default} path, but harder to spot because the node carries a
+     * plausible-looking name.
+     */
+    private static boolean isUnusable(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return true;
+        }
+        return PLACEHOLDER.matcher(value).find();
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEvent.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEvent.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/** Immutable event contract shared by engines and lineage backends. */
+public final class LineageEvent implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final UUID runId;
+    private final ZonedDateTime eventTime;
+    private final LineageEventType eventType;
+    private final String jobNamespace;
+    private final String jobName;
+    private final String producer;
+    private final String runFacet;
+    private final Map<String, Object> runProperties;
+    private final List<LineageDataset> inputs;
+    private final List<LineageDataset> outputs;
+
+    private LineageEvent(Builder builder) {
+        this.runId = require(builder.runId, "runId");
+        this.eventTime = require(builder.eventTime, "eventTime");
+        this.eventType = require(builder.eventType, "eventType");
+        this.jobNamespace = LineageValidation.requireText(builder.jobNamespace, "jobNamespace");
+        this.jobName = LineageValidation.requireText(builder.jobName, "jobName");
+        this.producer = LineageValidation.requireText(builder.producer, "producer");
+        this.runFacet = LineageValidation.requireText(builder.runFacet, "runFacet");
+        this.runProperties =
+                Collections.unmodifiableMap(new LinkedHashMap<>(builder.runProperties));
+        this.inputs = Collections.unmodifiableList(new ArrayList<>(builder.inputs));
+        this.outputs = Collections.unmodifiableList(new ArrayList<>(builder.outputs));
+    }
+
+    /** Returns a builder for an immutable lineage event. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Returns a builder pre-populated with every field of this event. */
+    private Builder toBuilder() {
+        return builder()
+                .runId(runId)
+                .eventTime(eventTime)
+                .eventType(eventType)
+                .jobNamespace(jobNamespace)
+                .jobName(jobName)
+                .producer(producer)
+                .runFacet(runFacet)
+                .runProperties(runProperties)
+                .inputs(inputs)
+                .outputs(outputs);
+    }
+
+    /** Returns a copy with a different lifecycle event type and a fresh event time. */
+    public LineageEvent withEventType(LineageEventType type) {
+        return toBuilder()
+                .eventTime(ZonedDateTime.now(eventTime.getZone()))
+                .eventType(type)
+                .build();
+    }
+
+    /**
+     * Returns a copy with one additional run-facet property.
+     *
+     * <p>Used for identifiers that only become known after the event was built, such as an engine
+     * job identifier assigned at submission time. A {@code null} value leaves the event unchanged
+     * so that callers do not need to branch.
+     *
+     * @param key run-facet property name
+     * @param value run-facet property value; {@code null} is ignored
+     * @return a copy carrying the property, or this event when the value is {@code null}
+     */
+    public LineageEvent withRunProperty(String key, Object value) {
+        if (key == null || key.trim().isEmpty() || value == null) {
+            return this;
+        }
+        Map<String, Object> updatedProperties = new LinkedHashMap<>(runProperties);
+        updatedProperties.put(key, value);
+        return toBuilder().runProperties(updatedProperties).build();
+    }
+
+    /** Returns a copy with the same statistics attached to every output dataset. */
+    public LineageEvent withOutputStatistics(LineageOutputStatistics statistics) {
+        List<LineageDataset> updatedOutputs = new ArrayList<>();
+        for (LineageDataset output : outputs) {
+            updatedOutputs.add(output.withOutputStatistics(statistics));
+        }
+        return toBuilder()
+                .eventTime(ZonedDateTime.now(eventTime.getZone()))
+                .outputs(updatedOutputs)
+                .build();
+    }
+
+    /** Returns the run ID. */
+    public UUID runId() {
+        return runId;
+    }
+
+    /** Returns the timezone-aware event time. */
+    public ZonedDateTime eventTime() {
+        return eventTime;
+    }
+
+    /** Returns the lifecycle event type. */
+    public LineageEventType eventType() {
+        return eventType;
+    }
+
+    /** Returns the OpenLineage job namespace. */
+    public String jobNamespace() {
+        return jobNamespace;
+    }
+
+    /** Returns the OpenLineage job name. */
+    public String jobName() {
+        return jobName;
+    }
+
+    /** Returns the producer URI. */
+    public String producer() {
+        return producer;
+    }
+
+    /** Returns the custom run facet name. */
+    public String runFacet() {
+        return runFacet;
+    }
+
+    /** Returns immutable custom run properties. */
+    public Map<String, Object> runProperties() {
+        return runProperties;
+    }
+
+    /** Returns immutable input datasets. */
+    public List<LineageDataset> inputs() {
+        return inputs;
+    }
+
+    /** Returns immutable output datasets. */
+    public List<LineageDataset> outputs() {
+        return outputs;
+    }
+
+    /** Builder for the immutable lineage event contract. */
+    public static final class Builder {
+        private UUID runId;
+        private ZonedDateTime eventTime;
+        private LineageEventType eventType = LineageEventType.START;
+        private String jobNamespace;
+        private String jobName;
+        private String producer;
+        private String runFacet = LineageConfig.DEFAULT_RUN_FACET;
+        private Map<String, Object> runProperties = new LinkedHashMap<>();
+        private List<LineageDataset> inputs = new ArrayList<>();
+        private List<LineageDataset> outputs = new ArrayList<>();
+
+        /** Sets the run ID. */
+        public Builder runId(UUID value) {
+            this.runId = value;
+            return this;
+        }
+
+        /** Sets the timezone-aware event time. */
+        public Builder eventTime(ZonedDateTime value) {
+            this.eventTime = value;
+            return this;
+        }
+
+        /** Sets the lifecycle event type. */
+        public Builder eventType(LineageEventType value) {
+            this.eventType = value;
+            return this;
+        }
+
+        /** Sets the OpenLineage job namespace. */
+        public Builder jobNamespace(String value) {
+            this.jobNamespace = value;
+            return this;
+        }
+
+        /** Sets the OpenLineage job name. */
+        public Builder jobName(String value) {
+            this.jobName = value;
+            return this;
+        }
+
+        /** Sets the producer URI. */
+        public Builder producer(String value) {
+            this.producer = value;
+            return this;
+        }
+
+        /** Sets the custom run facet name. */
+        public Builder runFacet(String value) {
+            this.runFacet = value;
+            return this;
+        }
+
+        /** Replaces the custom run properties. */
+        public Builder runProperties(Map<String, ?> values) {
+            this.runProperties = new LinkedHashMap<>();
+            if (values != null) {
+                values.forEach((key, value) -> this.runProperties.put(key, value));
+            }
+            return this;
+        }
+
+        /** Replaces the input datasets. */
+        public Builder inputs(List<LineageDataset> values) {
+            this.inputs = values == null ? new ArrayList<>() : new ArrayList<>(values);
+            return this;
+        }
+
+        /** Replaces the output datasets. */
+        public Builder outputs(List<LineageDataset> values) {
+            this.outputs = values == null ? new ArrayList<>() : new ArrayList<>(values);
+            return this;
+        }
+
+        /** Builds the immutable event, validating required fields. */
+        public LineageEvent build() {
+            return new LineageEvent(this);
+        }
+    }
+
+    private static <T> T require(T value, String field) {
+        if (value == null) {
+            throw new IllegalArgumentException(field + " must not be null");
+        }
+        return value;
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEventType.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageEventType.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/** OpenLineage lifecycle meanings used by the contract layer. */
+public enum LineageEventType {
+    START,
+    RUNNING,
+    COMPLETE,
+    ABORT,
+    FAIL
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageOutputStatistics.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageOutputStatistics.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.io.Serializable;
+
+/** Cumulative output counters. A null field is intentionally omitted from JSON. */
+public final class LineageOutputStatistics implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Long rowCount;
+    private final Long size;
+    private final String semantics;
+
+    /** Creates cumulative output statistics with an engine-specific counting semantic. */
+    public LineageOutputStatistics(Long rowCount, Long size, String semantics) {
+        this.rowCount = rowCount;
+        this.size = size;
+        this.semantics = semantics;
+    }
+
+    /** Returns the cumulative output row count, if available. */
+    public Long rowCount() {
+        return rowCount;
+    }
+
+    /** Returns the cumulative output size in bytes, if available. */
+    public Long size() {
+        return size;
+    }
+
+    /** Returns the counting semantic, such as {@code committed} or {@code attempted}. */
+    public String semantics() {
+        return semantics;
+    }
+
+    /** Returns whether at least one numeric statistic is present. */
+    public boolean hasValue() {
+        return rowCount != null || size != null;
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageReportingException.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageReportingException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/** Runtime wrapper used by engine call sites to apply their failure policy. */
+public final class LineageReportingException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /** Creates an exception wrapping a lineage delivery failure. */
+    public LineageReportingException(Throwable cause) {
+        super("Lineage event delivery failed", cause);
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRunIds.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRunIds.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/** Deterministic run identity helpers. */
+public final class LineageRunIds {
+    private static final String PREFIX = "seatunnel-job:";
+
+    private LineageRunIds() {}
+
+    /** Returns a deterministic run ID for a numeric SeaTunnel job ID. */
+    public static UUID forJob(long jobId, String namespace, String name, String attempt) {
+        return forJob(String.valueOf(jobId), namespace, name, attempt);
+    }
+
+    /** Returns a deterministic run ID for a job and dataset identity. */
+    public static UUID forJob(String jobId, String namespace, String name, String attempt) {
+        StringBuilder value =
+                new StringBuilder(PREFIX)
+                        .append(jobId)
+                        .append(':')
+                        .append(namespace)
+                        .append('/')
+                        .append(name);
+        if (attempt != null && !attempt.trim().isEmpty()) {
+            value.append(':').append(attempt);
+        }
+        // The prefix isolates this type-3 UUID namespace from other emitters that use the same
+        // nameUUIDFromBytes algorithm. It must not be removed as redundant.
+        return UUID.nameUUIDFromBytes(value.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRuntime.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageRuntime.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/**
+ * The single seam through which every engine emits a lineage event.
+ *
+ * <p>The event carries its own {@link LineageEventType}, so there is deliberately no per-lifecycle
+ * method here: a reporter-style API would need one method per type and would still leave the caller
+ * to route the types it does not cover.
+ */
+public final class LineageRuntime {
+    private LineageRuntime() {}
+
+    /** Emits an event through the configured backend, or returns immediately when disabled. */
+    public static void emit(LineageConfig config, LineageEvent event) {
+        if (!config.enabled()) {
+            return;
+        }
+        try {
+            LineageBackendLoader.load(config).emit(config, event);
+        } catch (Exception e) {
+            throw new LineageReportingException(e);
+        }
+    }
+}

--- a/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageValidation.java
+++ b/seatunnel-lineage/src/main/java/org/apache/seatunnel/lineage/LineageValidation.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+/**
+ * Argument checks shared by the lineage contract classes.
+ *
+ * <p>This module carries no dependencies so that it can be shaded into the Flink {@code lib}
+ * directory, which rules out {@code StringUtils} and the usual precondition helpers.
+ */
+final class LineageValidation {
+
+    private LineageValidation() {}
+
+    /** Returns the value, rejecting null and whitespace-only text for a required field. */
+    static String requireText(String value, String field) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageConfigTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageConfigTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageConfigTest {
+
+    @Test
+    void resolvesEachOptionByPriority() {
+        Map<String, Object> job = new HashMap<>();
+        job.put(LineageConfig.ENABLED, true);
+        job.put(LineageConfig.TIMEOUT_MS, 2000);
+        Map<String, Object> cluster = new HashMap<>();
+        cluster.put("openlineage.timeout_ms", 3000);
+        cluster.put("openlineage.namespace", "cluster");
+        Map<String, Object> environment = new HashMap<>();
+        environment.put("OPENLINEAGE_NAMESPACE", "environment");
+
+        LineageConfig config = LineageConfig.resolve(job, cluster, environment);
+
+        assertEquals(true, config.enabled());
+        assertEquals(2000, config.timeoutMs());
+        assertEquals("environment", config.namespace());
+        assertFalse(config.toString().contains("secret"));
+    }
+
+    /**
+     * The producer default must be derived from the running version rather than from a build-time
+     * constant, which would silently keep reporting a stale version after a release. Setting the
+     * version property must therefore change the resolved producer.
+     */
+    @Test
+    void producerDefaultFollowsTheRunningVersion() {
+        String originalVersion = System.getProperty("seatunnel.version");
+        try {
+            System.setProperty("seatunnel.version", "9.9.9");
+            assertEquals("https://seatunnel.apache.org/9.9.9", LineageConfig.defaults().producer());
+
+            System.setProperty("seatunnel.version", "");
+            String withoutVersion = LineageConfig.defaults().producer();
+            assertEquals("https://seatunnel.apache.org/", withoutVersion);
+        } finally {
+            if (originalVersion == null) {
+                System.clearProperty("seatunnel.version");
+            } else {
+                System.setProperty("seatunnel.version", originalVersion);
+            }
+        }
+    }
+
+    @Test
+    void tokenUsesOnlyEnvironmentThenCluster() {
+        Map<String, Object> cluster =
+                Collections.singletonMap("openlineage.auth_token", "cluster-token");
+        Map<String, Object> environment =
+                Collections.singletonMap("OPENLINEAGE_AUTH_TOKEN", "env-token");
+
+        assertEquals("env-token", LineageConfig.resolveToken(cluster, environment));
+        assertEquals("cluster-token", LineageConfig.resolveToken(cluster, Collections.emptyMap()));
+
+        LineageConfig config = LineageConfig.resolve(Collections.emptyMap(), cluster, environment);
+        assertFalse(config.toString().contains("env-token"));
+        assertFalse(config.withAuthToken(null).toMap().containsKey(LineageConfig.AUTH_TOKEN));
+    }
+
+    @Test
+    void rejectsTokenInJobOptions() {
+        Map<String, Object> job =
+                Collections.singletonMap(LineageConfig.AUTH_TOKEN, "not-a-real-token");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LineageConfig.resolve(job, Collections.emptyMap(), Collections.emptyMap()));
+    }
+
+    @Test
+    void parsesStringRunPropertiesWithSourcePriority() {
+        Map<String, Object> cluster = new HashMap<>();
+        cluster.put("openlineage.run_properties", "cluster: value, shared: cluster");
+        Map<String, Object> environment = new HashMap<>();
+        environment.put("OPENLINEAGE_RUN_PROPERTIES", "{environment: value, shared: environment}");
+
+        LineageConfig environmentConfig =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, environment);
+
+        assertEquals("value", environmentConfig.runProperties().get("environment"));
+        assertEquals("environment", environmentConfig.runProperties().get("shared"));
+        assertFalse(environmentConfig.runProperties().containsKey("cluster"));
+
+        LineageConfig clusterConfig =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, Collections.emptyMap());
+        assertEquals("value", clusterConfig.runProperties().get("cluster"));
+        assertEquals("cluster", clusterConfig.runProperties().get("shared"));
+    }
+
+    @Test
+    void parsesPrefixedClusterRunProperties() {
+        Map<String, Object> cluster = new HashMap<>();
+        cluster.put("openlineage.run_properties.owner", "platform");
+        cluster.put("openlineage.run_properties.region", "cn");
+
+        LineageConfig config =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, Collections.emptyMap());
+
+        assertEquals("platform", config.runProperties().get("owner"));
+        assertEquals("cn", config.runProperties().get("region"));
+    }
+
+    /**
+     * The five string options share one validation path, so an unnamed error leaves the operator
+     * guessing which of them was blanked out.
+     */
+    @Test
+    void namesTheBlankOptionItRejects() {
+        Map<String, Object> cluster = Collections.singletonMap(LineageConfig.NAMESPACE, "  ");
+
+        IllegalArgumentException failure =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                LineageConfig.resolve(
+                                        Collections.emptyMap(), cluster, Collections.emptyMap()));
+
+        assertTrue(
+                failure.getMessage().contains(LineageConfig.NAMESPACE),
+                "the error must name the option at fault, was: " + failure.getMessage());
+    }
+
+    @Test
+    void rejectsMalformedStringRunProperties() {
+        Map<String, Object> environment =
+                Collections.singletonMap("OPENLINEAGE_RUN_PROPERTIES", "not-a-map");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        LineageConfig.resolve(
+                                Collections.emptyMap(), Collections.emptyMap(), environment));
+    }
+
+    /**
+     * The separators of the string map form are also legal inside a value: a team name carries a
+     * comma and a URL carries a colon. Quoting is the only way to write either, so the parser must
+     * keep the quoted section intact instead of splitting inside it.
+     */
+    @Test
+    void keepsSeparatorsThatAppearInsideQuotedRunPropertyValues() {
+        Map<String, Object> cluster =
+                Collections.singletonMap(
+                        "openlineage.run_properties",
+                        "owner: \"data, platform\", docs: 'http://wiki/x', plain: value");
+
+        LineageConfig config =
+                LineageConfig.resolve(Collections.emptyMap(), cluster, Collections.emptyMap());
+
+        assertEquals("data, platform", config.runProperties().get("owner"));
+        assertEquals("http://wiki/x", config.runProperties().get("docs"));
+        assertEquals("value", config.runProperties().get("plain"));
+    }
+
+    /**
+     * A duration written the way the rest of SeaTunnel accepts one is the likely mistake here. The
+     * configuration is resolved again on every reported event, so a failure that names only the
+     * text repeats forever in a log that never says which of the numeric options to correct.
+     */
+    @Test
+    void namesTheNumericOptionThatCouldNotBeParsed() {
+        Map<String, Object> job = Collections.singletonMap(LineageConfig.TIMEOUT_MS, "10s");
+
+        IllegalArgumentException failure =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                LineageConfig.resolve(
+                                        job, Collections.emptyMap(), Collections.emptyMap()));
+
+        assertTrue(failure.getMessage().contains(LineageConfig.TIMEOUT_MS), failure.getMessage());
+        assertTrue(failure.getMessage().contains("10s"), failure.getMessage());
+    }
+
+    @Test
+    void namesTheHeartbeatOptionThatCouldNotBeParsed() {
+        Map<String, Object> cluster =
+                Collections.singletonMap("openlineage.heartbeat_min_interval_ms", "1h");
+
+        IllegalArgumentException failure =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                LineageConfig.resolve(
+                                        Collections.emptyMap(), cluster, Collections.emptyMap()));
+
+        assertTrue(
+                failure.getMessage().contains(LineageConfig.HEARTBEAT_MIN_INTERVAL_MS),
+                failure.getMessage());
+    }
+
+    @Test
+    void rejectsRunPropertiesThatEndInsideAQuote() {
+        Map<String, Object> cluster =
+                Collections.singletonMap("openlineage.run_properties", "owner: \"unterminated");
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        LineageConfig.resolve(
+                                Collections.emptyMap(), cluster, Collections.emptyMap()));
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetFactoryTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetFactoryTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageDatasetFactoryTest {
+
+    /**
+     * A SeaTunnel job normally declares a connector as a named block, for example {@code sink {
+     * Paimon { ... } }}. The option map for that block carries no {@code plugin_name} entry, so the
+     * caller must pass the plugin name; otherwise the most common job syntax silently produces no
+     * lineage at all.
+     */
+    @Test
+    void usesTheSuppliedPluginNameWhenOptionsDoNotCarryOne() {
+        Map<String, Object> options = paimonOptions();
+
+        assertTrue(
+                LineageDatasetFactory.fromConnectorOptions(options).isEmpty(),
+                "options from a named block cannot identify the connector on their own");
+
+        List<LineageDataset> datasets =
+                LineageDatasetFactory.fromConnectorOptions("Paimon", options);
+
+        assertEquals(1, datasets.size());
+        assertEquals("paimon://paimon_s3/seatunnel_lineage_verify", datasets.get(0).namespace());
+        assertEquals("st_verify_paimon", datasets.get(0).name());
+    }
+
+    @Test
+    void stillReadsThePluginNameFromOptionsWhenPresent() {
+        Map<String, Object> options = paimonOptions();
+        options.put("plugin_name", "Paimon");
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals(1, datasets.size());
+        assertEquals("paimon://paimon_s3/seatunnel_lineage_verify", datasets.get(0).namespace());
+    }
+
+    /**
+     * Paimon's catalog is part of the dataset identity, so an absent catalog must not be guessed.
+     */
+    @Test
+    void emitsNothingForPaimonWithoutAnExplicitCatalog() {
+        Map<String, Object> options = paimonOptions();
+        options.remove("catalog_name");
+
+        assertTrue(LineageDatasetFactory.fromConnectorOptions("Paimon", options).isEmpty());
+    }
+
+    /**
+     * Doris advertises its Stream Load HTTP port in {@code fenodes}, but the lineage namespace must
+     * use the MySQL query port, otherwise the table splits into two nodes in the graph.
+     */
+    @Test
+    void usesTheDorisQueryPortRatherThanTheFenodesPort() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("fenodes", "192.168.10.131:8030");
+        options.put("database", "ds71");
+        options.put("table", "orders");
+
+        List<LineageDataset> datasets =
+                LineageDatasetFactory.fromConnectorOptions("Doris", options);
+
+        assertEquals(1, datasets.size());
+        assertEquals("mysql://192.168.10.131:9030", datasets.get(0).namespace());
+        assertEquals("ds71.orders", datasets.get(0).name());
+    }
+
+    @Test
+    void emitsNothingForAnUnsupportedConnector() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("row.num", 10);
+
+        assertTrue(LineageDatasetFactory.fromConnectorOptions("FakeSource", options).isEmpty());
+    }
+
+    private static Map<String, Object> paimonOptions() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("warehouse", "s3a://lineage-paimon-warehouse/");
+        options.put("catalog_name", "paimon_s3");
+        options.put("database", "seatunnel_lineage_verify");
+        options.put("table", "st_verify_paimon");
+        Map<String, Object> hadoopConf = new LinkedHashMap<>();
+        hadoopConf.put("fs.s3a.endpoint", "http://example.invalid");
+        options.put("paimon.hadoop.conf", hadoopConf);
+        return options;
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetNamingTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageDatasetNamingTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageDatasetNamingTest {
+
+    @Test
+    void mapsConnectorOptionsAndKeepsDorisQueryPort() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Doris");
+        options.put("fenodes", "fe.example:8030");
+        options.put("query-port", 9030);
+        options.put("database", "warehouse");
+        options.put("table", "orders");
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals("mysql://fe.example:9030", datasets.get(0).namespace());
+        assertEquals("warehouse.orders", datasets.get(0).name());
+    }
+
+    @Test
+    void usesExplicitPaimonCatalogAndTableList() {
+        Map<String, Object> first = new HashMap<>();
+        first.put("database", "db");
+        first.put("table", "one");
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("catalog_name", "analytics");
+        options.put("table_list", Arrays.asList(first));
+
+        assertEquals(
+                "paimon://analytics/db",
+                LineageDatasetFactory.fromConnectorOptions(options).get(0).namespace());
+    }
+
+    @Test
+    void mapsJdbcSourceTablePath() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Jdbc");
+        options.put("url", "jdbc:mysql://db.example:3306/connection_default");
+        options.put("table_path", "table_database.orders");
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals("mysql://db.example:3306", datasets.get(0).namespace());
+        // table_path wins over the database named in the JDBC URL.
+        assertEquals("table_database.orders", datasets.get(0).name());
+    }
+
+    @Test
+    void skipsDefaultTablePath() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Jdbc");
+        options.put("url", "jdbc:mysql://db.example:3306/warehouse");
+        options.put("table_path", "default.default.default");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    @Test
+    void requiresExplicitPaimonCatalog() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("database", "analytics");
+        options.put("table", "orders");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    /**
+     * Two tables that share a name in different databases must stay distinct nodes on the lineage
+     * graph, so the database has to be part of the dataset identity rather than only of the
+     * namespace.
+     */
+    @Test
+    void keepsSameNamedPaimonTablesInDifferentDatabasesDistinct() {
+        Map<String, Object> first = new HashMap<>();
+        first.put("database", "db_one");
+        first.put("table", "orders");
+        Map<String, Object> second = new HashMap<>();
+        second.put("database", "db_two");
+        second.put("table", "orders");
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("catalog_name", "analytics");
+        options.put("table_list", Arrays.asList(first, second));
+
+        List<LineageDataset> datasets = LineageDatasetFactory.fromConnectorOptions(options);
+
+        assertEquals(2, datasets.size());
+        assertEquals("paimon://analytics/db_one", datasets.get(0).namespace());
+        assertEquals("paimon://analytics/db_two", datasets.get(1).namespace());
+        assertEquals("orders", datasets.get(0).name());
+        assertEquals("orders", datasets.get(1).name());
+        assertNotEquals(datasets.get(0), datasets.get(1));
+    }
+
+    @Test
+    void excludesDefaultTablePathFromEveryConnectorMapping() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Doris");
+        options.put("fenodes", "fe.example:8030");
+        options.put("database", "warehouse");
+        options.put("table", "orders");
+        options.put("table_path", "default.default.default");
+
+        assertTrue(LineageDatasetNaming.isDefaultTablePath("default.default.default"));
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    @Test
+    void ignoresMalformedDorisQueryPort() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Doris");
+        options.put("fenodes", "fe.example:8030");
+        options.put("query-port", "not-a-port");
+        options.put("database", "warehouse");
+        options.put("table", "orders");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+
+    /**
+     * A multi-table sink routes rows with a template that is substituted per row, so the template
+     * itself is never a real table. Emitting it would collapse every placeholder-routed job onto
+     * one shared graph node whose name looks plausible.
+     */
+    @Test
+    void rejectsUnresolvedPlaceholdersInTableIdentity() {
+        assertFalse(LineageDatasetNaming.paimon("catalog", "db", "${table_name}").isPresent());
+        assertFalse(
+                LineageDatasetNaming.paimon("catalog", "${database_name}", "orders").isPresent());
+        assertFalse(LineageDatasetNaming.paimon("${catalog}", "db", "orders").isPresent());
+        assertFalse(
+                LineageDatasetNaming.doris("fe.example", 9030, "db", "${table_name}").isPresent());
+        assertFalse(
+                LineageDatasetNaming.jdbc("mysql", "host", 3306, "db", "${table_name}")
+                        .isPresent());
+
+        // A name that merely contains a dollar sign is a legal identifier and must still pass.
+        assertTrue(LineageDatasetNaming.paimon("catalog", "db", "orders$archive").isPresent());
+    }
+
+    @Test
+    void placeholderRoutedSinkYieldsNoDatasetThroughTheFactory() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("plugin_name", "Paimon");
+        options.put("catalog_name", "paimon_s3");
+        options.put("database", "${database_name}");
+        options.put("table", "${table_name}");
+
+        assertEquals(0, LineageDatasetFactory.fromConnectorOptions(options).size());
+    }
+}

--- a/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageEventTest.java
+++ b/seatunnel-lineage/src/test/java/org/apache/seatunnel/lineage/LineageEventTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.lineage;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LineageEventTest {
+
+    @Test
+    void addsRunPropertyWithoutDisturbingTheRestOfTheEvent() {
+        LineageEvent event = event();
+
+        LineageEvent withProperty = event.withRunProperty("flink_job_id", "abc123");
+
+        assertEquals("abc123", withProperty.runProperties().get("flink_job_id"));
+        assertEquals("kept", withProperty.runProperties().get("existing"));
+        assertEquals(event.runId(), withProperty.runId());
+        assertEquals(event.eventType(), withProperty.eventType());
+        assertEquals(event.eventTime(), withProperty.eventTime());
+        assertEquals(event.outputs(), withProperty.outputs());
+
+        // The source event must stay immutable so a shared event can be reused per callback.
+        assertFalse(event.runProperties().containsKey("flink_job_id"));
+    }
+
+    /**
+     * The Flink status hook has no job identifier for a callback that does not carry one, so a null
+     * value must be a no-op rather than something the caller has to branch on. Emitting a null
+     * property would also send a null into the run facet.
+     */
+    @Test
+    void ignoresAbsentRunPropertyValues() {
+        LineageEvent event = event();
+
+        assertSame(event, event.withRunProperty("flink_job_id", null));
+        assertSame(event, event.withRunProperty(null, "abc123"));
+        assertSame(event, event.withRunProperty("  ", "abc123"));
+    }
+
+    @Test
+    void runPropertiesStayImmutable() {
+        LineageEvent event = event().withRunProperty("flink_job_id", "abc123");
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> event.runProperties().put("injected", "value"));
+    }
+
+    @Test
+    void changingEventTypeKeepsRunIdentityAndProperties() {
+        LineageEvent event = event().withRunProperty("flink_job_id", "abc123");
+
+        LineageEvent completed = event.withEventType(LineageEventType.COMPLETE);
+
+        assertEquals(LineageEventType.COMPLETE, completed.eventType());
+        assertEquals(event.runId(), completed.runId());
+        assertEquals("abc123", completed.runProperties().get("flink_job_id"));
+        assertTrue(completed.eventTime().getOffset().equals(ZoneOffset.UTC));
+    }
+
+    private static LineageEvent event() {
+        return LineageEvent.builder()
+                .runId(UUID.nameUUIDFromBytes("seatunnel-job:1".getBytes()))
+                .eventTime(ZonedDateTime.now(ZoneOffset.UTC))
+                .eventType(LineageEventType.START)
+                .jobNamespace("seatunnel")
+                .jobName("job")
+                .producer("https://seatunnel.apache.org/")
+                .runFacet(LineageConfig.DEFAULT_RUN_FACET)
+                .runProperties(Collections.singletonMap("existing", "kept"))
+                .outputs(
+                        Collections.singletonList(
+                                LineageDataset.of("mysql://host:3306", "db.orders")))
+                .build();
+    }
+}

--- a/tools/dependencies/known-dependencies.txt
+++ b/tools/dependencies/known-dependencies.txt
@@ -133,3 +133,4 @@ seatunnel-shade-jetty-9.4.56.v20240826-3.0.0.jar
 seatunnel-shade-scala-compiler-2.12-3.0.0.jar
 seatunnel-shade-calcite-1.38.0-3.0.0.jar
 seatunnel-shade-jackson-yaml-2.15.4-3.0.0.jar
+openlineage-java-1.29.0.jar


### PR DESCRIPTION
> **Stacked on #12208.** This branch is built on top of `feature/openlineage-core` (PR #12208), so until #12208 merges, this diff also shows #12208's changes (the `seatunnel-lineage`/`seatunnel-lineage-openlineage` modules and the new `openlineage_*` options). It will shrink to just the Flink-specific commits once #12208 merges into `dev`. Please review this PR's own commits (`git log feature/openlineage-core..feature/openlineage-flink`); #12208's commits are under separate review there.

### Purpose of this pull request

Implements #12206 (part of the umbrella #12207), stacked on #12208. Adds `seatunnel-lineage-flink` (`LineageJobStatusHook`, the Flink-1.16+-only half) and `FlinkLineageHooks`/`FlinkLineageSupport` in `seatunnel-flink-20-starter`/`seatunnel-flink-starter-common`, so a job submitted through the Flink 1.20 starter reports OpenLineage events when `openlineage_enabled = true`. The Flink 13/15 starters are untouched and get no lineage capability — documented as a known limitation (`JobStatusHook` doesn't exist before Flink 1.16), not a bug to fix here.

### Does this PR introduce _any_ user-facing change?

Yes, but opt-in only, and only for the Flink 1.20 starter. Enabling it also requires a one-time deployment step: a shaded jar (`seatunnel-lineage-flink-*-shaded.jar`) must be placed in `$FLINK_HOME/lib` on every JobManager and the JobManager restarted, because `JobGraph` deserialization happens before the user classloader exists. Documented in this PR's docs update, including the requirement that the client-side starter jar and the cluster-side shaded jar be upgraded together.

### How was this patch tested?

- Unit tests: `LineageJobStatusHookTest`, `FlinkLineageRegistrationTest`, `FlinkLineageHookNamingTest`, `FlinkLineageSupportTest`, and `ShadedArtifactIT` (builds the actual shaded jar and asserts its OpenLineage facets survive shading without corruption — gated behind `-DskipIT=false` like the rest of this repo's IT suite; passes).
- End-to-end against a real Gravitino instance, using a shared sandbox Flink 1.20 standalone cluster: the shaded jar was placed in `lib/` on both the JobManager and TaskManager, the cluster restarted, tested, then restored — `conf/config.yaml`'s checksum was verified to match the pre-change baseline exactly after restoring, and the lineage jar was removed from `lib/` again.
  - **Detached** submission (`flink run -d`) of `FakeSource (10 rows) → Doris`: Gravitino received exactly one `start` and one `complete` event — the JobManager-side hook's own terminal report, carrying the Flink job ID but no statistics, as designed for detached mode. Verified against the table: `SELECT COUNT(*) = 10`.
  - **Attached** submission (`flink run`) of the same job: exactly one `start` and one `complete` event — this time the client-side report, carrying `outputStatistics: {rowCount: 10, size: 170}` and an `output_statistics_semantics: attempted` facet. Same table verification. End-to-end client wall time was ~9.8s, confirming the JobManager-side terminal send (asynchronous in this PR) does not block job completion.
  - Both runs used this PR's client jar and cluster jar together, avoiding the version-mismatch pitfall documented in the deployment doc.
- `./mvnw -q -DskipTests verify` across the whole reactor — 470 modules, BUILD SUCCESS. This branch's affected-module unit tests all pass.

### Check list

* [ ] No new JAR beyond what #12208 already registers (this PR only adds a shaded packaging of existing dependencies for cluster-side deployment)
* [x] Documentation updated (`docs/en`, `docs/zh` — Flink section of the lineage concept page, including the `$FLINK_HOME/lib` deployment step)
* [ ] `incompatible-changes.md` — not applicable
* [ ] Connector-specific checklist items — not applicable
