### PR TITLE
[Feature][Connector-V2] Add zendesk sink

### DIFF
--- a/config/plugin_config
+++ b/config/plugin_config
@@ -73,6 +73,7 @@ connector-http-notion
 connector-http-onesignal
 connector-http-wechat
 connector-http-airtable
+connector-http-zendesk
 connector-http-posthog
 connector-hudi
 connector-iceberg

--- a/docs/en/connectors/sink/Zendesk.md
+++ b/docs/en/connectors/sink/Zendesk.md
@@ -35,15 +35,16 @@ URL (e.g., `{"ticket": {...}}` for the tickets endpoint).
 | api_token                | String  | Yes      | -             | The Zendesk API token. See the [Zendesk API token docs](https://support.zendesk.com/hc/en-us/articles/4408889192858) for how to generate one. |
 | request_interval_ms      | int     | No       | 100           | Minimum interval in milliseconds between API requests. Default 100ms. Must be `>= 0`. |
 | rate_limit_backoff_ms    | int     | No       | 30000         | Base backoff time in milliseconds when receiving a 429 (rate limit) response. Default 30000ms. Must be `>= 0`. |
+| resource_key             | String  | No       | -             | The JSON wrapping key for the Zendesk API request body (e.g. `"ticket"`, `"user"`, `"organization"`). When set, this value is used directly instead of inferring the key from the URL path. Useful for endpoints whose plural form is not handled by the automatic inference. |
 | rate_limit_max_retries   | int     | No       | 3             | Maximum number of retries after receiving a 429 response. Default 3. Must be `>= 0`. |
 | common-options           |         | No       | -             | Sink common options. See [Sink Common Options](../common-options/sink-common-options.md). |
 
 ## Usage Notes
 
 - `api_token` is sensitive. Avoid hardcoding real tokens in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
-- The connector infers the Zendesk resource type from the URL path. For example, `/api/v2/tickets` wraps each record as `{"ticket": {...}}`, `/api/v2/users/create_or_update` wraps as `{"user": {...}}`.
+- The connector infers the Zendesk resource type from the URL path. For example, `/api/v2/tickets` wraps each record as `{"ticket": {...}}`, `/api/v2/users/create_or_update` wraps as `{"user": {...}}`. If the automatic inference produces the wrong key for a non-standard endpoint, set `resource_key` explicitly.
 - Each input record is sent as an individual API call. The connector does not use Zendesk bulk endpoints.
-- Zendesk enforces rate limits (typically 400-700 requests/minute depending on plan). The default `request_interval_ms = 100` keeps a single connector within that limit. Configure `rate_limit_backoff_ms` and `rate_limit_max_retries` to control how the connector reacts to HTTP 429 responses.
+- Zendesk enforces rate limits (typically 400-700 requests/minute depending on plan). The default `request_interval_ms = 100` keeps a single connector within that limit. When `parallelism > 1`, the connector automatically multiplies the interval by the number of parallel subtasks so that the aggregate request rate across all writers stays within the account-wide limit. Configure `rate_limit_backoff_ms` and `rate_limit_max_retries` to control how the connector reacts to HTTP 429 responses.
 - Zendesk create endpoints return HTTP 201 on success. The connector treats both 200 and 201 as success.
 
 ## Task Examples

--- a/docs/en/connectors/sink/Zendesk.md
+++ b/docs/en/connectors/sink/Zendesk.md
@@ -1,0 +1,131 @@
+import ChangeLog from '../changelog/connector-http-zendesk.md';
+
+# Zendesk
+
+> Zendesk sink connector
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Description
+
+Used to write data to the [Zendesk REST API](https://developer.zendesk.com/api-reference/). It
+authenticates with a Zendesk account email and API token (sent as an HTTP Basic `Authorization`
+header) and writes records to a Zendesk endpoint such as tickets, users, or organizations.
+
+The connector automatically wraps each record in the appropriate Zendesk resource key based on the
+URL (e.g., `{"ticket": {...}}` for the tickets endpoint).
+
+## Key Features
+
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [support multiple table write](../../introduction/concepts/connector-v2-features.md)
+- [ ] [timer flush](../../introduction/concepts/connector-v2-features.md)
+
+## Sink Options
+
+| Name                     | Type    | Required | Default Value | Description |
+|--------------------------|---------|----------|---------------|-------------|
+| url                      | String  | Yes      | -             | The Zendesk REST API endpoint to write to, for example `https://your-subdomain.zendesk.com/api/v2/tickets`. |
+| email                    | String  | Yes      | -             | The Zendesk account email used for API token authentication. It is combined with `api_token` as `{email}/token:{api_token}` and sent as an HTTP Basic `Authorization` header. |
+| api_token                | String  | Yes      | -             | The Zendesk API token. See the [Zendesk API token docs](https://support.zendesk.com/hc/en-us/articles/4408889192858) for how to generate one. |
+| request_interval_ms      | int     | No       | 100           | Minimum interval in milliseconds between API requests. Default 100ms. Must be `>= 0`. |
+| rate_limit_backoff_ms    | int     | No       | 30000         | Base backoff time in milliseconds when receiving a 429 (rate limit) response. Default 30000ms. Must be `>= 0`. |
+| rate_limit_max_retries   | int     | No       | 3             | Maximum number of retries after receiving a 429 response. Default 3. Must be `>= 0`. |
+| common-options           |         | No       | -             | Sink common options. See [Sink Common Options](../common-options/sink-common-options.md). |
+
+## Usage Notes
+
+- `api_token` is sensitive. Avoid hardcoding real tokens in shared job files. Use SeaTunnel variable substitution or your deployment secret mechanism.
+- The connector infers the Zendesk resource type from the URL path. For example, `/api/v2/tickets` wraps each record as `{"ticket": {...}}`, `/api/v2/users/create_or_update` wraps as `{"user": {...}}`.
+- Each input record is sent as an individual API call. The connector does not use Zendesk bulk endpoints.
+- Zendesk enforces rate limits (typically 400-700 requests/minute depending on plan). The default `request_interval_ms = 100` keeps a single connector within that limit. Configure `rate_limit_backoff_ms` and `rate_limit_max_retries` to control how the connector reacts to HTTP 429 responses.
+- Zendesk create endpoints return HTTP 201 on success. The connector treats both 200 and 201 as success.
+
+## Task Examples
+
+### Create Tickets
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        subject = string
+        status = string
+        priority = string
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Help me with billing", "open", "normal"]
+      },
+      {
+        kind = INSERT
+        fields = ["Cannot login", "open", "high"]
+      }
+    ]
+  }
+}
+
+sink {
+  Zendesk {
+    url = "https://your-subdomain.zendesk.com/api/v2/tickets"
+    email = "agent@example.com"
+    api_token = "${ZENDESK_API_TOKEN}"
+  }
+}
+```
+
+### Create Or Update Users
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        name = string
+        email = string
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Alice", "alice@example.com"]
+      },
+      {
+        kind = INSERT
+        fields = ["Bob", "bob@example.com"]
+      }
+    ]
+  }
+}
+
+sink {
+  Zendesk {
+    url = "https://your-subdomain.zendesk.com/api/v2/users/create_or_update"
+    email = "agent@example.com"
+    api_token = "${ZENDESK_API_TOKEN}"
+    request_interval_ms = 100
+  }
+}
+```
+
+## Changelog
+
+<ChangeLog />

