### PR TITLE
[Fix][Zeta] Bound observability edge-override warning cache #12225

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/observability/ObservabilityConfig.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/observability/ObservabilityConfig.java
@@ -46,6 +46,12 @@ public class ObservabilityConfig {
     private static final int DEFAULT_RETENTION_MINUTES = 3;
     private static final int MAX_RETENTION_MINUTES = 10;
     private static final int MAX_EDGE_OVERRIDE_CAPACITY = 100_000;
+    /** Upper bound on retained warning keys. Categories are finite; this is a safety cap. */
+    private static final int MAX_LOGGED_EDGE_OVERRIDE_ISSUES = 32;
+    /**
+     * Deduplicates edge-override warnings. Keys are warning categories, not caller-supplied
+     * strings, so retained size does not grow with job count or invalid-input cardinality.
+     */
     private static final Set<String> LOGGED_EDGE_OVERRIDE_ISSUES = ConcurrentHashMap.newKeySet();
 
     private final boolean enabled;
@@ -259,8 +265,7 @@ public class ObservabilityConfig {
         for (Object item : (List<?>) value) {
             if (!(item instanceof Map)) {
                 warnOnce(
-                        "edge_overrides:not_map:"
-                                + (item == null ? "null" : item.getClass().getName()),
+                        "edge_overrides:not_map",
                         "Invalid {} item (expected map): {}",
                         key,
                         item == null ? "null" : item.getClass().getName());
@@ -271,7 +276,7 @@ public class ObservabilityConfig {
             Object capacity = map.get("capacity");
             if (boundary == null || capacity == null) {
                 warnOnce(
-                        "edge_overrides:missing:" + map.keySet(),
+                        "edge_overrides:missing",
                         "Invalid {} item (missing boundary/capacity), keys={}",
                         key,
                         map.keySet());
@@ -281,7 +286,7 @@ public class ObservabilityConfig {
                 int cap = Integer.parseInt(String.valueOf(capacity));
                 if (cap < 0) {
                     warnOnce(
-                            "edge_overrides:negative:" + boundary + ":" + cap,
+                            "edge_overrides:negative",
                             "Invalid {} item (capacity must be >= 0), boundary={}, capacity={}",
                             key,
                             boundary,
@@ -290,7 +295,7 @@ public class ObservabilityConfig {
                 }
                 if (cap > MAX_EDGE_OVERRIDE_CAPACITY) {
                     warnOnce(
-                            "edge_overrides:too_large:" + boundary + ":" + cap,
+                            "edge_overrides:too_large",
                             "Invalid {} item (capacity must be <= {}), boundary={}, capacity={}. Clamp to {}.",
                             key,
                             MAX_EDGE_OVERRIDE_CAPACITY,
@@ -302,7 +307,7 @@ public class ObservabilityConfig {
                 overrides.put(String.valueOf(boundary), cap);
             } catch (Exception e) {
                 warnOnce(
-                        "edge_overrides:invalid:" + boundary + ":" + capacity,
+                        "edge_overrides:invalid",
                         "Invalid {} item (cannot parse capacity), boundary={}, capacity={}",
                         key,
                         boundary,
@@ -313,6 +318,12 @@ public class ObservabilityConfig {
     }
 
     private static void warnOnce(String uniqKey, String message, Object... args) {
+        if (LOGGED_EDGE_OVERRIDE_ISSUES.contains(uniqKey)) {
+            return;
+        }
+        if (LOGGED_EDGE_OVERRIDE_ISSUES.size() >= MAX_LOGGED_EDGE_OVERRIDE_ISSUES) {
+            return;
+        }
         if (!LOGGED_EDGE_OVERRIDE_ISSUES.add(uniqKey)) {
             return;
         }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/observability/ObservabilityConfigTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/observability/ObservabilityConfigTest.java
@@ -18,15 +18,26 @@
 package org.apache.seatunnel.engine.server.observability;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 public class ObservabilityConfigTest {
+
+    @BeforeEach
+    public void clearLoggedEdgeOverrideIssues() throws Exception {
+        loggedEdgeOverrideIssues().clear();
+    }
 
     @Test
     public void testDefaultsFromEmptyEnvOptions() {
@@ -150,6 +161,85 @@ public class ObservabilityConfigTest {
         m.put("boundary", boundary);
         m.put("capacity", capacity);
         return m;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<Object> loggedEdgeOverrideIssues() throws Exception {
+        Field field = ObservabilityConfig.class.getDeclaredField("LOGGED_EDGE_OVERRIDE_ISSUES");
+        field.setAccessible(true);
+        return (Set<Object>) field.get(null);
+    }
+
+    private static int maxLoggedEdgeOverrideIssues() throws Exception {
+        Field field = ObservabilityConfig.class.getDeclaredField("MAX_LOGGED_EDGE_OVERRIDE_ISSUES");
+        field.setAccessible(true);
+        return field.getInt(null);
+    }
+
+    private static ObservabilityConfig parseOverride(int index, Object capacity, boolean enabled) {
+        String padding = String.join("", Collections.nCopies(128, "x"));
+        Map<String, Object> env = new HashMap<>();
+        env.put("engine.observability.enabled", enabled);
+        env.put(
+                "engine.observability.edge_overrides",
+                Collections.singletonList(override("source-" + index + "-" + padding, capacity)));
+        return ObservabilityConfig.fromEnvOptions(env, "job-" + index, 0L);
+    }
+
+    @Test
+    public void testValidEdgeOverridesDoNotRetainWarningKeys() throws Exception {
+        for (int i = 0; i < 200; i++) {
+            parseOverride(i, 32, false);
+        }
+        Assertions.assertEquals(0, loggedEdgeOverrideIssues().size());
+    }
+
+    @Test
+    public void testDistinctInvalidEdgeOverridesStayBounded() throws Exception {
+        int max = maxLoggedEdgeOverrideIssues();
+        for (int i = 0; i < 500; i++) {
+            ObservabilityConfig cfg = parseOverride(i, -1, false);
+            Assertions.assertEquals(Collections.emptyMap(), cfg.getEdgeOverrides());
+        }
+        int afterFirst = loggedEdgeOverrideIssues().size();
+        Assertions.assertTrue(afterFirst >= 1);
+        Assertions.assertTrue(afterFirst <= max);
+        for (int i = 500; i < 1000; i++) {
+            parseOverride(i, -1, false);
+        }
+        Assertions.assertEquals(afterFirst, loggedEdgeOverrideIssues().size());
+        for (int i = 0; i < 500; i++) {
+            parseOverride(i, -1, false);
+        }
+        Assertions.assertEquals(afterFirst, loggedEdgeOverrideIssues().size());
+    }
+
+    @Test
+    public void testConcurrentInvalidEdgeOverrideParsingStaysBounded() throws Exception {
+        int threads = 8;
+        int perThread = 200;
+        int max = maxLoggedEdgeOverrideIssues();
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                final int start = t * perThread;
+                futures.add(
+                        pool.submit(
+                                () -> {
+                                    for (int i = 0; i < perThread; i++) {
+                                        parseOverride(start + i, -1, false);
+                                    }
+                                }));
+            }
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+        Assertions.assertTrue(loggedEdgeOverrideIssues().size() <= max);
+        Assertions.assertTrue(loggedEdgeOverrideIssues().size() >= 1);
     }
 
     @Test


### PR DESCRIPTION
### Purpose of this pull request

Invalid `edge_overrides` warning keys were stored in a process-wide set with no bound, so distinct bad configs kept growing retained heap. I switched uniqueness to warning categories and capped the set.

### Does this PR introduce _any_ user-facing change?

No. Validation, clamping, and enablement are unchanged. The first warning of each category is still logged.

### How was this patch tested?

Unit tests in `ObservabilityConfigTest` for valid inputs, distinct invalid inputs, repeats, and concurrent parsing.

Fixes #12225

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
