### PR TITLE
[Fix][Connector-V2] Complete connector distribution registrations

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -85,12 +85,7 @@ jobs:
             echo "No .class files found in git repository."
           fi
       - name: Check connector registration completeness
-        run: |
-          if [ -n "$GITHUB_BASE_REF" ]; then
-            python3 tools/check_connector_registration.py --base-ref "$GITHUB_BASE_REF"
-          else
-            echo "GITHUB_BASE_REF is not set (push event), skipping connector registration check."
-          fi
+        run: python3 tools/check_connector_registration.py
 
   helm-chart-check:
     name: Check Helm Chart

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -22,6 +22,7 @@
 --connectors-v2--
 connector-amazondocumentdb
 connector-amazondynamodb
+connector-aerospike
 connector-azurecosmosdb
 connector-assert
 connector-cassandra
@@ -42,6 +43,7 @@ connector-doris
 connector-elasticsearch
 connector-email
 connector-file-ftp
+connector-file-cos
 connector-file-hadoop
 connector-file-local
 connector-file-oss
@@ -71,13 +73,17 @@ connector-http-lemlist
 connector-http-myhours
 connector-http-notion
 connector-http-onesignal
+connector-http-persistiq
+connector-http-shopify
 connector-http-wechat
 connector-http-airtable
 connector-http-posthog
+connector-http-zendesk
 connector-hudi
 connector-iceberg
 connector-influxdb
 connector-iotdb
+connector-iotdb-v2
 connector-jdbc
 connector-kafka
 connector-kudu
@@ -95,6 +101,7 @@ connector-s3-redshift
 connector-sentry
 connector-slack
 connector-socket
+connector-edge-socket
 connector-starrocks
 connector-tablestore
 connector-selectdb-cloud

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -30,6 +30,7 @@ seatunnel.sink.Kafka = connector-kafka
 seatunnel.source.Http = connector-http-base
 seatunnel.sink.Http = connector-http-base
 seatunnel.sink.Feishu = connector-http-feishu
+seatunnel.sink.WeChat = connector-http-wechat
 seatunnel.source.Socket = connector-socket
 seatunnel.source.EdgeSocket = connector-edge-socket
 seatunnel.sink.Hive = connector-hive


### PR DESCRIPTION
## Purpose of this pull request

Complete the distribution registration of existing Connector V2 modules and make the CI guard validate the whole registration set.

SeaTunnel has four registration points for a standalone connector:

1. its parent Maven module list;
2. `seatunnel-dist/pom.xml`;
3. `plugin-mapping.properties` for runtime jar and isolated-dependency discovery;
4. `config/plugin_config` for `install-plugin.sh`.

All standalone connector modules are already present in `seatunnel-dist/pom.xml`, but seven artifacts were absent from `config/plugin_config` and the WeChat sink was absent from `plugin-mapping.properties`.

## What changed

| Connector | Missing registration | Effect before this change |
| --- | --- | --- |
| `connector-aerospike` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-edge-socket` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-file-cos` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-http-persistiq` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-http-shopify` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-http-zendesk` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-iotdb-v2` | `config/plugin_config` | Not downloaded by the default plugin installer |
| `connector-http-wechat` | `plugin-mapping.properties` | The `WeChat` sink jar and isolated dependencies could not be discovered by plugin name |

The connector registration CI check now runs in full-scan mode for both pull-request and push events:

```text
all connector modules
  -> parent Maven module
  -> seatunnel-dist dependency
  -> runtime plugin mapping
  -> install-plugin configuration
```

The previous `--base-ref` invocation only checked newly added top-level connector directories. It did not cover nested modules such as `connector-http/connector-http-shopify`, push events, or removal of an existing registration. A full scan takes less than one second and removes those blind spots.

## Does this PR introduce any user-facing change?

Yes. The seven connectors listed above can now be selected for download through the default `install-plugin.sh` configuration, and the WeChat sink can be resolved through the packaged plugin mapping.

No connector implementation, public API, configuration option, or dependency version is changed.

## How was this patch tested?

- `python3 tools/check_connector_registration.py`
  - `OK: All 110 all connector module(s) pass all critical registration checks.`
- `./mvnw spotless:apply`
  - all 297 reactor modules completed successfully
- `git diff --check`

The full Maven `verify` lifecycle was not run because this patch only changes distribution registration data and its lightweight CI guard.

## Check list

* [x] Code changed is covered by the connector registration checker.
* [x] No new binary dependency is introduced.
* [x] No connector behavior or user-facing option is changed.
