### PR TITLE
[Improve][Zeta] Preserve per-fork benchmark diagnostics

### DIFF
--- a/docs/en/engines/zeta/benchmark.md
+++ b/docs/en/engines/zeta/benchmark.md
@@ -326,6 +326,24 @@ Zero samples in lock mode normally means that the run did not observe lock conte
 profiler changes execution cost, use diagnostics only to locate the cause; confirm an improvement or
 regression with the unprofiled PR comparison.
 
+### Fork-level variation
+
+The normalized JSON preserves JMH `primaryMetric.rawData` as the optional `fork_samples`
+field, including fork and iteration order. The existing flattened `samples`, Score, Error
+and overall CV are unchanged. Older schema-version-1 reports without this field still render.
+
+Expand **JMH fork diagnostics** to inspect each fork's sample count, mean iteration score
+and within-fork CV. The fork-mean CV is the sample standard deviation of the unweighted
+fork means divided by their mean. This helps distinguish variation within a fork from
+shifts between forks; it is descriptive evidence, not a regression gate or a root-cause claim.
+CV is `n/a` when fewer than two observations are available or the mean is zero. Missing or
+non-finite observations do not count as stable measurements.
+
+For ABBA comparisons, diagnostics stay separate for each baseline/candidate run and retain
+the source run ID. One-fork runs can show within-fork variation, but cannot establish
+between-fork variation. Consult the original JMH JSON and profiling evidence to investigate
+the observations; changing the report does not demonstrate a production speedup.
+
 ## Research References
 
 1. Andy Georges, Dries Buytaert, and Lieven Eeckhout,

--- a/docs/zh/engines/zeta/benchmark.md
+++ b/docs/zh/engines/zeta/benchmark.md
@@ -306,6 +306,21 @@ wall-clock 和 lock 模式提供火焰图，GC 模式提供分配与回收摘要
 lock 模式显示 0 个样本通常表示本次运行未观察到锁竞争。Profiler 会改变程序执行成本，
 因此诊断结果只用于定位原因，性能提升或回退仍应由不带 Profiler 的 PR 对比确认。
 
+### Fork 级波动
+
+规范化 JSON 将 JMH 的 `primaryMetric.rawData` 保存为可选的 `fork_samples` 字段，
+保留 fork 和迭代的原始顺序。原有的扁平 `samples`、Score、Error 和整体 CV 不变；
+不含此字段的旧版 schema-version-1 报告仍可正常渲染。
+
+展开 **JMH fork diagnostics**，可以查看各 fork 的样本数、迭代得分均值和 fork 内 CV。
+fork 均值 CV 是各 fork 均值（不加权）的样本标准差除以这些均值的平均值。
+这些诊断有助于区分 fork 内波动和 fork 间偏移，但不构成回归门禁或根因结论。
+不足两个观测值或均值为零时，CV 显示为 `n/a`；缺失或非有限观测值不能当作稳定证据。
+
+ABBA 比较分别展示每次 baseline/candidate 运行的诊断，并保留源 run ID。
+单 fork 运行可分析内部波动，但无法据此判断 fork 间波动。请结合原始 JMH JSON
+和剖析证据继续调查；报告展示变化并不代表生产代码提速。
+
 ## 参考论文
 
 1. Andy Georges、Dries Buytaert、Lieven Eeckhout，

--- a/tools/benchmarks/regression_report.py
+++ b/tools/benchmarks/regression_report.py
@@ -20,6 +20,7 @@
 
 import argparse
 import json
+import math
 import pathlib
 import statistics
 
@@ -267,6 +268,64 @@ def jmh_report_lines(metrics):
     return lines
 
 
+def sample_mean_and_cv(samples):
+    """Describe available iterations without inferring stability from one sample."""
+    try:
+        values = [float(value) for value in samples]
+    except (TypeError, ValueError):
+        return None, None
+    if not values or not all(math.isfinite(value) for value in values):
+        return None, None
+    mean = statistics.mean(values)
+    cv = (
+        statistics.stdev(values) / abs(mean) * 100.0
+        if len(values) > 1 and mean != 0.0
+        else None
+    )
+    return mean, cv
+
+def jmh_fork_report_lines(metrics, context=""):
+    metrics = [
+        metric
+        for metric in metrics
+        if metric.get("kind") == "jmh" and metric.get("fork_samples")
+    ]
+    if not metrics:
+        return []
+    lines = [
+        "<details>",
+        "<summary>JMH fork diagnostics{}</summary>".format(context),
+        "",
+        "Values in each list follow the original JMH fork order. Means describe iteration "
+        "scores; within-fork CV describes variation between iterations in that fork. "
+        "Fork-mean CV describes variation between the unweighted fork means.",
+        "",
+        "CV is n/a for fewer than two observations or a zero mean. Missing or non-finite "
+        "observations are not treated as evidence of stability. These diagnostics do not "
+        "change Score, Error, overall CV, or establish a performance defect or its cause.",
+        "",
+        "| Benchmark | Parameters | Samples per fork | Fork means | Within-fork CV | Fork-mean CV | Unit |",
+        "| --- | --- | --- | --- | --- | ---: | --- |",
+    ]
+    for metric in metrics:
+        forks = metric["fork_samples"]
+        summaries = [sample_mean_and_cv(samples) for samples in forks]
+        means = [mean for mean, _ in summaries]
+        between_cv = sample_mean_and_cv(means)[1]
+        lines.append(
+            "| `{}` | `{}` | {} | {} | {} | {} | {} |".format(
+                short_benchmark_name(metric),
+                compact_params(metric.get("params", {})),
+                ", ".join(str(len(samples)) for samples in forks),
+                "; ".join(format_number(mean) for mean in means),
+                "; ".join(format_percent(cv, signed=False) for _, cv in summaries),
+                format_percent(between_cv, signed=False),
+                metric["unit"],
+            )
+        )
+    return lines + ["", "</details>"]
+
+
 def pipeline_report_lines(report, metrics):
     groups = pipeline_groups(metrics)
     if not groups:
