### PR TITLE
[Test][Connector-V2] Reproduce Paimon fixed-bucket DELETE residue on Flink

### DIFF
--- a/seatunnel-connectors-v2/connector-paimon/pom.xml
+++ b/seatunnel-connectors-v2/connector-paimon/pom.xml
@@ -38,6 +38,31 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-flink-starter-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-translation-flink-15</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>1.18.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>1.18.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
             <artifactId>connector-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/core/starter/flink/execution/PaimonUpstreamDeleteTest.java
+++ b/seatunnel-connectors-v2/connector-paimon/src/test/java/org/apache/seatunnel/core/starter/flink/execution/PaimonUpstreamDeleteTest.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.core.starter.flink.execution;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.sink.SeaTunnelSink;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.PrimaryKey;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TablePath;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.RowKind;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.paimon.catalog.PaimonCatalog;
+import org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSink;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.Partitioner;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.paimon.data.InternalRow;
+import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.reader.RecordReaderIterator;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.source.ReadBuilder;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class PaimonUpstreamDeleteTest {
+    @TempDir private Path temporaryDirectory;
+
+    @org.junit.jupiter.api.RepeatedTest(3)
+    @Timeout(120)
+    void shouldDeleteWithTwoWriters() throws Exception {
+        runPipeline(2, false);
+    }
+
+    @org.junit.jupiter.api.RepeatedTest(3)
+    @Timeout(120)
+    void shouldDeleteAfterCheckpointWithTwoWriters() throws Exception {
+        runPipeline(2, true);
+    }
+
+    @Test
+    @Timeout(120)
+    void singleWriterControl() throws Exception {
+        runPipeline(1, false);
+    }
+
+    @Test
+    @Timeout(120)
+    void singleWriterCheckpointControl() throws Exception {
+        runPipeline(1, true);
+    }
+
+    private void runPipeline(int sinkParallelism, boolean checkpointed) throws Exception {
+        for (Class<?> type :
+                Arrays.asList(
+                        PaimonSink.class,
+                        org.apache.seatunnel.connectors.seatunnel.paimon.sink.PaimonSinkWriter
+                                .class,
+                        SinkExecuteProcessor.class,
+                        org.apache.seatunnel.translation.flink.sink.FlinkSink.class,
+                        SeaTunnelRow.class)) {
+            System.out.println(
+                    "UPSTREAM_CLASS "
+                            + type.getName()
+                            + " "
+                            + type.getProtectionDomain().getCodeSource().getLocation());
+        }
+        JobContext jobContext = new JobContext(12243L);
+        jobContext.setJobMode(JobMode.STREAMING);
+        jobContext.setEnableCheckpoint(true);
+        Map<TablePath, SeaTunnelSink> sinks = new LinkedHashMap<>();
+        List<CatalogTable> tables = new ArrayList<>();
+        List<PaimonCatalog> catalogs = new ArrayList<>();
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        try {
+            for (int tableIndex = 0; tableIndex < 1; tableIndex++) {
+                String tableName = "table_" + tableIndex;
+                Map<String, Object> properties = new HashMap<>();
+                properties.put("warehouse", temporaryDirectory.resolve("warehouse").toString());
+                properties.put("plugin_name", "Paimon");
+                properties.put("database", "routing_test");
+                properties.put("table", tableName);
+                Map<String, String> options = new HashMap<>();
+                options.put("bucket", "1");
+                options.put("write-only", "true");
+                properties.put("paimon.table.write-props", options);
+                ReadonlyConfig config = ReadonlyConfig.fromMap(properties);
+                PaimonCatalog catalog = new PaimonCatalog("paimon", config);
+                catalog.open();
+                catalogs.add(catalog);
+                TablePath tablePath = TablePath.of("routing_test", tableName);
+                catalog.createDatabase(tablePath, true);
+                TableSchema schema =
+                        TableSchema.builder()
+                                .column(
+                                        PhysicalColumn.of(
+                                                "id",
+                                                BasicType.INT_TYPE,
+                                                (Long) null,
+                                                false,
+                                                null,
+                                                null))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "part",
+                                                BasicType.STRING_TYPE,
+                                                (Long) null,
+                                                false,
+                                                null,
+                                                null))
+                                .column(
+                                        PhysicalColumn.of(
+                                                "value",
+                                                BasicType.STRING_TYPE,
+                                                (Long) null,
+                                                true,
+                                                null,
+                                                null))
+                                .primaryKey(PrimaryKey.of("pk", Arrays.asList("id", "part")))
+                                .build();
+                CatalogTable table =
+                        CatalogTable.of(
+                                TableIdentifier.of("paimon", "routing_test", tableName),
+                                schema,
+                                new HashMap<>(),
+                                Collections.emptyList(),
+                                "routing regression");
+                catalog.createTable(tablePath, table, false);
+                tables.add(table);
+                PaimonSink sink = new PaimonSink(config, table);
+                sink.setJobContext(jobContext);
+                sinks.put(tablePath, sink);
+                for (int identifier = 0; identifier < 100; identifier++) {
+                    rows.add(row(tablePath, RowKind.INSERT, identifier, "before"));
+                }
+                rows.add(row(tablePath, RowKind.DELETE, 99, "before"));
+                for (int update = 0; update < 4; update++) {
+                    rows.add(row(tablePath, RowKind.UPDATE_AFTER, 98, "after-" + update));
+                }
+            }
+            StreamExecutionEnvironment environment =
+                    StreamExecutionEnvironment.createLocalEnvironment(2);
+            environment.getConfig().disableClosureCleaner();
+            environment.setRestartStrategy(
+                    org.apache.flink.api.common.restartstrategy.RestartStrategies.noRestart());
+            DataStream<SeaTunnelRow> input;
+            if (checkpointed) {
+                environment.enableCheckpointing(200);
+                input = environment.addSource(new CheckpointOrderedSource(rows)).setParallelism(2);
+            } else {
+                input =
+                        environment
+                                .fromCollection(rows)
+                                .partitionCustom(
+                                        (Partitioner<Integer>) (writer, count) -> writer,
+                                        (KeySelector<SeaTunnelRow, Integer>)
+                                                value ->
+                                                        value.getRowKind() == RowKind.INSERT
+                                                                ? 0
+                                                                : 1)
+                                .map(
+                                        (MapFunction<SeaTunnelRow, SeaTunnelRow>)
+                                                value -> {
+                                                    if (value.getRowKind() != RowKind.INSERT) {
+                                                        Thread.sleep(200);
+                                                    }
+                                                    return value;
+                                                })
+                                .setParallelism(2);
+            }
+            SeaTunnelSink sink = sinks.values().iterator().next();
+            SinkExecuteProcessor processor =
+                    new SinkExecuteProcessor(
+                            new ArrayList<>(),
+                            ConfigFactory.parseString("job.mode=STREAMING"),
+                            Collections.emptyList(),
+                            jobContext);
+            processor
+                    .createVersionSpecificDataStreamSink(
+                            new DataStreamTableInfo(input, tables, "input"),
+                            sink,
+                            sinkParallelism,
+                            ConfigFactory.empty())
+                    .setParallelism(sinkParallelism)
+                    .uid("upstream-sink");
+            environment.execute("issue12243-upstream-delete");
+            FileStoreTable table =
+                    (FileStoreTable)
+                            catalogs.get(0).getPaimonTable(sinks.keySet().iterator().next());
+            ReadBuilder read = table.newReadBuilder();
+            Map<List<Object>, String> actual = new HashMap<>();
+            try (RecordReader<InternalRow> reader =
+                            read.newRead().createReader(read.newScan().plan());
+                    RecordReaderIterator<InternalRow> iterator =
+                            new RecordReaderIterator<>(reader)) {
+                while (iterator.hasNext()) {
+                    InternalRow value = iterator.next();
+                    actual.put(
+                            Arrays.asList(value.getInt(0), value.getString(1).toString()),
+                            value.getString(2).toString());
+                }
+            }
+            Map<List<Object>, String> expected = new HashMap<>();
+            for (int id = 0; id < 99; id++) {
+                expected.put(Arrays.asList(id, "part-" + id % 2), id == 98 ? "after-3" : "before");
+            }
+            System.out.println(
+                    "UPSTREAM_RESULT sinkParallelism="
+                            + sinkParallelism
+                            + ", checkpointed="
+                            + checkpointed
+                            + ", options="
+                            + table.schema().options()
+                            + ", primaryKeys="
+                            + table.schema().primaryKeys()
+                            + ", partitionKeys="
+                            + table.schema().partitionKeys()
+                            + ", snapshot="
+                            + table.snapshotManager().latestSnapshotId()
+                            + ", count="
+                            + actual.size()
+                            + ", deletedKeyValue="
+                            + actual.get(Arrays.asList(99, "part-1"))
+                            + ", updatedKeyValue="
+                            + actual.get(Arrays.asList(98, "part-0")));
+            org.junit.jupiter.api.Assertions.assertAll(
+                    () -> assertEquals(99, actual.size(), "committed row count"),
+                    () ->
+                            assertFalse(
+                                    actual.containsKey(Arrays.asList(99, "part-1")),
+                                    "DELETE must remove complete primary key"),
+                    () ->
+                            assertEquals(
+                                    "after-3",
+                                    actual.get(Arrays.asList(98, "part-0")),
+                                    "UPDATE must replace old value"),
+                    () -> assertEquals(expected, actual, "all primary keys and values"));
+        } finally {
+            for (PaimonCatalog catalog : catalogs) {
+                catalog.close();
+            }
+        }
+    }
+
+    /** Emit INSERTs from subtask 0, then changes from subtask 1 after a completed checkpoint. */
+    private static final class CheckpointOrderedSource
+            extends RichParallelSourceFunction<SeaTunnelRow>
+            implements CheckpointedFunction, CheckpointListener {
+        private final List<SeaTunnelRow> rows;
+        private final Map<Long, Integer> phases = new java.util.concurrent.ConcurrentHashMap<>();
+        private volatile boolean running = true;
+        private volatile int phase;
+        private volatile int completedPhase;
+
+        private CheckpointOrderedSource(List<SeaTunnelRow> rows) {
+            this.rows = rows;
+        }
+
+        @Override
+        public void run(SourceContext<SeaTunnelRow> context) throws Exception {
+            synchronized (context.getCheckpointLock()) {
+                if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+                    for (SeaTunnelRow row : rows) {
+                        if (row.getRowKind() == RowKind.INSERT) {
+                            context.collect(row);
+                        }
+                    }
+                }
+                phase = 1;
+            }
+            while (running && completedPhase < 1) {
+                Thread.sleep(10);
+            }
+            synchronized (context.getCheckpointLock()) {
+                if (getRuntimeContext().getIndexOfThisSubtask() == 1) {
+                    for (SeaTunnelRow row : rows) {
+                        if (row.getRowKind() != RowKind.INSERT) {
+                            context.collect(row);
+                        }
+                    }
+                }
+                phase = 2;
+            }
+            while (running && completedPhase < 2) {
+                Thread.sleep(10);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) {
+            phases.put(context.getCheckpointId(), phase);
+        }
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) {}
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            Integer saved = phases.get(checkpointId);
+            if (saved != null) {
+                completedPhase = Math.max(completedPhase, saved);
+                phases.keySet().removeIf(id -> id <= checkpointId);
+            }
+        }
+    }
+
+    private static SeaTunnelRow row(TablePath table, RowKind kind, int identifier, String value) {
+        SeaTunnelRow row =
+                new SeaTunnelRow(new Object[] {identifier, "part-" + identifier % 2, value});
+        row.setTableId(table.toString());
+        row.setRowKind(kind);
+        return row;
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

Related to #12243. This draft adds a failing regression for fixed-bucket Paimon DELETE/UPDATE residue through the actual SeaTunnel Flink sink integration. With two writers, inserting 100 keys and deleting one leaves 100 keys in a fresh Paimon read; the updated key also retains its old value. Both single-writer controls pass.

The runtime source is unchanged from upstream dev commit `a0561d4045281c8e31ca96c6812b5024534db481`. This is a reproduction-only draft, not a fix or a merge-ready change: the new multi-writer tests are expected to fail until the underlying issue is resolved.

The test uses the original `SinkExecuteProcessor`, `FlinkSink`, and `PaimonSinkWriter`, without a custom sink subclass or downstream routing code. Test-scoped starter/adapter and Flink clients/streaming dependencies are needed to run that integration in a local MiniCluster. No production dependency or runtime implementation is changed.

### Does this PR introduce _any_ user-facing change?

No. Only one test class and four test-scoped dependencies are added.

### How was this patch tested?

Environment: Java 8, Flink 1.18.1 with the SeaTunnel Flink 1.15 adapter/starter, and Paimon 1.1.1. The warehouse is a temporary local filesystem directory; no external services or credentials are needed.

Effective table configuration:

- Table: `routing_test.table_0`; fields: `id INT NOT NULL`, `part STRING NOT NULL`, `value STRING`.
- Primary key: `(id, part)`; partition keys: none.
- Options: `bucket=1`, `write-only=true` (plus the generated temporary table path).
- Job mode: `STREAMING`; two upstream tasks; sink parallelism 2, or 1 for controls.
- Input: INSERT 100 distinct keys; DELETE `(99, part-1)`; four UPDATE_AFTER events for `(98, part-0)`, ending in `after-3`.

The finite-input case explicitly sends INSERTs through upstream task 0 and changes through task 1. The checkpoint case uses two real parallel source subtasks and sends changes only after the INSERT checkpoint completes (200 ms checkpoint interval). After the job finishes, native Paimon read-back compares all complete primary keys and values, with separate count, DELETE, and UPDATE assertions.

| Scenario | Sink writers | Repetitions | Result |
| --- | --- | --- | --- |
| Finite input, delayed changes | 2 | 3 | All fail: 100 rows; deleted key and old update value remain |
| Changes after completed INSERT checkpoint | 2 | 3 | All fail identically |
| Finite-input control | 1 | 1 | Pass: 99 rows, deleted key absent, updated value correct |
| Checkpoint control | 1 | 1 | Pass, including full key/value comparison |

Local result: **8 tests, 6 assertion failures, 0 errors, 0 skipped**, in 27.974 seconds. Runtime CodeSource output confirms the relevant classes came from the isolated upstream build.

From this PR branch, with Java 8 selected:

```bash
mvn -B -pl seatunnel-connectors-v2/connector-paimon -am \
  -Dskip.spotless=true \
  -Dtest=PaimonUpstreamDeleteTest \
  -Dsurefire.failIfNoSpecifiedTests=false verify
```

Expected exit code: **1**, from the six data assertions above. Use `verify` rather than `test` for this reactor invocation so the upstream shaded Config dependency is packaged before its dependent module is compiled.

Independent build verification passed for all 27 selected reactor modules:

```bash
mvn -B -pl seatunnel-connectors-v2/connector-paimon -am \
  -Dskip.spotless=true -DskipTests verify
```

The affected module's `spotless:apply` and subsequent `spotless:check`, plus `git diff --check`, passed.

### Relevant current routing path

In the pinned upstream revision, `PaimonSinkWriter` sets `dynamicBucket` only for `HASH_DYNAMIC` and initializes/uses `PaimonBucketAssigner` only in that branch. Fixed buckets take the `tableWrite.write(rowData)` branch, and each writer creates its own `paimonTable.newWrite(commitUser)`. The Flink starter adds the schema handler and then calls `sinkTo`, without establishing a unique writer owner for the fixed bucket.

- [Fixed/dynamic bucket selection](https://github.com/apache/seatunnel/blob/a0561d4045281c8e31ca96c6812b5024534db481/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java#L174)
- [Fixed-bucket write branch](https://github.com/apache/seatunnel/blob/a0561d4045281c8e31ca96c6812b5024534db481/seatunnel-connectors-v2/connector-paimon/src/main/java/org/apache/seatunnel/connectors/seatunnel/paimon/sink/PaimonSinkWriter.java#L230)
- [Flink sink integration](https://github.com/apache/seatunnel/blob/a0561d4045281c8e31ca96c6812b5024534db481/seatunnel-core/seatunnel-flink-starter/seatunnel-flink-starter-common/src/main/java/org/apache/seatunnel/core/starter/flink/execution/SinkExecuteProcessor.java#L51)

### Check list

- No binary files or production dependencies are added.
- User documentation, incompatible-change notes, and new-connector registration are not applicable to this reproduction-only draft.
- A local Flink integration regression and single-writer controls are included; no production source changes are proposed.
