### PR TITLE
[Fix][Connector-V2] Return catalog tables from Aerospike and SLS sinks

### DIFF
--- a/seatunnel-connectors-v2/connector-aerospike/src/main/java/org/apache/seatunnel/connectors/seatunnel/aerospike/sink/AerospikeSink.java
+++ b/seatunnel-connectors-v2/connector-aerospike/src/main/java/org/apache/seatunnel/connectors/seatunnel/aerospike/sink/AerospikeSink.java
@@ -21,25 +21,35 @@ import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.SinkWriter;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSimpleSink;
 import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
+
+import java.util.Optional;
 
 public class AerospikeSink extends AbstractSimpleSink<SeaTunnelRow, Void> {
     private final ReadonlyConfig pluginConfig;
     private final CatalogTable catalogTable;
+    private final SeaTunnelRowType seaTunnelRowType;
 
     public AerospikeSink(ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
         this.pluginConfig = pluginConfig;
         this.catalogTable = catalogTable;
+        this.seaTunnelRowType = catalogTable.getSeaTunnelRowType();
     }
 
     @Override
     public AbstractSinkWriter<SeaTunnelRow, Void> createWriter(SinkWriter.Context context) {
-        return new AerospikeSinkWriter(catalogTable.getSeaTunnelRowType(), pluginConfig);
+        return new AerospikeSinkWriter(seaTunnelRowType, pluginConfig);
     }
 
     @Override
     public String getPluginName() {
         return "aerospike";
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.of(catalogTable);
     }
 }

--- a/seatunnel-connectors-v2/connector-sls/src/main/java/org/apache/seatunnel/connectors/seatunnel/sls/sink/SlsSink.java
+++ b/seatunnel-connectors-v2/connector-sls/src/main/java/org/apache/seatunnel/connectors/seatunnel/sls/sink/SlsSink.java
@@ -20,6 +20,7 @@ package org.apache.seatunnel.connectors.seatunnel.sls.sink;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.sink.SeaTunnelSink;
 import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.sls.config.SlsBaseOptions;
@@ -29,16 +30,19 @@ import org.apache.seatunnel.connectors.seatunnel.sls.state.SlsSinkState;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Optional;
 
 public class SlsSink
         implements SeaTunnelSink<
                 SeaTunnelRow, SlsSinkState, SlsCommitInfo, SlsAggregatedCommitInfo> {
     private final ReadonlyConfig pluginConfig;
     private final SeaTunnelRowType seaTunnelRowType;
+    private final CatalogTable catalogTable;
 
-    public SlsSink(ReadonlyConfig pluginConfig, SeaTunnelRowType rowType) {
+    public SlsSink(ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
         this.pluginConfig = pluginConfig;
-        this.seaTunnelRowType = rowType;
+        this.catalogTable = catalogTable;
+        this.seaTunnelRowType = catalogTable.getSeaTunnelRowType();
     }
 
     @Override
@@ -50,5 +54,10 @@ public class SlsSink
     public SinkWriter<SeaTunnelRow, SlsCommitInfo, SlsSinkState> createWriter(
             SinkWriter.Context context) throws IOException {
         return new SlsSinkWriter(context, seaTunnelRowType, pluginConfig, Collections.emptyList());
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.of(catalogTable);
     }
 }

--- a/seatunnel-connectors-v2/connector-sls/src/main/java/org/apache/seatunnel/connectors/seatunnel/sls/sink/SlsSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-sls/src/main/java/org/apache/seatunnel/connectors/seatunnel/sls/sink/SlsSinkFactory.java
@@ -48,9 +48,6 @@ public class SlsSinkFactory implements TableSinkFactory {
 
     @Override
     public TableSink createSink(TableSinkFactoryContext context) {
-        return () ->
-                new SlsSink(
-                        context.getOptions(),
-                        context.getCatalogTable().getTableSchema().toPhysicalRowDataType());
+        return () -> new SlsSink(context.getOptions(), context.getCatalogTable());
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

AerospikeSinkFactory and SlsSinkFactory implement TableSinkFactory, but their created sinks inherited the default getWriteCatalogTable implementation, which returns Optional.empty. As a result, the engine cannot resolve the configured sink table metadata and falls back to the default table path.

This patch:

- Preserves the CatalogTable in AerospikeSink and SlsSink.
- Returns the configured table from getWriteCatalogTable.
- Passes the complete CatalogTable from SlsSinkFactory while continuing to derive the writer row type from it.

### Does this PR introduce any user-facing change?

Yes. Aerospike and SLS sinks now expose the configured catalog table to the engine instead of reporting no write table. Connector configuration and data-writing behavior are unchanged.

### How was this patch tested?

- ./mvnw spotless:apply
- git diff upstream/dev...HEAD --check

No new dependencies, configuration options, or documentation changes are introduced.

### Check list

* [x] No new Jar binary package is added.
* [x] Documentation changes are not necessary because no connector option or documented behavior changes.
* [x] incompatible-changes.md changes are not necessary because this is backward compatible.
* [x] Connector packaging and E2E metadata changes are not necessary because no new connector is added.