### PR TITLE
[Feature][Connector-V2] Support multi-table InfluxDB source

### DIFF
--- a/docs/en/connectors/source/InfluxDB.md
+++ b/docs/en/connectors/source/InfluxDB.md
@@ -14,6 +14,7 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 Read data from InfluxDB 1.x by using an InfluxQL query. The connector supports a normal single
 query and an optional parallel scan mode that splits one query by an integer column range.
+Use `tables_configs` to read multiple queries, databases, and output schemas through one source.
 
 ## Key Features
 
@@ -23,6 +24,7 @@ query and an optional parallel scan mode that splits one query by an integer col
 - [x] [column projection](../../introduction/concepts/connector-v2-features.md)
 - [x] [parallelism](../../introduction/concepts/connector-v2-features.md)
 - [x] [support user-defined split](../../introduction/concepts/connector-v2-features.md)
+- [x] [multi-table](../../introduction/concepts/connector-v2-features.md)
 
 ## Data Type Mapping
 
@@ -43,9 +45,10 @@ Other SeaTunnel types are not supported by the current InfluxDB source converter
 | name               | type   | required | default value | description                                                                                      |
 |--------------------|--------|----------|---------------|--------------------------------------------------------------------------------------------------|
 | url                | string | yes      | -             | InfluxDB server URL, for example `http://influxdb-host:8086`.                                    |
-| sql                | string | yes      | -             | InfluxQL query used to read data.                                                                |
-| schema             | config | yes      | -             | Output schema returned by the source.                                                            |
-| database           | string | yes      | -             | InfluxDB database name.                                                                          |
+| sql                | string | no       | -             | Required in single-table mode; mutually exclusive with `tables_configs`.                         |
+| schema             | config | no       | -             | Required in single-table mode; define it per entry in multi-table mode.                            |
+| database           | string | no       | -             | Required in single-table mode; optional default for multi-table entries.                           |
+| tables_configs     | list   | no       | -             | Queries and schemas to read in multi-table mode; see below.                                       |
 | username           | string | no       | -             | InfluxDB username. It must be configured together with `password`.                               |
 | password           | string | no       | -             | InfluxDB password. It must be configured together with `username`.                               |
 | lower_bound        | int    | no       | -             | Lower bound of `split_column` when parallel scan is enabled.                                      |
@@ -61,6 +64,33 @@ Other SeaTunnel types are not supported by the current InfluxDB source converter
 ### url [string]
 
 The URL to connect to InfluxDB, for example `http://influxdb-host:8086`.
+
+### tables_configs [list]
+
+An alternative to the root-level `sql` and `schema`. Each entry requires:
+
+- `sql`: its InfluxQL query.
+- `database`: its database, or inherit the root-level `database`.
+- `schema`: its output fields and a non-blank `schema.table` that uniquely identifies the output table.
+
+An entry can also configure `split_column`, `lower_bound`, `upper_bound`, and `partition_num`
+together. Configure range options inside each entry, not at root level. In this mode the inclusive
+integer range is divided without overlaps, including uneven ranges; no more than one split per
+integer value is created. The existing single-table range behavior is unchanged.
+Partitioned entries support simple `SELECT fields FROM measurement` queries with an optional
+`WHERE` predicate (case-insensitive). Quoted identifiers, string literals, functions, subqueries,
+multiple statements, and trailing clauses such as `LIMIT`, `ORDER BY`, or `tz(...)` are rejected
+for range splitting. Use an unpartitioned entry for these queries; it is sent unchanged.
+
+All entries share the root connection options: `url`, credentials, `epoch`, and timeouts.
+Connection options inside entries are rejected. Root-level `sql` or `schema`, an empty list,
+missing table names, and duplicate output table identities are rejected before connecting.
+The table identity is independent of the measurement name in the query and is used for downstream
+table routing. Keep these identities and their query/schema definitions stable when restoring a
+checkpoint; changing from single-table to multi-table mode requires a fresh job.
+
+Each query must return the columns declared in its own schema. Empty query results are allowed.
+Queries without range splitting, including `tz(...)`, are sent unchanged to InfluxDB.
 
 ### sql [string]
 
@@ -173,6 +203,42 @@ Connection timeout for the InfluxDB client, in milliseconds.
 Source plugin common parameters, please refer to [Source Common Options](../common-options/source-common-options.md) for details.
 
 ## Task Example
+
+### Read Multiple Tables
+
+```hocon
+env {
+    parallelism = 2
+    job.mode = "BATCH"
+}
+source {
+    InfluxDB {
+        url = "http://influxdb-host:8086"
+        tables_configs = [
+            {
+                database = "telemetry"
+                sql = "select value from temperature"
+                schema {
+                    table = "temperatures"
+                    fields { value = DOUBLE }
+                }
+            },
+            {
+                database = "operations"
+                sql = "select active, label from alerts"
+                schema {
+                    table = "alerts"
+                    fields {
+                        active = BOOLEAN
+                        label = STRING
+                    }
+                }
+            }
+        ]
+    }
+}
+sink { Console {} }
+```
 
 ### Read With Parallel Range Splits
 

--- a/docs/zh/connectors/source/InfluxDB.md
+++ b/docs/zh/connectors/source/InfluxDB.md
@@ -14,6 +14,7 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 
 通过 InfluxQL 查询从 InfluxDB 1.x 读取数据。连接器支持普通单查询，也支持按一个整数列范围切分查询，
 让多个并行任务分别读取不同范围的数据。
+使用 `tables_configs` 可以在一个 source 中读取多个查询、数据库以及不同的输出 schema。
 
 ## 关键特性
 
@@ -23,6 +24,7 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 - [x] [列投影](../../introduction/concepts/connector-v2-features.md)
 - [x] [并行度](../../introduction/concepts/connector-v2-features.md)
 - [x] [支持用户自定义切分](../../introduction/concepts/connector-v2-features.md)
+- [x] [多表读取](../../introduction/concepts/connector-v2-features.md)
 
 ## 数据类型映射
 
@@ -43,9 +45,10 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 | 参数名                | 类型     | 必须 | 默认值   | 描述                                                                            |
 |---------------------|--------|----|-------|-------------------------------------------------------------------------------|
 | url                | string | 是  | -     | InfluxDB 连接 URL，例如 `http://influxdb-host:8086`。                                |
-| sql                | string | 是  | -     | 用于读取数据的 InfluxQL 查询。                                                            |
-| schema             | config | 是  | -     | 上游数据的 schema 信息。更多详情请参考 [Schema 特性](../../introduction/concepts/schema-feature.md)。 |
-| database           | string | 是  | -     | InfluxDB 数据库名称。                                                                  |
+| sql                | string | 否  | -     | 单表模式必填，与 `tables_configs` 互斥。 |
+| schema             | config | 否  | -     | 单表模式必填；多表模式需要在每个条目中配置。 |
+| database           | string | 否  | -     | 单表模式必填；可作为多表条目的默认数据库。 |
+| tables_configs     | list   | 否  | -     | 多表模式的查询及 schema 配置，详见下文。 |
 | username           | string | 否  | -     | InfluxDB 用户名。必须和 `password` 一起配置。                                                |
 | password           | string | 否  | -     | InfluxDB 密码。必须和 `username` 一起配置。                                                |
 | lower_bound        | int    | 否  | -     | 启用并行范围读取时，`split_column` 的下界。                                                   |
@@ -61,6 +64,29 @@ import ChangeLog from '../changelog/connector-influxdb.md';
 ### url [string]
 
 连接到 InfluxDB 的 URL，例如 `http://influxdb-host:8086`。
+
+### tables_configs [list]
+
+用于替代根级别的 `sql` 和 `schema`。每个条目需要配置：
+
+- `sql`：该表的 InfluxQL 查询。
+- `database`：数据库名称；未配置时继承根级别的 `database`。
+- `schema`：输出字段以及非空的 `schema.table`，该标识在所有输出表中必须唯一。
+
+每个条目还可一起配置 `split_column`、`lower_bound`、`upper_bound` 和 `partition_num`。
+多表模式的范围选项必须放在条目内，不能放在根级别。此模式按包含上下界的整数范围切分，
+范围不能整除时也不会重叠，切分数量不超过范围内的整数数量。原有单表范围切分行为保持不变。
+启用切分的条目支持简单的 `SELECT fields FROM measurement`，以及可选的 `WHERE` 条件，
+关键字不区分大小写。范围切分不支持带引号的标识符、字符串字面量、函数、子查询、多条语句，
+以及 `LIMIT`、`ORDER BY`、`tz(...)` 等尾部子句；这些查询请使用不切分的条目，查询会原样发送。
+
+所有条目共享根级别的 `url`、认证信息、`epoch` 和超时选项，条目内的连接选项会被拒绝。
+根级别的 `sql` 或 `schema`、空列表、缺失的表名以及重复输出表标识会在连接前报错。
+输出表标识可以不同于查询中的 measurement 名称，并用于下游路由。
+恢复 checkpoint 时请保持表标识及其查询、schema 定义不变；从单表模式切换到多表模式需要启动新作业。
+
+每个查询必须返回其 schema 声明的字段；允许空查询结果。
+不启用范围切分时，查询（包括 `tz(...)`）会原样发送到 InfluxDB。
 
 ### sql [string]
 
