### PR TITLE
[Improve][Connector-V2] Add declarative validation for Druid sink options

### DIFF
--- a/docs/en/connectors/sink/Druid.md
+++ b/docs/en/connectors/sink/Druid.md
@@ -36,7 +36,7 @@ Write data to Apache Druid through the Druid indexing task API.
 |----------------|--------|----------|---------------|-------------|
 | coordinatorUrl | string | yes      | -             | Druid coordinator or router host and port. |
 | datasource     | string | yes      | -             | Druid datasource name. Supports placeholders such as `${table_name}`. |
-| batchSize      | int    | no       | 10000         | Number of rows buffered before one indexing task is submitted. |
+| batchSize      | int    | no       | 10000         | Number of rows buffered before one indexing task is submitted. Must be greater than `0`. |
 | common-options |        | no       | -             | Sink common options. |
 
 ### coordinatorUrl [string]
@@ -53,7 +53,7 @@ When the upstream source has multiple tables, you can use placeholders such as `
 
 ### batchSize [int]
 
-The number of rows buffered before SeaTunnel sends one indexing task to Druid. The default value is `10000`.
+The number of rows buffered before SeaTunnel sends one indexing task to Druid. The default value is `10000`, and the configured value must be greater than `0`.
 
 SeaTunnel also flushes the remaining buffered rows when the writer closes.
 

--- a/docs/zh/connectors/sink/Druid.md
+++ b/docs/zh/connectors/sink/Druid.md
@@ -36,7 +36,7 @@ import ChangeLog from '../changelog/connector-druid.md';
 |----------------|--------|------|--------|------|
 | coordinatorUrl | string | 是   | -      | Druid 协调器或路由节点的主机和端口。 |
 | datasource     | string | 是   | -      | Druid datasource 名称，支持 `${table_name}` 这类占位符。 |
-| batchSize      | int    | 否   | 10000  | 缓存多少行后提交一次索引任务。 |
+| batchSize      | int    | 否   | 10000  | 缓存多少行后提交一次索引任务，取值必须大于 `0`。 |
 | common-options |        | 否   | -      | Sink 通用参数。 |
 
 ### coordinatorUrl [string]
@@ -53,7 +53,7 @@ SeaTunnel 会向 `http://{coordinatorUrl}/druid/indexer/v1/task` 提交索引任
 
 ### batchSize [int]
 
-SeaTunnel 缓存多少行之后向 Druid 提交一次索引任务。默认值为 `10000`。
+SeaTunnel 缓存多少行之后向 Druid 提交一次索引任务。默认值为 `10000`，配置值必须大于 `0`。
 
 写入器关闭时，SeaTunnel 也会把剩余缓存数据提交到 Druid。
 

--- a/seatunnel-connectors-v2/connector-druid/src/main/java/org/apache/seatunnel/connectors/druid/sink/DruidSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-druid/src/main/java/org/apache/seatunnel/connectors/druid/sink/DruidSinkFactory.java
@@ -29,6 +29,9 @@ import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.greaterThan;
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+import static org.apache.seatunnel.connectors.druid.config.DruidSinkOptions.BATCH_SIZE;
 import static org.apache.seatunnel.connectors.druid.config.DruidSinkOptions.COORDINATOR_URL;
 import static org.apache.seatunnel.connectors.druid.config.DruidSinkOptions.DATASOURCE;
 
@@ -42,7 +45,9 @@ public class DruidSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(COORDINATOR_URL, DATASOURCE)
+                .required(COORDINATOR_URL, notBlank(COORDINATOR_URL))
+                .required(DATASOURCE, notBlank(DATASOURCE))
+                .optional(BATCH_SIZE, greaterThan(BATCH_SIZE, 0))
                 .optional(SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
                 .build();
     }

