### PR TITLE
[Docs] Refactor Zeta benchmark guide

### DIFF
--- a/docs/en/engines/zeta/benchmark.md
+++ b/docs/en/engines/zeta/benchmark.md
@@ -4,38 +4,30 @@ title: Zeta Benchmark
 
 # Zeta Benchmark
 
-This chapter explains how to run repeatable Zeta benchmarks under fixed resources and load, and how
-to interpret throughput, latency, and stability without overstating the result. A comparison is
-meaningful only when the code revision, JDK, machine, JVM limits, workload, and JMH configuration are
-recorded and kept consistent.
+This guide explains why SeaTunnel benchmarks are needed, how they are structured, how to interpret
+their metrics, how to run them locally, and how to diagnose and compare performance. Architecture
+diagrams and research references accompany the practical examples.
 
-The benchmarks run the current in-repository Zeta code and provide a repeatable local baseline. They
-exclude real connectors, external systems, network costs, and multi-node communication, so they do
-not replace a production proof of concept.
+## Why Benchmarks Are Needed
 
-## How It Works
+:::tip A Faster, More Stable Engine
 
-The `seatunnel-benchmarks` module provides these types of tests:
+The goal of benchmarking is to help the SeaTunnel Zeta engine run more consistently, process data
+faster, and use compute and storage resources more efficiently as it evolves.
 
-- `SeaTunnelRowBenchmark` measures hot paths such as row creation, access, copying, projection, and
-  size calculation.
-- `SeaTunnelPipelineBenchmark` starts an embedded single-node Zeta cluster and runs complete bounded
-  jobs through the normal client and configuration parser APIs.
-- `CheckpointingTimeBenchmark` keeps one streaming job running and measures the time required to
-  complete explicitly triggered regular checkpoints.
-- `CheckpointStorageBenchmark` measures checkpoint ID allocation, completed-checkpoint persistence,
-  and checkpoint-overview updates after checkpoint coordination has completed.
-- `IMapJobStorageBenchmark` measures task-state transitions, metrics reports, active and completed
-  job growth, and running-job recovery through the production IMaps.
-- `IMapDagStorageBenchmark` measures persisted `JobDAGInfo` growth and reload with controlled DAG
-  sizes.
-- `IMapWalStorageBenchmark` measures file-backed IMap WAL append cost, byte growth, and recovery as
-  live-key count and per-key history depth change independently.
+:::
 
-For benchmarks that require the Zeta runtime, JMH controls the forks, warmup, measurement, and Trial
-lifecycle. The Environment Context creates the Client and starts embedded Zeta during Trial setup.
-Setup and teardown are outside the timing; only operations performed by the `@Benchmark` method are
-measured.
+As data volumes grow and use cases expand, the engine must sustain throughput and control latency
+under greater load while supporting checkpointing, state storage, and observability. Benchmarks
+help identify bottlenecks that limit processing capacity and reveal performance variability as
+load increases, providing evidence for improvements in efficiency and runtime stability.
+
+They also give the community a shared way to validate performance: quantify the benefit of an
+optimization, detect potential regressions earlier, and let contributors reproduce and compare
+results. Building a growing set of baselines and test scenarios helps the community assess each
+change and improve engine performance over time.
+
+## Architecture
 
 ```mermaid
 %%{init: {"theme": "base", "themeVariables": {"background": "#0f1d33", "primaryColor": "#0c2530", "primaryBorderColor": "#2dd4bf", "primaryTextColor": "#f8fbff", "actorBkg": "#0c2530", "actorBorder": "#2dd4bf", "actorTextColor": "#f8fbff", "activationBkgColor": "#1f1a34", "activationBorderColor": "#8d7cf6", "noteBkgColor": "#1f1a34", "noteBorderColor": "#8d7cf6", "noteTextColor": "#f8fbff", "signalColor": "#5db8e2", "signalTextColor": "#f8fbff", "labelBoxBkgColor": "#0f1d33", "labelBoxBorderColor": "#5db8e2", "labelTextColor": "#f8fbff", "loopTextColor": "#f8fbff"}}}%%
@@ -65,439 +57,276 @@ flowchart LR
     style Zeta fill:#081d24,stroke:#2dd4bf,stroke-width:1.5px,color:#f8fbff
 ```
 
-In `SeaTunnelPipelineBenchmark`, the Source follows an absolute open-loop schedule. Each row carries
-its planned generation time. If Zeta falls behind, planned time continues to advance, so queueing
-and backlog remain visible in event-time latency instead of being hidden while the Source waits for
-the engine.
+### Responsibilities and Lifecycle
 
-### Test Scope
+JMH manages forked JVMs, warmup, measurement, and result collection. The environment context
+prepares fixtures and, when required, starts the runtime shown above. The measured method invokes
+the production operation under investigation, and teardown releases resources.
 
-| JMH selector | Data path and purpose |
-|---|---|
-| `sourceSink` | `Source -> Sink`; baseline Zeta data path. |
-| `sourceTransformSink` | `Source -> Transform -> Sink`; adds row copy and deterministic Transform work. |
-| `sourceTransformSinkWithObservability` | The same Transform pipeline with realtime busyness observability and a bounded async boundary enabled. |
-| `sourceTransformSinkWithTrace` | The same Transform pipeline with StainTrace enabled. |
-| `sourceTransformSinkWithObservabilityAndTrace` | Realtime observability and StainTrace enabled together, isolating their combined overhead. |
+Fixture preparation, environment startup, and cleanup belong outside the timed operation unless
+their cost is the subject of the test. The benchmark should make this boundary explicit and verify
+that the measured work produces a valid result.
 
-These scenarios compare one controlled data path while changing only Transform or observability
-features. The observability scenario measures instrumentation and async-boundary overhead; it does
-not artificially throttle the Sink or create backpressure. To test overload, set
-`offeredRatePerSecond` above engine capacity and inspect throughput, P99, and latency growth.
+### Execution Settings
 
-### Default Resources
+The shared JMH configuration defines 3 forks, 3 warmup iterations, and 5 measurement iterations.
+Each fork runs in an independent JVM. Warmup precedes the samples used to calculate the Score;
+method annotations and command-line arguments can override the shared defaults.
 
-| Setting | Default |
-|---|---:|
-| JVM heap | Fixed 4 GiB `-Xms` / `-Xmx` |
-| JVM-visible processors | 4 |
-| Garbage collector | G1 with pre-touch |
-| Zeta slots / pipeline parallelism | 12 / 4 |
-| Records per invocation | 1,000,000 |
-| Offered rate | 600,000 rows/s |
-| Payload size | 256 characters |
-| Transform work | 64 hash operations per row |
-| StainTrace sampling interval | 10,000 rows |
-| StainTrace file flush interval | 1 second |
-| JMH forks | 3 |
-| Warmup / measurement iterations | 3 / 5 |
+Thread count, heap size, garbage collector, and JVM-visible processor count are experiment
+settings. Record their effective values and keep them consistent between revisions. A limit on
+JVM-visible processors does not provide operating-system CPU affinity.
 
-The benchmark class passes these JVM limits to each fork. No additional heap configuration is
-required at launch. With the default load and parallelism, the StainTrace interval produces about
-100 sampled rows per invocation and 15 samples per second per Worker, below the default
-50-sample-per-second Worker budget. The one-second flush interval keeps local trace output active
-during each measured job instead of deferring file writes across several invocations.
+### Environment and Reproducibility
 
-## Run the Benchmarks
+Resource requirements depend on the selected workload. Keep unrelated machine activity low and
+use the same machine for baseline and candidate. Record the JDK, JVM settings, input parameters,
+and code revisions alongside the raw results.
 
-### Build the Benchmark Runner
+A benchmark establishes the behavior of the operation and workload it measures. Validate broader
+production benefits under the relevant deployment conditions.
 
