### PR TITLE
Migrated GraphQL according to issue #11007

### DIFF
--- a/seatunnel-connectors-v2/connector-graphql/src/main/java/org/apache/seatunnel/connectors/seatunnel/graphql/sink/GraphQLSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-graphql/src/main/java/org/apache/seatunnel/connectors/seatunnel/graphql/sink/GraphQLSinkFactory.java
@@ -28,6 +28,8 @@ import org.apache.seatunnel.connectors.seatunnel.http.sink.HttpSinkFactory;
 
 import com.google.auto.service.AutoService;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+
 @AutoService(Factory.class)
 public class GraphQLSinkFactory extends HttpSinkFactory {
     @Override
@@ -43,7 +45,7 @@ public class GraphQLSinkFactory extends HttpSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(GraphQLSinkOptions.QUERY)
+                .required(GraphQLSinkOptions.QUERY, notBlank(GraphQLSinkOptions.QUERY))
                 .optional(GraphQLSinkOptions.TIMEOUT)
                 .optional(GraphQLSinkOptions.VALUE_COVER)
                 .optional(GraphQLSinkOptions.VARIABLES)

--- a/seatunnel-connectors-v2/connector-graphql/src/main/java/org/apache/seatunnel/connectors/seatunnel/graphql/source/GraphQLSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-graphql/src/main/java/org/apache/seatunnel/connectors/seatunnel/graphql/source/GraphQLSourceFactory.java
@@ -30,6 +30,8 @@ import com.google.auto.service.AutoService;
 
 import java.io.Serializable;
 
+import static org.apache.seatunnel.api.configuration.util.Conditions.notBlank;
+
 @AutoService(Factory.class)
 public class GraphQLSourceFactory extends HttpSourceFactory {
     @Override
@@ -46,7 +48,7 @@ public class GraphQLSourceFactory extends HttpSourceFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
-                .required(GraphQLSourceOptions.QUERY)
+                .required(GraphQLSourceOptions.QUERY, notBlank(GraphQLSourceOptions.QUERY))
                 .optional(GraphQLSourceOptions.VARIABLES)
                 .optional(GraphQLSourceOptions.ENABLE_SUBSCRIPTION)
                 .optional(GraphQLSourceOptions.TIMEOUT)

--- a/seatunnel-connectors-v2/connector-graphql/src/main/java/org/apache/seatunnel/connectors/seatunnel/graphql/util/GraphQLUtil.java
+++ b/seatunnel-connectors-v2/connector-graphql/src/main/java/org/apache/seatunnel/connectors/seatunnel/graphql/util/GraphQLUtil.java
@@ -79,11 +79,6 @@ public class GraphQLUtil {
     }
 
     public static void validateSinkOperation(String query) {
-        if (query == null || query.isEmpty()) {
-            throw new GraphQLConnectorException(
-                    GraphQLConnectorErrorCode.GRAPHQL_SOURCE_PARAMETER_ERROR,
-                    "GraphQL Sink query is required.");
-        }
         OperationDefinition.Operation operationType = parseOperationType(query);
         switch (operationType) {
             case MUTATION:
@@ -98,11 +93,6 @@ public class GraphQLUtil {
     }
 
     public static void validateSourceOperation(String query, Boolean enableSubscription) {
-        if (query == null) {
-            throw new GraphQLConnectorException(
-                    GraphQLConnectorErrorCode.GRAPHQL_SOURCE_PARAMETER_ERROR,
-                    "GraphQL Source is required.");
-        }
         OperationDefinition.Operation operationType;
         try {
             operationType = parseOperationType(query);


### PR DESCRIPTION
### Purpose of this pull request

Hello @nzw921rx! Sorry for the delay in submitting this PR, but I have migrated the GraphQL connector now. Not many changes were required, though. 
Addresses #11007 (connector-graphql)

Modifications: 
- GraphQLSinkFactory.java - added a notBlank() requirement for QUERY
- GraphQLSourceFactory.java - same modification
- GraphQLUtil.java - removed the two null/non-empty guards, notBlank() can handle the check now.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

No tests were added, existing tests were run against the changed code and succeeded. 


### Check list

* [/ ] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md)
* [/ ] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [/ ] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR.
* [ ] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml)
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml)
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config)
