### PR TITLE
[Improve][Connector-V2] Migrate BigQuery validation to declarative OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-bigquery/src/main/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySink.java
+++ b/seatunnel-connectors-v2/connector-bigquery/src/main/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySink.java
@@ -31,7 +31,6 @@ import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
-import org.apache.seatunnel.common.exception.CommonError;
 import org.apache.seatunnel.connectors.bigquery.catalog.BigQueryCatalog;
 import org.apache.seatunnel.connectors.bigquery.convert.BigQuerySerializer;
 import org.apache.seatunnel.connectors.bigquery.option.BigQuerySinkOptions;
@@ -55,16 +54,8 @@ public class BigQuerySink
 
     public BigQuerySink(ReadonlyConfig config, CatalogTable catalogTable) {
         this.config = config;
-        if (BigQuerySinkBatchWriter.BATCH.equals(config.get(BigQuerySinkOptions.WRITE_MODE))) {
-            this.isBatch = true;
-        } else if (BigQuerySinkStreamWriter.STREAMING.equals(
-                config.get(BigQuerySinkOptions.WRITE_MODE))) {
-            this.isBatch = false;
-        } else {
-            throw CommonError.illegalArgument(
-                    config.get(BigQuerySinkOptions.WRITE_MODE),
-                    BigQuerySinkOptions.WRITE_MODE.key());
-        }
+        this.isBatch =
+                BigQuerySinkBatchWriter.BATCH.equals(config.get(BigQuerySinkOptions.WRITE_MODE));
         this.catalogTable = catalogTable;
     }
 

--- a/seatunnel-connectors-v2/connector-bigquery/src/main/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySink.java
+++ b/seatunnel-connectors-v2/connector-bigquery/src/main/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySink.java
@@ -31,6 +31,7 @@ import org.apache.seatunnel.api.table.catalog.Catalog;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
 import org.apache.seatunnel.api.table.catalog.TablePath;
 import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.exception.CommonError;
 import org.apache.seatunnel.connectors.bigquery.catalog.BigQueryCatalog;
 import org.apache.seatunnel.connectors.bigquery.convert.BigQuerySerializer;
 import org.apache.seatunnel.connectors.bigquery.option.BigQuerySinkOptions;
@@ -54,8 +55,16 @@ public class BigQuerySink
 
     public BigQuerySink(ReadonlyConfig config, CatalogTable catalogTable) {
         this.config = config;
-        this.isBatch =
-                BigQuerySinkBatchWriter.BATCH.equals(config.get(BigQuerySinkOptions.WRITE_MODE));
+        if (BigQuerySinkBatchWriter.BATCH.equals(config.get(BigQuerySinkOptions.WRITE_MODE))) {
+            this.isBatch = true;
+        } else if (BigQuerySinkStreamWriter.STREAMING.equals(
+                config.get(BigQuerySinkOptions.WRITE_MODE))) {
+            this.isBatch = false;
+        } else {
+            throw CommonError.illegalArgument(
+                    config.get(BigQuerySinkOptions.WRITE_MODE),
+                    BigQuerySinkOptions.WRITE_MODE.key());
+        }
         this.catalogTable = catalogTable;
     }
 

--- a/seatunnel-connectors-v2/connector-bigquery/src/main/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySinkFactory.java
+++ b/seatunnel-connectors-v2/connector-bigquery/src/main/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySinkFactory.java
@@ -18,6 +18,8 @@
 package org.apache.seatunnel.connectors.bigquery.sink;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConditionExtension;
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.options.SinkConnectorCommonOptions;
 import org.apache.seatunnel.api.table.catalog.CatalogTable;