-```bash
-./mvnw -Pbenchmark -pl seatunnel-benchmarks -am -DskipTests package
-```
-
-### Import the Module in IntelliJ IDEA
-
-The module is behind the inactive `benchmark` Maven profile, so IDEA may not import it when the
-root project is first opened. In the Maven tool window, expand `Profiles`, enable `benchmark`, and
-click `Reload All Maven Projects`. If the module is still absent, right-click
-`seatunnel-benchmarks/pom.xml`, select `Add as Maven Project`, and reload Maven once more.
-
-List every JMH method:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar -l
-```
-
-### Run a Complete Pipeline
-
-For a steady-load evaluation, fix one pipeline and payload size and save standard JMH JSON. The
-following command checks whether Zeta can sustain 600,000 scheduled rows per second:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'sourceTransformSink$' \
-  -p offeredRatePerSecond=600000 \
-  -p parallelism=4 \
-  -p payloadSize=256 \
-  -p transformOperations=64 \
-  -rf json \
-  -rff seatunnel-benchmarks/target/zeta-pipeline-result.json
-```
-
-Change only `offeredRatePerSecond` while finding the capacity boundary. Start above expected
-capacity and lower the rate until output is complete and P99 no longer grows throughout the run.
-For example, use `-p offeredRatePerSecond=1000000` to start a capacity comparison above the default
-load. Use `0` only to measure an unpaced throughput ceiling; without an open-loop schedule, that
-mode cannot expose latency caused by queued input.
-
-Run all five pipeline scenarios with the default workload:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelPipelineBenchmark
-```
-
-JMH accepts a class name, method name, or regular expression. For example, run all Trace methods:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'SeaTunnelPipelineBenchmark.*Trace'
-```
-
-JMH selectors are regular expressions. Append `$` when selecting one exact method; without it,
-`sourceTransformSink` also matches methods whose names start with that text.
-
-### Run the SeaTunnelRow Microbenchmarks
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
-  -rf json \
-  -rff seatunnel-benchmarks/target/seatunnel-row-result.json
-```
-
-For a quick functional validation, add `-f 1 -wi 0 -i 1 -r 1s` to shorten the run. A single un-warmed
-sample is not valid performance evidence.
-
-### Run the ProtoStuff Serializer Microbenchmarks
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
-  -rf json -rff seatunnel-benchmarks/target/protostuff.json
-```
-
-Measures in-memory `IMapFileData` serialization and deserialization throughput (`ops/ms`) with four
-threads by default. Both methods exercise shared schema-cache lookup, excluding file I/O and
-Hazelcast scheduling.
-
-### Run the Checkpoint Benchmark
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar CheckpointingTimeBenchmark
-```
-
-The benchmark runs both `recordSize=1b` and `recordSize=1kb`. `checkpointSingleInput` uses a
-controlled input rate and equal Source/Sink parallelism. Its dedicated JMH environment starts an
-isolated two-node Zeta cluster with separate master and worker roles and one streaming job per trial.
-The master has no worker slots, the worker executes the pipeline, and IMap backup count is zero. A
-separate checkpoint engine configuration (not the shared benchmark engine configuration) enables
-the `engine*` MapStore with the HDFS file storage implementation on the local filesystem, and stores
-checkpoints through the HDFS checkpoint plugin in local mode. Every invocation explicitly triggers
-one regular checkpoint and waits until Zeta has persisted and completed it. The score is checkpoint
-completion time in `s/op`, so lower is better. Job startup, workload ramp-up, persistence
-verification, and job shutdown are outside the measured invocation.
-
-### Run the Checkpoint Storage Benchmarks
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar CheckpointStorageBenchmark
-```
-
-`CheckpointStorageBenchmark` uses coordinator-produced checkpoint state and the production HDFS
-checkpoint storage plugin over `file:///`. It contains three storage-only hot paths:
-
-- `checkpointPersistenceTransaction` atomically allocates a checkpoint ID, serializes and stores a
-  completed checkpoint, and updates its checkpoint overview;
-- `checkpointIdAtomicIncrement` isolates the production checkpoint counter state store;
-- `checkpointOverviewIncrementalUpdate` isolates the completed-count, latest-checkpoint, and
-  checkpoint-history update.
-
-Barrier delivery, task snapshotting, ACK waiting, fixture generation, durability validation, and
-cleanup are outside measured time. Each invocation processes a fixed batch of 100 logical
-operations and reports the normalized time per operation in `us/op`; lower is better.
-
-Run one exact method when only one part of the persistence transaction is under investigation:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'CheckpointStorageBenchmark.checkpointIdAtomicIncrement$'
-```
-
-### Run the IMap Job Storage Benchmarks
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar IMapJobStorageBenchmark
-```
-
-The class uses the same running-state, history, and metrics IMaps as Zeta. Fixture values come from
-a real streaming job, while job startup and cleanup are outside measurement. Its methods cover:
-
-- `taskGroupStateTransition`, with `storedTaskGroupCount=0|1000`;
-- `runningMetricsReport`, with `taskCount=10|100|1000`;
-- `runningJobGrowth` and `completedJobHistoryGrowth`, with
-  `initialStoredJobCount=0|1000`;
-- `runningJobRecovery`, with `runningJobCount=100|1000`.
-
-The fixed growth and transition methods perform 100 logical operations and report normalized
-`us/op`. Recovery evicts the in-memory values, calls the production `IMap.loadAll(true)` path, and
-scans the restored entries. For example, run only the largest running-job recovery fixture:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapJobStorageBenchmark.runningJobRecovery$' \
-  -p runningJobCount=1000
-```
-
-### Run the IMap DAG Storage Benchmarks
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar IMapDagStorageBenchmark -foe true
-```
-
-`finishedJobDagStore` writes a fixed batch of 100 unique production `JobDAGInfo` values through
-the finished-job DAG IMap and its file-backed MapStore. `finishedJobDagLoad` evicts one value and
-reloads it through MapStore. `pipelineCount=1|10|100` controls the exact number of code-built
-source-to-sink pipelines in each DAG, and `storedDagCount=0|100` controls retained storage pressure.
-
-Store teardown checks the first, middle, and last cached values and deletes the batch outside
-timing. After the final measurement in each fork, those samples are evicted and reloaded from
-MapStore before deletion. Intermediate iterations do not replay the WAL for verification:
-full-WAL scans allocate more as writes and deletion records accumulate, affecting later samples
-even though teardown is not timed. WAL history still grows through the unchanged writes and
-deletes; this is not a storage compaction or steady-state benchmark.
-
-Only the final batch has a persistence read-back in each benchmark fork. Dedicated tests cover
-complete batch round trips. Local-file read-back establishes visible persisted contents, not
-crash durability. Results from the former per-iteration reload fixture are not directly comparable
-to this corrected baseline and must not be reported as a production speedup.
-Use `-foe true` so a verification failure rejects the run. Allocation/GC profiler results may
-include untimed teardown, including the terminal reload; they are not write-only measurements.
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapDagStorageBenchmark.finishedJobDagLoad$' \
-  -p pipelineCount=100 \
-  -p storedDagCount=100
-```
-
-### Run the IMap WAL Storage Benchmarks
-
-`appendNewKey` and `appendHotKey` each perform 100 production IMap writes and report both normalized
-time and the auxiliary `walBytesPerAppend` counter. `pipelineCount=1|10|100` changes the serialized
-DAG payload. `recoverAll` executes `IMap.loadAll(true)` over a prebuilt WAL;
-`uniqueKeyCount=100|1000` controls live values and `mutationsPerKey=1|10|100` controls obsolete
-history that must be replayed.
-
-Select an exact method for normal investigation. The `IMapWalStorageBenchmark` class selector runs
-every append and recovery parameter combination and can take a long time:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapWalStorageBenchmark.appendHotKey$' \
-  -p pipelineCount=10
-```
-
-WAL recovery can be expensive, especially with 1,000 keys and 100 mutations per key, so it is an
-on-demand diagnostic rather than part of `benchmarks_core`. Run one controlled case explicitly:
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapWalStorageBenchmark.recoverAll$' \
-  -p uniqueKeyCount=1000 \
-  -p mutationsPerKey=100
-```
-
-All four storage benchmark classes start an isolated single-node Zeta/Hazelcast environment with
-IMap MapStore enabled, backup count `0`, and local file-backed IMap and checkpoint storage. They do
-not require HDFS, S3, OSS, or another external storage service. Setup, validation, and cleanup do
-not contribute to the reported score.
-
-### Read Workflow Reports
-
-The scheduled and manually triggered `Benchmarks` workflow runs each selected benchmark on Java 8
-and Java 11. Each Java job uploads one artifact containing:
-
-- the original `*.jmh.json`, preserving every fork and iteration sample;
-- a versioned `*.report.json`, normalizing benchmark names, parameters, scores, errors, units,
-  direction, commit, JVM, CPU, and runner metadata;
-- `summary.md`, which is also rendered in the GitHub Actions Job Summary;
-- the environment fingerprint and any full-pipeline sample JSON.
-
-The normalized report includes median pipeline throughput, P50/P95/P99/max latency, latency growth,
-completeness, and sustainable-sample counts. Raw samples and a schema version allow later tooling to
-consume saved artifacts without parsing console logs. The workflow does not push results to a
-repository branch.
-
-Manual runs offer common selectors through `benchmarks`; `custom_benchmarks` accepts a class,
-method, or regular expression and overrides that choice. `.*` selects all current and future
-benchmarks. When `pr_number` is set, the workflow executes `baseline -> PR -> PR -> baseline` on the
-same worker, compares the median of both runs for each revision, and reports a direction-adjusted
-percentage where a positive value is favorable.
-
-Absolute results remain sensitive to machine load, warmup, CPU frequency, and runner hardware.
-Use GitHub-hosted results as trend and functional-check evidence. Prefer repeated baseline/change
-runs on the same machine, as the PR comparison does, or use a fixed self-hosted runner for a future
-regression gate.
-
-### Diagnose an Unstable Benchmark
-
-Use profiling only after a normal run shows an unexpected Score, Error, or CV. The diagnostic
-runner keeps its report separate because profiler overhead makes its Score unsuitable for
-regression comparisons. A diagnostic selector must resolve to exactly one benchmark method;
-selectors such as `.*` or a class name that matches several methods are rejected.
-
-Install the complete async-profiler distribution and set `ASYNC_PROFILER_HOME` before running CPU,
-wall-clock, or lock profiling. The runner records JFR first and uses the bundled `jfrconv` to create
-forward and reverse flame graphs. GC profiling and JFR capture use JMH's built-in profilers and do
-not need async-profiler:
-
-```bash
-bash tools/benchmarks/profile_benchmarks.sh profile cpu --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh profile wall --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh profile lock --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh profile gc --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh capture jfr --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-```
-
-CPU, wall-clock, and lock modes use JMH's async-profiler integration. GC mode uses JMH's GC
-profiler, and `capture jfr` uses JMH's JFR profiler. The runner always uses exactly one fork so that
-file-based profiler output cannot be overwritten by later forks. Warmup and measurement settings
-still come from benchmark annotations unless they are overridden after `--`, for example
-`-- -wi 1 -i 1 -w 1s -r 1s`. Each run gets a new default output directory; an explicit `--output`
-directory must be empty to prevent stale artifacts from being mixed into the report.
-
-The raw JMH JSON records async-profiler as `secondaryMetrics.async` with a `NaN` Score because it
-produces files rather than a numeric secondary metric. This is expected. The diagnostic report
-shows the collected sample count; when lock profiling observes no contention, it reports zero
-samples and intentionally omits an empty flame graph.
-
-The manual `Benchmarks Diagnostics` workflow requires one exact `benchmark` method and one
-`java_version`. It is separate from the scheduled and manually triggered `Benchmarks` workflow,
-which continues to run the Java 8/11 matrix. Selecting `all` runs CPU, wall-clock, lock, and GC
-profiling as separate steps and uploads four independently downloadable artifacts; `capture_jfr`
-adds a fifth JFR artifact. Each artifact contains only its mode's JFR recordings, flame graphs, text
-summaries, JMH logs, and JSON reports. The job summary shows the target, benchmark settings,
-per-mode results, and independent artifact names without repeating the full file inventory. On the
-hosted Linux runner, CPU profiling uses async-profiler's `ctimer` event so it does not depend on
-`perf_event` permissions.
-
-## Metrics
-
-### Sample Validity
-
-Before interpreting performance, verify that:
-
-- `processed_rows` equals `expected_rows`;
-- `sourceSink` has a zero `checksum`;
-- every Transform scenario has a non-zero `checksum`.
-
-These conditions reject incomplete output and prove that Transform work reached the Sink.
+## Metrics and Result Interpretation
 
 ### JMH Metrics
 
-| Field | Description |
-|---|---|
-| `Score` | Processed rows per second for a Pipeline benchmark; higher is better. Row microbenchmarks retain `ops/ms`; checkpoint completion reports `s/op`; storage benchmarks report `us/op`. Time-per-operation scores are lower-is-better. |
-| `Error` | Uncertainty calculated from samples inside this JMH run. |
-| `Cnt` | Aggregated measurement samples, not processed rows. |
-| `Units` | Unit of the score. |
+A JMH result answers four questions: what ran, how it was measured, what the result was, and how
+stable the evidence was.
 
-`SeaTunnelPipelineBenchmark` declares 1,000,000 logical operations per invocation, so JMH converts
-each completed job into its processed row count and reports `ops/s`. JMH timing includes job
-submission, scheduling, and complete pipeline execution. It has a different measurement boundary
-from the Sink-only `throughput_rows_per_second` value.
+```text
+Benchmark    (Parameters)    Mode    Cnt    Score    Error    Units
+```
 
-JMH `Error` does not include differences between machines. Do not use confidence interval overlap
-from two different machines as a standalone regression decision.
-
-### Pipeline Metrics
-
-Each invocation writes one JSON file under `seatunnel-benchmarks/target/pipeline-results`:
-
-| Field | Description |
-|---|---|
-| `offered_rate_rows_per_second` | Target rate scheduled by the Source; this is load, not achieved throughput. |
-| `throughput_rows_per_second` | Achieved rate during the Sink's first-to-last receive interval. |
-| `event_time_latency_p50_ms` | Median time from planned generation to Sink receipt. |
-| `event_time_latency_p95_ms` / `event_time_latency_p99_ms` | Tail delay, including backlog when the engine cannot keep up. |
-| `event_time_latency_max_ms` | Worst recorded delay; inspect it together with percentiles. |
-| `first_half_p99_ms` / `second_half_p99_ms` | P99 in each half of the run, showing whether backlog keeps growing. |
-| `latency_growth_ratio` | `(second-half P99 + 1) / (first-half P99 + 1)`; values above 1 indicate worsening latency. |
-| `latency_percentiles_clamped` | Whether any reported percentile fell into the histogram's overflow bucket and is therefore only a lower bound. |
-| `latency_overflow_rows` | Rows whose latency exceeded the histogram's tracked range. |
-| `sustainable` | By default, requires complete output, no clamped percentile, P99 at most 1,000 ms, and growth ratio at most 1.20. |
-
-`sustainable` is a convenience guardrail, not a universal service-level objective. Use the target
-workload's throughput and latency requirements for the final decision.
-
-## Evaluate the Result
-
-Determine whether the load is stable before locating the source of a difference.
-
-| Observation | Conclusion | Next step |
+| Field | Meaning | How to read it |
 |---|---|---|
-| Output is complete, throughput is close to offered rate, and first-half and second-half P99 are similar | The current load is in steady state | Increase offered rate and continue locating the capacity boundary. |
-| Throughput is below offered rate and second-half P99 keeps rising | Backlog is growing and load exceeds sustainable capacity | Lower the rate, or increase resources and parallelism before retesting. |
-| `sourceSink` is stable while `sourceTransformSink` is much slower | Transform work is the main incremental cost | Vary `transformOperations` and inspect Row copy and Transform hot paths. |
-| The base Transform case is stable while an observability or Trace case is slower | The corresponding feature has measurable cost | Repeat with identical parameters and compare each feature separately and together. |
-| Every benchmark for the same commit shifts sharply in one run | The execution host may have different CPU performance | Mark the run inconclusive, inspect the CPU fingerprint, and do not update a precise baseline. |
+| `Benchmark` / `Parameters` | Method and workload parameters | Must match when comparing results. |
+| `Mode` | `thrpt` measures throughput; `avgt` average time; `sample` duration distribution; `ss` single-shot time | Higher is better for `thrpt`; lower is better for time modes. |
+| `Cnt` | Measurement samples used in the statistics, excluding warmup | For throughput and average time, usually `forks × measurement iterations`. |
+| `Score` | Mean performance across measurement samples | `Score = Σxᵢ / n`. Use Mode and Units to determine direction. |
+| `Error` | Confidence-interval half-width, in the same unit as Score | `Interval = [Score − Error, Score + Error]`. Smaller means a more precise mean estimate. |
+| `Units` | Unit of Score | `ops/time` is throughput; `time/op` is elapsed time per operation. |
+| `CV` | Relative sample variability calculated by the SeaTunnel report | `CV = sample standard deviation / abs(Score) × 100%`. Lower means more tightly grouped samples. |
 
-Find capacity with a sweep of fixed offered rates. Repeat each rate in independent JVMs on the same
-otherwise-idle machine and preserve every sample. When comparing scenarios or commits, keep the JDK,
-machine, payload, parallelism, offered rate, and Transform work identical.
+Here, `xᵢ` is one measurement sample, `n` is Cnt, and `abs` means absolute value. Also verify
+the JDK, thread count, and JVM arguments before comparing results.
 
-## Visualization
+### Comparison Report Metrics
+
+`B` is Baseline and `C` is Candidate; `median` summarizes valid per-run values.
+Calculate B/C separately for each revision. Verify SHAs, methods, parameters, and environments first.
+
+| Field | Purpose | Calculation | Interpretation |
+|---|---|---|---|
+| Benchmark | Identifies the method | Match full method name and parameters | The table displays a shortened name. |
+| Parameters | Identifies the workload | Recorded test parameters | Must match on both sides. |
+| Score B / C | Representative performance | `median(per-run Score)` | Higher throughput or lower elapsed time is better. |
+| Score Change | Performance change | Throughput: `(C / B − 1) × 100%`; time: `(1 − C / B) × 100%` | Positive means improvement; negative means regression. |
+| CV B / C | Sample variability | `median(per-run CV)` | Lower means more tightly grouped samples. |
+| CV Change | Change in variability | `(CV C / CV B − 1) × 100%` | Negative means less variability. |
+| Error B / C | Relative uncertainty | `median(per-run Error / abs(Score) × 100%)` | A percentage, not raw JMH's absolute Error. |
+| Error Change | Change in relative uncertainty | `(Error C / Error B − 1) × 100%` | Negative means less relative uncertainty. |
+| Unit | Common unit for Score | For example, `ops/ms` or `us/op` | Other numeric columns are percentages. |
+
+`abs` means absolute value. Missing usable data or a zero change denominator produces `n/a`.
+A displayed `0.00%` may reflect rounding; recalculate from the original JSON.
+
+:::info Changes and Statistical Conclusions
+
+These changes are not significance tests. A successful workflow does not guarantee the absence of regression.
+
+:::
+
+### Assess the Evidence
+
+First confirm that the intended revision and method ran successfully, the output passed its
+correctness checks, and both revisions used the same settings. Then inspect the Score together
+with Error, CV, and individual fork/iteration samples.
+
+| Observation | Interpretation and next step |
+|---|---|
+| Repeated runs show a consistent improvement with limited variability | Report the change together with its workload and measurement boundary. |
+| The difference is small relative to variability, or changes direction between runs | Treat the result as inconclusive and repeat under controlled conditions. |
+| Most methods shift together on the same revision | Check machine load, CPU frequency, JDK, and environment metadata before attributing the shift to code. |
+| A method consistently regresses | Use profiling to locate the additional cost, then repeat the unprofiled comparison. |
+
+Preserve every sample. A single favorable iteration or a large percentage alone is not enough to
+establish a repeatable improvement.
+
+### Visualization
 
 Generate JMH JSON with `-rf json -rff <file>`, open
 [JMH Visualizer](https://jmh.morethan.io/), and compare scores, errors, forks, and iterations by
 method name and parameters.
 
-JMH Visualizer combines parameter values into labels. For example,
-`600000:4:256:64` means `offeredRatePerSecond=600000`, `parallelism=4`, `payloadSize=256`, and
-`transformOperations=64`, in the order shown in the chart legend. JMH Score includes job submission,
-scheduling, and complete pipeline execution. Inspect the Pipeline JSON throughput, latency, and
-completeness fields before deciding whether the configured load is sustainable.
+Parameter values may be combined into chart labels; consult the legend and original JSON to
+identify each experiment. Keep the raw JMH files when sharing charts so others can inspect the
+underlying samples. The scripts `tools/benchmarks/save_jmh_result.py` and
+`tools/benchmarks/regression_report.py` generate normalized JSON and Markdown reports.
 
-Files under `pipeline-results` are custom JSON rather than JMH JSON. Inspect them directly or use
-`tools/benchmarks/save_jmh_result.py` and `tools/benchmarks/regression_report.py` to generate
-normalized JSON and Markdown reports.
+## Local Execution
 
-## Add a Benchmark
+### Build and Prepare
 
-Keep cases small and focused on hot paths that run on one machine without external services. Useful
-targets include `SeaTunnelRow` operations, format parsing and serialization, Transform hot paths,
-connector option parsing, and split generation.
+Run commands from the repository root. Enable the `benchmark` profile to build the JMH runner:
 
-Extend `BenchmarkBase` to inherit the shared JMH mode, forks, warmup, measurement, state, and output
-unit defaults. Keep benchmark-specific state and setup in the benchmark class. Full-pipeline engine
-lifecycle and controls belong in `SeaTunnelEnvironmentContext` or a focused subclass so checkpoint,
-failure-recovery, and metrics scenarios can be added without duplicating cluster setup.
+```bash
+./mvnw -Pbenchmark -pl seatunnel-benchmarks -am -DskipTests package
+git rev-parse HEAD
+java -version
+```
 
-## Performance Cost and Limitations
+The runner is `seatunnel-benchmarks/target/benchmarks.jar`. Rebuild after changing the checkout
+or benchmark code: the current Git HEAD does not prove that an existing JAR contains that revision.
+Record uncommitted production or fixture changes alongside the SHA.
 
-- A pipeline benchmark starts an embedded Zeta cluster and requires at least 4 GiB of available heap.
-- A complete run uses 3 forks, 3 warmup iterations, and 5 measurement iterations. Running all five
-  scenarios takes substantially longer than a shortened validation run.
-- `ActiveProcessorCount=4` limits processors visible to the JVM; it does not provide operating-system
-  CPU affinity.
-- Precise comparisons require a fixed machine or alternating base and candidate on the same
-  otherwise-idle machine.
-- This benchmark excludes real connectors, external brokers, network, disk, and multi-node costs.
+In IntelliJ IDEA, enable `benchmark` under Maven `Profiles` and select `Reload All Maven Projects`.
+If the module is still absent, add `seatunnel-benchmarks/pom.xml` as a Maven project and reload.
 
-To measure production end-to-end performance, repeat the experiment with the required connectors and
-external systems, and correlate the result with error logs, checkpoint status, and external-system
-monitoring.
+### Execute Through the JAR
 
-## References
+List available methods with `-l`. Replace `<benchmark-method>` in the examples with the full method
+name from that output, retaining the trailing `$`. Use `-lp` to inspect its parameters:
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar -l
+java -jar seatunnel-benchmarks/target/benchmarks.jar \
+  '<benchmark-method>$' -lp
+```
+
+Run one method with its configured warmup, measurement, and forks, and save JMH JSON:
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar \
+  '<benchmark-method>$' \
+  -rf json -rff seatunnel-benchmarks/target/benchmark-result.json
+```
+
+Selectors are regular expressions. Use the full method name followed by `$` to select one method.
+Check the matches with `-l` before a long run.
+
+:::caution Smoke Checks Are Not Performance Evidence
+
+A short smoke check can add
+`-f 1 -wi 1 -i 1 -w 1s -r 1s`; its result is only a functional check.
+
+:::
+
+Use `-p` to override workload parameters supported by the selected method. Replace `<parameter>`
+and `<value>` with a parameter name from `-lp` and the desired value:
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar \
+  '<benchmark-method>$' \
+  -p '<parameter>=<value>' \
+  -rf json -rff seatunnel-benchmarks/target/benchmark-result.json
+```
+
+Change one workload parameter at a time when exploring its effect. Keep the selector, parameters,
+thread count, JDK, and JVM settings identical when comparing revisions.
+
+## Performance Diagnostics and Comparison
+
+### Compare a PR
+
+The `Benchmarks` workflow compares a baseline and a PR under the same workload and runtime
+environment. It answers one central question: did the change make the selected operation faster,
+or did it introduce a regression?
+
+#### Workflow Inputs
+
+Open GitHub Actions, select `Benchmarks`, and choose `Run workflow`:
+
+| Input | Value |
+|---|---|
+| `Use workflow from` | Branch containing the workflow, normally `dev`; this is not the revision being measured. |
+| `seatunnel_ref` | Baseline branch, tag, or SHA; prefer a fixed SHA. |
+| `pr_number` | Numeric ID of the candidate PR; leave empty to run only the baseline. |
+| `benchmarks` | Select a predefined benchmark suite or test. |
+| `custom_benchmarks` | Optionally enter one exact method, `<benchmark-method>$`; this overrides `benchmarks`. |
+
+Baseline and Candidate must contain the same benchmark method and fixtures, or their results cannot
+be paired. Avoid `.*` for routine PR comparisons because it runs every method and parameter
+combination; select only operations affected by the change.
+
+The workflow alternates revisions on the same worker to reduce bias from machine conditions changing
+over time:
+
+```text
+Baseline → Candidate → Candidate → Baseline
+```
+
+Java 8 and Java 11 run this comparison separately, and the report summarizes two runs of each
+revision.
+
+After the run, confirm that the job reached JMH measurement and verify the SHAs, method, and
+parameters in the summary. See [Comparison Report Metrics](#comparison-report-metrics) for field
+definitions and formulas; rerun an inconclusive result. The artifact provides the raw JMH JSON,
+normalized report, and environment details.
+
+### Performance Diagnostics
+
+:::info Use Profiling to Explain the Result
+
+Use profiling to explain an observed performance change, an unexpected Score, or high Error/CV.
+The diagnostic runner keeps its report separate because profiler overhead makes its Score unsuitable for
+regression comparisons.
+
+:::
+
+A diagnostic selector must resolve to exactly one benchmark method;
+selectors such as `.*` or a class name that matches several methods are rejected.
+
+#### Workflow Inputs
+
+`Benchmarks Diagnostics` profiles one revision; it does not run a baseline/candidate comparison.
+
+| Input | What to enter |
+|---|---|
+| `Use workflow from` | Branch containing the diagnostic workflow and tools, normally `dev`. |
+| `seatunnel_ref` | Branch, tag, or SHA to diagnose when no PR is selected. |
+| `pr_number` | Optional trusted PR ID. When set, its head replaces `seatunnel_ref` as the diagnostic target. |
+| `benchmark` | One method selector, `<benchmark-method>$`, obtained from `-l`. Selectors matching multiple methods are rejected. |
+| `java_version` | `8` or `11`; use the JDK of the normal run being investigated. |
+| `profile` | `cpu` for execution hot spots, `wall` for elapsed-time stacks including waits, `lock` for lock contention, `gc` for allocation/GC metrics, or `all` for separate runs of all four. |
+| `capture_jfr` | Enable to add a separate JFR recording for offline analysis. |
+| `jmh_args` | Optional JMH arguments or workload parameters, using the selected method's `-lp` output. Leave empty for defaults; forks remain fixed at 1. |
+
+#### Run Profiling Locally
+
+Use the same script to diagnose a built benchmark locally. The following example profiles CPU;
+replace `cpu` with `wall`, `lock`, or `gc` to select another mode:
+
+```bash
+bash tools/benchmarks/profile_benchmarks.sh profile cpu \
+  --benchmark '<benchmark-method>$'
+
+bash tools/benchmarks/profile_benchmarks.sh capture jfr --benchmark '<benchmark-method>$'
+```
+
+| Argument | Purpose |
+|---|---|
+| `profile <mode>` | Select CPU hotspots, elapsed-time stacks, lock contention, or GC allocation analysis. |
+| `--benchmark` | Select exactly one benchmark method. |
+| `--repository` | Optional directory containing a built benchmark JAR. |
+| `--output` | Optional output directory that does not exist or is empty. |
+| `-- <JMH arguments>` | Optional overrides for warmup, measurement, or workload settings. |
+
+CPU, wall-clock, and lock modes require async-profiler and `ASYNC_PROFILER_HOME`. GC and JFR use
+JMH's built-in profilers. Diagnostic runs use one fork and create a separate directory under
+`seatunnel-benchmarks/target/profiles` by default.
+
+#### Read Diagnostic Artifacts
+
+First confirm the target revision, benchmark settings, and sample results in the job summary, then
+download the artifact for the selected mode. CPU, wall-clock, and lock modes provide flame graphs;
+GC provides allocation and collection summaries. Use the JMH log and JSON to verify the run.
+Enabling `capture_jfr` also creates a JFR recording for offline analysis.
+
+Zero samples in lock mode normally means that the run did not observe lock contention. Because a
+profiler changes execution cost, use diagnostics only to locate the cause; confirm an improvement or
+regression with the unprofiled PR comparison.
+
+## Research References
 
 1. Andy Georges, Dries Buytaert, and Lieven Eeckhout,
    [Statistically Rigorous Java Performance Evaluation](https://dri.es/files/oopsla07-georges.pdf),
@@ -509,7 +338,7 @@ monitoring.
    [Benchmarking Distributed Stream Data Processing Systems](https://arxiv.org/pdf/1802.08496),
    ICDE 2018.
 
-## Related Documentation
+### Related Documentation
 
 - [Busyness and Backpressure](./busyness-and-backpressure.md)
 - [Monitoring Metrics](./telemetry.md)

--- a/docs/en/engines/zeta/benchmark.md
+++ b/docs/en/engines/zeta/benchmark.md
@@ -338,8 +338,3 @@ regression with the unprofiled PR comparison.
    [Benchmarking Distributed Stream Data Processing Systems](https://arxiv.org/pdf/1802.08496),
    ICDE 2018.
 
-### Related Documentation
-
-- [Busyness and Backpressure](./busyness-and-backpressure.md)
-- [Monitoring Metrics](./telemetry.md)
-- [Tuning Guide](./tuning-guide.md)

--- a/docs/zh/engines/zeta/benchmark.md
+++ b/docs/zh/engines/zeta/benchmark.md
@@ -4,33 +4,27 @@ title: Zeta 基准测试
 
 # Zeta 基准测试
 
-本章说明如何在固定资源和固定负载下运行可重复的 Zeta 基准测试，以及如何解释吞吐、延迟和
-稳定性而不过度推断结果。只有记录并保持代码版本、JDK、机器、JVM 限制、负载和 JMH 配置
-一致，两个结果才具有可比性。
+本文依次介绍 SeaTunnel 为什么需要基准测试、测试架构、指标解读、本地运行、性能诊断与对比，
+以及相关研究论文。架构图与操作示例共同说明各类测试的测量边界。
 
-该测试直接运行当前仓库中的 Zeta 代码，适合建立可重复的本地基线。它不包含真实 Connector、
-外部系统、网络和多节点开销，因此不能替代生产环境 PoC。
+## 为什么需要基准测试
 
-## 工作原理
+:::tip 更稳定、更高效的引擎
 
-`seatunnel-benchmarks` 提供以下测试：
+基准测试的目标，是让 SeaTunnel Zeta 引擎在持续演进中运行得更稳定、处理得更快，
+并更高效地利用计算与存储资源。
 
-- `SeaTunnelRowBenchmark`：测试 Row 创建、读取、复制、投影和大小计算等热点代码。
-- `SeaTunnelPipelineBenchmark`：启动单节点嵌入式 Zeta 集群，并通过正常的 Client 和配置
-  解析 API 运行完整的有界作业。
-- `CheckpointingTimeBenchmark`：保持一个流式作业运行，并测量显式触发普通 Checkpoint 的
-  完成耗时。
-- `CheckpointStorageBenchmark`：测量 Checkpoint 协调完成后的 ID 分配、完成态 Checkpoint
-  持久化和 Checkpoint 概览更新。
-- `IMapJobStorageBenchmark`：通过生产 IMap 测量任务状态迁移、Metrics 上报、运行中与已完成
-  作业增长以及运行中作业恢复。
-- `IMapDagStorageBenchmark`：使用可控 DAG 大小测量 `JobDAGInfo` 持久化增长和重新加载。
-- `IMapWalStorageBenchmark`：分别改变有效 Key 数和单 Key 历史深度，测量文件型 IMap WAL
-  追加耗时、字节增长和恢复性能。
+:::
 
-对于需要 Zeta 运行时的测试，JMH 负责 Fork、预热、测量和 Trial 生命周期；Environment
-Context 在 Trial Setup 阶段创建 Client 并启动嵌入式 Zeta。Setup 和 TearDown 不计时，只有
-`@Benchmark` 方法执行的操作计入 JMH 测量。
+随着数据规模增长和使用场景丰富，引擎需要在更高负载下保持吞吐、控制延迟，并承担
+Checkpoint、状态存储和可观测性等能力的开销。基准测试帮助我们发现限制处理能力的瓶颈，
+识别负载增长时出现的性能波动，为提升引擎的处理效率和运行稳定性提供依据。
+
+它也为社区提供了一套共同的性能验证方式：让优化收益可以被量化，让潜在的性能回退更早
+被发现，让不同贡献者能够复现和比较结果。通过持续积累基线与测试场景，我们可以更有
+依据地评估每次改动，推动引擎性能持续改进。
+
+## 架构
 
 ```mermaid
 %%{init: {"theme": "base", "themeVariables": {"background": "#0f1d33", "primaryColor": "#0c2530", "primaryBorderColor": "#2dd4bf", "primaryTextColor": "#f8fbff", "actorBkg": "#0c2530", "actorBorder": "#2dd4bf", "actorTextColor": "#f8fbff", "activationBkgColor": "#1f1a34", "activationBorderColor": "#8d7cf6", "noteBkgColor": "#1f1a34", "noteBorderColor": "#8d7cf6", "noteTextColor": "#f8fbff", "signalColor": "#5db8e2", "signalTextColor": "#f8fbff", "labelBoxBkgColor": "#0f1d33", "labelBoxBorderColor": "#5db8e2", "labelTextColor": "#f8fbff", "loopTextColor": "#f8fbff"}}}%%
@@ -60,414 +54,259 @@ flowchart LR
     style Zeta fill:#081d24,stroke:#2dd4bf,stroke-width:1.5px,color:#f8fbff
 ```
 
-在 `SeaTunnelPipelineBenchmark` 中，Source 使用基于绝对时间的开环调度。每条记录都携带
-计划生成时间；当 Zeta 跟不上时，计划时间仍持续向前推进，因此排队和 backlog 会体现在
-event-time latency 中，不会因 Source 等待引擎而被隐藏。
+### 职责与生命周期
 
-### 测试范围
+JMH 负责独立 JVM、预热、测量和结果采集。环境上下文负责准备测试数据，并在需要时启动
+上图中的运行环境。被测方法调用要研究的生产操作，测试结束后统一释放资源。
 
-| JMH 选择器 | 数据链路与目的 |
-|---|---|
-| `sourceSink` | `Source -> Sink`，作为 Zeta 数据链路基线。 |
-| `sourceTransformSink` | `Source -> Transform -> Sink`，增加 Row 复制和确定性的 Transform 工作。 |
-| `sourceTransformSinkWithObservability` | 在相同 Transform 链路上开启实时忙碌度观测和有界 async boundary。 |
-| `sourceTransformSinkWithTrace` | 在相同 Transform 链路上开启 StainTrace。 |
-| `sourceTransformSinkWithObservabilityAndTrace` | 同时开启实时可观测性与 StainTrace，用于隔离组合开销。 |
+测试数据准备、环境启动和清理通常放在计时之外；只有它们本身就是研究对象时，才纳入测量。
+基准测试应明确这个边界，并校验被测工作确实产生了有效结果。
 
-这些场景保持数据链路一致，只改变 Transform 或可观测能力。Observability 场景测量指标采集
-与 async boundary 的开销，不会人为限制 Sink 或制造背压。要测试过载，应将
-`offeredRatePerSecond` 设置到高于引擎容量，再检查吞吐、P99 和延迟增长。
+### 运行配置
 
-### 默认测试资源
+共享 JMH 配置定义 3 个 fork、3 次预热和 5 次测量。每个 fork 在独立 JVM 中运行，预热在
+用于计算 Score 的样本采集之前完成；方法注解和命令行参数可以覆盖共享默认值。
 
-| 配置 | 默认值 |
-|---|---:|
-| JVM 堆内存 | 固定 4 GiB `-Xms` / `-Xmx` |
-| JVM 可见处理器 | 4 |
-| 垃圾回收器 | G1，并启用 pre-touch |
-| Zeta slot / Pipeline 并行度 | 12 / 4 |
-| 每次 invocation 记录数 | 1,000,000 |
-| 输入速率 | 600,000 行/秒 |
-| Payload 大小 | 256 个字符 |
-| Transform 工作量 | 每行 64 次 hash 操作 |
-| StainTrace 采样间隔 | 10,000 行 |
-| StainTrace 文件刷新间隔 | 1 秒 |
-| JMH fork | 3 |
-| 预热 / 测量 iteration | 3 / 5 |
+线程数、堆大小、垃圾回收器和 JVM 可见处理器数都属于实验条件。应记录最终生效的值，
+并在跨版本对比时保持一致。限制 JVM 可见处理器数量不等于操作系统级 CPU 绑核。
 
-这些 JVM 限制由 Benchmark 类传给 fork JVM，启动时不需要额外配置堆内存。在默认负载和
-并行度下，StainTrace 每次 invocation 约采样 100 行，每个 Worker 每秒约采样 15 行，低于
-默认的每 Worker 每秒 50 条限制。1 秒刷新间隔保证本地 Trace 输出发生在每个测量作业内，
-避免文件写入延后到后续多个 invocation。
+### 环境与可复现性
 
-## 运行基准测试
+资源需求取决于所选负载。尽量减少机器上的无关任务，在同一台机器上运行 Baseline 和
+Candidate，并随原始结果记录 JDK、JVM 设置、输入参数和代码版本。
 
-### 构建 Benchmark Runner
+基准测试的结论适用于它所测量的操作和负载。评估更广泛的生产收益时，还需要在对应的
+部署条件下验证。
 
-```bash
-./mvnw -Pbenchmark -pl seatunnel-benchmarks -am -DskipTests package
-```
-
-### 在 IntelliJ IDEA 中导入模块
-
-该模块位于默认未启用的 `benchmark` Maven profile 中，因此首次打开根项目时 IDEA 可能不会
-自动导入。在 Maven 工具窗口中展开 `Profiles`，启用 `benchmark`，然后点击
-`Reload All Maven Projects`。如果仍未显示该模块，右键点击
-`seatunnel-benchmarks/pom.xml`，选择 `Add as Maven Project`，再重新加载一次 Maven。
-
-查看全部 JMH 方法：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar -l
-```
-
-### 运行完整 Pipeline
-
-评估固定负载时，建议先固定一条链路和一种 Payload，并保存标准 JMH JSON。下面的命令用于
-检查 Zeta 能否持续处理每秒计划输入的 600,000 行数据：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'sourceTransformSink$' \
-  -p offeredRatePerSecond=600000 \
-  -p parallelism=4 \
-  -p payloadSize=256 \
-  -p transformOperations=64 \
-  -rf json \
-  -rff seatunnel-benchmarks/target/zeta-pipeline-result.json
-```
-
-寻找容量边界时，每次只修改 `offeredRatePerSecond`。先从高于预期容量的速率开始，再逐步
-降低，直到输出完整并且 P99 不再随运行持续增长。例如，可以先设置
-`-p offeredRatePerSecond=1000000`，从高于默认负载的位置开始扫描容量。只有在
-测量不控速的吞吐上限时才使用 `0`；该模式没有开环调度，无法暴露输入排队产生的延迟。
-
-使用默认负载运行全部五个 Pipeline 场景：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelPipelineBenchmark
-```
-
-JMH 支持按类名、方法名或正则选择测试。例如运行全部 Trace 相关方法：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'SeaTunnelPipelineBenchmark.*Trace'
-```
-
-JMH 的选择器本质上是正则表达式。只运行一个方法时应在末尾加 `$`；否则
-`sourceTransformSink` 还会匹配所有以该文本开头的方法。
-
-### 运行 SeaTunnelRow 微基准
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar SeaTunnelRowBenchmark \
-  -rf json \
-  -rff seatunnel-benchmarks/target/seatunnel-row-result.json
-```
-
-快速功能验证时可以增加 `-f 1 -wi 0 -i 1 -r 1s` 缩短运行时间。没有预热且只有一个样本的
-结果不能用于性能结论。
-
-### 运行 ProtoStuff 序列化微基准
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar ProtoStuffSerializerBenchmark \
-  -rf json -rff seatunnel-benchmarks/target/protostuff.json
-```
-
-默认使用 4 个线程，测量 `IMapFileData` 的内存序列化和反序列化吞吐（`ops/ms`）。
-两个方法均覆盖共享 Schema 缓存的查询路径，不包含文件 I/O 和 Hazelcast 调度。
-
-### 运行 Checkpoint 基准测试
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar CheckpointingTimeBenchmark
-```
-
-该测试覆盖 `recordSize=1b` 和 `recordSize=1kb`。`checkpointSingleInput` 使用受控输入速率
-以及相同的 Source/Sink 并行度。专用 JMH 环境会在每个 Trial 中启动 master/worker 角色
-分离的双节点 Zeta 集群和一个流式作业。master 不提供 worker slot，pipeline 只在 worker
-执行，IMap backup count 为 0。该环境使用一份独立的 Checkpoint Engine 配置（不复用普通
-Benchmark 的 Engine 配置），为 `engine*` 开启基于本地文件系统的 HDFS MapStore，并通过
-HDFS Checkpoint 插件的 local 模式保存状态。每次 invocation 显式触发一个普通 Checkpoint，
-并等待 Zeta 完成持久化。Score 使用 `s/op`，数值越低越好；作业启动、负载建立、持久化
-校验和作业关闭不计入 invocation 时间。
-
-### 运行 Checkpoint Storage Benchmark
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar CheckpointStorageBenchmark
-```
-
-`CheckpointStorageBenchmark` 使用 Coordinator 生成的 Checkpoint 状态，并通过基于
-`file:///` 的生产 HDFS Checkpoint Storage 插件执行三个纯存储热点：
-
-- `checkpointPersistenceTransaction`：原子分配 Checkpoint ID、序列化并存储完成态
-  Checkpoint，然后更新 Checkpoint 概览；
-- `checkpointIdAtomicIncrement`：单独测量生产 Checkpoint Counter State Store；
-- `checkpointOverviewIncrementalUpdate`：单独测量完成次数、最新 Checkpoint 和 Checkpoint
-  历史的更新。
-
-Barrier 传递、任务快照、ACK 等待、Fixture 生成、持久性校验和清理均不计入测量。每次
-invocation 固定执行 100 个逻辑操作，并按单个操作归一化为 `us/op`；数值越低越好。
-
-只分析持久化事务中的一个环节时，应精确选择对应方法：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'CheckpointStorageBenchmark.checkpointIdAtomicIncrement$'
-```
-
-### 运行 IMap Job Storage Benchmark
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar IMapJobStorageBenchmark
-```
-
-该类使用与 Zeta 相同的运行状态、历史和 Metrics IMap。Fixture 数据来自真实流式作业，作业
-启动与清理不计入测量。各方法及参数如下：
-
-- `taskGroupStateTransition`：`storedTaskGroupCount=0|1000`；
-- `runningMetricsReport`：`taskCount=10|100|1000`；
-- `runningJobGrowth` 和 `completedJobHistoryGrowth`：
-  `initialStoredJobCount=0|1000`；
-- `runningJobRecovery`：`runningJobCount=100|1000`。
-
-固定增长和状态迁移场景执行 100 个逻辑操作，并报告归一化后的 `us/op`。恢复场景先逐出
-内存值，再调用生产 `IMap.loadAll(true)` 路径并扫描恢复结果。例如，只运行最大规模的运行中
-作业恢复 Fixture：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapJobStorageBenchmark.runningJobRecovery$' \
-  -p runningJobCount=1000
-```
-
-### 运行 IMap DAG Storage Benchmark
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar IMapDagStorageBenchmark -foe true
-```
-
-`finishedJobDagStore` 通过已完成作业 DAG IMap 及其文件型 MapStore 固定写入 100 个唯一的
-生产 `JobDAGInfo`；`finishedJobDagLoad` 逐出一个值后再通过 MapStore 重新加载。
-`pipelineCount=1|10|100` 控制代码构建的 Source-to-Sink Pipeline 数量，
-`storedDagCount=0|100` 控制已有存储压力。
-
-Store 的 TearDown 在计时之外检查缓存中的首个、中间和最后一个值，并删除本批数据。
-每个 Fork 的最后一次测量结束后，会先逐出这些样本，再通过 MapStore 重新加载并校验，
-然后删除数据。中间迭代不再为校验重放 WAL：随着写入和删除记录累积，全量 WAL 扫描的
-分配量会增长，即使 TearDown 不计时，也会影响后续样本。原有写入和删除操作保持不变，
-WAL 历史仍会增长；这不是存储压缩或稳态 Benchmark。
-
-每个 Benchmark Fork 仅对最后一批数据进行持久化回读，独立测试覆盖完整批次的往返校验。
-本地文件回读只能证明持久化内容可见，不能证明崩溃后的持久性。旧版每次迭代都回读的
-结果不能与修正后的基线直接比较，也不能将差异描述为生产性能提升。
-使用 `-foe true` 确保校验失败时拒绝本次运行。分配量和 GC Profiler 的结果可能包含不计时的
-TearDown，包括最后的回读，因此不能将它们视为仅包含写入的指标。
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapDagStorageBenchmark.finishedJobDagLoad$' \
-  -p pipelineCount=100 \
-  -p storedDagCount=100
-```
-
-### 运行 IMap WAL Storage Benchmark
-
-`appendNewKey` 和 `appendHotKey` 分别执行 100 次生产 IMap 写入，同时报告归一化耗时和辅助
-指标 `walBytesPerAppend`。`pipelineCount=1|10|100` 控制序列化 DAG Payload 大小。
-`recoverAll` 在预先构建的 WAL 上执行 `IMap.loadAll(true)`；
-`uniqueKeyCount=100|1000` 控制有效值数量，`mutationsPerKey=1|10|100` 控制需要重放的过期
-历史深度。
-
-日常分析应精确选择一个方法。使用 `IMapWalStorageBenchmark` 类选择器会运行全部追加和恢复
-参数组合，可能耗时很长：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapWalStorageBenchmark.appendHotKey$' \
-  -p pipelineCount=10
-```
-
-WAL 恢复可能耗时较长，尤其是 1,000 个 Key、每个 Key 100 次变更的组合，因此它属于按需
-诊断场景，不包含在 `benchmarks_core` 中。应显式运行一个受控参数组合：
-
-```bash
-java -jar seatunnel-benchmarks/target/benchmarks.jar \
-  'IMapWalStorageBenchmark.recoverAll$' \
-  -p uniqueKeyCount=1000 \
-  -p mutationsPerKey=100
-```
-
-上述四个 Storage Benchmark 都会启动隔离的单节点 Zeta/Hazelcast 环境，开启 IMap MapStore，
-将 backup count 设为 `0`，并使用本地文件型 IMap 和 Checkpoint Storage。运行时无需 HDFS、
-S3、OSS 或其他外部存储服务。Setup、校验和清理均不计入 Score。
-
-### 查看 Workflow 报告
-
-定时或手动触发的 `Benchmarks` workflow 会在 Java 8 和 Java 11 上运行所选 benchmark。
-每个 Java job 会上传一个 artifact，其中包含：
-
-- 原始 `*.jmh.json`，保留所有 fork 和 iteration 样本；
-- 带版本的 `*.report.json`，统一记录 benchmark 名称、参数、Score、Error、单位、优化方向、
-  Commit、JVM、CPU 和 Runner 元数据；
-- `summary.md`，同时展示在 GitHub Actions Job Summary 中；
-- 环境指纹和完整 Pipeline 的样本 JSON（如有）。
-
-标准化报告还包含 Pipeline 吞吐中位数、P50/P95/P99/最大延迟、延迟增长、完整性和可持续样本
-数量。保留原始样本和 Schema 版本后，后续工具无需解析控制台日志即可消费已有 artifact。
-该 workflow 不会把结果推送到仓库分支。
-
-手动运行可以通过 `benchmarks` 选择常用 selector；`custom_benchmarks` 可以填写类名、方法名或
-正则表达式，并覆盖前者。`.*` 会选择当前及未来的所有 benchmark。设置 `pr_number` 后，
-workflow 会在同一 Worker 上按 `baseline -> PR -> PR -> baseline` 顺序运行，比较两个版本各自
-两次结果的中位数，并输出经过优化方向校正的百分比；正值表示 Candidate 向更优方向变化。
-
-绝对结果仍会受到机器负载、预热、CPU 频率和 Runner 硬件影响。GitHub 托管 Runner 的结果
-适合用于趋势与功能检查。精确比较应像 PR 对比一样，在同一台机器上重复运行 Base 与 Change；
-未来如需作为回归门禁，则应使用固定的 Self-hosted Runner。
-
-### 诊断不稳定的 Benchmark
-
-只有正常运行出现异常的 Score、Error 或 CV 后，才使用 profiling 继续定位。Profiler 会引入
-额外开销，因此诊断报告与正常报告完全分开，诊断 Score 不能用于性能回归比较。诊断 selector
-必须且只能匹配一个 benchmark 方法；`.*` 或能够匹配多个方法的类名会被拒绝。
-
-运行 CPU、wall-clock 或 lock profiling 前，需要安装完整的 async-profiler，并设置
-`ASYNC_PROFILER_HOME`。Runner 会先生成 JFR，再使用安装包内的 `jfrconv` 生成正向和反向
-火焰图。GC profiling 和 JFR capture 使用 JMH 内置 profiler，不依赖 async-profiler：
-
-```bash
-bash tools/benchmarks/profile_benchmarks.sh profile cpu --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh profile wall --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh profile lock --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh profile gc --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-bash tools/benchmarks/profile_benchmarks.sh capture jfr --benchmark 'IntermediateQueueBenchmark.disruptorRecordHandoff$'
-```
-
-CPU、wall-clock 和 lock 模式直接使用 JMH 的 async-profiler 集成，GC 模式使用 JMH GC
-profiler，`capture jfr` 使用 JMH JFR profiler。Runner 始终使用一个 fork，防止后续 fork
-覆盖文件型 profiler 的产物。预热和测量设置默认仍来自 benchmark 注解；如需覆盖，将参数
-放在 `--` 后，例如 `-- -wi 1 -i 1 -w 1s -r 1s`。默认输出目录每次运行都不同；显式指定
-的 `--output` 目录必须为空，避免旧产物混入报告。
-
-async-profiler 产生文件而不是数值型 secondary metric，因此原始 JMH JSON 中的
-`secondaryMetrics.async` Score 为 `NaN`，这是预期行为。诊断报告会显示采集到的样本数；
-lock profiling 没有观察到竞争时会报告 0 个样本，并且不会生成没有内容的火焰图。
-
-手动触发 `Benchmarks Diagnostics` workflow 时，必须指定一个精确的 `benchmark` 方法和一个
-`java_version`。该 workflow 与定时或手动触发的 `Benchmarks` workflow 相互独立，后者继续
-运行 Java 8/11 matrix。选择 `all` 会分别执行 CPU、wall-clock、lock 和 GC step，并上传四个
-可以独立下载的 artifact；`capture_jfr` 会增加第五个 JFR artifact。每个 artifact 只包含对应
-模式的 JFR、火焰图、文本摘要、JMH 日志和 JSON 报告。Job Summary 会集中显示目标、
-benchmark 设置、各模式结果和独立 artifact 名称，不再重复完整文件清单。GitHub 托管的
-Linux runner 使用 async-profiler 的 `ctimer` 事件进行 CPU profiling，不依赖 `perf_event`
-权限。
-
-## 指标
-
-### 样本有效性
-
-解释性能指标前，先检查：
-
-- `processed_rows` 等于 `expected_rows`；
-- `sourceSink` 的 `checksum` 为 0；
-- 所有 Transform 场景的 `checksum` 非 0。
-
-这些条件用于拒绝输出不完整的运行，并证明 Transform 工作确实到达 Sink。
+## 指标与结果解读
 
 ### JMH 指标
 
-| 字段 | 说明 |
-|---|---|
-| `Score` | Pipeline Benchmark 每秒处理的行数，越大越好；Row 微基准使用 `ops/ms`；Checkpoint 完成耗时使用 `s/op`；Storage Benchmark 使用 `us/op`。每操作耗时类指标越低越好。 |
-| `Error` | 根据本次 JMH 运行内部样本计算的不确定性。 |
-| `Cnt` | 参与聚合的 Measurement 样本数，不是处理行数。 |
-| `Units` | Score 的单位。 |
+一行 JMH 结果由“测什么、怎么测、结果多少、结果有多稳定”四部分组成：
 
-`SeaTunnelPipelineBenchmark` 声明每个 invocation 包含 1,000,000 个逻辑操作，因此 JMH
-会把一次完整 Job 换算成处理行数，并使用 `ops/s` 输出。JMH 计时包含作业提交、调度和
-完整链路执行；它和只计算 Sink 接收区间的 `throughput_rows_per_second` 不是同一个测量边界。
+```text
+Benchmark    (Parameters)    Mode    Cnt    Score    Error    Units
+```
 
-JMH `Error` 不包含不同机器之间的差异，不能只根据两台机器上的 JMH 置信区间是否重叠
-来判断性能回归。
-
-### Pipeline 指标
-
-每次 invocation 会在 `seatunnel-benchmarks/target/pipeline-results` 写入一份 JSON：
-
-| 字段 | 说明 |
-|---|---|
-| `offered_rate_rows_per_second` | Source 计划输入的目标速率；它表示负载，不是实际吞吐。 |
-| `throughput_rows_per_second` | Sink 从接收第一条到最后一条记录期间的实际完成速率。 |
-| `event_time_latency_p50_ms` | 从计划生成到 Sink 接收的中位耗时。 |
-| `event_time_latency_p95_ms` / `event_time_latency_p99_ms` | 尾延迟；引擎跟不上时包含 backlog 等待。 |
-| `event_time_latency_max_ms` | 最大记录延迟，应和百分位一起分析。 |
-| `first_half_p99_ms` / `second_half_p99_ms` | 前半段和后半段 P99，用于判断 backlog 是否持续增长。 |
-| `latency_growth_ratio` | `(后半段 P99 + 1) / (前半段 P99 + 1)`；大于 1 表示延迟在恶化。 |
-| `latency_percentiles_clamped` | 是否有已报告的百分位落入 Histogram overflow bucket，因此只能视为下界。 |
-| `latency_overflow_rows` | 延迟超过 Histogram 统计范围的记录数。 |
-| `sustainable` | 默认要求输出完整、没有被截断的百分位、P99 不超过 1,000 ms、增长比例不超过 1.20。 |
-
-`sustainable` 是便捷保护条件，不是通用 SLA。最终是否满足要求，应由目标业务的吞吐和延迟
-目标决定。
-
-## 判断测试结果
-
-建议先判断负载是否稳定，再定位是哪一部分造成差异。
-
-| 观察结果 | 结论 | 下一步 |
+| 字段 | 含义 | 解读方式 |
 |---|---|---|
-| 输出完整，实际吞吐接近输入速率，前后半段 P99 相近 | 当前负载处于稳态 | 提高输入速率，继续寻找容量边界。 |
-| 实际吞吐低于输入速率，后半段 P99 持续升高 | 正在积累 backlog，超过当前配置的可持续容量 | 降低输入速率，或增加资源与并行度后重测。 |
-| `sourceSink` 稳定，`sourceTransformSink` 明显变慢 | Transform 工作是主要增量 | 调整 `transformOperations`，检查 Row copy 和 Transform 热点。 |
-| 基础 Transform 稳定，Observability 或 Trace 场景明显变慢 | 对应功能产生可见开销 | 使用相同参数重复运行，比较单独开启与同时开启的结果。 |
-| 同一 Commit 的全部 Benchmark 在某次运行中同时大幅变化 | 执行机器的 CPU 性能可能不同 | 将本次标记为不确定，检查 CPU 指纹，不更新精细性能基线。 |
+| `Benchmark` / `Parameters` | 被测方法与负载参数 | 对比时必须一致。 |
+| `Mode` | `thrpt` 测吞吐；`avgt` 测平均耗时；`sample` 测耗时分布；`ss` 测单次执行耗时 | `thrpt` 越大越好，其余耗时模式越小越好。 |
+| `Cnt` | 参与统计的测量样本数，不包含预热 | 吞吐与平均耗时模式通常为 `fork 数 × 测量 iteration 数`。 |
+| `Score` | 测量样本的平均性能 | `Score = Σxᵢ / n`。结合 Mode 和 Units 判断方向。 |
+| `Error` | Score 置信区间的半宽，与 Score 单位相同 | `置信区间 = [Score − Error, Score + Error]`。越小表示均值估计越精确。 |
+| `Units` | Score 的单位 | `ops/time` 表示吞吐；`time/op` 表示单次操作耗时。 |
+| `CV` | SeaTunnel 报告计算的样本相对波动 | `CV = 样本标准差 / abs(Score) × 100%`。越小表示样本越集中。 |
 
-容量评估应使用多个固定速率进行扫描，每个速率都在同一台空闲机器上通过独立 JVM 重复运行，
-并保留全部样本。比较两个场景或两个 Commit 时，JDK、机器、Payload、并行度、输入速率和
-Transform 工作量必须相同。
+其中 `xᵢ` 为单个测量样本，`n` 为 Cnt，`abs` 表示绝对值。比较不同结果前，
+还要确认 JDK、线程数和 JVM 参数一致。
 
-## 可视化
+### 对比报告指标
+
+`B` 为 Baseline，`C` 为 Candidate；`median` 为各轮有效结果的中位数。
+B/C 分别按各自版本计算，比较前先核对 SHA、方法、参数和运行环境。
+
+| 字段 | 用途 | 计算方式 | 如何解读 |
+|---|---|---|---|
+| Benchmark | 标识被测方法 | 按完整方法名与参数配对 | 表中显示简写名称。 |
+| Parameters | 标识负载条件 | 取测试参数 | 两侧应一致。 |
+| Score B / C | 两个版本的代表性能 | `median(各轮 Score)` | 吞吐越大越好，耗时越小越好。 |
+| Score Change | 性能变化幅度 | 吞吐：`(C / B − 1) × 100%`；耗时：`(1 − C / B) × 100%` | 正值改善，负值回退。 |
+| CV B / C | 两个版本的样本波动 | `median(各轮 CV)` | 越小表示样本越集中。 |
+| CV Change | 波动变化幅度 | `(CV C / CV B − 1) × 100%` | 负值表示波动减小。 |
+| Error B / C | 两个版本的相对不确定性 | `median(各轮 Error / abs(Score) × 100%)` | 百分比，不是原始 JMH 的绝对 Error。 |
+| Error Change | 相对不确定性变化幅度 | `(Error C / Error B − 1) × 100%` | 负值表示相对不确定性减小。 |
+| Unit | Score 的共同单位 | 如 `ops/ms`、`us/op` | 其余数值列均为百分比。 |
+
+`abs` 表示绝对值。缺少有效数据或变化公式的分母为 0 时显示 `n/a`；
+`0.00%` 可能来自舍入，复算使用原始 JSON。
+
+:::info 变化幅度与统计结论
+
+表中的变化幅度不是显著性检验；Workflow 执行成功也不等于性能没有回退。
+
+:::
+
+### 判断结果是否可信
+
+先确认运行的是目标版本与方法、输出通过了正确性检查，且两个版本使用相同设置。
+再结合 Score、Error、CV 以及各个 fork/iteration 的原始样本判断变化。
+
+| 观察结果 | 解读与下一步 |
+|---|---|
+| 多轮运行都表现出一致改善，且波动较小 | 连同负载条件和测量边界一起报告收益。 |
+| 差异接近波动幅度，或多轮变化方向不一致 | 暂不下结论，在受控环境下复测。 |
+| 同一版本的多数方法同时明显变化 | 先检查机器负载、CPU 频率、JDK 和环境信息，再判断是否来自代码。 |
+| 某个方法持续回退 | 使用 Profiler 定位新增开销，再重复不带 Profiler 的对比。 |
+
+保留全部样本。单次更好的 iteration 或较大的提升百分比，都不足以单独证明改善可以重复。
+
+### 可视化
 
 使用 `-rf json -rff <file>` 生成 JMH JSON，打开
 [JMH Visualizer](https://jmh.morethan.io/)，按方法名和参数比较 Score、Error、fork 和
 iteration。
 
-JMH Visualizer 会把参数值拼成标签。例如 `600000:4:256:64` 依次表示
-`offeredRatePerSecond=600000`、`parallelism=4`、`payloadSize=256` 和
-`transformOperations=64`，顺序与图例一致。JMH Score 包含作业提交、调度和完整 Pipeline
-执行时间。判断该负载是否可持续时，还需要结合 Pipeline JSON 的吞吐、延迟和完整性字段。
+图表可能将多个参数值组合成标签，应结合图例和原始 JSON 确认各组实验条件。分享图表时
+保留原始 JMH 文件，让其他人能够查看底层样本。`tools/benchmarks/save_jmh_result.py`
+和 `tools/benchmarks/regression_report.py` 可生成标准化 JSON 与 Markdown 报告。
 
-`pipeline-results` 下的 JSON 不是 JMH 格式，应直接查看，或者使用
-`tools/benchmarks/save_jmh_result.py` 和 `tools/benchmarks/regression_report.py` 生成
-标准化 JSON 和 Markdown 报告。
+## 本地运行
 
-## 添加 Benchmark
+### 构建与准备
 
-Benchmark 应保持小而专注，优先选择无需外部服务、可以在单机运行的热点路径，例如
-`SeaTunnelRow` 操作、格式解析与序列化、Transform 热点、Connector 参数解析和 Split 生成。
+在仓库根目录执行命令，启用 `benchmark` profile，构建 JMH Runner：
 
-新 Benchmark 应继承 `BenchmarkBase`，复用统一的 JMH Mode、Fork、预热、测量、State 和输出
-单位配置；Benchmark 自身只保留场景相关的状态与 Setup。完整 Pipeline 的引擎生命周期和控制
-逻辑应放在 `SeaTunnelEnvironmentContext` 或职责明确的子类中，以便后续增加 Checkpoint、
-故障恢复和 Metrics 场景时无需复制集群 Setup。
+```bash
+./mvnw -Pbenchmark -pl seatunnel-benchmarks -am -DskipTests package
+git rev-parse HEAD
+java -version
+```
 
-## 开销与限制
+Runner 产物为 `seatunnel-benchmarks/target/benchmarks.jar`。切换代码版本或修改 Benchmark
+后必须重新构建：当前 Git HEAD 不能证明已有 JAR 包含该版本。未提交的生产代码或 Fixture
+改动也应与 SHA 一起记录。
 
-- Pipeline Benchmark 会在本机启动嵌入式 Zeta 集群，需要至少 4 GiB 可用堆内存。
-- 完整测试包含 3 个 fork、3 次预热和 5 次测量；运行全部五个场景会花费较长时间。
-- `ActiveProcessorCount=4` 只限制 JVM 可见处理器数量，不提供操作系统级 CPU 绑核。
-- 精细性能对比应使用固定机器，或在同一台其他负载保持空闲的机器上交替运行 Base 与
-  Candidate。
-- 本测试不包含真实 Connector、外部消息队列、网络、磁盘和多节点通信成本。
+在 IntelliJ IDEA 中，启用 Maven `Profiles` 下的 `benchmark`，点击
+`Reload All Maven Projects`。如果仍未显示模块，将 `seatunnel-benchmarks/pom.xml`
+添加为 Maven 项目后重新加载。
 
-测量生产端到端性能时，应使用所需 Connector 和外部系统重复实验，并结合错误日志、Checkpoint
-状态和外部系统监控解释结果。
+### 通过 JAR 执行
 
-## 参考资料
+通过 `-l` 列出可用方法。以下示例中的 `<benchmark-method>` 应替换为输出中的完整方法名，
+保留末尾的 `$`；再用 `-lp` 查看它支持的参数：
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar -l
+java -jar seatunnel-benchmarks/target/benchmarks.jar \
+  '<benchmark-method>$' -lp
+```
+
+使用方法配置的预热、测量和 fork 运行，并保存 JMH JSON：
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar \
+  '<benchmark-method>$' \
+  -rf json -rff seatunnel-benchmarks/target/benchmark-result.json
+```
+
+选择器是正则表达式。使用完整方法名并在末尾加 `$`，即可选择一个方法。
+长时间运行前先用 `-l` 确认匹配范围。
+
+:::caution 短跑只用于功能验证
+
+冒烟验证可以追加 `-f 1 -wi 1 -i 1 -w 1s -r 1s`，
+短跑结果仅用于确认功能可用。
+
+:::
+
+使用 `-p` 覆盖所选方法支持的负载参数。将 `<parameter>` 替换为 `-lp` 列出的参数名，
+将 `<value>` 替换为要测试的值：
+
+```bash
+java -jar seatunnel-benchmarks/target/benchmarks.jar \
+  '<benchmark-method>$' \
+  -p '<parameter>=<value>' \
+  -rf json -rff seatunnel-benchmarks/target/benchmark-result.json
+```
+
+研究负载的影响时，每轮只改变一个参数。跨版本对比时，选择器、参数、线程数、JDK 和
+JVM 设置应保持一致。
+
+## 性能诊断与对比
+
+### PR 对比
+
+`Benchmarks` Workflow 用相同的负载和运行环境比较 Baseline 与 PR，回答一个核心问题：
+这次改动让目标操作变快了，还是引入了回退？
+
+#### Workflow 参数
+
+进入 GitHub Actions，选择 `Benchmarks`，点击 `Run workflow`：
+
+| 输入项 | 填写内容 |
+|---|---|
+| `Use workflow from` | Workflow 所在分支，通常选择 `dev`；它不代表被测代码版本。 |
+| `seatunnel_ref` | Baseline 的分支、Tag 或 SHA；推荐填写固定 SHA。 |
+| `pr_number` | Candidate PR 的数字编号；留空则只测试 Baseline。 |
+| `benchmarks` | 选择预设的测试套件或测试项。 |
+| `custom_benchmarks` | 可选，填写精确方法 `<benchmark-method>$`；填写后覆盖 `benchmarks`。 |
+
+Baseline 和 Candidate 必须包含相同的测试方法与 Fixture，否则结果无法配对。不要使用 `.*`
+做日常 PR 对比，它会运行全部方法和参数组合；只选择改动影响的操作即可。
+
+Workflow 会在同一个 Worker 上按以下顺序交替运行，降低机器状态随时间变化带来的偏差：
+
+```text
+Baseline → Candidate → Candidate → Baseline
+```
+
+Java 8 和 Java 11 分别执行这组对比，报告汇总每个版本的两轮结果。
+
+运行完成后，确认 Job 已执行到 JMH 测量，并核对 Summary 中的 SHA、方法和参数。各字段及
+变化公式见[对比报告指标](#对比报告指标)；结论不明确时应重新运行。原始 JMH JSON、标准化
+报告和环境信息可从 artifact 下载。
+
+### 性能诊断
+
+:::info 诊断用于解释性能变化
+
+使用 Profiling 解释已经观察到的性能变化、异常 Score 或较高的 Error/CV。Profiler 会引入
+额外开销，因此诊断报告与正常报告完全分开，诊断 Score 不能用于性能回归比较。
+
+:::
+
+诊断选择器必须且只能匹配一个 benchmark 方法；`.*` 或能够匹配多个方法的类名会被拒绝。
+
+#### Workflow 参数
+
+`Benchmarks Diagnostics` 每次诊断一个版本，不执行 Baseline/Candidate 对比。
+
+| 输入项 | 填写方式 |
+|---|---|
+| `Use workflow from` | 诊断 Workflow 与工具所在分支，通常为 `dev`。 |
+| `seatunnel_ref` | 未选择 PR 时，要诊断的分支、Tag 或 SHA。 |
+| `pr_number` | 可选可信 PR 编号；填写后以 PR Head 替代 `seatunnel_ref` 作为诊断目标。 |
+| `benchmark` | 填写从 `-l` 查询到的方法选择器 `<benchmark-method>$`；匹配多个方法的选择器会被拒绝。 |
+| `java_version` | `8` 或 `11`，与待分析的正常运行保持一致。 |
+| `profile` | `cpu` 查看执行热点，`wall` 查看含等待在内的耗时栈，`lock` 查看锁竞争，`gc` 查看分配与 GC 指标；`all` 分别运行这四种模式。 |
+| `capture_jfr` | 勾选后增加一次独立 JFR 录制，用于离线分析。 |
+| `jmh_args` | 可选 JMH 参数或负载参数，以所选方法的 `-lp` 输出为准；留空使用默认值，fork 固定为 1。 |
+
+#### 本地运行 Profiler
+
+使用同一脚本可以在本地诊断已构建的 Benchmark。下面以 CPU 分析为例；将 `cpu` 替换为
+`wall`、`lock` 或 `gc` 即可切换模式：
+
+```bash
+bash tools/benchmarks/profile_benchmarks.sh profile cpu \
+  --benchmark '<benchmark-method>$'
+
+bash tools/benchmarks/profile_benchmarks.sh capture jfr --benchmark '<benchmark-method>$'
+```
+
+| 参数 | 用途 |
+|---|---|
+| `profile <mode>` | 选择 CPU 热点、耗时栈、锁竞争或 GC 分配分析。 |
+| `--benchmark` | 指定一个精确的 Benchmark 方法。 |
+| `--repository` | 可选，指定已构建 Benchmark JAR 的代码目录。 |
+| `--output` | 可选，指定一个不存在或内容为空的输出目录。 |
+| `-- <JMH 参数>` | 可选，覆盖预热、测量或负载参数。 |
+
+CPU、wall-clock 和 lock 模式需要安装 async-profiler 并设置 `ASYNC_PROFILER_HOME`；GC 和
+JFR 使用 JMH 内置 Profiler。诊断运行固定使用一个 fork，默认在
+`seatunnel-benchmarks/target/profiles` 下创建独立输出目录。
+
+#### 查看诊断产物
+
+先在 Job Summary 中确认目标版本、测试参数和采样结果，再下载对应模式的 artifact。CPU、
+wall-clock 和 lock 模式提供火焰图，GC 模式提供分配与回收摘要；JMH 日志和 JSON 用于复核
+本次运行。启用 `capture_jfr` 时还会生成可供离线分析的 JFR 文件。
+
+lock 模式显示 0 个样本通常表示本次运行未观察到锁竞争。Profiler 会改变程序执行成本，
+因此诊断结果只用于定位原因，性能提升或回退仍应由不带 Profiler 的 PR 对比确认。
+
+## 参考论文
 
 1. Andy Georges、Dries Buytaert、Lieven Eeckhout，
    [Statistically Rigorous Java Performance Evaluation](https://dri.es/files/oopsla07-georges.pdf)，
@@ -479,7 +318,7 @@ Benchmark 应保持小而专注，优先选择无需外部服务、可以在单�
    [Benchmarking Distributed Stream Data Processing Systems](https://arxiv.org/pdf/1802.08496)，
    ICDE 2018。
 
-## 相关文档
+### 相关文档
 
 - [忙碌度与背压](./busyness-and-backpressure.md)
 - [监控与指标](./telemetry.md)

--- a/docs/zh/engines/zeta/benchmark.md
+++ b/docs/zh/engines/zeta/benchmark.md
@@ -317,9 +317,3 @@ lock 模式显示 0 个样本通常表示本次运行未观察到锁竞争。Pro
 3. Jeyhun Karimov 等，
    [Benchmarking Distributed Stream Data Processing Systems](https://arxiv.org/pdf/1802.08496)，
    ICDE 2018。
-
-### 相关文档
-
-- [忙碌度与背压](./busyness-and-backpressure.md)
-- [监控与指标](./telemetry.md)
-- [调优指南](./tuning-guide.md)


### PR DESCRIPTION
## Purpose

Restructure the English and Chinese Zeta benchmark documentation into a concise, task-oriented guide for understanding, running, comparing, and diagnosing benchmarks.

## What Changed

The bilingual guide now follows the same structure:

1. why benchmarks are needed;
2. architecture and measurement lifecycle;
3. JMH and comparison-report metrics;
4. local JAR execution and workload parameters;
5. PR comparison and performance diagnostics;
6. research references and related documentation.

Important details:

- keep the architecture diagram near the beginning of the guide;
- preserve the existing research citations;
- remove fixed benchmark-class inventories and pipeline-specific examples;
- explain JMH fields and comparison-report formulas with compact tables;
- document local execution with an exact benchmark-method selector and JSON output;
- document every `Benchmarks` and `Benchmarks Diagnostics` workflow input;
- explain the same-worker comparison order: Baseline → Candidate → Candidate → Baseline;
- separate unprofiled performance comparisons from profiled diagnostics;
- reduce local profiler usage to one reusable command example and an argument table.

## Conflict Resolution

The branch is rebuilt on the latest `dev`. The bilingual `benchmark.md` rewrite is kept as the source of truth. The class-specific ProtoStuff execution section recently added to `dev` is not carried into this guide because this rewrite intentionally avoids coupling the documentation to individual benchmark class names.

## Scope and Non-Goals

This PR changes only:

- `docs/en/engines/zeta/benchmark.md`
- `docs/zh/engines/zeta/benchmark.md`

It does not modify benchmark implementations, fixtures, suites, workflows, JMH execution, or report calculations. The performance contribution guide has been moved to a separate PR.

## Verification

- [x] English and Chinese heading, table, code-block, and callout parity checked
- [x] Documentation links checked
- [x] Architecture diagrams retained
- [x] Research references retained
- [x] Markdown diff check passed
- [ ] Full Maven verify was not run because this is a documentation-only change
