### PR TITLE
[Fix][Core] Make plugin type lookup in plugin discovery locale independent

### DIFF
--- a/seatunnel-plugin-discovery/src/main/java/org/apache/seatunnel/plugin/discovery/AbstractPluginDiscovery.java
+++ b/seatunnel-plugin-discovery/src/main/java/org/apache/seatunnel/plugin/discovery/AbstractPluginDiscovery.java
@@ -59,6 +59,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -466,7 +467,7 @@ public abstract class AbstractPluginDiscovery<T> implements PluginDiscovery<T> {
         if (ArrayUtils.isEmpty(targetPluginFiles)) {
             return Optional.empty();
         }
-        PluginType type = PluginType.valueOf(pluginType.toUpperCase());
+        PluginType type = PluginType.valueOf(pluginType.toUpperCase(Locale.ROOT));
         List<URL> pluginJarPaths;
         try {
             if (targetPluginFiles.length == 1) {

--- a/seatunnel-plugin-discovery/src/test/java/org/apache/seatunnel/plugin/discovery/seatunnel/SeaTunnelSourcePluginDiscoveryTest.java
+++ b/seatunnel-plugin-discovery/src/test/java/org/apache/seatunnel/plugin/discovery/seatunnel/SeaTunnelSourcePluginDiscoveryTest.java
@@ -30,15 +30,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -313,6 +316,31 @@ class SeaTunnelSourcePluginDiscoveryTest {
                         Paths.get(
                                 seatunnelHome, "/plugins/otherWithLib/lib/common-dependency3.jar")),
                 paths);
+    }
+
+    @Test
+    @ResourceLock("default-locale")
+    void getSinkPluginJarPathsUnderTurkishLocale() throws Exception {
+        Locale originalLocale = Locale.getDefault();
+        try {
+            // Under tr-TR, "sink".toUpperCase() turns the 'i' into a dotted capital I
+            // (U+0130), so the result no longer matches the PluginType.SINK constant.
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+            List<PluginIdentifier> pluginIdentifiers =
+                    Collections.singletonList(
+                            PluginIdentifier.of(
+                                    "seatunnel", PluginType.SINK.getType(), "Clickhouse"));
+            SeaTunnelSinkPluginDiscovery seaTunnelSinkPluginDiscovery =
+                    new SeaTunnelSinkPluginDiscovery();
+            List<URL> pluginJarPaths =
+                    seaTunnelSinkPluginDiscovery.getPluginJarPaths(pluginIdentifiers);
+            Assertions.assertEquals(1, pluginJarPaths.size());
+            Assertions.assertEquals(
+                    Paths.get(seatunnelHome, "connectors", "connector-clickhouse.jar").toString(),
+                    new File(pluginJarPaths.get(0).toURI()).getPath());
+        } finally {
+            Locale.setDefault(originalLocale);
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
### Purpose of this pull request

While going through the recent locale fixes (#11894 for `JobStatus`, #11994 for the rename transforms) I looked for the same `valueOf(x.toUpperCase())` pattern elsewhere and found one in `AbstractPluginDiscovery.findPluginJarPath`:

```java
final String pluginType = pluginIdentifier.getPluginType().toLowerCase();
...
PluginType type = PluginType.valueOf(pluginType.toUpperCase());
```

The plugin type comes in as `"sink"`, `"source"` or `"transform"`. When the JVM default locale is Turkish (or Azerbaijani), `"sink".toUpperCase()` returns `"SİNK"` with a dotted capital I, so the lookup throws:

```
java.lang.IllegalArgumentException: No enum constant org.apache.seatunnel.common.constants.PluginType.SİNK
```

This line runs as soon as a matching jar is found under `connectors/`, so on such a JVM every sink that is resolved from the connectors directory fails to load. Sources and transforms are not affected because neither word contains an `i`.

The fix passes `Locale.ROOT`, like the earlier locale fixes did. I left the `toLowerCase()` calls on the identifier alone: as far as I can tell from the code, their results only feed `equalsIgnoreCase`, `startsWithIgnoreCase` and `contains("cdc")`, which do not break the lookup, so I kept the diff to the line that actually throws.

### Does this PR introduce _any_ user-facing change?

Only for JVMs running with a Turkish or Azerbaijani default locale, where sink plugin jars are now discovered instead of failing with the exception above. No public signature changes: the edited line is inside the private `findPluginJarPath`, and for the three inputs it can receive (`source`, `sink`, `transform`) `toUpperCase(Locale.ROOT)` returns the same string as `toUpperCase()` under every other default locale, so behaviour elsewhere is unchanged.

### How was this patch tested?

I added `getSinkPluginJarPathsUnderTurkishLocale` to `SeaTunnelSourcePluginDiscoveryTest`. It reuses the existing `duplicate` fixture, sets the default locale to `tr-TR`, resolves the `Clickhouse` sink jar and restores the locale afterwards (guarded with `@ResourceLock("default-locale")`, as in `JobStatusTest`).

Without the change in `AbstractPluginDiscovery` the new test fails:

```
[ERROR] getSinkPluginJarPathsUnderTurkishLocale  Time elapsed: 0.013 s  <<< ERROR!
java.lang.IllegalArgumentException: No enum constant org.apache.seatunnel.common.constants.PluginType.SİNK
[ERROR] Tests run: 6, Failures: 0, Errors: 1, Skipped: 0
```

With the change:

```
./mvnw test -pl seatunnel-plugin-discovery
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

The spotless check runs as part of that build and passes. I ran it locally on JDK 17.

### Check list

* [ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)

AI tools used