@@ -338,7 +397,11 @@ def report_lines(report):
     ]
     jmh = [metric for metric in report["metrics"] if metric["kind"] == "jmh"]
     pipeline = [metric for metric in report["metrics"] if metric["kind"] == "pipeline"]
-    for section in (jmh_report_lines(jmh), pipeline_report_lines(report, pipeline)):
+    for section in (
+        jmh_report_lines(jmh),
+        jmh_fork_report_lines(jmh),
+        pipeline_report_lines(report, pipeline),
+    ):
         if section:
             lines.extend([""] + section)
     return lines
@@ -589,6 +652,13 @@ def comparison_lines(baselines, candidates):
     ):
         if section:
             lines.extend([""] + section)
+    for label, reports in (("Baseline", baselines), ("Candidate", candidates)):
+        for index, report in enumerate(reports, start=1):
+            run_id = report["source"].get("run_id", "unknown")
+            context = ": {} run {} ({})".format(label, index, run_id)
+            section = jmh_fork_report_lines(report["metrics"], context)
+            if section:
+                lines.extend([""] + section)
     return lines
 
 

--- a/tools/benchmarks/save_jmh_result.py
+++ b/tools/benchmarks/save_jmh_result.py
@@ -108,6 +108,7 @@ def jmh_metrics(results):
                 "params": result.get("params", {}),
                 "forks": result["forks"],
                 "samples": samples,
+                "fork_samples": primary.get("rawData", []),
             }
         )
     return metrics

--- a/tools/benchmarks/test_regression_report.py
+++ b/tools/benchmarks/test_regression_report.py
@@ -149,6 +149,67 @@ class RegressionReportTest(unittest.TestCase):
         self.assertIn("Queue.publish", markdown)
         self.assertTrue(markdown.endswith("\n"))
 
