### PR TITLE
[Fix][CI] Use SeaTunnel public team for merge queue bypass

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,9 +58,9 @@ github:
         - actor_id: 118420
           actor_type: Team
           bypass_mode: always
-        # davidzollo can bypass the merge queue when necessary.
-        - actor_id: 15833811
-          actor_type: User
+        # Apache SeaTunnel public team can bypass the merge queue when necessary.
+        - actor_id: 19408713
+          actor_type: Team
           bypass_mode: pull_request
       conditions:
         ref_name:


### PR DESCRIPTION
## Purpose

Use the ASF-managed public SeaTunnel team for the Merge Queue bypass actor instead of a single GitHub user.

ASF Infra confirmed in INFRA-28376 that project teams are secret by default and cannot be used in GitHub rulesets. The opt-in public team for SeaTunnel should be used instead.

## Change

Replace the temporary `davidzollo` user bypass actor with the `apache/seatunnel-public` team (`actor_id: 19408713`) while keeping `bypass_mode: pull_request`.

The existing `apache/root` bypass remains unchanged.

Related: https://issues.apache.org/jira/browse/INFRA-28376