--- a/docs/zh/connectors/sink/Zendesk.md
+++ b/docs/zh/connectors/sink/Zendesk.md
@@ -32,15 +32,16 @@ import ChangeLog from '../changelog/connector-http-zendesk.md';
 | api_token                | String  | 是   | -      | Zendesk API 令牌。参见 [Zendesk API 令牌文档](https://support.zendesk.com/hc/en-us/articles/4408889192858) 了解如何生成。 |
 | request_interval_ms      | int     | 否   | 100    | API 请求之间的最小间隔（毫秒）。默认 100ms。必须 `>= 0`。 |
 | rate_limit_backoff_ms    | int     | 否   | 30000  | 收到 429（速率限制）响应时的基础退避时间（毫秒）。默认 30000ms。必须 `>= 0`。 |
+| resource_key             | String  | 否   | -      | Zendesk API 请求体的 JSON 包装键（如 `"ticket"`、`"user"`、`"organization"`）。设置后将直接使用该值，而不从 URL 路径自动推断。适用于自动推断无法正确处理的端点。 |
 | rate_limit_max_retries   | int     | 否   | 3      | 收到 429 响应后的最大重试次数。默认 3。必须 `>= 0`。 |
 | common-options           |         | 否   | -      | Sink 通用选项。参见 [Sink 通用选项](../common-options/sink-common-options.md)。 |
 
 ## 使用说明
 
 - `api_token` 是敏感信息。避免在共享的作业文件中硬编码真实令牌。请使用 SeaTunnel 变量替换或部署密钥机制。
-- 连接器从 URL 路径推断 Zendesk 资源类型。例如，`/api/v2/tickets` 将每条记录包装为 `{"ticket": {...}}`，`/api/v2/users/create_or_update` 包装为 `{"user": {...}}`。
+- 连接器从 URL 路径推断 Zendesk 资源类型。例如，`/api/v2/tickets` 将每条记录包装为 `{"ticket": {...}}`，`/api/v2/users/create_or_update` 包装为 `{"user": {...}}`。如果自动推断对非标准端点产生了错误的键，可以通过 `resource_key` 显式指定。
 - 每条输入记录作为单独的 API 调用发送。连接器不使用 Zendesk 批量端点。
-- Zendesk 有速率限制（通常每分钟 400-700 个请求，取决于计划）。默认 `request_interval_ms = 100` 使单个连接器保持在该限制之内。配置 `rate_limit_backoff_ms` 和 `rate_limit_max_retries` 来控制连接器对 HTTP 429 响应的反应。
+- Zendesk 有速率限制（通常每分钟 400-700 个请求，取决于计划）。默认 `request_interval_ms = 100` 使单个连接器保持在该限制之内。当 `parallelism > 1` 时，连接器会自动将间隔乘以并行子任务数，确保所有 writer 的总请求速率保持在账户级别限制之内。配置 `rate_limit_backoff_ms` 和 `rate_limit_max_retries` 来控制连接器对 HTTP 429 响应的反应。
 - Zendesk 创建端点在成功时返回 HTTP 201。连接器将 200 和 201 都视为成功。
 
 ## 任务示例

--- a/docs/zh/connectors/sink/Zendesk.md
+++ b/docs/zh/connectors/sink/Zendesk.md
@@ -1,0 +1,128 @@
+import ChangeLog from '../changelog/connector-http-zendesk.md';
+
+# Zendesk
+
+> Zendesk sink 连接器
+
+## 支持的引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 描述
+
+用于向 [Zendesk REST API](https://developer.zendesk.com/api-reference/) 写入数据。使用 Zendesk 账户邮箱和 API 令牌进行认证（以 HTTP Basic `Authorization` 头发送），将记录写入 Zendesk 的端点，如工单（tickets）、用户（users）或组织（organizations）。
+
+连接器会根据 URL 自动将每条记录包装在相应的 Zendesk 资源键中（例如，对于工单端点包装为 `{"ticket": {...}}`）。
+
+## 主要特性
+
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [ ] [cdc](../../introduction/concepts/connector-v2-features.md)
+- [ ] [支持多表写入](../../introduction/concepts/connector-v2-features.md)
+- [ ] [定时刷新](../../introduction/concepts/connector-v2-features.md)
+
+## Sink 选项
+
+| 名称                     | 类型    | 必填 | 默认值 | 描述 |
+|--------------------------|---------|------|--------|------|
+| url                      | String  | 是   | -      | 要写入的 Zendesk REST API 端点，例如 `https://your-subdomain.zendesk.com/api/v2/tickets`。 |
+| email                    | String  | 是   | -      | 用于 API 令牌认证的 Zendesk 账户邮箱。与 `api_token` 组合为 `{email}/token:{api_token}`，作为 HTTP Basic `Authorization` 头发送。 |
+| api_token                | String  | 是   | -      | Zendesk API 令牌。参见 [Zendesk API 令牌文档](https://support.zendesk.com/hc/en-us/articles/4408889192858) 了解如何生成。 |
+| request_interval_ms      | int     | 否   | 100    | API 请求之间的最小间隔（毫秒）。默认 100ms。必须 `>= 0`。 |
+| rate_limit_backoff_ms    | int     | 否   | 30000  | 收到 429（速率限制）响应时的基础退避时间（毫秒）。默认 30000ms。必须 `>= 0`。 |
+| rate_limit_max_retries   | int     | 否   | 3      | 收到 429 响应后的最大重试次数。默认 3。必须 `>= 0`。 |
+| common-options           |         | 否   | -      | Sink 通用选项。参见 [Sink 通用选项](../common-options/sink-common-options.md)。 |
+
+## 使用说明
+
+- `api_token` 是敏感信息。避免在共享的作业文件中硬编码真实令牌。请使用 SeaTunnel 变量替换或部署密钥机制。
+- 连接器从 URL 路径推断 Zendesk 资源类型。例如，`/api/v2/tickets` 将每条记录包装为 `{"ticket": {...}}`，`/api/v2/users/create_or_update` 包装为 `{"user": {...}}`。
+- 每条输入记录作为单独的 API 调用发送。连接器不使用 Zendesk 批量端点。
+- Zendesk 有速率限制（通常每分钟 400-700 个请求，取决于计划）。默认 `request_interval_ms = 100` 使单个连接器保持在该限制之内。配置 `rate_limit_backoff_ms` 和 `rate_limit_max_retries` 来控制连接器对 HTTP 429 响应的反应。
+- Zendesk 创建端点在成功时返回 HTTP 201。连接器将 200 和 201 都视为成功。
+
+## 任务示例
+
+### 创建工单
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        subject = string
+        status = string
+        priority = string
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["帮我处理账单问题", "open", "normal"]
+      },
+      {
+        kind = INSERT
+        fields = ["无法登录", "open", "high"]
+      }
+    ]
+  }
+}
+
+sink {
+  Zendesk {
+    url = "https://your-subdomain.zendesk.com/api/v2/tickets"
+    email = "agent@example.com"
+    api_token = "${ZENDESK_API_TOKEN}"
+  }
+}
+```
+
+### 创建或更新用户
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+
+source {
+  FakeSource {
+    schema = {
+      fields {
+        name = string
+        email = string
+      }
+    }
+    rows = [
+      {
+        kind = INSERT
+        fields = ["Alice", "alice@example.com"]
+      },
+      {
+        kind = INSERT
+        fields = ["Bob", "bob@example.com"]
+      }
+    ]
+  }
+}
+
+sink {
+  Zendesk {
+    url = "https://your-subdomain.zendesk.com/api/v2/users/create_or_update"
+    email = "agent@example.com"
+    api_token = "${ZENDESK_API_TOKEN}"
+    request_interval_ms = 100
+  }
+}
+```
+
+## 更新日志
+
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -109,6 +109,7 @@ seatunnel.source.Lemlist = connector-http-lemlist
 seatunnel.source.Klaviyo = connector-http-klaviyo
 seatunnel.source.Shopify = connector-http-shopify
 seatunnel.source.Zendesk = connector-http-zendesk
