### PR TITLE
[Fix][Zeta] Clean empty checkpoint barrier counters

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SinkAggregatedCommitterTask.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/task/SinkAggregatedCommitterTask.java
@@ -303,6 +303,7 @@ public class SinkAggregatedCommitterTask<CommandInfoT, AggregatedCommitInfoT>
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         List<AggregatedCommitInfoT> aggregatedCommitInfo = new ArrayList<>();
+        checkpointBarrierCounter.keySet().removeIf(key -> key <= checkpointId);
         checkpointCommitInfoMap.forEach(
                 (key, value) -> {
                     if (key > checkpointId) {
@@ -311,7 +312,6 @@ public class SinkAggregatedCommitterTask<CommandInfoT, AggregatedCommitInfoT>
                     aggregatedCommitInfo.addAll(value);
                     checkpointCommitInfoMap.remove(key);
                     commitInfoCache.remove(key);
-                    checkpointBarrierCounter.remove(key);
                 });
         List<AggregatedCommitInfoT> commit = aggregatedCommitter.commit(aggregatedCommitInfo);
         tryClose(checkpointId);

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/SinkAggregatedCommitterTaskTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/task/SinkAggregatedCommitterTaskTest.java
@@ -135,6 +135,26 @@ public class SinkAggregatedCommitterTaskTest {
     }
 
     @Test
+    void testCheckpointBarrierCountersAreCleanedWithoutCommitInfo() throws Exception {
+        Map<Long, Integer> checkpointBarrierCounter = getCheckpointBarrierCounter();
+        checkpointBarrierCounter.put(1L, 1);
+        checkpointBarrierCounter.put(2L, 1);
+        checkpointBarrierCounter.put(3L, 1);
+
+        task.notifyCheckpointComplete(2L);
+
+        Assertions.assertFalse(
+                checkpointBarrierCounter.containsKey(1L),
+                "completed empty checkpoints must not retain barrier counters");
+        Assertions.assertFalse(
+                checkpointBarrierCounter.containsKey(2L),
+                "completed empty checkpoints must not retain barrier counters");
+        Assertions.assertTrue(
+                checkpointBarrierCounter.containsKey(3L),
+                "future checkpoints must retain their barrier counters");
+    }
+
+    @Test
     void testCheckpointCacheCleanupAfterNotifyCheckpointAborted() throws Exception {
         // Simulate receiving commit info for a checkpoint
         task.receivedWriterCommitInfo(5L, "commitInfo5");


### PR DESCRIPTION
## What does this PR do?

Fixes #12256. Successful checkpoints now clear barrier-counter entries independently of aggregated commit payloads. This prevents empty checkpoints from retaining one counter entry for the lifetime of a streaming task.

## Verification

- Added a regression test covering completed checkpoints with no commit information.
- `./mvnw -nsu -Dmaven.gitcommitid.skip=true -pl seatunnel-engine/seatunnel-engine-server -DskipITs -DskipIT=true -Dtest=SinkAggregatedCommitterTaskTest test`
- `./mvnw -nsu spotless:apply`
- `./mvnw -nsu -q -DskipTests verify`