@@ -33,6 +35,21 @@ import com.google.auto.service.AutoService;
 
 @AutoService(Factory.class)
 public class BigQuerySinkFactory implements TableSinkFactory {
+
+    private static final ConditionExtension<String> WRITE_MODE_VALIDATOR =
+            new ConditionExtension<String>() {
+                @Override
+                public String description() {
+                    return "must be either 'batch' or 'streaming'";
+                }
+
+                @Override
+                public boolean evaluate(ReadonlyConfig config, String value) {
+                    return BigQuerySinkBatchWriter.BATCH.equals(value)
+                            || BigQuerySinkStreamWriter.STREAMING.equals(value);
+                }
+            };
+
     @Override
     public String factoryIdentifier() {
         return BigQuerySinkOptions.IDENTIFIER;
@@ -43,14 +60,23 @@ public class BigQuerySinkFactory implements TableSinkFactory {
         return OptionRule.builder()
                 .required(
                         BigQuerySinkOptions.PROJECT_ID,
+                        Conditions.notBlank(BigQuerySinkOptions.PROJECT_ID))
+                .required(
                         BigQuerySinkOptions.DATASET_ID,
-                        BigQuerySinkOptions.TABLE_ID)
+                        Conditions.notBlank(BigQuerySinkOptions.DATASET_ID))
+                .required(
+                        BigQuerySinkOptions.TABLE_ID,
+                        Conditions.notBlank(BigQuerySinkOptions.TABLE_ID))
+                .optional(
+                        BigQuerySinkOptions.WRITE_MODE,
+                        Conditions.extension(BigQuerySinkOptions.WRITE_MODE, WRITE_MODE_VALIDATOR))
+                .optional(
+                        BigQuerySinkOptions.BATCH_SIZE,
+                        Conditions.greaterThan(BigQuerySinkOptions.BATCH_SIZE, 0))
                 .optional(
                         BigQuerySinkOptions.SERVICE_ACCOUNT_KEY_PATH,
                         BigQuerySinkOptions.SERVICE_ACCOUNT_KEY_JSON,
-                        BigQuerySinkOptions.WRITE_MODE,
                         BigQuerySinkOptions.SEQUENCE_NUMBER_COLUMN,
-                        BigQuerySinkOptions.BATCH_SIZE,
                         BigQuerySinkOptions.EMULATOR_HOST,
                         BigQuerySinkOptions.UNIVERSE_DOMAIN,
                         SinkConnectorCommonOptions.MULTI_TABLE_SINK_REPLICA)

--- a/seatunnel-connectors-v2/connector-bigquery/src/test/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-bigquery/src/test/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySinkFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
 import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
 import org.apache.seatunnel.connectors.bigquery.option.BigQuerySinkOptions;
 
 import org.junit.jupiter.api.Test;
@@ -82,6 +83,19 @@ class BigQuerySinkFactoryTest {
                 () ->
                         ConfigValidator.of(ReadonlyConfig.fromConfig(config))
                                 .validate(factory.optionRule()));
+    }
+
+    @Test
+    void testInvalidWriteModeRejectedBySinkConstructor() {
+        Config config =
+                ConfigFactory.parseString(
+                        requiredOptions()
+                                + BigQuerySinkOptions.WRITE_MODE.key()
+                                + " = \"invalid\"\n");
+
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromConfig(config);
+
+        assertThrows(SeaTunnelRuntimeException.class, () -> new BigQuerySink(readonlyConfig, null));
     }
 
     @Test

--- a/seatunnel-connectors-v2/connector-bigquery/src/test/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-bigquery/src/test/java/org/apache/seatunnel/connectors/bigquery/sink/BigQuerySinkFactoryTest.java
@@ -22,11 +22,13 @@ import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
 
 import org.apache.seatunnel.api.configuration.ReadonlyConfig;
 import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
 import org.apache.seatunnel.connectors.bigquery.option.BigQuerySinkOptions;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class BigQuerySinkFactoryTest {
 
@@ -34,12 +36,7 @@ class BigQuerySinkFactoryTest {
     void testStreamingModeDoesNotRequireSequenceNumberColumn() {
         Config config =
                 ConfigFactory.parseString(
-                        BigQuerySinkOptions.PROJECT_ID.key()
-                                + " = \"test-project\"\n"
-                                + BigQuerySinkOptions.DATASET_ID.key()
-                                + " = \"test_dataset\"\n"
-                                + BigQuerySinkOptions.TABLE_ID.key()
-                                + " = \"test_table\"\n"
+                        requiredOptions()
                                 + BigQuerySinkOptions.WRITE_MODE.key()
                                 + " = \"streaming\"\n"
                                 + BigQuerySinkOptions.SERVICE_ACCOUNT_KEY_JSON.key()
@@ -57,12 +54,7 @@ class BigQuerySinkFactoryTest {
     void testUniverseDomainConfigurationParsing() {
         Config config =
                 ConfigFactory.parseString(
-                        BigQuerySinkOptions.PROJECT_ID.key()
-                                + " = \"test-project\"\n"
-                                + BigQuerySinkOptions.DATASET_ID.key()
-                                + " = \"test_dataset\"\n"
-                                + BigQuerySinkOptions.TABLE_ID.key()
-                                + " = \"test_table\"\n"
+                        requiredOptions()
                                 + BigQuerySinkOptions.UNIVERSE_DOMAIN.key()
                                 + " = \"s3nsapis.fr\"\n");
 
@@ -73,5 +65,66 @@ class BigQuerySinkFactoryTest {
 
         org.junit.jupiter.api.Assertions.assertEquals(
                 "s3nsapis.fr", readonlyConfig.get(BigQuerySinkOptions.UNIVERSE_DOMAIN));
+    }
+
+    @Test
+    void testInvalidWriteModeRejectedByOptionRule() {
+        Config config =
+                ConfigFactory.parseString(
+                        requiredOptions()
+                                + BigQuerySinkOptions.WRITE_MODE.key()
+                                + " = \"invalid\"\n");
+
+        BigQuerySinkFactory factory = new BigQuerySinkFactory();
+
+        assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromConfig(config))
+                                .validate(factory.optionRule()));
+    }
+
+    @Test
+    void testNonPositiveBatchSizeRejectedByOptionRule() {
+        Config config =
+                ConfigFactory.parseString(
+                        requiredOptions() + BigQuerySinkOptions.BATCH_SIZE.key() + " = 0\n");
+
+        BigQuerySinkFactory factory = new BigQuerySinkFactory();
+
+        assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromConfig(config))
+                                .validate(factory.optionRule()));
+    }
+
+    @Test
+    void testBlankRequiredOptionRejectedByOptionRule() {
+        Config config =
+                ConfigFactory.parseString(
+                        BigQuerySinkOptions.PROJECT_ID.key()
+                                + " = \" \"\n"
+                                + BigQuerySinkOptions.DATASET_ID.key()
+                                + " = \"test_dataset\"\n"
+                                + BigQuerySinkOptions.TABLE_ID.key()
+                                + " = \"test_table\"\n");
+
+        BigQuerySinkFactory factory = new BigQuerySinkFactory();
+
+        assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromConfig(config))
+                                .validate(factory.optionRule()));
+    }
+
+    private static String requiredOptions() {
+        return BigQuerySinkOptions.PROJECT_ID.key()
+                + " = \"test-project\"\n"
+                + BigQuerySinkOptions.DATASET_ID.key()
+                + " = \"test_dataset\"\n"
+                + BigQuerySinkOptions.TABLE_ID.key()
+                + " = \"test_table\"\n";
     }
 }


### PR DESCRIPTION
### Purpose of this pull request

This PR migrates BigQuery sink configuration validation from imperative runtime checks to the declarative `OptionRule` / `Conditions` validation framework.

It is part of #11007.

### Changes

- Validate `write_mode` declaratively.
- Restrict `write_mode` to supported values:
  - `batch`
  - `streaming`
- Validate that `batch_size` is greater than `0`.
- Validate required BigQuery identifiers as non-blank:
  - `project_id`
  - `dataset_id`
  - `table_id`
- Remove redundant runtime `write_mode` validation from `BigQuerySink`.
- Add unit tests for:
  - invalid `write_mode`
  - invalid `batch_size`
  - blank required identifiers

### Does this PR introduce any user-facing change?

No.

Valid existing BigQuery configurations are not affected.

Invalid configurations are now rejected earlier during option validation instead of failing later during sink initialization.

### Testing

Added unit test coverage in `BigQuerySinkFactoryTest` for the migrated declarative validation rules.

### Related issue

#11007