+seatunnel.sink.Zendesk = connector-http-zendesk
 seatunnel.source.Stripe = connector-http-stripe
 seatunnel.sink.Slack = connector-slack
 seatunnel.source.OneSignal = connector-http-onesignal

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/config/ZendeskConfig.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/config/ZendeskConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.zendesk.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+import org.apache.seatunnel.connectors.seatunnel.http.config.HttpCommonOptions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ZendeskConfig extends HttpCommonOptions {
+
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BASIC = "Basic ";
+    public static final String ACCEPT = "Accept";
+    public static final String CONTENT_TYPE = "Content-Type";
+    public static final String APPLICATION_JSON = "application/json";
+
+    public static final Option<String> EMAIL =
+            Options.key("email")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Zendesk account email used for API token authentication");
+
+    public static final Option<String> API_TOKEN =
+            Options.key("api_token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Zendesk API token");
+
+    public static final Option<Integer> REQUEST_INTERVAL_MS =
+            Options.key("request_interval_ms")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription(
+                            "Minimum interval in milliseconds between Zendesk API requests, must be >= 0.");
+
+    public static final Option<Integer> RATE_LIMIT_BACKOFF_MS =
+            Options.key("rate_limit_backoff_ms")
+                    .intType()
+                    .defaultValue(30000)
+                    .withDescription(
+                            "Base backoff time in milliseconds when Zendesk returns 429, must be >= 0.");
+
+    public static final Option<Integer> RATE_LIMIT_MAX_RETRIES =
+            Options.key("rate_limit_max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Maximum retries after receiving Zendesk 429 responses, must be >= 0.");
+
+    public static Map<String, String> buildAuthHeaders(
+            String email, String apiToken, Map<String, String> existingHeaders) {
+        Map<String, String> headers =
+                Optional.ofNullable(existingHeaders).map(HashMap::new).orElse(new HashMap<>());
+        String credentials = email + "/token:" + apiToken;
+        String encoded =
+                Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        headers.put(AUTHORIZATION, BASIC + encoded);
+        headers.put(ACCEPT, APPLICATION_JSON);
+        headers.put(CONTENT_TYPE, APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSink.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSink.java
@@ -26,6 +26,7 @@ import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
 import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSimpleSink;
 import org.apache.seatunnel.connectors.seatunnel.http.config.HttpParameter;
 import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
+import org.apache.seatunnel.connectors.seatunnel.zendesk.sink.config.ZendeskSinkOptions;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -36,6 +37,7 @@ public class ZendeskSink extends AbstractSimpleSink<SeaTunnelRow, Void>
     private final CatalogTable catalogTable;
     private final SeaTunnelRowType seaTunnelRowType;
     private final HttpParameter httpParameter;
+    private final String resourceKey;
     private final int requestIntervalMs;
     private final int rateLimitBackoffMs;
     private final int rateLimitMaxRetries;
@@ -52,6 +54,7 @@ public class ZendeskSink extends AbstractSimpleSink<SeaTunnelRow, Void>
         this.httpParameter.setUrl(url);
         this.httpParameter.setHeaders(ZendeskConfig.buildAuthHeaders(email, apiToken, null));
 
+        this.resourceKey = pluginConfig.getOptional(ZendeskSinkOptions.RESOURCE_KEY).orElse(null);
         this.requestIntervalMs = pluginConfig.get(ZendeskConfig.REQUEST_INTERVAL_MS);
         this.rateLimitBackoffMs = pluginConfig.get(ZendeskConfig.RATE_LIMIT_BACKOFF_MS);
         this.rateLimitMaxRetries = pluginConfig.get(ZendeskConfig.RATE_LIMIT_MAX_RETRIES);
@@ -67,9 +70,11 @@ public class ZendeskSink extends AbstractSimpleSink<SeaTunnelRow, Void>
         return new ZendeskSinkWriter(
                 seaTunnelRowType,
                 httpParameter,
+                resourceKey,
                 requestIntervalMs,
                 rateLimitBackoffMs,
-                rateLimitMaxRetries);
+                rateLimitMaxRetries,
+                context.getNumberOfParallelSubtasks());
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSink.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSink.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.zendesk.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SinkWriter;
+import org.apache.seatunnel.api.sink.SupportMultiTableSink;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSimpleSink;
+import org.apache.seatunnel.connectors.seatunnel.http.config.HttpParameter;
+import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class ZendeskSink extends AbstractSimpleSink<SeaTunnelRow, Void>
+        implements SupportMultiTableSink {
+
+    private final CatalogTable catalogTable;
+    private final SeaTunnelRowType seaTunnelRowType;
+    private final HttpParameter httpParameter;
+    private final int requestIntervalMs;
+    private final int rateLimitBackoffMs;
+    private final int rateLimitMaxRetries;
+
+    public ZendeskSink(ReadonlyConfig pluginConfig, CatalogTable catalogTable) {
+        this.catalogTable = catalogTable;
+        this.seaTunnelRowType = catalogTable.getSeaTunnelRowType();
+
+        String url = pluginConfig.get(ZendeskConfig.URL);
+        String email = pluginConfig.get(ZendeskConfig.EMAIL);
+        String apiToken = pluginConfig.get(ZendeskConfig.API_TOKEN);
+
+        this.httpParameter = new HttpParameter();
+        this.httpParameter.setUrl(url);
+        this.httpParameter.setHeaders(ZendeskConfig.buildAuthHeaders(email, apiToken, null));
+
+        this.requestIntervalMs = pluginConfig.get(ZendeskConfig.REQUEST_INTERVAL_MS);
+        this.rateLimitBackoffMs = pluginConfig.get(ZendeskConfig.RATE_LIMIT_BACKOFF_MS);
+        this.rateLimitMaxRetries = pluginConfig.get(ZendeskConfig.RATE_LIMIT_MAX_RETRIES);
+    }
+
+    @Override
+    public String getPluginName() {
+        return "Zendesk";
+    }
+
+    @Override
+    public ZendeskSinkWriter createWriter(SinkWriter.Context context) throws IOException {
+        return new ZendeskSinkWriter(
+                seaTunnelRowType,
+                httpParameter,
+                requestIntervalMs,
+                rateLimitBackoffMs,
+                rateLimitMaxRetries);
+    }
+
+    @Override
+    public Optional<CatalogTable> getWriteCatalogTable() {
+        return Optional.ofNullable(catalogTable);
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkFactory.java
@@ -24,6 +24,7 @@ import org.apache.seatunnel.api.table.factory.Factory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactory;
 import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
 import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
+import org.apache.seatunnel.connectors.seatunnel.zendesk.sink.config.ZendeskSinkOptions;
 
 import com.google.auto.service.AutoService;
 
@@ -40,6 +41,7 @@ public class ZendeskSinkFactory implements TableSinkFactory {
         return OptionRule.builder()
                 .required(ZendeskConfig.URL, ZendeskConfig.EMAIL, ZendeskConfig.API_TOKEN)
                 .optional(
+                        ZendeskSinkOptions.RESOURCE_KEY,
                         ZendeskConfig.REQUEST_INTERVAL_MS,
                         ZendeskConfig.RATE_LIMIT_BACKOFF_MS,
                         ZendeskConfig.RATE_LIMIT_MAX_RETRIES,

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.zendesk.sink;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
+import org.apache.seatunnel.api.table.connector.TableSink;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactory;
+import org.apache.seatunnel.api.table.factory.TableSinkFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
+
+import com.google.auto.service.AutoService;
+
+@AutoService(Factory.class)
+public class ZendeskSinkFactory implements TableSinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "Zendesk";
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(ZendeskConfig.URL, ZendeskConfig.EMAIL, ZendeskConfig.API_TOKEN)
+                .optional(
+                        ZendeskConfig.REQUEST_INTERVAL_MS,
+                        ZendeskConfig.RATE_LIMIT_BACKOFF_MS,
+                        ZendeskConfig.RATE_LIMIT_MAX_RETRIES,
+                        SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)
+                .build();
+    }
+
+    @Override
+    public TableSink createSink(TableSinkFactoryContext context) {
+        return () -> new ZendeskSink(context.getOptions(), context.getCatalogTable());
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriter.java
@@ -62,16 +62,23 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
     public ZendeskSinkWriter(
             SeaTunnelRowType seaTunnelRowType,
             HttpParameter httpParameter,
+            String resourceKeyOverride,
             int requestIntervalMs,
             int rateLimitBackoffMs,
-            int rateLimitMaxRetries) {
+            int rateLimitMaxRetries,
+            int numberOfParallelSubtasks) {
         this.url = httpParameter.getUrl();
         this.headers = httpParameter.getHeaders();
         this.httpClient = new HttpClientProvider(httpParameter);
         this.serializationSchema = new JsonSerializationSchema(seaTunnelRowType);
         this.objectMapper = serializationSchema.getMapper();
-        this.resourceKey = inferResourceKey(this.url);
-        this.requestIntervalMs = Math.max(0, requestIntervalMs);
+        if (resourceKeyOverride != null && resourceKeyOverride.trim().isEmpty()) {
+            throw new IllegalArgumentException("resource_key must not be blank");
+        }
+        this.resourceKey =
+                resourceKeyOverride != null ? resourceKeyOverride : inferResourceKey(this.url);
+        int parallelism = Math.max(1, numberOfParallelSubtasks);
+        this.requestIntervalMs = Math.max(0, requestIntervalMs) * parallelism;
         this.rateLimitBackoffMs = Math.max(0, rateLimitBackoffMs);
         this.rateLimitMaxRetries = Math.max(0, rateLimitMaxRetries);
         this.lastRequestTimeMillis = 0L;
@@ -83,6 +90,7 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         sendWithRateLimitRetry(body);
     }
 
+    /** Wraps the serialized row in a Zendesk resource key, e.g. {"ticket": {...}}. */
     @VisibleForTesting
     String buildRequestBody(SeaTunnelRow row) throws IOException {
         byte[] serialized = serializationSchema.serialize(row);
@@ -97,6 +105,7 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         return objectMapper.writeValueAsString(root);
     }
 
+    /** Extracts the first path segment after /api/v2/ and singularizes it (tickets → ticket). */
     @VisibleForTesting
     static String inferResourceKey(String url) {
         if (url == null) {
@@ -127,14 +136,21 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         }
 
         String resource = segments[0];
-        if (resource.endsWith("ies")) {
+        if (resource.endsWith("sses")) {
+            return resource.substring(0, resource.length() - 2);
+        } else if (resource.endsWith("ies")) {
             return resource.substring(0, resource.length() - 3) + "y";
+        } else if (resource.endsWith("ses")
+                || resource.endsWith("xes")
+                || resource.endsWith("zes")) {
+            return resource.substring(0, resource.length() - 2);
         } else if (resource.endsWith("s")) {
             return resource.substring(0, resource.length() - 1);
         }
         return resource;
     }
 
+    /** POSTs body to Zendesk, retrying with exponential backoff on HTTP 429. */
     private void sendWithRateLimitRetry(String body) throws IOException {
         int retryCount = 0;
         while (true) {
@@ -163,8 +179,8 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
                 }
                 throw new IOException(
                         String.format(
-                                "Zendesk API request failed, status code:[%s], content:[%s]",
-                                response.getCode(), response.getContent()));
+                                "Zendesk API request failed, url:[%s], status code:[%s], content:[%s]",
+                                url, response.getCode(), response.getContent()));
             } catch (IOException e) {
                 throw e;
             } catch (Exception e) {
@@ -173,6 +189,7 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         }
     }
 
+    /** Throttles requests to respect requestIntervalMs between consecutive calls. */
     private void waitForRequestSlot() {
         if (requestIntervalMs <= 0) {
             return;
@@ -190,26 +207,16 @@ public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
         lastRequestTimeMillis = System.currentTimeMillis();
     }
 
+    /** Equal jitter backoff: half the exponential ceiling plus random jitter in [0, half]. */
     @VisibleForTesting
     long calculateBackoffMillis(int retryCount) {
         if (rateLimitBackoffMs <= 0) {
             return 0L;
         }
         long exponential = 1L << Math.min(20, Math.max(0, retryCount - 1));
-        long waitMillis = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
-
-        long extra = Math.min(waitMillis, MAX_BACKOFF_MILLIS - waitMillis);
-        if (extra > 0) {
-            return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
-        }
-
-        long floor = waitMillis / 2;
-        for (long scheduled = rateLimitBackoffMs; scheduled < MAX_BACKOFF_MILLIS; scheduled <<= 1) {
-            if (scheduled > floor) {
-                floor = scheduled;
-            }
-        }
-        return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
+        long ceiling = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
+        long half = ceiling / 2;
+        return half + ThreadLocalRandom.current().nextLong(half + 1);
     }
 
     @Override

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriter.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriter.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.zendesk.sink;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.seatunnel.shade.com.google.common.annotations.VisibleForTesting;
+
+import org.apache.seatunnel.api.sink.SupportMultiTableSinkWriter;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.common.sink.AbstractSinkWriter;
+import org.apache.seatunnel.connectors.seatunnel.http.client.HttpClientProvider;
+import org.apache.seatunnel.connectors.seatunnel.http.client.HttpResponse;
+import org.apache.seatunnel.connectors.seatunnel.http.config.HttpParameter;
+import org.apache.seatunnel.format.json.JsonSerializationSchema;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+public class ZendeskSinkWriter extends AbstractSinkWriter<SeaTunnelRow, Void>
+        implements SupportMultiTableSinkWriter<Void> {
+
+    private static final int STATUS_OK = 200;
+    private static final int STATUS_CREATED = 201;
+    private static final int STATUS_TOO_MANY_REQUESTS = 429;
+    private static final long MAX_BACKOFF_MILLIS = 300000L;
+
+    private final HttpClientProvider httpClient;
+    private final String url;
+    private final Map<String, String> headers;
+    private final JsonSerializationSchema serializationSchema;
+    private final ObjectMapper objectMapper;
+    private final String resourceKey;
+    private final int requestIntervalMs;
+    private final int rateLimitBackoffMs;
+    private final int rateLimitMaxRetries;
+    private long lastRequestTimeMillis;
+
+    public ZendeskSinkWriter(
+            SeaTunnelRowType seaTunnelRowType,
+            HttpParameter httpParameter,
+            int requestIntervalMs,
+            int rateLimitBackoffMs,
+            int rateLimitMaxRetries) {
+        this.url = httpParameter.getUrl();
+        this.headers = httpParameter.getHeaders();
+        this.httpClient = new HttpClientProvider(httpParameter);
+        this.serializationSchema = new JsonSerializationSchema(seaTunnelRowType);
+        this.objectMapper = serializationSchema.getMapper();
+        this.resourceKey = inferResourceKey(this.url);
+        this.requestIntervalMs = Math.max(0, requestIntervalMs);
+        this.rateLimitBackoffMs = Math.max(0, rateLimitBackoffMs);
+        this.rateLimitMaxRetries = Math.max(0, rateLimitMaxRetries);
+        this.lastRequestTimeMillis = 0L;
+    }
+
+    @Override
+    public void write(SeaTunnelRow element) throws IOException {
+        String body = buildRequestBody(element);
+        sendWithRateLimitRetry(body);
+    }
+
+    @VisibleForTesting
+    String buildRequestBody(SeaTunnelRow row) throws IOException {
+        byte[] serialized = serializationSchema.serialize(row);
+        JsonNode fieldsNode = objectMapper.readTree(serialized);
+
+        if (resourceKey == null) {
+            return objectMapper.writeValueAsString(fieldsNode);
+        }
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set(resourceKey, fieldsNode);
+        return objectMapper.writeValueAsString(root);
+    }
+
+    @VisibleForTesting
+    static String inferResourceKey(String url) {
+        if (url == null) {
+            return null;
+        }
+
+        String path = url;
+        int queryIdx = path.indexOf('?');
+        if (queryIdx >= 0) {
+            path = path.substring(0, queryIdx);
+        }
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        if (path.endsWith(".json")) {
+            path = path.substring(0, path.length() - 5);
+        }
+
+        int v2Idx = path.indexOf("/api/v2/");
+        if (v2Idx < 0) {
+            return null;
+        }
+
+        String afterV2 = path.substring(v2Idx + "/api/v2/".length());
+        String[] segments = afterV2.split("/");
+        if (segments.length == 0 || segments[0].isEmpty()) {
+            return null;
+        }
+
+        String resource = segments[0];
+        if (resource.endsWith("ies")) {
+            return resource.substring(0, resource.length() - 3) + "y";
+        } else if (resource.endsWith("s")) {
+            return resource.substring(0, resource.length() - 1);
+        }
+        return resource;
+    }
+
+    private void sendWithRateLimitRetry(String body) throws IOException {
+        int retryCount = 0;
+        while (true) {
+            waitForRequestSlot();
+            try {
+                HttpResponse response = httpClient.doPost(url, headers, body);
+                if (STATUS_OK == response.getCode() || STATUS_CREATED == response.getCode()) {
+                    return;
+                }
+                if (response.getCode() == STATUS_TOO_MANY_REQUESTS
+                        && retryCount < rateLimitMaxRetries) {
+                    retryCount++;
+                    long backoffMillis = calculateBackoffMillis(retryCount);
+                    log.warn(
+                            "Zendesk API rate limit reached, retry {}/{} after {} ms",
+                            retryCount,
+                            rateLimitMaxRetries,
+                            backoffMillis);
+                    try {
+                        Thread.sleep(backoffMillis);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                    continue;
+                }
+                throw new IOException(
+                        String.format(
+                                "Zendesk API request failed, status code:[%s], content:[%s]",
+                                response.getCode(), response.getContent()));
+            } catch (IOException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new IOException("Failed to send Zendesk API request", e);
+            }
+        }
+    }
+
+    private void waitForRequestSlot() {
+        if (requestIntervalMs <= 0) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        long elapsed = now - lastRequestTimeMillis;
+        if (elapsed < requestIntervalMs) {
+            try {
+                Thread.sleep(requestIntervalMs - elapsed);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+        lastRequestTimeMillis = System.currentTimeMillis();
+    }
+
+    @VisibleForTesting
+    long calculateBackoffMillis(int retryCount) {
+        if (rateLimitBackoffMs <= 0) {
+            return 0L;
+        }
+        long exponential = 1L << Math.min(20, Math.max(0, retryCount - 1));
+        long waitMillis = Math.min(rateLimitBackoffMs * exponential, MAX_BACKOFF_MILLIS);
+
+        long extra = Math.min(waitMillis, MAX_BACKOFF_MILLIS - waitMillis);
+        if (extra > 0) {
+            return waitMillis + ThreadLocalRandom.current().nextLong(extra + 1);
+        }
+
+        long floor = waitMillis / 2;
+        for (long scheduled = rateLimitBackoffMs; scheduled < MAX_BACKOFF_MILLIS; scheduled <<= 1) {
+            if (scheduled > floor) {
+                floor = scheduled;
+            }
+        }
+        return waitMillis - ThreadLocalRandom.current().nextLong(waitMillis - floor + 1);
+    }
+
+    @Override
+    public Optional<Void> prepareCommit() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (Objects.nonNull(httpClient)) {
+            httpClient.close();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/config/ZendeskSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/config/ZendeskSinkOptions.java
@@ -17,6 +17,19 @@
 
 package org.apache.seatunnel.connectors.seatunnel.zendesk.sink.config;
 
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
 import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
 
-public class ZendeskSinkOptions extends ZendeskConfig {}
+public class ZendeskSinkOptions extends ZendeskConfig {
+
+    public static final Option<String> RESOURCE_KEY =
+            Options.key("resource_key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The JSON wrapping key for the Zendesk API request body "
+                                    + "(e.g. \"ticket\", \"user\", \"organization\"). "
+                                    + "When set, this value is used directly instead of "
+                                    + "inferring the key from the URL path.");
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/config/ZendeskSinkOptions.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/main/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/config/ZendeskSinkOptions.java
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.zendesk.source.config;
+package org.apache.seatunnel.connectors.seatunnel.zendesk.sink.config;
 
 import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
 
-public class ZendeskSourceOptions extends ZendeskConfig {}
+public class ZendeskSinkOptions extends ZendeskConfig {}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/test/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/test/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkFactoryTest.java
@@ -15,8 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.seatunnel.connectors.seatunnel.zendesk.source.config;
+package org.apache.seatunnel.connectors.seatunnel.zendesk.sink;
 
-import org.apache.seatunnel.connectors.seatunnel.zendesk.config.ZendeskConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-public class ZendeskSourceOptions extends ZendeskConfig {}
+class ZendeskSinkFactoryTest {
+
+    @Test
+    void optionRule() {
+        Assertions.assertNotNull(new ZendeskSinkFactory().optionRule());
+    }
+
+    @Test
+    void factoryIdentifier() {
+        Assertions.assertEquals("Zendesk", new ZendeskSinkFactory().factoryIdentifier());
+    }
+}

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/test/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/test/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriterTest.java
@@ -64,6 +64,11 @@ public class ZendeskSinkWriterTest {
     }
 
     private ZendeskSinkWriter createWriter(String url) throws Exception {
+        return createWriter(url, null, 1);
+    }
+
+    private ZendeskSinkWriter createWriter(String url, String resourceKeyOverride, int parallelism)
+            throws Exception {
         HttpParameter param = new HttpParameter();
         param.setUrl(url);
         Map<String, String> headers = new HashMap<>();
@@ -71,7 +76,8 @@ public class ZendeskSinkWriterTest {
         headers.put("Content-Type", "application/json");
         param.setHeaders(headers);
 
-        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 0, 3);
+        ZendeskSinkWriter writer =
+                new ZendeskSinkWriter(rowType, param, resourceKeyOverride, 0, 0, 3, parallelism);
 
         Field field = ZendeskSinkWriter.class.getDeclaredField("httpClient");
         field.setAccessible(true);
@@ -151,6 +157,32 @@ public class ZendeskSinkWriterTest {
     }
 
     @Test
+    public void testInferResourceKeyAddresses() {
+        Assertions.assertEquals(
+                "address",
+                ZendeskSinkWriter.inferResourceKey("https://example.zendesk.com/api/v2/addresses"));
+    }
+
+    @Test
+    public void testResourceKeyOverrideBypassesInference() throws Exception {
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(201, "{}"));
+
+        ZendeskSinkWriter writer =
+                createWriter(
+                        "https://example.zendesk.com/api/v2/custom_endpoint", "my_resource", 1);
+        writer.write(new SeaTunnelRow(new Object[] {"Test", "open"}));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(httpClient, times(1)).doPost(anyString(), any(), bodyCaptor.capture());
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bodyCaptor.getValue());
+        Assertions.assertTrue(root.has("my_resource"));
+        Assertions.assertEquals("Test", root.get("my_resource").get("subject").asText());
+    }
+
+    @Test
     public void testTicketBodyFormat() throws Exception {
         when(httpClient.doPost(anyString(), any(), anyString()))
                 .thenReturn(new HttpResponse(201, "{}"));
@@ -181,7 +213,7 @@ public class ZendeskSinkWriterTest {
         headers.put("Authorization", "Basic dGVzdA==");
         param.setHeaders(headers);
 
-        ZendeskSinkWriter writer = new ZendeskSinkWriter(userRowType, param, 0, 0, 3);
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(userRowType, param, null, 0, 0, 3, 1);
 
         Field field = ZendeskSinkWriter.class.getDeclaredField("httpClient");
         field.setAccessible(true);
@@ -235,6 +267,9 @@ public class ZendeskSinkWriterTest {
                         IOException.class,
                         () -> writer.write(new SeaTunnelRow(new Object[] {"Test", "open"})));
         Assertions.assertTrue(exception.getMessage().contains("422"));
+        Assertions.assertTrue(
+                exception.getMessage().contains("example.zendesk.com"),
+                "error message should contain the request URL");
     }
 
     @Test
@@ -255,7 +290,7 @@ public class ZendeskSinkWriterTest {
     public void testBackoffIsZeroWhenDisabled() {
         HttpParameter param = new HttpParameter();
         param.setUrl("https://example.zendesk.com/api/v2/tickets");
-        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 0, 3);
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, null, 0, 0, 3, 1);
 
         Assertions.assertEquals(0L, writer.calculateBackoffMillis(1));
         Assertions.assertEquals(0L, writer.calculateBackoffMillis(5));
@@ -265,7 +300,7 @@ public class ZendeskSinkWriterTest {
     public void testBackoffIsNotDeterministic() {
         HttpParameter param = new HttpParameter();
         param.setUrl("https://example.zendesk.com/api/v2/tickets");
-        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 1000, 3);
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, null, 0, 1000, 3, 1);
 
         Set<Long> observed = new HashSet<>();
         for (int i = 0; i < 200; i++) {
@@ -281,12 +316,56 @@ public class ZendeskSinkWriterTest {
     public void testBackoffRespectsMaximum() {
         HttpParameter param = new HttpParameter();
         param.setUrl("https://example.zendesk.com/api/v2/tickets");
-        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 60000, 30);
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, null, 0, 60000, 30, 1);
 
         for (int i = 0; i < 100; i++) {
             Assertions.assertTrue(
                     writer.calculateBackoffMillis(20) <= 300000L,
                     "jittered backoff must never exceed MAX_BACKOFF_MILLIS");
         }
+    }
+
+    @Test
+    public void testBackoffHasMinimumFloor() {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/tickets");
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, null, 0, 1000, 3, 1);
+
+        for (int i = 0; i < 100; i++) {
+            long backoff = writer.calculateBackoffMillis(1);
+            Assertions.assertTrue(
+                    backoff >= 500L,
+                    "equal jitter backoff must be at least half the base, got " + backoff);
+        }
+    }
+
+    @Test
+    public void testBlankResourceKeyThrows() {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/tickets");
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new ZendeskSinkWriter(rowType, param, "", 0, 0, 3, 1));
+
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new ZendeskSinkWriter(rowType, param, "   ", 0, 0, 3, 1));
+    }
+
+    @Test
+    public void testParallelismScalesRequestInterval() throws Exception {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/tickets");
+        Map<String, String> headers = new HashMap<>();
+        param.setHeaders(headers);
+
+        // parallelism=4, requestIntervalMs=100 → effective interval should be 400
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, null, 100, 0, 3, 4);
+
+        Field intervalField = ZendeskSinkWriter.class.getDeclaredField("requestIntervalMs");
+        intervalField.setAccessible(true);
+        int effectiveInterval = (int) intervalField.get(writer);
+        Assertions.assertEquals(400, effectiveInterval);
     }
 }

--- a/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/test/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriterTest.java
+++ b/seatunnel-connectors-v2/connector-http/connector-http-zendesk/src/test/java/org/apache/seatunnel/connectors/seatunnel/zendesk/sink/ZendeskSinkWriterTest.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.zendesk.sink;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.connectors.seatunnel.http.client.HttpClientProvider;
+import org.apache.seatunnel.connectors.seatunnel.http.client.HttpResponse;
+import org.apache.seatunnel.connectors.seatunnel.http.config.HttpParameter;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ZendeskSinkWriterTest {
+
+    @Mock private HttpClientProvider httpClient;
+
+    private SeaTunnelRowType rowType;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        rowType =
+                new SeaTunnelRowType(
+                        new String[] {"subject", "status"},
+                        new SeaTunnelDataType[] {BasicType.STRING_TYPE, BasicType.STRING_TYPE});
+    }
+
+    private ZendeskSinkWriter createWriter(String url) throws Exception {
+        HttpParameter param = new HttpParameter();
+        param.setUrl(url);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Basic dGVzdEBleGFtcGxlLmNvbS90b2tlbjpzZWNyZXQ=");
+        headers.put("Content-Type", "application/json");
+        param.setHeaders(headers);
+
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 0, 3);
+
+        Field field = ZendeskSinkWriter.class.getDeclaredField("httpClient");
+        field.setAccessible(true);
+        field.set(writer, httpClient);
+        return writer;
+    }
+
+    @Test
+    public void testInferResourceKeyTickets() {
+        Assertions.assertEquals(
+                "ticket",
+                ZendeskSinkWriter.inferResourceKey("https://example.zendesk.com/api/v2/tickets"));
+    }
+
+    @Test
+    public void testInferResourceKeyTicketsWithJsonSuffix() {
+        Assertions.assertEquals(
+                "ticket",
+                ZendeskSinkWriter.inferResourceKey(
+                        "https://example.zendesk.com/api/v2/tickets.json"));
+    }
+
+    @Test
+    public void testInferResourceKeyUsers() {
+        Assertions.assertEquals(
+                "user",
+                ZendeskSinkWriter.inferResourceKey("https://example.zendesk.com/api/v2/users"));
+    }
+
+    @Test
+    public void testInferResourceKeyUsersCreateOrUpdate() {
+        Assertions.assertEquals(
+                "user",
+                ZendeskSinkWriter.inferResourceKey(
+                        "https://example.zendesk.com/api/v2/users/create_or_update"));
+    }
+
+    @Test
+    public void testInferResourceKeyOrganizations() {
+        Assertions.assertEquals(
+                "organization",
+                ZendeskSinkWriter.inferResourceKey(
+                        "https://example.zendesk.com/api/v2/organizations"));
+    }
+
+    @Test
+    public void testInferResourceKeyTrailingSlash() {
+        Assertions.assertEquals(
+                "ticket",
+                ZendeskSinkWriter.inferResourceKey("https://example.zendesk.com/api/v2/tickets/"));
+    }
+
+    @Test
+    public void testInferResourceKeyWithQueryParams() {
+        Assertions.assertEquals(
+                "ticket",
+                ZendeskSinkWriter.inferResourceKey(
+                        "https://example.zendesk.com/api/v2/tickets?page=1"));
+    }
+
+    @Test
+    public void testInferResourceKeyReturnsNullForUnrecognizedUrl() {
+        Assertions.assertNull(ZendeskSinkWriter.inferResourceKey("https://example.com/other"));
+    }
+
+    @Test
+    public void testInferResourceKeyReturnsNullForNull() {
+        Assertions.assertNull(ZendeskSinkWriter.inferResourceKey(null));
+    }
+
+    @Test
+    public void testInferResourceKeyCategories() {
+        Assertions.assertEquals(
+                "category",
+                ZendeskSinkWriter.inferResourceKey(
+                        "https://example.zendesk.com/api/v2/categories"));
+    }
+
+    @Test
+    public void testTicketBodyFormat() throws Exception {
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(201, "{}"));
+
+        ZendeskSinkWriter writer = createWriter("https://example.zendesk.com/api/v2/tickets");
+        writer.write(new SeaTunnelRow(new Object[] {"Help me", "open"}));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(httpClient, times(1)).doPost(anyString(), any(), bodyCaptor.capture());
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bodyCaptor.getValue());
+        Assertions.assertTrue(root.has("ticket"));
+        Assertions.assertEquals("Help me", root.get("ticket").get("subject").asText());
+        Assertions.assertEquals("open", root.get("ticket").get("status").asText());
+    }
+
+    @Test
+    public void testUserBodyFormat() throws Exception {
+        SeaTunnelRowType userRowType =
+                new SeaTunnelRowType(
+                        new String[] {"name", "email"},
+                        new SeaTunnelDataType[] {BasicType.STRING_TYPE, BasicType.STRING_TYPE});
+
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/users/create_or_update");
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Basic dGVzdA==");
+        param.setHeaders(headers);
+
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(userRowType, param, 0, 0, 3);
+
+        Field field = ZendeskSinkWriter.class.getDeclaredField("httpClient");
+        field.setAccessible(true);
+        field.set(writer, httpClient);
+
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(201, "{}"));
+
+        writer.write(new SeaTunnelRow(new Object[] {"John", "john@example.com"}));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(httpClient, times(1)).doPost(anyString(), any(), bodyCaptor.capture());
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(bodyCaptor.getValue());
+        Assertions.assertTrue(root.has("user"));
+        Assertions.assertEquals("John", root.get("user").get("name").asText());
+    }
+
+    @Test
+    public void testSuccessOn201Response() throws Exception {
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(201, "{}"));
+
+        ZendeskSinkWriter writer = createWriter("https://example.zendesk.com/api/v2/tickets");
+        writer.write(new SeaTunnelRow(new Object[] {"Test", "open"}));
+
+        verify(httpClient, times(1)).doPost(anyString(), any(), anyString());
+    }
+
+    @Test
+    public void testSuccessOn200Response() throws Exception {
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(200, "{}"));
+
+        ZendeskSinkWriter writer = createWriter("https://example.zendesk.com/api/v2/tickets");
+        writer.write(new SeaTunnelRow(new Object[] {"Test", "open"}));
+
+        verify(httpClient, times(1)).doPost(anyString(), any(), anyString());
+    }
+
+    @Test
+    public void testThrowsOnValidationError() throws Exception {
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(422, "{\"error\":\"RecordInvalid\"}"));
+
+        ZendeskSinkWriter writer = createWriter("https://example.zendesk.com/api/v2/tickets");
+
+        IOException exception =
+                Assertions.assertThrows(
+                        IOException.class,
+                        () -> writer.write(new SeaTunnelRow(new Object[] {"Test", "open"})));
+        Assertions.assertTrue(exception.getMessage().contains("422"));
+    }
+
+    @Test
+    public void testThrowsAfterMaxRetries() throws Exception {
+        when(httpClient.doPost(anyString(), any(), anyString()))
+                .thenReturn(new HttpResponse(429, "{\"error\":\"rate_limit\"}"));
+
+        ZendeskSinkWriter writer = createWriter("https://example.zendesk.com/api/v2/tickets");
+
+        Assertions.assertThrows(
+                IOException.class,
+                () -> writer.write(new SeaTunnelRow(new Object[] {"Test", "open"})));
+        // 1 initial + 3 retries = 4 calls
+        verify(httpClient, times(4)).doPost(anyString(), any(), anyString());
+    }
+
+    @Test
+    public void testBackoffIsZeroWhenDisabled() {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/tickets");
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 0, 3);
+
+        Assertions.assertEquals(0L, writer.calculateBackoffMillis(1));
+        Assertions.assertEquals(0L, writer.calculateBackoffMillis(5));
+    }
+
+    @Test
+    public void testBackoffIsNotDeterministic() {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/tickets");
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 1000, 3);
+
+        Set<Long> observed = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            observed.add(writer.calculateBackoffMillis(3));
+        }
+
+        Assertions.assertTrue(
+                observed.size() > 1,
+                "backoff must vary between calls, but observed only " + observed);
+    }
+
+    @Test
+    public void testBackoffRespectsMaximum() {
+        HttpParameter param = new HttpParameter();
+        param.setUrl("https://example.zendesk.com/api/v2/tickets");
+        ZendeskSinkWriter writer = new ZendeskSinkWriter(rowType, param, 0, 60000, 30);
+
+        for (int i = 0; i < 100; i++) {
+            Assertions.assertTrue(
+                    writer.calculateBackoffMillis(20) <= 300000L,
+                    "jittered backoff must never exceed MAX_BACKOFF_MILLIS");
+        }
+    }
+}


