### PR TITLE
[Fix][Zeta] Continue lifecycle cleanup after close failure

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SeaTunnelTask.java
@@ -439,18 +439,18 @@ public abstract class SeaTunnelTask extends AbstractTask {
     /**
      * Performs an ordered teardown of all {@link FlowLifeCycle} objects in this task.
      *
-     * <p>Each lifecycle's {@link FlowLifeCycle#close()} is called in iteration order. If any
-     * lifecycle throws an {@link IOException}, the error is collected but does not prevent the
-     * remaining lifecycles from being closed.
+     * <p>Each lifecycle's {@link FlowLifeCycle#close()} is called in iteration order. If any close
+     * operation fails, the error is collected but does not prevent the remaining lifecycles from
+     * being closed.
      *
      * @throws IOException if the parent {@link AbstractTask#close()} or any lifecycle close fails
      */
     @Override
     public void close() throws IOException {
-        IOException[] closeException = {null};
+        Throwable[] closeException = {null};
         try {
             super.close();
-        } catch (IOException e) {
+        } catch (Throwable e) {
             closeException[0] = e;
         }
         MDCTracer.tracing(allCycles.stream())
@@ -458,7 +458,7 @@ public abstract class SeaTunnelTask extends AbstractTask {
                         flowLifeCycle -> {
                             try {
                                 flowLifeCycle.close();
-                            } catch (IOException e) {
+                            } catch (Throwable e) {
                                 log.error("Close FlowLifeCycle error.", e);
                                 if (closeException[0] == null) {
                                     closeException[0] = e;
@@ -468,7 +468,7 @@ public abstract class SeaTunnelTask extends AbstractTask {
                             }
                         });
         if (closeException[0] != null) {
-            throw closeException[0];
+            sneakyThrow(closeException[0]);
         }
     }
 

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/SeaTunnelTaskCloseTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/SeaTunnelTaskCloseTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.engine.server.task;
+
+import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
+import org.apache.seatunnel.engine.server.task.flow.FlowLifeCycle;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class SeaTunnelTaskCloseTest {
+
+    @Test
+    void shouldCloseRemainingCyclesAfterUncheckedFailure() throws Exception {
+        IllegalStateException failure = new IllegalStateException("first close failed");
+        FlowLifeCycle first = mock(FlowLifeCycle.class);
+        FlowLifeCycle second = mock(FlowLifeCycle.class);
+        doThrow(failure).when(first).close();
+        SeaTunnelTask task = taskWithCycles(first, second);
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, task::close);
+
+        assertSame(failure, thrown);
+        verify(second).close();
+    }
+
+    @Test
+    void shouldPreserveFirstFailureAndSuppressLaterFailures() throws Exception {
+        IOException firstFailure = new IOException("first close failed");
+        IllegalStateException secondFailure = new IllegalStateException("second close failed");
+        FlowLifeCycle first = mock(FlowLifeCycle.class);
+        FlowLifeCycle second = mock(FlowLifeCycle.class);
+        FlowLifeCycle third = mock(FlowLifeCycle.class);
+        doThrow(firstFailure).when(first).close();
+        doThrow(secondFailure).when(second).close();
+        SeaTunnelTask task = taskWithCycles(first, second, third);
+
+        IOException thrown = assertThrows(IOException.class, task::close);
+
+        assertSame(firstFailure, thrown);
+        assertSame(secondFailure, thrown.getSuppressed()[0]);
+        verify(third).close();
+    }
+
+    @Test
+    void shouldAttemptEveryCycleOnRepeatedClose() throws Exception {
+        FlowLifeCycle first = mock(FlowLifeCycle.class);
+        FlowLifeCycle second = mock(FlowLifeCycle.class);
+        doThrow(new IllegalStateException("close failed")).when(first).close();
+        SeaTunnelTask task = taskWithCycles(first, second);
+
+        assertThrows(IllegalStateException.class, task::close);
+        assertThrows(IllegalStateException.class, task::close);
+
+        verify(first, times(2)).close();
+        verify(second, times(2)).close();
+    }
+
+    private static SeaTunnelTask taskWithCycles(FlowLifeCycle... cycles) throws Exception {
+        SeaTunnelTask task = mock(SeaTunnelTask.class, Mockito.CALLS_REAL_METHODS);
+        setField(SeaTunnelTask.class, "allCycles", task, Arrays.asList(cycles));
+        setField(AbstractTask.class, "restoreComplete", task, new CompletableFuture<>());
+        return task;
+    }
+
+    private static void setField(Class<?> type, String name, Object target, Object value)
+            throws Exception {
+        Field field = type.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Fixes #12231.

`SeaTunnelTask.close()` previously collected only `IOException`. If a lifecycle threw an unchecked exception, the stream stopped immediately and the remaining initialized lifecycles were never closed.

This change makes task teardown best-effort and ordered: every lifecycle close is attempted, the first failure is preserved, and later failures are attached as suppressed exceptions before the original failure is rethrown.

### Does this PR introduce _any_ user-facing change?

Yes. Task shutdown now attempts to release all initialized lifecycle resources even when one close operation fails. The original failure remains visible to the caller.

### How was this patch tested?

Added `SeaTunnelTaskCloseTest` covering:

- an unchecked close failure followed by another lifecycle
- multiple failures with first-failure and suppressed-failure preservation
- repeated close attempts

Verified on JDK 8 with:

```bash
./mvnw -pl seatunnel-engine/seatunnel-engine-server -am \
  -Dtest=SeaTunnelTaskCloseTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipITs -Dskip.ui=true clean verify
```

Result: 40 reactor modules built successfully; 3 tests passed.

Also ran `./mvnw spotless:apply` successfully.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