@@ -150,6 +176,42 @@ InfluxDB 客户端的查询超时时间，单位为秒。
 Source 插件通用参数，请参考 [Source 通用选项](../common-options/source-common-options.md) 详见。
 
 ## 任务示例
+
+### 读取多张表
+
+```hocon
+env {
+    parallelism = 2
+    job.mode = "BATCH"
+}
+source {
+    InfluxDB {
+        url = "http://influxdb-host:8086"
+        tables_configs = [
+            {
+                database = "telemetry"
+                sql = "select value from temperature"
+                schema {
+                    table = "temperatures"
+                    fields { value = DOUBLE }
+                }
+            },
+            {
+                database = "operations"
+                sql = "select active, label from alerts"
+                schema {
+                    table = "alerts"
+                    fields {
+                        active = BOOLEAN
+                        label = STRING
+                    }
+                }
+            }
+        ]
+    }
+}
+sink { Console {} }
+```
 
 ### 使用并行范围读取
 

--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSource.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSource.java
@@ -55,12 +55,20 @@ public class InfluxDBSource
 
     private final CatalogTable catalogTable;
     private final SourceConfig sourceConfig;
+    private final List<InfluxDBSourceTable> tables;
 
     private static final String QUERY_LIMIT = " limit 1";
 
     public InfluxDBSource(CatalogTable catalogTable, SourceConfig sourceConfig) {
         this.catalogTable = catalogTable;
         this.sourceConfig = sourceConfig;
+        this.tables = Collections.emptyList();
+    }
+
+    InfluxDBSource(List<InfluxDBSourceTable> tables) {
+        this.tables = Collections.unmodifiableList(new ArrayList<>(tables));
+        this.catalogTable = tables.get(0).getCatalogTable();
+        this.sourceConfig = tables.get(0).getSourceConfig();
     }
 
     @Override
@@ -75,7 +83,13 @@ public class InfluxDBSource
 
     @Override
     public SourceReader createReader(SourceReader.Context readerContext) throws Exception {
-        List<Integer> columnsIndexList = initColumnsIndex(InfluxDBClient.getInfluxDB(sourceConfig));
+        if (!tables.isEmpty()) {
+            return new InfluxdbSourceReader(sourceConfig, readerContext, tables);
+        }
+        List<Integer> columnsIndexList;
+        try (InfluxDB client = InfluxDBClient.getInfluxDB(sourceConfig)) {
+            columnsIndexList = initColumnsIndex(client);
+        }
         return new InfluxdbSourceReader(
                 sourceConfig, readerContext, catalogTable.getSeaTunnelRowType(), columnsIndexList);
     }
@@ -83,7 +97,7 @@ public class InfluxDBSource
     @Override
     public SourceSplitEnumerator createEnumerator(SourceSplitEnumerator.Context enumeratorContext)
             throws Exception {
-        return new InfluxDBSourceSplitEnumerator(enumeratorContext, sourceConfig);
+        return new InfluxDBSourceSplitEnumerator(enumeratorContext, null, sourceConfig, tables);
     }
 
     @Override
@@ -91,11 +105,17 @@ public class InfluxDBSource
             SourceSplitEnumerator.Context<InfluxDBSourceSplit> enumeratorContext,
             InfluxDBSourceState checkpointState)
             throws Exception {
-        return new InfluxDBSourceSplitEnumerator(enumeratorContext, checkpointState, sourceConfig);
+        return new InfluxDBSourceSplitEnumerator(
+                enumeratorContext, checkpointState, sourceConfig, tables);
     }
 
     @Override
     public List<CatalogTable> getProducedCatalogTables() {
+        if (!tables.isEmpty()) {
+            return tables.stream()
+                    .map(InfluxDBSourceTable::getCatalogTable)
+                    .collect(Collectors.toList());
+        }
         return Collections.singletonList(catalogTable);
     }
 

--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSourceFactory.java
@@ -17,10 +17,18 @@
 
 package org.apache.seatunnel.connectors.seatunnel.influxdb.source;
 
