### PR TITLE
[Fix][CI] Fix merge queue bypass actor

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,8 +58,8 @@ github:
         - actor_id: 118420
           actor_type: Team
           bypass_mode: always
-        # DanielLeens can bypass the merge queue when necessary.
-        - actor_id: 48329107
+        # davidzollo can bypass the merge queue when necessary.
+        - actor_id: 15833811
           actor_type: User
           bypass_mode: pull_request
       conditions:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,9 +58,9 @@ github:
         - actor_id: 118420
           actor_type: Team
           bypass_mode: always
-        # Apache SeaTunnel committers can bypass the merge queue when necessary.
-        - actor_id: 5467871
-          actor_type: Team
+        # DanielLeens can bypass the merge queue when necessary.
+        - actor_id: 48329107
+          actor_type: User
           bypass_mode: pull_request
       conditions:
         ref_name:


### PR DESCRIPTION
## Purpose
Follow up on #12198. ASF Infra rejected the previous merge-queue bypass actor because the `seatunnel committers` team is not part of the repository ruleset source or owner organization.

## Change
Replace the rejected `Team` bypass actor with the explicit GitHub `User` actor for `davidzollo` (`actor_id: 15833811`) while keeping `bypass_mode: pull_request`. The existing `apache/root` team bypass remains unchanged.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".asf.yaml"); puts "YAML OK"'`
- `git diff --check`
- `./mvnw spotless:apply -nsu -Dmaven.gitcommitid.skip=true`
- Independent maintainer-style review of the local diff: no blockers.

No local Maven build/test was run because this is a `.asf.yaml` config-only change; SeaTunnel build/test validation is left to GitHub CI.