### PR TITLE
[Fix][CI] Skip integration tests on Apache dev pushes

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: 'true'
+      RUN_INTEGRATION_TESTS:
+        required: false
+        type: string
+        default: 'true'
 
 concurrency:
   group: backend-${{ github.event.pull_request.number || github.ref }}
@@ -581,7 +585,7 @@ jobs:
 
   updated-modules-integration-test-part-1:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -614,7 +618,7 @@ jobs:
 
   updated-modules-integration-test-part-2:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -647,7 +651,7 @@ jobs:
 
   updated-modules-integration-test-part-3:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -680,7 +684,7 @@ jobs:
 
   updated-modules-integration-test-part-4:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -712,7 +716,7 @@ jobs:
           MAVEN_OPTS: -Xmx4096m
   updated-modules-integration-test-part-5:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -744,7 +748,7 @@ jobs:
           MAVEN_OPTS: -Xmx4096m
   updated-modules-integration-test-part-6:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -776,7 +780,7 @@ jobs:
           MAVEN_OPTS: -Xmx4096m
   updated-modules-integration-test-part-7:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -809,7 +813,7 @@ jobs:
 
   updated-modules-integration-test-part-8:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'false' && needs.changes.outputs.engine == 'false' && needs.changes.outputs.it-modules != '[]')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -842,7 +846,7 @@ jobs:
 
   engine-v2-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.engine-e2e == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.engine-e2e == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -868,7 +872,7 @@ jobs:
 
   edge-agent-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.edge-agent == 'true' || needs.changes.outputs.edge-agent-e2e == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'seatunnel-edge-agent-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.edge-agent == 'true' || needs.changes.outputs.edge-agent-e2e == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'seatunnel-edge-agent-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -894,7 +898,7 @@ jobs:
 
   engine-k8s-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'seatunnel-engine-k8s-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'seatunnel-engine-k8s-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -929,7 +933,7 @@ jobs:
 
   transform-v2-it-part-1:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -958,7 +962,7 @@ jobs:
 
   transform-v2-it-part-2:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -989,7 +993,7 @@ jobs:
   # tools/update_modules_check/update_modules_check.py.
   all-connectors-it-1:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1021,7 +1025,7 @@ jobs:
 
   all-connectors-it-2:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1053,7 +1057,7 @@ jobs:
 
   all-connectors-it-3:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1085,7 +1089,7 @@ jobs:
 
   all-connectors-it-4:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1117,7 +1121,7 @@ jobs:
 
   all-connectors-it-5:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1149,7 +1153,7 @@ jobs:
 
   all-connectors-it-6:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1181,7 +1185,7 @@ jobs:
 
   all-connectors-it-7:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1213,7 +1217,7 @@ jobs:
 
   iceberg-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-iceberg-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-iceberg-e2e'))
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1242,7 +1246,7 @@ jobs:
 
   hbase-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-hbase-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-hbase-e2e'))
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1271,7 +1275,7 @@ jobs:
 
   jdbc-connectors-it-part-1:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1300,7 +1304,7 @@ jobs:
 
   jdbc-connectors-it-part-2:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1329,7 +1333,7 @@ jobs:
 
   jdbc-connectors-it-part-3:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1358,7 +1362,7 @@ jobs:
 
   jdbc-connectors-it-part-4:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1387,7 +1391,7 @@ jobs:
 
   jdbc-connectors-it-part-5:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1416,7 +1420,7 @@ jobs:
 
   jdbc-connectors-it-part-6:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1445,7 +1449,7 @@ jobs:
 
   jdbc-connectors-it-part-7:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1474,7 +1478,7 @@ jobs:
 
   jdbc-connectors-it-ddl:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true'
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true')
     runs-on: ${{ matrix.os }}
     env:
       RUN_ALL_CONTAINER: ${{ needs.changes.outputs.api }}
@@ -1503,7 +1507,7 @@ jobs:
 
   kudu-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-kudu-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-kudu-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1530,7 +1534,7 @@ jobs:
 
   amazonSqs-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-amazonsqs-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-amazonsqs-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1556,7 +1560,7 @@ jobs:
 
   google-pubsub-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-google-pubsub-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-google-pubsub-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -1581,7 +1585,7 @@ jobs:
 
   kafka-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-kafka-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-kafka-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1607,7 +1611,7 @@ jobs:
 
   rocketmq-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-rocketmq-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-rocketmq-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1633,7 +1637,7 @@ jobs:
 
   elasticsearch-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-elasticsearch-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-elasticsearch-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1659,7 +1663,7 @@ jobs:
 
   mysql-cdc-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-cdc-mysql-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-cdc-mysql-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1685,7 +1689,7 @@ jobs:
 
   doris-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-doris-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-doris-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1711,7 +1715,7 @@ jobs:
 
   paimon-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-paimon-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-paimon-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1737,7 +1741,7 @@ jobs:
 
   oracle-cdc-connector-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-cdc-oracle-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-cdc-oracle-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1768,7 +1772,7 @@ jobs:
 
   connector-file-local-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-file-local-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-file-local-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1794,7 +1798,7 @@ jobs:
 
   connector-file-sftp-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-file-sftp-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-file-sftp-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1820,7 +1824,7 @@ jobs:
 
   connector-redis-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-redis-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-redis-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -1846,7 +1850,7 @@ jobs:
 
   connector-sensorsdata-it:
     needs: [ changes, sanity-check ]
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-sensorsdata-e2e')
+    if: inputs.RUN_INTEGRATION_TESTS == 'true' && (needs.changes.outputs.api == 'true' || needs.changes.outputs.engine == 'true' || contains(fromJSON(needs.changes.outputs.it-modules), 'connector-sensorsdata-e2e'))
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -31,3 +31,5 @@ jobs:
       packages: write
     name: Run
     uses: ./.github/workflows/backend.yml
+    with:
+      RUN_INTEGRATION_TESTS: ${{ github.repository == 'apache/seatunnel' && github.ref == 'refs/heads/dev' && 'false' || 'true' }}


### PR DESCRIPTION
### Summary
- keep the existing full API-triggered backend build coverage for `apache/seatunnel` `dev` push runs
- skip integration-test and E2E jobs only for post-merge `dev` push runs in the Apache repository
- leave fork/PR head push runs and scheduled backend runs on the existing integration-test behavior

### Root Cause
The PR `Build` check is mirrored from the PR head repository, so PR-stage E2E runs stay in the contributor fork as intended. The slow main-repository runs come from a different path: after a PR is merged, `apache/seatunnel` receives a `push` event on `dev`, and `.github/workflows/build_main.yml` calls the reusable backend workflow in the Apache repository. Existing CI scope logic correctly forces full API build coverage for that `dev` push, but many integration-test jobs also use `api == 'true'` as their trigger, so the post-merge build expands into the E2E/IT matrix.

### Behavior After This Change
- `apache/seatunnel` + `refs/heads/dev` push: full backend build/check coverage remains, integration-test and E2E jobs are skipped.
- Fork push / PR head push: integration-test behavior remains enabled by default.
- Scheduled backend workflow: integration-test behavior remains enabled by default.

### Tests
- `./mvnw spotless:apply`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/backend.yml .github/workflows/build_main.yml`
- `git diff --check upstream/dev -- .github/workflows/backend.yml .github/workflows/build_main.yml`

`actionlint` is not installed in the local environment, so final workflow execution validity should be confirmed by GitHub Actions on this PR head.
