### PR TITLE
[Fix][CI] Make ruleset bypass cover full merge gate

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -68,6 +68,25 @@ github:
             - refs/heads/dev
           exclude: []
       rules:
+        # Preserve branch safety in the ruleset so bypass actors cover the full merge gate.
+        - type: deletion
+        - type: non_fast_forward
+        - type: pull_request
+          parameters:
+            allowed_merge_methods:
+              - squash
+            dismiss_stale_reviews_on_push: true
+            require_code_owner_review: false
+            require_extra_approval_for_unattributed_changes: false
+            require_last_push_approval: false
+            required_approving_review_count: 1
+            required_review_thread_resolution: false
+        - type: required_status_checks
+          parameters:
+            strict_required_status_checks_policy: false
+            required_status_checks:
+              - context: Build
+                integration_id: 15368
         - type: merge_queue
           parameters:
             # Allow enough time for runner scheduling before the 30-minute job starts.
@@ -79,16 +98,9 @@ github:
             merge_method: SQUASH
             min_entries_to_merge: 1
             min_entries_to_merge_wait_minutes: 0
-  protected_branches:
-    dev:
-      required_status_checks:
-        strict: false
-        checks:
-          - context: Build
-            app_id: 15368
-      required_pull_request_reviews:
-        dismiss_stale_reviews: true
-        required_approving_review_count: 1
+  # Classic branch protection is intentionally disabled: the ruleset above now owns
+  # the dev branch merge requirements and its bypass actors can bypass the full gate.
+  protected_branches: ~
 
 notifications:
   commits:      commits@seatunnel.apache.org


### PR DESCRIPTION
## Purpose

Ensure the GitHub bypass option remains available to authorized ruleset actors even when the required `Build` check or the required review is unsatisfied. GitHub layers classic branch protection with rulesets, so requirements outside the ruleset cannot be bypassed by that ruleset's actors.

## Change

- Move the existing `Build` status-check requirement into the `Merge Queue` ruleset.
- Move the existing one-approval requirement into the same ruleset.
- Preserve the default protection against branch deletion and non-fast-forward updates.
- Keep the existing Apache SeaTunnel public-team and ASF Infra bypass actors.
- Remove the overlapping classic branch-protection configuration so it cannot impose a separate, non-bypassable merge gate.

## Validation

- Parsed `.asf.yaml` with Ruby YAML.
- Verified the change is limited to `.asf.yaml` and `git diff --check` is clean.
- Verified the raw ruleset payload is supported by ASF `infrastructure-asfyaml`.

No local build or test was run: this is an ASF configuration-only change, and SeaTunnel policy delegates runtime validation to GitHub CI.