+import org.apache.seatunnel.shade.com.typesafe.config.Config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.api.options.ConnectorCommonOptions;
 import org.apache.seatunnel.api.source.SeaTunnelSource;
 import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
 import org.apache.seatunnel.api.table.connector.TableSource;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -32,6 +40,12 @@ import org.apache.seatunnel.connectors.seatunnel.influxdb.config.SourceConfig;
 import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @AutoService(Factory.class)
 public class InfluxDBSourceFactory implements TableSourceFactory {
@@ -43,11 +57,16 @@ public class InfluxDBSourceFactory implements TableSourceFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(
-                        InfluxDBSourceOptions.URL,
+                .required(InfluxDBSourceOptions.URL)
+                .exclusive(InfluxDBSourceOptions.SQL, ConnectorCommonOptions.TABLE_CONFIGS)
+                .optional(
                         InfluxDBSourceOptions.SQL,
-                        InfluxDBSourceOptions.DATABASES,
-                        ConnectorCommonOptions.SCHEMA)
+                        Conditions.extension(InfluxDBSourceOptions.SQL, new SingleTableValidator()))
+                .optional(
+                        ConnectorCommonOptions.TABLE_CONFIGS,
+                        Conditions.notEmpty(ConnectorCommonOptions.TABLE_CONFIGS),
+                        Conditions.extension(
+                                ConnectorCommonOptions.TABLE_CONFIGS, new TablesValidator()))
                 .bundled(InfluxDBSourceOptions.USERNAME, InfluxDBSourceOptions.PASSWORD)
                 .bundled(
                         InfluxDBSourceOptions.LOWER_BOUND,
@@ -55,6 +74,8 @@ public class InfluxDBSourceFactory implements TableSourceFactory {
                         InfluxDBSourceOptions.PARTITION_NUM,
                         InfluxDBSourceOptions.SPLIT_COLUMN)
                 .optional(
+                        InfluxDBSourceOptions.DATABASES,
+                        ConnectorCommonOptions.SCHEMA,
                         InfluxDBSourceOptions.EPOCH,
                         InfluxDBSourceOptions.SQL_WHERE,
                         InfluxDBSourceOptions.CONNECT_TIMEOUT_MS,
@@ -65,15 +86,152 @@ public class InfluxDBSourceFactory implements TableSourceFactory {
     @Override
     public <T, SplitT extends SourceSplit, StateT extends Serializable>
             TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
-        return () ->
-                (SeaTunnelSource<T, SplitT, StateT>)
-                        new InfluxDBSource(
-                                CatalogTableUtil.buildWithConfig(context.getOptions()),
-                                SourceConfig.loadConfig(context.getOptions()));
+        return () -> {
+            ReadonlyConfig config = context.getOptions();
+            ConfigValidator.of(config).validate(optionRule());
+            return (SeaTunnelSource<T, SplitT, StateT>)
+                    (config.getOptional(ConnectorCommonOptions.TABLE_CONFIGS).isPresent()
+                            ? new InfluxDBSource(buildTables(config))
+                            : new InfluxDBSource(
+                                    CatalogTableUtil.buildWithConfig(config),
+                                    SourceConfig.loadConfig(config)));
+        };
     }
 
     @Override
     public Class<? extends SeaTunnelSource> getSourceClass() {
         return InfluxDBSource.class;
+    }
+
+    private static OptionRule tableRule() {
+        return OptionRule.builder()
+                .required(
+                        InfluxDBSourceOptions.SQL,
+                        InfluxDBSourceOptions.DATABASES,
+                        ConnectorCommonOptions.SCHEMA)
+                .bundled(
+                        InfluxDBSourceOptions.LOWER_BOUND,
+                        InfluxDBSourceOptions.UPPER_BOUND,
+                        InfluxDBSourceOptions.PARTITION_NUM,
+                        InfluxDBSourceOptions.SPLIT_COLUMN)
+                .build();
+    }
+
+    private static List<InfluxDBSourceTable> buildTables(ReadonlyConfig config) {
+        if (config.getOptional(ConnectorCommonOptions.SCHEMA).isPresent()) {
+            throw new OptionValidationException(
+                    "root-level 'schema' cannot be used with 'tables_configs'");
+        }
+        if (config.getOptional(InfluxDBSourceOptions.SQL_WHERE).isPresent()) {
+            throw new OptionValidationException(
+                    "With tables_configs, put each WHERE predicate inside that entry's sql, not in a separate where option");
+        }
+        for (String key :
+                Arrays.asList("lower_bound", "upper_bound", "partition_num", "split_column")) {
+            if (config.toConfig().hasPath(key)) {
+                throw new OptionValidationException(
+                        "Configure '%s' inside each tables_configs entry", key);
+            }
+        }
+        Set<String> supported =
+                new HashSet<>(
+                        Arrays.asList(
+                                "sql",
+                                "database",
+                                "schema",
+                                "lower_bound",
+                                "upper_bound",
+                                "partition_num",
+                                "split_column"));
+        List<InfluxDBSourceTable> tables = new ArrayList<>();
+        Set<String> ids = new HashSet<>();
+        List<Map<String, Object>> entries = config.get(ConnectorCommonOptions.TABLE_CONFIGS);
+        if (entries.isEmpty()) {
+            throw new OptionValidationException("'tables_configs' must not be empty");
+        }
+        Config sharedConfig =
+                config.toConfig().withoutPath(ConnectorCommonOptions.TABLE_CONFIGS.key());
+        for (int i = 0; i < entries.size(); i++) {
+            Map<String, Object> entry = entries.get(i);
+            for (String key : entry.keySet()) {
+                if (!supported.contains(key)) {
+                    throw new OptionValidationException(
+                            "tables_configs[%d]: unsupported table option '%s'; connection options belong at root level",
+                            i, key);
+                }
+            }
+            ReadonlyConfig tableConfig =
+                    ReadonlyConfig.fromConfig(
+                            ReadonlyConfig.fromMap(entry).toConfig().withFallback(sharedConfig));
+            try {
+                ConfigValidator.of(tableConfig).validate(tableRule());
+                String sql = tableConfig.get(InfluxDBSourceOptions.SQL);
+                String database = tableConfig.get(InfluxDBSourceOptions.DATABASES);
+                if (sql.trim().isEmpty() || database.trim().isEmpty()) {
+                    throw new OptionValidationException("'sql' and 'database' must be non-blank");
+                }
+                Object table =
+                        tableConfig
+                                .get(ConnectorCommonOptions.SCHEMA)
+                                .get(ConnectorCommonOptions.TABLE.key());
+                if (!(table instanceof String) || ((String) table).trim().isEmpty()) {
+                    throw new OptionValidationException(
+                            "'schema.table' must be configured and non-blank");
+                }
+                CatalogTable catalogTable = CatalogTableUtil.buildWithConfig(tableConfig);
+                SourceConfig sourceConfig = SourceConfig.loadConfig(tableConfig);
+                if (sourceConfig.getPartitionNum() < 0
+                        || (sourceConfig.getPartitionNum() > 0
+                                && (sourceConfig.getLowerBound() > sourceConfig.getUpperBound()
+                                        || sourceConfig.getSplitKey().trim().isEmpty()))) {
+                    throw new OptionValidationException(
+                            "invalid range split configuration: partition_num must be non-negative, lower_bound <= upper_bound, and split_column non-blank");
+                }
+                String id = catalogTable.getTableId().toTablePath().toString();
+                if (sourceConfig.getPartitionNum() > 0
+                        && (!sql.matches(
+                                        "(?is)\\s*select\\s+(?:\\*|\\w+(?:\\s*,\\s*\\w+)*)\\s+from\\s+\\w+(?:\\s+where\\s+.+)?\\s*")
+                                || sql.matches("(?s).*[\\\"';()/].*")
+                                || sql.contains("--")
+                                || sql.matches(
+                                        "(?is).*\\b(group|order|limit|offset|slimit|soffset|fill|tz)\\b.*"))) {
+                    throw new OptionValidationException(
+                            "range splitting in tables_configs supports simple SELECT fields FROM measurement with an optional WHERE predicate; use an unpartitioned query for quoted identifiers, string literals, functions, subqueries, or trailing clauses");
+                }
+                if (!ids.add(id)) {
+                    throw new OptionValidationException("duplicate table identity '%s'", id);
+                }
+                tables.add(new InfluxDBSourceTable(catalogTable, sourceConfig));
+            } catch (RuntimeException e) {
+                throw new OptionValidationException("tables_configs[%d]: %s", i, e.getMessage());
+            }
+        }
+        return tables;
+    }
+
+    static class SingleTableValidator implements ConditionExtension<String> {
+        @Override
+        public String description() {
+            return "'database' and 'schema' are required with root-level 'sql'";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, String sql) {
+            ConfigValidator.of(config).validate(tableRule());
+            return true;
+        }
+    }
+
+    static class TablesValidator implements ConditionExtension<List<Map<String, Object>>> {
+        @Override
+        public String description() {
+            return "each table needs a query, database, and schema with a unique table identity";
+        }
+
+        @Override
+        public boolean evaluate(ReadonlyConfig config, List<Map<String, Object>> entries) {
+            buildTables(config);
+            return true;
+        }
     }
 }

--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSourceSplitEnumerator.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSourceSplitEnumerator.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 public class InfluxDBSourceSplitEnumerator
         implements SourceSplitEnumerator<InfluxDBSourceSplit, InfluxDBSourceState> {
     final SourceConfig config;
+    private final List<InfluxDBSourceTable> tables;
     private final Context<InfluxDBSourceSplit> context;
     private final Map<Integer, List<InfluxDBSourceSplit>> pendingSplit;
     private final Object stateLock = new Object();
@@ -59,8 +60,17 @@ public class InfluxDBSourceSplitEnumerator
             SourceSplitEnumerator.Context<InfluxDBSourceSplit> context,
             InfluxDBSourceState sourceState,
             SourceConfig config) {
+        this(context, sourceState, config, Collections.emptyList());
+    }
+
+    InfluxDBSourceSplitEnumerator(
+            SourceSplitEnumerator.Context<InfluxDBSourceSplit> context,
+            InfluxDBSourceState sourceState,
+            SourceConfig config,
+            List<InfluxDBSourceTable> tables) {
         this.context = context;
         this.config = config;
+        this.tables = tables;
         this.pendingSplit = new HashMap<>();
         this.shouldEnumerate = sourceState == null;
         if (sourceState != null) {
@@ -126,20 +136,46 @@ public class InfluxDBSourceSplitEnumerator
     }
 
     private Set<InfluxDBSourceSplit> getInfluxDBSplit() {
+        if (tables.isEmpty()) {
+            return getInfluxDBSplit(config, null);
+        }
+        Set<InfluxDBSourceSplit> splits = new HashSet<>();
+        for (InfluxDBSourceTable table : tables) {
+            splits.addAll(getInfluxDBSplit(table.getSourceConfig(), table.getTableId()));
+        }
+        return splits;
+    }
+
+    private Set<InfluxDBSourceSplit> getInfluxDBSplit(SourceConfig config, String tableId) {
         String sql = config.getSql();
         Set<InfluxDBSourceSplit> influxDBSourceSplits = new HashSet<>();
         // no need numPartitions, use one partition
         if (config.getPartitionNum() == 0) {
             influxDBSourceSplits.add(
-                    new InfluxDBSourceSplit(String.valueOf(SourceConfig.DEFAULT_PARTITIONS), sql));
+                    new InfluxDBSourceSplit(
+                            tableId == null
+                                    ? String.valueOf(SourceConfig.DEFAULT_PARTITIONS)
+                                    : tableId + ":0",
+                            sql,
+                            tableId));
             return influxDBSourceSplits;
         }
         // calculate numRange base on (lowerBound upperBound partitionNum)
         List<Pair<Long, Long>> rangePairs =
-                genSplitNumRange(
-                        config.getLowerBound(), config.getUpperBound(), config.getPartitionNum());
+                tableId == null
+                        ? genSplitNumRange(
+                                config.getLowerBound(),
+                                config.getUpperBound(),
+                                config.getPartitionNum())
+                        : genTableSplitRanges(
+                                config.getLowerBound(),
+                                config.getUpperBound(),
+                                config.getPartitionNum());
 
-        String[] sqls = sql.split(InfluxDBSourceOptions.SQL_WHERE.key());
+        String[] sqls =
+                tableId == null
+                        ? sql.split(InfluxDBSourceOptions.SQL_WHERE.key())
+                        : sql.split("(?i)\\s+where\\s+", 2);
         if (sqls.length > 2) {
             throw new InfluxdbConnectorException(
                     CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
@@ -164,7 +200,12 @@ public class InfluxDBSourceSplitEnumerator
                 query = query + " and ( " + sqls[1] + " ) ";
             }
             influxDBSourceSplits.add(
-                    new InfluxDBSourceSplit(String.valueOf(i + System.nanoTime()), query));
+                    new InfluxDBSourceSplit(
+                            tableId == null
+                                    ? String.valueOf(i + System.nanoTime())
+                                    : tableId + ":" + i,
+                            query,
+                            tableId));
         }
         return influxDBSourceSplits;
     }
@@ -189,6 +230,22 @@ public class InfluxDBSourceSplitEnumerator
             }
         }
         return rangeList;
