### PR TITLE
[Fix][Zeta] Preserve cooperative task classloaders across restore

### DIFF
--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -1129,17 +1129,16 @@ public class TaskExecutionService implements DynamicMetricsProvider {
         public void run() {
             TaskExecutionService.TaskGroupExecutionTracker taskGroupExecutionTracker =
                     tracker.taskGroupExecutionTracker;
-            ClassLoader classLoader =
-                    executionContexts
-                            .get(taskGroupExecutionTracker.taskGroup.getTaskGroupLocation())
-                            .getClassLoaders()
-                            .get(tracker.task.getTaskID());
-            ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
-            Thread.currentThread().setContextClassLoader(classLoader);
             final Task t = tracker.task;
             ProgressState result = null;
+            ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
             try {
                 startedLatch.countDown();
+                // Resolve through the tracker-owned context: the location-keyed map may
+                // already point to a newer generation published after a restore.
+                ClassLoader classLoader =
+                        taskGroupExecutionTracker.getTaskClassLoader(t.getTaskID());
+                Thread.currentThread().setContextClassLoader(classLoader);
                 t.init();
                 do {
                     result = t.call();
@@ -1458,9 +1457,11 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                             task.getTaskID(), taskGroupLocation));
             Throwable ex = executionException.get();
             if (completionLatch.decrementAndGet() == 0) {
-                recycleClassLoader(taskGroupLocation);
-                finishedExecutionContexts.put(
-                        taskGroupLocation, executionContexts.remove(taskGroupLocation));
+                recycleClassLoader();
+                // Remove only this generation's context: a newer generation may already be
+                // published at the same location after a restore, and it must stay there.
+                executionContexts.remove(taskGroupLocation, ownedContext);
+                finishedExecutionContexts.put(taskGroupLocation, ownedContext);
                 cancellationFutures.remove(taskGroupLocation);
                 try {
                     cancelAsyncFunction(taskGroupLocation);
@@ -1507,16 +1508,30 @@ public class TaskExecutionService implements DynamicMetricsProvider {
             }
         }
 
-        private void recycleClassLoader(TaskGroupLocation taskGroupLocation) {
-            TaskGroupContext context = executionContexts.get(taskGroupLocation);
-            executionContexts.get(taskGroupLocation).setClassLoaders(null);
-            for (Collection<URL> jars : context.getJars().values()) {
-                classLoaderService.releaseClassLoader(taskGroupLocation.getJobId(), jars);
+        private void recycleClassLoader() {
+            // Recycle this generation's own context. Resolving through the location-keyed map
+            // could hit a newer generation's context published at the same TaskGroupLocation
+            // after a restore, which would release the newer generation's classloaders.
+            ownedContext.setClassLoaders(null);
+            for (Collection<URL> jars : ownedContext.getJars().values()) {
+                classLoaderService.releaseClassLoader(
+                        taskGroup.getTaskGroupLocation().getJobId(), jars);
             }
         }
 
         ClassLoader getTaskClassLoader(long taskId) {
-            return ownedContext.getClassLoader(taskId);
+            ConcurrentHashMap<Long, ClassLoader> classLoaders = ownedContext.getClassLoaders();
+            if (classLoaders == null) {
+                // The context was recycled (its loader map nulled) by a stale generation
+                // finishing late, which means this task can no longer run safely.
+                throw new IllegalStateException(
+                        String.format(
+                                "Classloaders for task group %s have already been recycled",
+                                taskGroup.getTaskGroupLocation()));
+            }
+            // A task without a registered per-task loader falls back to the system TCCL,
+            // which is the case for task groups deployed without connector jars.
+            return classLoaders.get(taskId);
         }
 
         boolean executionCompletedExceptionally() {

--- a/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/main/java/org/apache/seatunnel/engine/server/TaskExecutionService.java
@@ -637,8 +637,10 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                             taskGroup.getTaskGroupLocation()));
             Collection<Task> tasks = taskGroup.getTasks();
             CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+            TaskGroupContext taskGroupContext = new TaskGroupContext(taskGroup, classLoaders, jars);
             TaskGroupExecutionTracker executionTracker =
-                    new TaskGroupExecutionTracker(cancellationFuture, taskGroup, resultFuture);
+                    new TaskGroupExecutionTracker(
+                            cancellationFuture, taskGroup, taskGroupContext, resultFuture);
             ConcurrentMap<Long, TaskExecutionContext> taskExecutionContextMap =
                     new ConcurrentHashMap<>();
             final Map<Boolean, List<Task>> byCooperation =
@@ -670,9 +672,7 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                                                 }
                                                 return true;
                                             }));
