### PR TITLE
[Fix][Zeta] Fix checkpoint retention after coordinator recreation

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointCoordinator.java
@@ -224,6 +224,7 @@ public class CheckpointCoordinator {
         this.pendingCheckpoints = new ConcurrentHashMap<>();
         this.completedCheckpointIds =
                 new ArrayDeque<>(coordinatorConfig.getStorage().getMaxRetainedCheckpoints() + 1);
+        restoreCompletedCheckpointIds();
         this.scheduler =
                 Executors.newScheduledThreadPool(
                         2,
@@ -1337,15 +1338,10 @@ public class CheckpointCoordinator {
                                 .build());
             }
             if (completedCheckpointIds.size()
-                                    % coordinatorConfig.getStorage().getMaxRetainedCheckpoints()
-                            == 0
-                    && completedCheckpointIds.size()
-                                    / coordinatorConfig.getStorage().getMaxRetainedCheckpoints()
-                            > 1) {
+                    > coordinatorConfig.getStorage().getMaxRetainedCheckpoints()) {
                 List<String> needDeleteCheckpointId = new ArrayList<>();
-                for (int i = 0;
-                        i < coordinatorConfig.getStorage().getMaxRetainedCheckpoints();
-                        i++) {
+                while (completedCheckpointIds.size()
+                        > coordinatorConfig.getStorage().getMaxRetainedCheckpoints()) {
                     needDeleteCheckpointId.add(completedCheckpointIds.removeFirst());
                 }
                 checkpointStorage.deleteCheckpoint(
@@ -1387,6 +1383,26 @@ public class CheckpointCoordinator {
                 checkpointCoordinatorFuture.complete(
                         new CheckpointCoordinatorState(CheckpointCoordinatorStatus.FINISHED, null));
             }
+        }
+    }
+
+    /** Restores persisted checkpoint IDs so retention survives coordinator recreation. */
+    private void restoreCompletedCheckpointIds() {
+        try {
+            checkpointStorage
+                    .getCheckpointsByJobIdAndPipelineId(
+                            String.valueOf(jobId), String.valueOf(pipelineId))
+                    .stream()
+                    .map(PipelineState::getCheckpointId)
+                    .sorted()
+                    .map(String::valueOf)
+                    .forEach(completedCheckpointIds::addLast);
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to restore retained checkpoint IDs, job id: {}, pipeline id: {}",
+                    jobId,
+                    pipelineId,
+                    e);
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManagerTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointManagerTest.java
@@ -38,8 +38,11 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.seatunnel.engine.common.Constant.IMAP_RUNNING_JOB_STATE;
 
@@ -268,5 +271,42 @@ public class CheckpointManagerTest extends AbstractSeaTunnelServerTest {
         Assertions.assertTrue(
                 checkpointStorage.getAllCheckpoints(jobId + "").isEmpty(),
                 "Checkpoint should be cleaned up after cancel when retain is disabled (default)");
+    }
+
+    @Test
+    public void testCheckpointRetentionAfterCoordinatorRecreation() throws Exception {
+        long jobId = (long) (Math.random() * 1000000L);
+        CheckpointStorage checkpointStorage = createCheckpointStorage();
+        for (long checkpointId = 1; checkpointId <= 5; checkpointId++) {
+            storeCompletedCheckpoint(checkpointStorage, jobId, checkpointId);
+        }
+
+        CheckpointStorageConfig storageConfig = new CheckpointStorageConfig();
+        storageConfig.setMaxRetainedCheckpoints(3);
+        CheckpointConfig config = new CheckpointConfig();
+        config.setStorage(storageConfig);
+        CheckpointManager checkpointManager =
+                createCheckpointManager(jobId, false, checkpointStorage, config);
+
+        checkpointManager
+                .getCheckpointCoordinator(1)
+                .completePendingCheckpoint(
+                        new CompletedCheckpoint(
+                                jobId,
+                                1,
+                                6L,
+                                Instant.now().toEpochMilli(),
+                                CheckpointType.CHECKPOINT_TYPE,
+                                Instant.now().toEpochMilli(),
+                                new HashMap<>(),
+                                new HashMap<>()));
+
+        List<Long> retainedCheckpointIds =
+                checkpointStorage.getCheckpointsByJobIdAndPipelineId(String.valueOf(jobId), "1")
+                        .stream()
+                        .map(PipelineState::getCheckpointId)
+                        .sorted()
+                        .collect(Collectors.toList());
+        Assertions.assertEquals(Arrays.asList(4L, 5L, 6L), retainedCheckpointIds);
     }
 }

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/checkpoint/CheckpointStorageTest.java
@@ -256,18 +256,23 @@ public class CheckpointStorageTest extends AbstractSeaTunnelServerTest {
         CheckpointService checkpointService = server.getCheckpointService();
         ReflectionUtils.setField(checkpointService, "checkpointStorage", checkpointStorage);
 
-        startJob(jobId, BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH, false);
-        await().atMost(120000, TimeUnit.MILLISECONDS)
-                .untilAsserted(
-                        () ->
-                                Assertions.assertEquals(
-                                        server.getCoordinatorService().getJobStatus(jobId),
-                                        JobStatus.FINISHED));
+        try {
+            startJob(jobId, BATCH_CONF_WITHOUT_CHECKPOINT_INTERVAL_PATH, false);
+            await().atMost(120000, TimeUnit.MILLISECONDS)
+                    .untilAsserted(
+                            () ->
+                                    Assertions.assertEquals(
+                                            server.getCoordinatorService().getJobStatus(jobId),
+                                            JobStatus.FINISHED));
 
-        checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
-        Assertions.assertEquals(1, accessCounter.get());
-
-        // restore the server's checkpointStorage to avoid affecting other unit cases
-        ReflectionUtils.setField(checkpointService, "checkpointStorage", originalCheckpointStorage);
+            checkpointStorage.getAllCheckpoints(String.valueOf(jobId));
+            // The coordinator restores retained checkpoint ids from storage during
+            // initialization, which adds one read on top of the final getAllCheckpoints.
+            Assertions.assertEquals(2, accessCounter.get());
+        } finally {
+            // restore the server's checkpointStorage to avoid affecting other unit cases
+            ReflectionUtils.setField(
+                    checkpointService, "checkpointStorage", originalCheckpointStorage);
+        }
     }
 }


### PR DESCRIPTION
## Purpose

Restore persisted checkpoint IDs when a `CheckpointCoordinator` is recreated, so retention continues to account for checkpoints completed before master failover.

## Changes

- Load and order existing checkpoint IDs for the coordinator pipeline during initialization.
- Delete every checkpoint exceeding the configured retention limit after a new checkpoint completes.
- Add regression coverage for a recreated coordinator with five existing checkpoints and a maximum retention of three.

## Verification

- `./mvnw spotless:apply`
- `./mvnw -pl seatunnel-engine/seatunnel-engine-server -Dtest=CheckpointManagerTest test` *(blocked before compilation by unavailable remote snapshot metadata)*
- `./mvnw -q -DskipTests verify` *(blocked before verification by unavailable remote snapshot metadata)*
- `./mvnw -o -pl seatunnel-engine/seatunnel-engine-server -am -Dtest=CheckpointManagerTest -DfailIfNoTests=false test` *(failed in the unrelated `seatunnel-config-shade` module because its required generated shaded Config classes were unavailable offline)*

Closes #12094