+    }
+
+    /**
+     * Splits an inclusive integer range without overlap, including uneven and single-value ranges.
+     */
+    static List<Pair<Long, Long>> genTableSplitRanges(long lower, long upper, int partitions) {
+        long count = upper - lower + 1;
+        int splitCount = (int) Math.min(count, partitions);
+        List<Pair<Long, Long>> ranges = new ArrayList<>(splitCount);
+        long start = lower;
+        for (int i = 0; i < splitCount; i++) {
+            long end = start + count / splitCount + (i < count % splitCount ? 1 : 0);
+            ranges.add(Pair.of(start, end));
+            start = end;
+        }
+        return ranges;
     }
 
     private void addPendingSplit(Collection<InfluxDBSourceSplit> splits) {

--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSourceTable.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBSourceTable.java
@@ -17,35 +17,25 @@
 
 package org.apache.seatunnel.connectors.seatunnel.influxdb.source;
 
-import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.config.SourceConfig;
 
-public class InfluxDBSourceSplit implements SourceSplit {
-    private static final long serialVersionUID = 7936658588681424786L;
-    private final String splitId;
+import lombok.Getter;
 
-    private final String query;
-    private final String tableId;
+import java.io.Serializable;
 
-    public InfluxDBSourceSplit(String splitId, String query) {
-        this(splitId, query, null);
+@Getter
+class InfluxDBSourceTable implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final CatalogTable catalogTable;
+    private final SourceConfig sourceConfig;
+
+    InfluxDBSourceTable(CatalogTable catalogTable, SourceConfig sourceConfig) {
+        this.catalogTable = catalogTable;
+        this.sourceConfig = sourceConfig;
     }
 
-    public InfluxDBSourceSplit(String splitId, String query, String tableId) {
-        this.query = query;
-        this.splitId = splitId;
-        this.tableId = tableId;
-    }
-
-    @Override
-    public String splitId() {
-        return splitId;
-    }
-
-    public String getQuery() {
-        return query;
-    }
-
-    public String getTableId() {
-        return tableId;
+    String getTableId() {
+        return catalogTable.getTableId().toTablePath().toString();
     }
 }

--- a/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxdbSourceReader.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/main/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxdbSourceReader.java
@@ -22,6 +22,7 @@ import org.apache.seatunnel.api.source.Collector;
 import org.apache.seatunnel.api.source.SourceReader;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
 import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.common.exception.CommonErrorCodeDeprecated;
 import org.apache.seatunnel.connectors.seatunnel.influxdb.client.InfluxDBClient;
 import org.apache.seatunnel.connectors.seatunnel.influxdb.config.InfluxDBConfig;
 import org.apache.seatunnel.connectors.seatunnel.influxdb.converter.InfluxDBRowConverter;
@@ -38,8 +39,11 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.net.ConnectException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 
 @Slf4j
@@ -52,6 +56,7 @@ public class InfluxdbSourceReader implements SourceReader<SeaTunnelRow, InfluxDB
     private final SeaTunnelRowType seaTunnelRowType;
 
     List<Integer> columnsIndexList;
+    private final Map<String, InfluxDBSourceTable> tables;
     private final Queue<InfluxDBSourceSplit> pendingSplits;
 
     private volatile boolean noMoreSplitsAssignment;
@@ -66,6 +71,19 @@ public class InfluxdbSourceReader implements SourceReader<SeaTunnelRow, InfluxDB
         this.context = readerContext;
         this.seaTunnelRowType = seaTunnelRowType;
         this.columnsIndexList = columnsIndexList;
+        this.tables = Collections.emptyMap();
+    }
+
+    InfluxdbSourceReader(
+            InfluxDBConfig config, Context readerContext, List<InfluxDBSourceTable> tables) {
+        this.config = config;
+        this.context = readerContext;
+        this.pendingSplits = new LinkedList<>();
+        this.seaTunnelRowType = null;
+        this.tables = new LinkedHashMap<>();
+        for (InfluxDBSourceTable table : tables) {
+            this.tables.put(table.getTableId(), table);
+        }
     }
 
     public void connect() throws ConnectException {
@@ -134,20 +152,70 @@ public class InfluxdbSourceReader implements SourceReader<SeaTunnelRow, InfluxDB
     public void notifyCheckpointComplete(long checkpointId) {}
 
     private void read(InfluxDBSourceSplit split, Collector<SeaTunnelRow> output) {
-        QueryResult queryResult = influxdb.query(new Query(split.getQuery(), config.getDatabase()));
+        InfluxDBSourceTable table = null;
+        if (!tables.isEmpty()) {
+            table = tables.get(split.getTableId());
+            if (table == null) {
+                throw new InfluxdbConnectorException(
+                        CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                        "Unknown table identity in InfluxDB split: " + split.getTableId());
+            }
+        } else if (split.getTableId() != null) {
+            throw new InfluxdbConnectorException(
+                    CommonErrorCodeDeprecated.ILLEGAL_ARGUMENT,
+                    "Cannot restore a multi-table split with a single-table configuration");
+        }
+        SeaTunnelRowType rowType =
+                table == null ? seaTunnelRowType : table.getCatalogTable().getSeaTunnelRowType();
+        String database =
+                table == null ? config.getDatabase() : table.getSourceConfig().getDatabase();
+        QueryResult queryResult = influxdb.query(new Query(split.getQuery(), database));
+        if (table != null && queryResult.hasError()) {
+            throw new InfluxdbConnectorException(
+                    CommonErrorCodeDeprecated.SQL_OPERATION_FAILED,
+                    "InfluxDB query failed for table "
+                            + table.getTableId()
+                            + ": "
+                            + queryResult.getError());
+        }
         List<QueryResult.Result> results = queryResult.getResults();
         if (CollectionUtils.isEmpty(results)) {
             log.debug("split[{}] reader influxDB query result is empty.", split.splitId());
             return;
         }
         for (QueryResult.Result result : results) {
+            if (table != null && result.hasError()) {
+                throw new InfluxdbConnectorException(
+                        CommonErrorCodeDeprecated.SQL_OPERATION_FAILED,
+                        "InfluxDB query failed for table "
+                                + table.getTableId()
+                                + ": "
+                                + result.getError());
+            }
             List<QueryResult.Series> serieList = result.getSeries();
             if (CollectionUtils.isNotEmpty(serieList)) {
                 for (QueryResult.Series series : serieList) {
+                    List<Integer> indexes = columnsIndexList;
+                    if (table != null) {
+                        indexes = new ArrayList<>(rowType.getTotalFields());
+                        for (String field : rowType.getFieldNames()) {
+                            int index = series.getColumns().indexOf(field);
+                            if (index < 0) {
+                                throw new InfluxdbConnectorException(
+                                        InfluxdbConnectorErrorCode.GET_COLUMN_INDEX_FAILED,
+                                        "Missing query column '"
+                                                + field
+                                                + "' for table "
+                                                + table.getTableId());
+                            }
+                            indexes.add(index);
+                        }
+                    }
                     for (List<Object> values : series.getValues()) {
-                        SeaTunnelRow row =
-                                InfluxDBRowConverter.convert(
-                                        values, seaTunnelRowType, columnsIndexList);
+                        SeaTunnelRow row = InfluxDBRowConverter.convert(values, rowType, indexes);
+                        if (table != null) {
+                            row.setTableId(split.getTableId());
+                        }
                         output.collect(row);
                     }
                 }

--- a/seatunnel-connectors-v2/connector-influxdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBMultiTableSourceTest.java
+++ b/seatunnel-connectors-v2/connector-influxdb/src/test/java/org/apache/seatunnel/connectors/seatunnel/influxdb/source/InfluxDBMultiTableSourceTest.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.connectors.seatunnel.influxdb.source;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+import org.apache.seatunnel.shade.org.apache.commons.lang3.tuple.Pair;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.exception.InfluxdbConnectorException;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.state.InfluxDBSourceState;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class InfluxDBMultiTableSourceTest {
+    private static final String ROOT = "url=\"http://localhost:8086\"\n";
+    private static final String TEMPERATURE =
+            "{ database=temperature, sql=\"select value from readings\", schema { table=temperature, fields { value=DOUBLE } } }";
+    private static final String ALARMS =
+            "{ database=alarms, sql=\"select active from alerts tz('Asia/Shanghai')\", schema { table=alarms, fields { active=BOOLEAN, label=STRING } } }";
+    private static final String MULTI =
+            ROOT + "tables_configs=[" + TEMPERATURE + "," + ALARMS + "]";
+
+    @Test
+    void createsIndependentCatalogTablesWithoutRootSqlOrSchema() {
+        InfluxDBSource source = source(MULTI);
+        Assertions.assertEquals(2, source.getProducedCatalogTables().size());
+        Assertions.assertEquals(
+                "temperature",
+                source.getProducedCatalogTables().get(0).getTableId().toTablePath().toString());
+        Assertions.assertEquals(
+                "alarms",
+                source.getProducedCatalogTables().get(1).getTableId().toTablePath().toString());
+        Assertions.assertEquals(
+                1, source.getProducedCatalogTables().get(0).getSeaTunnelRowType().getTotalFields());
+        Assertions.assertEquals(
+                2, source.getProducedCatalogTables().get(1).getSeaTunnelRowType().getTotalFields());
+    }
+
+    @Test
+    void acceptsSingleEntryAndSharedDatabaseDefault() {
+        Assertions.assertEquals(
+                1,
+                source(
+                                ROOT
+                                        + "database=temperature\ntables_configs=["
+                                        + TEMPERATURE.replace("database=temperature,", "")
+                                        + "]")
+                        .getProducedCatalogTables()
+                        .size());
+    }
+
+    @Test
+    void preservesLegacyRootConfiguration() throws Exception {
+        List<InfluxDBSourceSplit> splits =
+                enumerate(
+                        source(
+                                ROOT
+                                        + "database=temperature\nsql=\"select value from readings\"\nschema { fields { value=DOUBLE } }"));
+        Assertions.assertEquals(1, splits.size());
+        Assertions.assertNull(splits.get(0).getTableId());
+        Assertions.assertEquals("0", splits.get(0).splitId());
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "tables_configs=[]",
+                "tables_configs=[{ database=db, sql=\"select x from m\", schema { table=t, fields { x=INT } }, where=\"x > 0\" }]",
+                "tables_configs=[{ database=db, sql=\"select x from m\", schema.fields.x=INT }]",
+                "tables_configs=[{ database=db, sql=\" \", schema { table=t, fields.x=INT } }]",
+                "tables_configs=[{ sql=\"select x from m\", schema { table=t, fields.x=INT } }]",
+                "tables_configs=[{ database=db, sql=\"select x from m\", schema { table=t, fields.x=INT }, partition_num=2 }]",
+                "tables_configs=[{ database=db, sql=\"select x from m\", schema { table=t, fields.x=INT }, url=\"http://other:8086\" }]",
+                "tables_configs=[{ database=db, sql=\"select x from m\", schema { table=t, fields.x=INT } }, { database=other, sql=\"select x from m\", schema { table=t, fields.x=INT } }]",
+                "sql=\"select x from m\"\ntables_configs=[]",
+                "schema.fields.x=INT\ntables_configs=[]"
+            })
+    void rejectsInvalidOrAmbiguousTableConfiguration(String config) {
+        Assertions.assertThrows(OptionValidationException.class, () -> source(ROOT + config));
+    }
+
+    @Test
+    void reportsTableIndexForInvalidSchema() {
+        OptionValidationException error =
+                Assertions.assertThrows(
+                        OptionValidationException.class,
+                        () ->
+                                source(
+                                        ROOT
+                                                + "tables_configs=[{ database=db, sql=\"select x from m\", schema { fields { x=INT } } }]"));
+        Assertions.assertTrue(error.getMessage().contains("tables_configs[0]"));
+        Assertions.assertTrue(error.getMessage().contains("schema.table"));
+    }
+
+    @Test
+    void rootWhereErrorDirectsUsersToTheSqlPredicate() {
+        OptionValidationException error =
+                Assertions.assertThrows(
+                        OptionValidationException.class,
+                        () -> source(MULTI + "\nwhere=\"value > 0\""));
+        Assertions.assertTrue(error.getMessage().contains("inside that entry's sql"));
+    }
+
+    @Test
+    void optionRuleAcceptsBothModes() {
+        ConfigValidator.of(config(MULTI)).validate(new InfluxDBSourceFactory().optionRule());
+        ConfigValidator.of(
+                        config(
+                                ROOT
+                                        + "database=db\nsql=\"select x from m\"\nschema { fields { x=INT } }"))
+                .validate(new InfluxDBSourceFactory().optionRule());
+    }
+
+    @Test
+    void enumeratesEachTableWithItsOwnQueryAndRange() throws Exception {
+        String splitTable =
+                TEMPERATURE.replace(
+                        "database=temperature,",
+                        "database=temperature, lower_bound=0, upper_bound=3, partition_num=2, split_column=value,");
+        List<InfluxDBSourceSplit> splits =
+                enumerate(source(ROOT + "tables_configs=[" + splitTable + "," + ALARMS + "]"));
+        Assertions.assertEquals(3, splits.size());
+        Assertions.assertEquals(
+                3,
+                splits.stream()
+                        .map(InfluxDBSourceSplit::splitId)
+                        .collect(Collectors.toSet())
+                        .size());
+        Assertions.assertEquals(
+                2, splits.stream().filter(s -> "temperature".equals(s.getTableId())).count());
+        Assertions.assertTrue(
+                splits.stream().anyMatch(s -> s.getQuery().contains("value >= 0 and value < 2")));
+        Assertions.assertTrue(
+                splits.stream().anyMatch(s -> s.getQuery().contains("value >= 2 and value < 4")));
+        Assertions.assertTrue(
+                splits.stream()
+                        .anyMatch(
+                                s ->
+                                        "alarms".equals(s.getTableId())
+                                                && s.getQuery()
+                                                        .equals(
+                                                                "select active from alerts tz('Asia/Shanghai')")));
+    }
+
+    @Test
+    void readsEachDatabaseWithIndependentColumnsAndRoutesRows() throws Exception {
+        InfluxDB client = Mockito.mock(InfluxDB.class);
+        Mockito.when(client.query(Mockito.any(Query.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Query query = invocation.getArgument(0);
+                            if ("temperature".equals(query.getDatabase())) {
+                                return result(
+                                        Arrays.asList("time", "value"), Arrays.asList(100D, 12.5D));
+                            }
+                            Assertions.assertEquals("alarms", query.getDatabase());
+                            Assertions.assertEquals(
+                                    "select active from alerts tz('Asia/Shanghai')",
+                                    query.getCommand());
+                            return result(
+                                    Arrays.asList("time", "label", "active"),
+                                    Arrays.asList(101D, "overheat", true));
+                        });
+        SourceReader.Context context = readerContext();
+        InfluxdbSourceReader reader = reader(source(MULTI), context, client);
+        reader.addSplits(enumerate(source(MULTI)));
+        reader.handleNoMoreSplits();
+        List<SeaTunnelRow> rows = collect(reader);
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertArrayEquals(
+                new Object[] {12.5D},
+                rows.stream()
+                        .filter(r -> "temperature".equals(r.getTableId()))
+                        .findFirst()
+                        .get()
+                        .getFields());
+        Assertions.assertArrayEquals(
+                new Object[] {true, "overheat"},
+                rows.stream()
+                        .filter(r -> "alarms".equals(r.getTableId()))
+                        .findFirst()
+                        .get()
+                        .getFields());
+        Mockito.verify(context).signalNoMoreElement();
+        reader.close();
+        reader.close();
+        Mockito.verify(client).close();
+    }
+
+    @Test
+    void emptyTableDoesNotPreventReadingAnotherTable() throws Exception {
+        InfluxDB client = Mockito.mock(InfluxDB.class);
+        Mockito.when(client.query(Mockito.any(Query.class)))
+                .thenAnswer(
+                        invocation ->
+                                "temperature"
+                                                .equals(
+                                                        ((Query) invocation.getArgument(0))
+                                                                .getDatabase())
+                                        ? new QueryResult()
+                                        : result(
+                                                Arrays.asList("active", "label"),
+                                                Arrays.asList(false, "normal")));
+        InfluxdbSourceReader reader = reader(source(MULTI), readerContext(), client);
+        reader.addSplits(enumerate(source(MULTI)));
+        List<SeaTunnelRow> rows = collect(reader);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("alarms", rows.get(0).getTableId());
+    }
+
+    @Test
+    void derivesColumnOrderForEverySeries() throws Exception {
+        QueryResult first = result(Arrays.asList("value", "time"), Arrays.asList(12D, 1D));
+        QueryResult second = result(Arrays.asList("time", "value"), Arrays.asList(2D, 13D));
+        first.getResults()
+                .get(0)
+                .setSeries(
+                        Arrays.asList(
+                                first.getResults().get(0).getSeries().get(0),
+                                second.getResults().get(0).getSeries().get(0)));
+        InfluxDB client = Mockito.mock(InfluxDB.class);
+        Mockito.when(client.query(Mockito.any(Query.class))).thenReturn(first);
+        InfluxdbSourceReader reader = reader(source(MULTI), readerContext(), client);
+        reader.addSplits(
+                Collections.singletonList(
+                        new InfluxDBSourceSplit("a", "select value from readings", "temperature")));
+        List<SeaTunnelRow> rows = collect(reader);
+        Assertions.assertEquals(12D, rows.get(0).getField(0));
+        Assertions.assertEquals(13D, rows.get(1).getField(0));
+    }
+
+    @Test
+    void failsOnMissingColumnsAndServerErrors() throws Exception {
+        InfluxDB client = Mockito.mock(InfluxDB.class);
+        QueryResult error = new QueryResult();
+        error.setError("database not found");
+        QueryResult resultError = new QueryResult();
+        QueryResult.Result failed = new QueryResult.Result();
+        failed.setError("permission denied");
+        resultError.setResults(Collections.singletonList(failed));
+        for (QueryResult result :
+                Arrays.asList(
+                        result(Collections.singletonList("wrong"), Collections.singletonList(1D)),
+                        error,
+                        resultError)) {
+            Mockito.when(client.query(Mockito.any(Query.class))).thenReturn(result);
+            InfluxdbSourceReader reader = reader(source(MULTI), readerContext(), client);
+            reader.addSplits(
+                    Collections.singletonList(
+                            new InfluxDBSourceSplit(
+                                    "a", "select value from readings", "temperature")));
+            InfluxdbConnectorException exception =
+                    Assertions.assertThrows(
+                            InfluxdbConnectorException.class, () -> collect(reader));
+            Assertions.assertTrue(exception.getMessage().contains("temperature"));
+        }
+    }
+
+    @Test
+    void rejectsUnroutableRestoredSplitsBeforeQuerying() throws Exception {
+        InfluxDB client = Mockito.mock(InfluxDB.class);
+        for (String id : Arrays.asList(null, "unknown")) {
+            InfluxdbSourceReader reader = reader(source(MULTI), readerContext(), client);
+            reader.addSplits(
+                    Collections.singletonList(
+                            new InfluxDBSourceSplit("old", "select value from readings", id)));
+            Assertions.assertThrows(InfluxdbConnectorException.class, () -> collect(reader));
+        }
+        Mockito.verifyNoInteractions(client);
+    }
+
+    @Test
+    void restoresEnumeratorAndReaderStateWithTableIdentity() throws Exception {
+        InfluxDBSource source = roundTrip(source(MULTI));
+        SourceSplitEnumerator.Context<InfluxDBSourceSplit> context = enumeratorContext();
+        Mockito.when(context.registeredReaders()).thenReturn(Collections.emptySet());
+        InfluxDBSourceSplitEnumerator enumerator =
+                (InfluxDBSourceSplitEnumerator) source.createEnumerator(context);
+        enumerator.run();
+        InfluxDBSourceState state = roundTrip(enumerator.snapshotState(1));
+        InfluxDBSourceSplitEnumerator restored =
+                (InfluxDBSourceSplitEnumerator) source.restoreEnumerator(context, state);
+        restored.registerReader(0);
+        ArgumentCaptor<List<InfluxDBSourceSplit>> captor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(context).assignSplit(Mockito.eq(0), captor.capture());
+        Assertions.assertEquals(2, captor.getValue().size());
+        InfluxdbSourceReader reader = reader(source, readerContext(), Mockito.mock(InfluxDB.class));
+        reader.addSplits(captor.getValue());
+        List<InfluxDBSourceSplit> readerState = roundTrip(reader.snapshotState(2));
+        Assertions.assertEquals(2, readerState.size());
+        Assertions.assertEquals(
+                captor.getValue().get(0).getTableId(), readerState.get(0).getTableId());
+        Assertions.assertEquals(captor.getValue().get(1).getQuery(), readerState.get(1).getQuery());
+    }
+
+    @Test
+    void readsFrozenLegacyJava8Split() throws Exception {
+        byte[] bytes =
+                Base64.getDecoder()
+                        .decode(
+                                "rO0ABXNyAE1vcmcuYXBhY2hlLnNlYXR1bm5lbC5jb25uZWN0b3JzLnNlYXR1bm5lbC5pbmZsdXhkYi5zb3VyY2UuSW5mbHV4REJTb3VyY2VTcGxpdG4krO+p6M+SAgACTAAFcXVlcnl0ABJMamF2YS9sYW5nL1N0cmluZztMAAdzcGxpdElkcQB+AAF4cHQAH3NlbGVjdCB0ZW1wZXJhdHVyZSBmcm9tIHNlbnNvcnN0ABhsZWdhY3ktbWVhc3VyZW1lbnQtcmFuZ2U=");
+        try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            InfluxDBSourceSplit split = (InfluxDBSourceSplit) input.readObject();
+            Assertions.assertNull(split.getTableId());
+            Assertions.assertEquals("legacy-measurement-range", split.splitId());
+            Assertions.assertEquals("select temperature from sensors", split.getQuery());
+        }
+    }
+
+    @Test
+    void tableRangesHaveNoGapsOrOverlap() {
+        for (int[] range :
+                Arrays.asList(
+                        new int[] {0, 100, 4},
+                        new int[] {7, 7, 4},
+                        new int[] {-2, 2, 10},
+                        new int[] {Integer.MIN_VALUE, Integer.MAX_VALUE, 3})) {
+            List<Pair<Long, Long>> ranges =
+                    InfluxDBSourceSplitEnumerator.genTableSplitRanges(range[0], range[1], range[2]);
+            long next = range[0];
+            for (Pair<Long, Long> part : ranges) {
+                Assertions.assertEquals(next, part.getLeft());
+                Assertions.assertTrue(part.getRight() > part.getLeft());
+                next = part.getRight();
+            }
+            Assertions.assertEquals((long) range[1] + 1, next);
+            Assertions.assertTrue(ranges.size() <= range[2]);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "lower_bound=4, upper_bound=0, partition_num=2, split_column=value,",
+                "lower_bound=0, upper_bound=4, partition_num=-1, split_column=value,",
+                "lower_bound=0, upper_bound=4, partition_num=2, split_column=\" \","
+            })
+    void rejectsInvalidRanges(String range) {
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        source(
+                                ROOT
+                                        + "tables_configs=["
+                                        + TEMPERATURE.replace(
+                                                "database=temperature,",
+                                                "database=temperature," + range)
+                                        + "]"));
+    }
+
+    @Test
+    void restoredSplitsStillRouteAfterReorderingTables() throws Exception {
+        List<InfluxDBSourceSplit> splits = roundTrip(enumerate(source(MULTI)));
+        InfluxDB client = Mockito.mock(InfluxDB.class);
+        Mockito.when(client.query(Mockito.any(Query.class)))
+                .thenAnswer(
+                        invocation ->
+                                "temperature"
+                                                .equals(
+                                                        ((Query) invocation.getArgument(0))
+                                                                .getDatabase())
+                                        ? result(
+                                                Collections.singletonList("value"),
+                                                Collections.singletonList(8D))
+                                        : result(
+                                                Arrays.asList("active", "label"),
+                                                Arrays.asList(true, "alarm")));
+        InfluxdbSourceReader reader =
+                reader(
+                        source(ROOT + "tables_configs=[" + ALARMS + "," + TEMPERATURE + "]"),
+                        readerContext(),
+                        client);
+        reader.addSplits(splits);
+        List<SeaTunnelRow> rows = collect(reader);
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals(
+                8D,
+                rows.stream()
+                        .filter(r -> "temperature".equals(r.getTableId()))
+                        .findFirst()
+                        .get()
+                        .getField(0));
+        Assertions.assertEquals(
+                "alarm",
+                rows.stream()
+                        .filter(r -> "alarms".equals(r.getTableId()))
+                        .findFirst()
+                        .get()
+                        .getField(1));
+    }
+
+    @Test
+    void preservesUppercaseWherePredicateInTableRangeQueries() throws Exception {
+        String table =
+                TEMPERATURE
+                        .replace(
+                                "select value from readings",
+                                "SELECT value FROM readings WHERE value >= 0")
+                        .replace(
+                                "database=temperature,",
+                                "database=temperature, lower_bound=0, upper_bound=4, partition_num=2, split_column=value,");
+        List<InfluxDBSourceSplit> splits =
+                enumerate(source(ROOT + "tables_configs=[" + table + "]"));
+        Assertions.assertEquals(2, splits.size());
+        Assertions.assertTrue(
+                splits.stream().allMatch(s -> s.getQuery().contains("and ( value >= 0 )")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "select value from readings limit 1",
+                "select value from readings tz('Asia/Shanghai')",
+                "select value from readings; select value from readings",
+                "select value from readings where label = 'where'",
+                "select value from (select value from readings)"
+            })
+    void rejectsComplexRangeQueriesWithoutRestrictingUnpartitionedQueries(String sql) {
+        String table = TEMPERATURE.replace("select value from readings", sql);
+        Assertions.assertDoesNotThrow(() -> source(ROOT + "tables_configs=[" + table + "]"));
+        String range =
+                table.replace(
+                        "database=temperature,",
+                        "database=temperature, lower_bound=0, upper_bound=4, partition_num=2, split_column=value,");
+        OptionValidationException error =
+                Assertions.assertThrows(
+                        OptionValidationException.class,
+                        () -> source(ROOT + "tables_configs=[" + range + "]"));
+        Assertions.assertTrue(error.getMessage().contains("unpartitioned query"));
+    }
+
+    private static ReadonlyConfig config(String config) {
+        return ReadonlyConfig.fromConfig(ConfigFactory.parseString(config));
+    }
+
+    static InfluxDBSource source(String config) {
+        return (InfluxDBSource)
+                new InfluxDBSourceFactory()
+                        .<SeaTunnelRow, InfluxDBSourceSplit, InfluxDBSourceState>createSource(
+                                new TableSourceFactoryContext(
+                                        config(config),
+                                        InfluxDBMultiTableSourceTest.class.getClassLoader()))
+                        .createSource();
+    }
+
+    private static SourceReader.Context readerContext() {
+        SourceReader.Context context = Mockito.mock(SourceReader.Context.class);
+        Mockito.when(context.getBoundedness()).thenReturn(Boundedness.BOUNDED);
+        return context;
+    }
+
+    private static InfluxdbSourceReader reader(
+            InfluxDBSource source, SourceReader.Context context, InfluxDB client) throws Exception {
+        InfluxdbSourceReader reader = (InfluxdbSourceReader) source.createReader(context);
+        Field field = InfluxdbSourceReader.class.getDeclaredField("influxdb");
+        field.setAccessible(true);
+        field.set(reader, client);
+        return reader;
+    }
+
+    private static List<SeaTunnelRow> collect(InfluxdbSourceReader reader) {
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        reader.pollNext(
+                new Collector<SeaTunnelRow>() {
+                    public void collect(SeaTunnelRow row) {
+                        rows.add(row);
+                    }
+
+                    public Object getCheckpointLock() {
+                        return this;
+                    }
+                });
+        return rows;
+    }
+
+    private static SourceSplitEnumerator.Context<InfluxDBSourceSplit> enumeratorContext() {
+        SourceSplitEnumerator.Context<InfluxDBSourceSplit> context =
+                Mockito.mock(SourceSplitEnumerator.Context.class);
+        Mockito.when(context.currentParallelism()).thenReturn(1);
+        Mockito.when(context.registeredReaders()).thenReturn(Collections.singleton(0));
+        return context;
+    }
+
+    private static List<InfluxDBSourceSplit> enumerate(InfluxDBSource source) throws Exception {
+        SourceSplitEnumerator.Context<InfluxDBSourceSplit> context = enumeratorContext();
+        source.createEnumerator(context).run();
+        ArgumentCaptor<List<InfluxDBSourceSplit>> captor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(context).assignSplit(Mockito.eq(0), captor.capture());
+        return captor.getValue();
+    }
+
+    private static QueryResult result(List<String> columns, List<Object> values) {
+        QueryResult.Series series = new QueryResult.Series();
+        series.setColumns(columns);
+        series.setValues(Collections.singletonList(values));
+        QueryResult.Result result = new QueryResult.Result();
+        result.setSeries(Collections.singletonList(series));
+        QueryResult query = new QueryResult();
+        query.setResults(Collections.singletonList(result));
+        return query;
+    }
+
+    private static <T> T roundTrip(T value) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(value);
+        }
+        try (ObjectInputStream input =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (T) input.readObject();
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/pom.xml
@@ -26,6 +26,12 @@
     <name>SeaTunnel : E2E : Connector V2 : Influxdb</name>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-assert</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <!-- SeaTunnel connectors -->
         <dependency>
             <groupId>org.apache.seatunnel</groupId>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/influxdb/InfluxDBMultiTableSourceIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/influxdb/InfluxDBMultiTableSourceIT.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.seatunnel.e2e.connector.influxdb;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.source.SourceSplitEnumerator;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.source.InfluxDBSource;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.source.InfluxDBSourceFactory;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.source.InfluxDBSourceSplit;
+import org.apache.seatunnel.connectors.seatunnel.influxdb.state.InfluxDBSourceState;
+
+import org.influxdb.InfluxDB;
+import org.influxdb.InfluxDBFactory;
+import org.influxdb.dto.BatchPoints;
+import org.influxdb.dto.Point;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/** Exercises the connector lifecycle against InfluxDB without requiring an engine distribution. */
+class InfluxDBMultiTableSourceIT {
+    private static GenericContainer<?> server;
+    private static String url;
+    private static final String TEMPERATURE =
+            "{ database=telemetry, sql=\"SELECT value, sequence FROM readings WHERE sequence >= 0\", lower_bound=0, upper_bound=4, partition_num=3, split_column=sequence, schema { table=temperatures, fields { value=DOUBLE, sequence=INT } } }";
+    private static final String ALARMS =
+            "{ database=operations, sql=\"select label, active from alerts tz('Asia/Shanghai')\", schema { table=alerts, fields { active=BOOLEAN, label=STRING } } }";
+    private static final String EMPTY =
+            "{ database=telemetry, sql=\"select missing from empty_measurement\", schema { table=empty, fields { missing=STRING } } }";
+
+    @BeforeAll
+    static void startServer() {
+        server =
+                new GenericContainer<>(DockerImageName.parse("influxdb:1.8"))
+                        .withExposedPorts(8086)
+                        .waitingFor(Wait.forHttp("/ping").forStatusCode(204));
+        server.start();
+        url = "http://" + server.getHost() + ":" + server.getMappedPort(8086);
+        try (InfluxDB client = InfluxDBFactory.connect(url)) {
+            client.createDatabase("telemetry");
+            client.createDatabase("operations");
+            BatchPoints temperature = BatchPoints.database("telemetry").build();
+            for (int i = 0; i < 5; i++) {
+                temperature.point(
+                        Point.measurement("readings")
+                                .time(i + 1, TimeUnit.SECONDS)
+                                .addField("value", i + 0.5D)
+                                .addField("sequence", i)
+                                .build());
+            }
+            client.write(temperature);
+            client.write(
+                    BatchPoints.database("operations")
+                            .point(
+                                    Point.measurement("alerts")
+                                            .time(1, TimeUnit.SECONDS)
+                                            .addField("active", true)
+                                            .addField("label", "high")
+                                            .build())
+                            .point(
+                                    Point.measurement("alerts")
+                                            .time(2, TimeUnit.SECONDS)
+                                            .addField("active", false)
+                                            .addField("label", "normal")
+                                            .build())
+                            .build());
+        }
+    }
+
+    @AfterAll
+    static void stopServer() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Test
+    void restoresAndReadsDifferentSchemasDatabasesUnevenRangesAndEmptyTables() throws Exception {
+        InfluxDBSource original =
+                source("tables_configs=[" + TEMPERATURE + "," + ALARMS + "," + EMPTY + "]");
+        List<InfluxDBSourceSplit> splits = roundTrip(enumerate(original));
+        Assertions.assertEquals(5, splits.size());
+        InfluxDBSource reordered =
+                source("tables_configs=[" + EMPTY + "," + ALARMS + "," + TEMPERATURE + "]");
+        List<SeaTunnelRow> rows = read(reordered, splits);
+        Assertions.assertEquals(7, rows.size());
+        List<SeaTunnelRow> temperatures =
+                rows.stream()
+                        .filter(r -> "temperatures".equals(r.getTableId()))
+                        .collect(Collectors.toList());
+        Assertions.assertEquals(5, temperatures.size());
+        Assertions.assertEquals(
+                5, temperatures.stream().map(r -> r.getField(1)).distinct().count());
+        for (SeaTunnelRow row : temperatures) {
+            Assertions.assertEquals(((Integer) row.getField(1)) + 0.5D, row.getField(0));
+        }
+        List<String> alerts =
+                rows.stream()
+                        .filter(r -> "alerts".equals(r.getTableId()))
+                        .map(r -> Arrays.toString(r.getFields()))
+                        .sorted()
+                        .collect(Collectors.toList());
+        Assertions.assertEquals(Arrays.asList("[false, normal]", "[true, high]"), alerts);
+        Assertions.assertFalse(rows.stream().anyMatch(r -> "empty".equals(r.getTableId())));
+    }
+
+    @Test
+    void preservesLegacySingleTableReadAndTimezoneProbe() throws Exception {
+        InfluxDBSource source =
+                source(
+                        "database=operations\nsql=\"select label, active from alerts tz('Asia/Shanghai')\"\nschema { fields { active=BOOLEAN, label=STRING } }");
+        List<SeaTunnelRow> rows = read(source, enumerate(source));
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals(Boolean.TRUE, rows.get(0).getField(0));
+        Assertions.assertEquals("high", rows.get(0).getField(1));
+    }
+
+    private static InfluxDBSource source(String tableConfig) {
+        ReadonlyConfig config =
+                ReadonlyConfig.fromConfig(
+                        ConfigFactory.parseString("url=\"" + url + "\"\n" + tableConfig));
+        return (InfluxDBSource)
+                new InfluxDBSourceFactory()
+                        .<SeaTunnelRow, InfluxDBSourceSplit, InfluxDBSourceState>createSource(
+                                new TableSourceFactoryContext(
+                                        config, InfluxDBMultiTableSourceIT.class.getClassLoader()))
+                        .createSource();
+    }
+
+    private static List<InfluxDBSourceSplit> enumerate(InfluxDBSource source) throws Exception {
+        SourceSplitEnumerator.Context<InfluxDBSourceSplit> context =
+                Mockito.mock(SourceSplitEnumerator.Context.class);
+        Mockito.when(context.currentParallelism()).thenReturn(1);
+        Mockito.when(context.registeredReaders()).thenReturn(Collections.singleton(0));
+        try (SourceSplitEnumerator<InfluxDBSourceSplit, InfluxDBSourceState> enumerator =
+                source.createEnumerator(context)) {
+            enumerator.open();
+            enumerator.run();
+        }
+        ArgumentCaptor<List<InfluxDBSourceSplit>> captor = ArgumentCaptor.forClass(List.class);
+        Mockito.verify(context).assignSplit(Mockito.eq(0), captor.capture());
+        return captor.getValue();
+    }
+
+    private static List<SeaTunnelRow> read(InfluxDBSource source, List<InfluxDBSourceSplit> splits)
+            throws Exception {
+        SourceReader.Context context = Mockito.mock(SourceReader.Context.class);
+        Mockito.when(context.getBoundedness()).thenReturn(Boundedness.BOUNDED);
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        try (SourceReader<SeaTunnelRow, InfluxDBSourceSplit> reader =
+                source.createReader(context)) {
+            reader.open();
+            reader.addSplits(splits);
+            reader.handleNoMoreSplits();
+            reader.pollNext(
+                    new Collector<SeaTunnelRow>() {
+                        public void collect(SeaTunnelRow row) {
+                            rows.add(row);
+                        }
+
+                        public Object getCheckpointLock() {
+                            return this;
+                        }
+                    });
+        }
+        Mockito.verify(context).signalNoMoreElement();
+        return rows;
+    }
+
+    private static <T> T roundTrip(T value) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(value);
+        }
+        try (ObjectInputStream input =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (T) input.readObject();
+        }
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/influxdb/InfluxdbIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/src/test/java/org/apache/seatunnel/e2e/connector/influxdb/InfluxdbIT.java
@@ -179,6 +179,13 @@ public class InfluxdbIT extends TestSuiteBase implements TestResource {
     }
 
     @TestTemplate
+    public void testMultiTableSource(TestContainer container)
+            throws IOException, InterruptedException {
+        Container.ExecResult result = container.executeJob("/influxdb-multi-table-source.conf");
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+    }
+
+    @TestTemplate
     public void testInfluxdb(TestContainer container) throws IOException, InterruptedException {
         Container.ExecResult execResult = container.executeJob("/influxdb-to-influxdb.conf");
         Assertions.assertEquals(0, execResult.getExitCode());

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/src/test/resources/influxdb-multi-table-source.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-influxdb-e2e/src/test/resources/influxdb-multi-table-source.conf
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+source {
+  InfluxDB {
+    url = "http://influxdb-host:8086"
+    database = "test"
+    tables_configs = [
+      {
+        sql = "select c_int, c_double from source"
+        lower_bound = 0
+        upper_bound = 99
+        partition_num = 3
+        split_column = "c_int"
+        schema {
+          table = "numbers"
+          fields {
+            c_double = DOUBLE
+            c_int = INT
+          }
+        }
+      },
+      {
+        sql = "select c_string, c_boolean from source tz('Asia/Shanghai')"
+        schema {
+          table = "states"
+          fields {
+            c_boolean = BOOLEAN
+            c_string = STRING
+          }
+        }
+      }
+    ]
+  }
+}
+sink {
+  Assert {
+    rules {
+      table-names = ["numbers", "states"]
+      tables_configs = [
+        {
+          table_path = "numbers"
+          row_rules = [
+            { rule_type = MAX_ROW, rule_value = 100 },
+            { rule_type = MIN_ROW, rule_value = 100 }
+          ]
+          field_rules = [
+            {
+              field_name = c_double
+              field_type = double
+              field_value = [{ equals_to = 1.1 }]
+            }
+          ]
+        },
+        {
+          table_path = "states"
+          row_rules = [
+            { rule_type = MAX_ROW, rule_value = 100 },
+            { rule_type = MIN_ROW, rule_value = 100 }
+          ]
+          field_rules = [
+            {
+              field_name = c_boolean
+              field_type = boolean
+              field_value = [{ rule_type = NOT_NULL }]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Purpose of this pull request

Part of #10425, limited to the existing InfluxQL source connector.

Add `tables_configs` so one source can read multiple queries and databases with independent output schemas. Route splits and rows by catalog table identity, and map returned series columns to the appropriate schema.

### Does this PR introduce _any_ user-facing change?

Yes. Previously, a configuration containing only `tables_configs` failed validation because root-level query and schema configuration was required. Different queries or schemas needed separate source definitions.

Each entry now defines `sql`, `schema.table`, and `schema.fields`, with a per-table database or a shared root default. Empty results do not prevent other tables from being read. In the new mode, query errors fail the read instead of appearing as empty data.

Existing single-table configuration and legacy split deserialization are retained. New-mode integer partitions cover inclusive bounds without overlap. Partitioned entries support simple SELECT queries; complex queries, including `tz(...)`, remain available without partition options.

Switching between single-table and multi-table mode requires a fresh job. The client dependency and legacy partition behavior are unchanged.

### How was this patch tested?

- Reproduced the missing feature on unchanged code with Java 8 and Java 11.
- Passed 39 connector tests on each JDK, covering validation, column mapping, empty/error results, partition boundaries, reordered restore, and legacy splits.
- Passed two real InfluxDB 1.8.10 integration tests on each JDK, covering separate databases and schemas, uneven partitions, empty results, restored table identities, and legacy timezone queries.
- Passed the new engine E2E fixture on Zeta with Java 8 and per-table Assert checks.
- Passed scoped Spotless checks and `git diff --check`.
- Passed the full repository `mvn -o -q -DskipTests verify` build on Java 11. Tests were executed separately as listed above.

The full engine test matrix was not run locally.

### Check list

- [x] No new third-party runtime dependencies or license/notice changes.
- [x] Updated English and Chinese connector documentation.
- [x] Existing single-table configuration remains compatible; no incompatible-changes entry is required.
- [x] Added connector E2E coverage.
- [x] Existing plugin mapping, distribution registration, CI labels, and plugin configuration already cover this connector.