### PR TITLE
[Fix][Transform-V2] Support small integer MOD divisors

### DIFF
--- a/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/NumericFunction.java
+++ b/seatunnel-transforms-v2/src/main/java/org/apache/seatunnel/transform/sql/zeta/functions/NumericFunction.java
@@ -221,6 +221,12 @@ public class NumericFunction {
                     CommonErrorCodeDeprecated.UNSUPPORTED_OPERATION, "Mod by zero");
         }
         BigDecimal[] res = leftBD.divideAndRemainder(rightBD);
+        if (rightValue instanceof Byte) {
+            return res[1].byteValue();
+        }
+        if (rightValue instanceof Short) {
+            return res[1].shortValue();
+        }
         if (rightValue instanceof Integer) {
             return res[1].intValue();
         }

--- a/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLNumericFunctionsTest.java
+++ b/seatunnel-transforms-v2/src/test/java/org/apache/seatunnel/transform/sql/SQLNumericFunctionsTest.java
@@ -85,6 +85,27 @@ public class SQLNumericFunctionsTest {
     }
 
     @Test
+    public void testModWithTinyIntAndSmallIntDivisors() {
+        SeaTunnelRowType rowType =
+                new SeaTunnelRowType(
+                        new String[] {"a", "tiny", "small"},
+                        new SeaTunnelDataType[] {
+                            BasicType.INT_TYPE, BasicType.BYTE_TYPE, BasicType.SHORT_TYPE
+                        });
+
+        SeaTunnelRow outRow =
+                runSql(
+                        "select MOD(a, tiny) as tiny_remainder, MOD(a, small) as small_remainder from dual",
+                        rowType,
+                        100,
+                        (byte) 7,
+                        (short) 30);
+
+        Assertions.assertEquals((byte) 2, outRow.getField(0));
+        Assertions.assertEquals((short) 10, outRow.getField(1));
+    }
+
+    @Test
     public void testModByZero() {
         SeaTunnelRowType rowType =
                 new SeaTunnelRowType(


### PR DESCRIPTION
## What does this PR do?

Fixes #12179. Zeta SQL `MOD` now supports `TINYINT` and `SMALLINT` divisors, returning a remainder of the divisor's declared type.

## Why is this needed?

`MOD` already accepts these values for decimal conversion but previously rejected their runtime `Byte` and `Short` representations while selecting the result type, causing valid SQL expressions to fail.

## Tests

- Added SQL regression coverage for `MOD` with `TINYINT` and `SMALLINT` divisors.
- `./mvnw -pl seatunnel-transforms-v2 -Dtest=SQLNumericFunctionsTest test`
- `./mvnw spotless:apply`
- Started `./mvnw -q -DskipTests verify` (still running in the local workspace).