### PR DESCRIPTION

### Purpose of this pull request

This pull request adds a **Zendesk Sink connector** to complement the existing Zendesk Source connector (PR #11030). It enables users to write data to the Zendesk REST API (create tickets, users, organizations) through SeaTunnel pipelines.

The implementation follows the Airtable Sink pattern (PR #10469):
- Custom `ZendeskSinkWriter` extending `AbstractSimpleSink` with Zendesk-specific JSON body wrapping (`{"ticket": {...}}`)
- HTTP 429 rate limit handling with exponential backoff and jitter
- Shared `ZendeskConfig` class extracted from `ZendeskSourceOptions` for auth reuse between source and sink

for #10753 (Zendesk Sink part)

### Does this PR introduce _any_ user-facing change?

Yes. Users can now use `Zendesk` as a sink connector to write data to the Zendesk REST API.

Example:
```hocon
sink {
  Zendesk {
    url = "https://your-subdomain.zendesk.com/api/v2/tickets"
    email = "agent@example.com"
    api_token = "${ZENDESK_API_TOKEN}"
  }
}
```

New sink documentation added in both English (`docs/en/connectors/sink/Zendesk.md`) and Chinese (`docs/zh/connectors/sink/Zendesk.md`).

### How was this patch tested?

- 23 unit tests (all passing), including:
  - `ZendeskSinkWriterTest` (19 tests): URL-to-resource-key inference, JSON body format for tickets/users, HTTP 200/201 success handling, 422 validation error, 429 rate limit retry, backoff algorithm
  - `ZendeskSinkFactoryTest` (2 tests): option rule and factory identifier
  - Existing source tests (2 tests): verify `ZendeskSourceOptions` refactor doesn't break backward compatibility
- Build verified: `mvn compile -pl seatunnel-connectors-v2/connector-http/connector-http-zendesk -DskipTests`
- Tests verified: `mvn test -pl seatunnel-connectors-v2/connector-http/connector-http-zendesk`

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. [x] Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) — added `seatunnel.sink.Zendesk = connector-http-zendesk`
  2. [x] Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml) — already included from source connector
  3. [ ] Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. [ ] Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/) — requires Zendesk sandbox account, planned for follow-up
  5. [ ] Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)