-            executionContexts.put(
-                    taskGroup.getTaskGroupLocation(),
-                    new TaskGroupContext(taskGroup, classLoaders, jars));
+            executionContexts.put(taskGroup.getTaskGroupLocation(), taskGroupContext);
             contextPublished = true;
             onContextPublished.run();
             cancellationFutures.put(taskGroup.getTaskGroupLocation(), cancellationFuture);
@@ -1267,12 +1267,12 @@ public class TaskExecutionService implements DynamicMetricsProvider {
                 }
                 ProgressState call = null;
                 try {
-                    // run task
+                    // Resolve the loader from this tracker's generation. A TaskGroupLocation is
+                    // reused after restore, so the location-keyed executionContexts map may
+                    // already point to a newer generation when a queued task resumes.
                     myThread.setContextClassLoader(
-                            executionContexts
-                                    .get(taskGroupExecutionTracker.taskGroup.getTaskGroupLocation())
-                                    .getClassLoaders()
-                                    .get(taskTracker.task.getTaskID()));
+                            taskGroupExecutionTracker.getTaskClassLoader(
+                                    taskTracker.task.getTaskID()));
                     call = taskTracker.task.call();
                     synchronized (timer) {
                         timer.timerStop();
@@ -1364,6 +1364,7 @@ public class TaskExecutionService implements DynamicMetricsProvider {
     public final class TaskGroupExecutionTracker {
 
         private final TaskGroup taskGroup;
+        private final TaskGroupContext ownedContext;
         final CompletableFuture<TaskExecutionState> future;
         volatile List<Future<?>> blockingFutures = emptyList();
 
@@ -1377,10 +1378,12 @@ public class TaskExecutionService implements DynamicMetricsProvider {
         TaskGroupExecutionTracker(
                 @NonNull CompletableFuture<Void> cancellationFuture,
                 @NonNull TaskGroup taskGroup,
+                @NonNull TaskGroupContext ownedContext,
                 @NonNull CompletableFuture<TaskExecutionState> future) {
             this.future = future;
             this.completionLatch = new AtomicInteger(taskGroup.getTasks().size());
             this.taskGroup = taskGroup;
+            this.ownedContext = ownedContext;
             cancellationFuture.whenComplete(
                     withTryCatch(
                             logger,
@@ -1510,6 +1513,10 @@ public class TaskExecutionService implements DynamicMetricsProvider {
             for (Collection<URL> jars : context.getJars().values()) {
                 classLoaderService.releaseClassLoader(taskGroupLocation.getJobId(), jars);
             }
+        }
+
+        ClassLoader getTaskClassLoader(long taskId) {
+            return ownedContext.getClassLoader(taskId);
         }
 
         boolean executionCompletedExceptionally() {

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
@@ -72,6 +72,7 @@ import static org.apache.seatunnel.engine.server.execution.ExecutionState.FAILED
 import static org.apache.seatunnel.engine.server.execution.ExecutionState.FINISHED;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
@@ -557,6 +558,71 @@ public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
 
         stop.set(true);
         taskExecutionService.cancelTaskGroup(location);
+    }
+
+    @Test
+    public void testCooperativeTrackerKeepsGenerationSpecificClassLoader() {
+        TaskExecutionService taskExecutionService = server.getTaskExecutionService();
+        TaskGroupLocation location = new TaskGroupLocation(jobId, pipeLineId, 101L);
+        Task firstTask = taskWithId(1L);
+        Task replacementTask = taskWithId(1L);
+        ClassLoader firstClassLoader = new URLClassLoader(new URL[0]);
+        ClassLoader replacementClassLoader = new URLClassLoader(new URL[0]);
+
+        ConcurrentHashMap<Long, ClassLoader> firstClassLoaders = new ConcurrentHashMap<>();
+        firstClassLoaders.put(firstTask.getTaskID(), firstClassLoader);
+        TaskGroupContext firstContext =
+                new TaskGroupContext(
+                        new TaskGroupDefaultImpl(location, "first", Lists.newArrayList(firstTask)),
+                        firstClassLoaders,
+                        new ConcurrentHashMap<>());
+        TaskExecutionService.TaskGroupExecutionTracker firstTracker =
+                taskExecutionService
+                .new TaskGroupExecutionTracker(
+                        new CompletableFuture<>(),
+                        firstContext.getTaskGroup(),
+                        firstContext,
+                        new CompletableFuture<>());
+
+        ConcurrentHashMap<Long, ClassLoader> replacementClassLoaders = new ConcurrentHashMap<>();
+        replacementClassLoaders.put(replacementTask.getTaskID(), replacementClassLoader);
+        TaskGroupContext replacementContext =
+                new TaskGroupContext(
+                        new TaskGroupDefaultImpl(
+                                location, "replacement", Lists.newArrayList(replacementTask)),
+                        replacementClassLoaders,
+                        new ConcurrentHashMap<>());
+        TaskExecutionService.TaskGroupExecutionTracker replacementTracker =
+                taskExecutionService
+                .new TaskGroupExecutionTracker(
+                        new CompletableFuture<>(),
+                        replacementContext.getTaskGroup(),
+                        replacementContext,
+                        new CompletableFuture<>());
+
+        assertSame(firstClassLoader, firstTracker.getTaskClassLoader(firstTask.getTaskID()));
+        assertSame(
+                replacementClassLoader,
+                replacementTracker.getTaskClassLoader(replacementTask.getTaskID()));
+    }
+
+    private Task taskWithId(long taskId) {
+        return new Task() {
+            @NonNull @Override
+            public ProgressState call() {
+                return ProgressState.DONE;
+            }
+
+            @NonNull @Override
+            public Long getTaskID() {
+                return taskId;
+            }
+
+            @Override
+            public boolean isThreadsShare() {
+                return true;
+            }
+        };
     }
 
     public List<Task> buildFixedTestTask(

--- a/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
+++ b/seatunnel-engine/seatunnel-engine-server/src/test/java/org/apache/seatunnel/engine/server/TaskExecutionServiceTest.java
@@ -19,6 +19,7 @@ package org.apache.seatunnel.engine.server;
 
 import org.apache.seatunnel.shade.com.google.common.collect.Lists;
 
+import org.apache.seatunnel.common.utils.ReflectionUtils;
 import org.apache.seatunnel.engine.common.utils.PassiveCompletableFuture;
 import org.apache.seatunnel.engine.common.utils.concurrent.CompletableFuture;
 import org.apache.seatunnel.engine.core.classloader.DefaultClassLoaderService;
@@ -61,6 +62,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -604,6 +606,77 @@ public class TaskExecutionServiceTest extends AbstractSeaTunnelServerTest {
         assertSame(
                 replacementClassLoader,
                 replacementTracker.getTaskClassLoader(replacementTask.getTaskID()));
+    }
+
+    @Test
+    public void testStaleGenerationCleanupDoesNotRecycleNewerContext() throws Exception {
+        TaskExecutionService taskExecutionService = server.getTaskExecutionService();
+        TaskGroupLocation location = new TaskGroupLocation(jobId, pipeLineId, 202L);
+        Task firstTask = taskWithId(1L);
+        Task replacementTask = taskWithId(1L);
+        try (URLClassLoader firstClassLoader = new URLClassLoader(new URL[0]);
+                URLClassLoader replacementClassLoader = new URLClassLoader(new URL[0])) {
+            ConcurrentHashMap<Long, ClassLoader> firstClassLoaders = new ConcurrentHashMap<>();
+            firstClassLoaders.put(firstTask.getTaskID(), firstClassLoader);
+            TaskGroupContext firstContext =
+                    new TaskGroupContext(
+                            new TaskGroupDefaultImpl(
+                                    location, "first", Lists.newArrayList(firstTask)),
+                            firstClassLoaders,
+                            new ConcurrentHashMap<>());
+            TaskExecutionService.TaskGroupExecutionTracker firstTracker =
+                    taskExecutionService
+                    .new TaskGroupExecutionTracker(
+                            new CompletableFuture<>(),
+                            firstContext.getTaskGroup(),
+                            firstContext,
+                            new CompletableFuture<>());
+
+            ConcurrentHashMap<Long, ClassLoader> replacementClassLoaders =
+                    new ConcurrentHashMap<>();
+            replacementClassLoaders.put(replacementTask.getTaskID(), replacementClassLoader);
+            TaskGroupContext replacementContext =
+                    new TaskGroupContext(
+                            new TaskGroupDefaultImpl(
+                                    location, "replacement", Lists.newArrayList(replacementTask)),
+                            replacementClassLoaders,
+                            new ConcurrentHashMap<>());
+            TaskExecutionService.TaskGroupExecutionTracker replacementTracker =
+                    taskExecutionService
+                    .new TaskGroupExecutionTracker(
+                            new CompletableFuture<>(),
+                            replacementContext.getTaskGroup(),
+                            replacementContext,
+                            new CompletableFuture<>());
+
+            // Simulate a restore that already replaced the first generation at the same
+            // TaskGroupLocation while the first generation's tasks have not finished yet.
+            ConcurrentMap<TaskGroupLocation, TaskGroupContext> executionContexts =
+                    (ConcurrentMap<TaskGroupLocation, TaskGroupContext>)
+                            ReflectionUtils.getField(taskExecutionService, "executionContexts")
+                                    .orElseThrow(
+                                            () ->
+                                                    new IllegalStateException(
+                                                            "executionContexts field missing"));
+            executionContexts.put(location, replacementContext);
+
+            // The stale first generation finishes late: its cleanup must recycle its own
+            // context only, and must leave the newer generation's context untouched.
+            firstTracker.taskDone(firstTask);
+
+            Assertions.assertNull(
+                    firstContext.getClassLoaders(),
+                    "the stale generation's own loaders should be recycled");
+            assertSame(
+                    replacementContext,
+                    executionContexts.get(location),
+                    "the newer generation's context must stay published");
+            assertSame(
+                    replacementClassLoader,
+                    replacementTracker.getTaskClassLoader(replacementTask.getTaskID()),
+                    "the newer generation's classloaders must not be recycled by the stale generation");
+            executionContexts.remove(location, replacementContext);
+        }
     }
 
     private Task taskWithId(long taskId) {


### PR DESCRIPTION
## Summary

- keep each cooperative task tracker bound to the class-loader context created for its own execution generation
- avoid resolving a resumed task's loader from the location-keyed active-context map after restore reuses the same task group location
- add regression coverage for two generations sharing a task location and task ID

Closes #12224

## Verification

- `./mvnw -q -pl seatunnel-engine/seatunnel-engine-server spotless:apply`
- `./mvnw -o -q -pl seatunnel-engine/seatunnel-engine-server -DskipITs -Dtest=TaskExecutionServiceTest -Dsurefire.failIfNoSpecifiedTests=false test`

The targeted suite passed: 16 tests, 0 failures, 0 errors.

A full reactor verification was attempted but the existing `seatunnel-config-shade` module fails before this change is compiled because required relocated Typesafe Config sources are missing.