--- a/seatunnel-connectors-v2/connector-druid/src/test/java/org/apache/seatunnel/connectors/seatunnel/druid/DruidFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-druid/src/test/java/org/apache/seatunnel/connectors/seatunnel/druid/DruidFactoryTest.java
@@ -18,14 +18,102 @@
 
 package org.apache.seatunnel.connectors.seatunnel.druid;
 
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.druid.config.DruidSinkOptions;
 import org.apache.seatunnel.connectors.druid.sink.DruidSinkFactory;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class DruidFactoryTest {
+
+    private final OptionRule optionRule = new DruidSinkFactory().optionRule();
+
     @Test
     public void optionRuleTest() {
-        Assertions.assertNotNull((new DruidSinkFactory()).optionRule());
+        Assertions.assertNotNull(optionRule);
+    }
+
+    @Test
+    void testValidRequiredOptions() {
+        Assertions.assertDoesNotThrow(() -> validate(requiredConfig()));
+    }
+
+    @Test
+    void testMissingRequiredOptionsRejected() {
+        for (String key :
+                new String[] {
+                    DruidSinkOptions.COORDINATOR_URL.key(), DruidSinkOptions.DATASOURCE.key()
+                }) {
+            Map<String, Object> config = requiredConfig();
+            config.remove(key);
+            Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+        }
+    }
+
+    @Test
+    void testBlankRequiredOptionsRejected() {
+        for (String key :
+                new String[] {
+                    DruidSinkOptions.COORDINATOR_URL.key(), DruidSinkOptions.DATASOURCE.key()
+                }) {
+            for (String value : new String[] {"", " \t\r\n "}) {
+                Map<String, Object> config = requiredConfig();
+                config.put(key, value);
+                Assertions.assertThrows(OptionValidationException.class, () -> validate(config));
+            }
+        }
+    }
+
+    @Test
+    void testDefaultBatchSize() {
+        ReadonlyConfig config = validate(requiredConfig());
+        Assertions.assertEquals(
+                DruidSinkOptions.BATCH_SIZE_DEFAULT, config.get(DruidSinkOptions.BATCH_SIZE));
+    }
+
+    @Test
+    void testPositiveBatchSize() {
+        Assertions.assertDoesNotThrow(() -> validateBatchSize(1));
+        Assertions.assertDoesNotThrow(() -> validateBatchSize(100));
+    }
+
+    @Test
+    void testNonPositiveBatchSizeRejected() {
+        assertInvalidBatchSize(0);
+        assertInvalidBatchSize(-1);
+    }
+
+    private void assertInvalidBatchSize(int batchSize) {
+        OptionValidationException exception =
+                Assertions.assertThrows(
+                        OptionValidationException.class, () -> validateBatchSize(batchSize));
+        Assertions.assertTrue(exception.getMessage().contains(DruidSinkOptions.BATCH_SIZE.key()));
+    }
+
+    private ReadonlyConfig validateBatchSize(int batchSize) {
+        Map<String, Object> config = requiredConfig();
+        config.put(DruidSinkOptions.BATCH_SIZE.key(), batchSize);
+        return validate(config);
+    }
+
+    private ReadonlyConfig validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "DruidSink");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+        return readonlyConfig;
+    }
+
+    private Map<String, Object> requiredConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(DruidSinkOptions.COORDINATOR_URL.key(), "localhost:8888");
+        config.put(DruidSinkOptions.DATASOURCE.key(), "seatunnel");
+        return config;
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

This PR improves declarative configuration validation for the Druid sink as part of #11007.

It:

- registers the existing optional `batchSize` option in `DruidSinkFactory.optionRule()`;
- requires a configured `batchSize` to be greater than `0`;
- rejects empty or whitespace-only `coordinatorUrl` and `datasource` values;
- preserves the existing default batch size of `10000`;
- keeps the existing writer, coordinator, and ingestion behavior unchanged;
- documents the positive-value requirement in both English and Chinese.

Related to #11007.

### Does this PR introduce _any_ user-facing change?

Yes.

Previously, an explicitly configured `batchSize` was not registered in the Druid sink option rule and could be rejected during unknown-option validation. Zero and negative values were also not rejected by the factory validation rule.

After this change:

- omitted `batchSize` continues to use the default value `10000`;
- positive values are accepted;
- zero and negative values are rejected during configuration validation;
- blank required string options are rejected during configuration validation.

### How was this patch tested?

Added focused unit tests covering:

- valid required options;
- missing required options;
- empty and whitespace-only required option values;
- the default `batchSize`;
- positive `batchSize` values;
- zero and negative `batchSize` values.

No running Druid instance is required because the tests exercise factory-level option validation.

```shell
./mvnw -B -T 1 -pl :connector-druid clean verify \
  -DskipUT=false \
  -DskipIT=true \
  -Dtest=DruidFactoryTest \
  -Dlicense.skipAddThirdParty=true \
  -Dskip.ui=true \
  -Dskip.spotless=false \
  --no-snapshot-updates
```

Result:

```text
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

### Check list

* [x] No new Jar binary package is added.
* [x] English and Chinese connector documentation has been updated.
* [x] No incompatible change requiring an entry in `incompatible-changes.md` is introduced.
* [x] Existing connector metadata does not require changes because this PR does not add a new connector.