+    def test_fork_diagnostics_distinguish_within_and_between_fork_variation(self):
+        shifted = self.jmh_metric(150.0, "ops/s")
+        shifted["fork_samples"] = [[100.0, 100.0, 100.0], [200.0, 200.0, 200.0]]
+        mixed = self.jmh_metric(150.0, "ops/s")
+        mixed["fork_samples"] = [[100.0, 200.0, 100.0], [200.0, 100.0, 200.0]]
+        # Both datasets have the same overall distribution; the fork boundaries differ.
+        self.assertEqual(
+            regression_report.jmh_report_lines([shifted]),
+            regression_report.jmh_report_lines([mixed]),
+        )
+        shifted_text = "\n".join(regression_report.jmh_fork_report_lines([shifted]))
+        mixed_text = "\n".join(regression_report.jmh_fork_report_lines([mixed]))
+        self.assertIn(
+            "| 3, 3 | 100.000; 200.000 | 0.00%; 0.00% | 47.14% |", shifted_text
+        )
+        self.assertIn(
+            "| 3, 3 | 133.333; 166.667 | 43.30%; 34.64% | 15.71% |", mixed_text
+        )
+
+    def test_fork_diagnostics_do_not_invent_zero_variance_for_missing_observations(
+        self,
+    ):
+        for samples in ([], [0.0], [0.0, 0.0], [10.0], [float("nan"), 1.0]):
+            with self.subTest(samples=samples):
+                self.assertIsNone(regression_report.sample_mean_and_cv(samples)[1])
+        metric = self.jmh_metric(10.0, "ops/s")
+        metric["fork_samples"] = [[10.0], []]
+        text = "\n".join(regression_report.jmh_fork_report_lines([metric]))
+        self.assertIn("| 1, 0 | 10.000; n/a | n/a; n/a | n/a |", text)
+
+    def test_fork_mean_cv_gives_each_fork_equal_weight(self):
+        metric = self.jmh_metric(20.0, "ops/s")
+        metric["fork_samples"] = [[10.0, 10.0, 10.0], [30.0]]
+        text = "\n".join(regression_report.jmh_fork_report_lines([metric]))
+        self.assertIn("| 3, 1 | 10.000; 30.000 | 0.00%; n/a | 70.71% |", text)
+
+    def test_legacy_reports_without_fork_samples_keep_their_output(self):
+        metric = self.jmh_metric(10.0, "ops/s")
+        self.assertEqual([], regression_report.jmh_fork_report_lines([metric]))
+        self.assertNotIn(
+            "JMH fork diagnostics",
+            "\n".join(regression_report.report_lines(self.report("dev", metric))),
+        )
+
+    def test_comparison_keeps_forks_separate_for_each_source_run(self):
+        baseline = self.jmh_metric(10.0, "ops/s")
+        baseline["fork_samples"] = [[9.0, 11.0]]
+        candidate = self.jmh_metric(20.0, "ops/s")
+        candidate["fork_samples"] = [[18.0, 22.0]]
+        text = "\n".join(
+            regression_report.comparison_lines(
+                [self.report("dev", baseline), self.report("dev", baseline)],
+                [self.report("pr", candidate), self.report("pr", candidate)],
+            )
+        )
+        self.assertEqual(4, text.count("<summary>JMH fork diagnostics:"))
+        self.assertIn("Baseline run 2 (42)", text)
+        self.assertIn("Candidate run 2 (42)", text)
+        self.assertEqual(2, text.count("| 2 | 10.000 | 14.14% | n/a |"))
+        self.assertEqual(2, text.count("| 2 | 20.000 | 14.14% | n/a |"))
+
     @staticmethod
     def jmh_metric(value, unit, direction="higher"):
         return {

--- a/tools/benchmarks/test_save_jmh_result.py
+++ b/tools/benchmarks/test_save_jmh_result.py
@@ -53,6 +53,7 @@ class SaveJmhResultTest(unittest.TestCase):
             metric["name"],
         )
         self.assertEqual([90.0, 110.0, 100.0], metric["samples"])
+        self.assertEqual([[90.0, 110.0], [100.0]], metric["fork_samples"])
         self.assertEqual(10.0, metric["sample_standard_deviation"])
         self.assertEqual(0.05, metric["relative_score_error"])
         self.assertEqual("higher", metric["direction"])


### PR DESCRIPTION
### Purpose of this pull request

Refs #12086. Preserve JMH fork boundaries in normalized reports so variation within a fork can be examined separately from shifts between forks.

The normalizer adds optional `fork_samples`. Reports display sample counts, per-fork means/CVs and the CV of unweighted fork means in a collapsible table. ABBA diagnostics remain separate for each baseline/candidate run. Existing Score, Error, overall CV and comparison formulas remain unchanged.

### Does this PR introduce _any_ user-facing change?

Benchmark reports include fork diagnostics when grouped samples are available. Existing schema-version-1 reports render without inventing missing grouping. CV is unavailable for insufficient observations or a zero mean, and non-finite observations are not evidence of stability. The English and Chinese benchmark guides describe these fields and their interpretation.

This reporting contribution supports the investigation in #12086. Establishing an engine performance defect or its cause still requires controlled benchmark evidence.

### How was this patch tested?

- [Fork CI run 34440901797](https://github.com/FenjuFu/seatunnel/actions/runs/34440901797) tests the exact PR head `ab08fead8d4ad5af4e3de9db1430b6b0d6e3baf3`. The 36 benchmark-tool Python tests pass, including normalizer/reporter coverage for fork grouping, unequal fork lengths, missing/zero/non-finite observations, legacy reports and ABBA run separation.
- Java 8 and Java 11 benchmark dependency builds, module unit tests and benchmark validation pass. Spotless, code style, license headers, dead links and the website build also pass. Unrelated integration jobs are skipped by the workflow's change filters.
- Replayed the [Java 11 artifact from run 33750118527](https://github.com/apache/seatunnel/actions/runs/33750118527) against the pre-change normalizer: all 11 metrics retain every existing field exactly, and each preserves its original three groups of five samples.
- For `runningJobGrowth[initialStoredJobCount=0]`, the existing overall CV remains 14.72%. The added within-fork CVs are 11.31%, 11.09% and 20.90%; fork-mean CV is 4.04%. These values describe that archived artifact.
- Python syntax/undefined-name checks and `git diff --check` pass.

Reproduce the script tests:

```bash
python3 -m unittest discover -s tools/benchmarks -p 'test_*.py'
```

### Check list

- [x] Regression coverage for the new reporting behavior.
- [x] English and Chinese documentation updated.
- [x] Existing report fields and formulas preserved.
- [x] Matching FenjuFu noreply identity and Signed-off-by trailer verified.
