### PR TITLE
[Improve][Connector-V2] Migrate S3 Redshift validation to declarative OptionRule

### DIFF
--- a/seatunnel-connectors-v2/connector-s3-redshift/src/main/java/org/apache/seatunnel/connectors/seatunnel/redshift/sink/S3RedshiftSinkFactory.java
+++ b/seatunnel-connectors-v2/connector-s3-redshift/src/main/java/org/apache/seatunnel/connectors/seatunnel/redshift/sink/S3RedshiftSinkFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.seatunnel.connectors.seatunnel.redshift.sink;
 
+import org.apache.seatunnel.api.configuration.util.Conditions;
 import org.apache.seatunnel.api.configuration.util.OptionRule;
 import org.apache.seatunnel.api.table.connector.TableSink;
 import org.apache.seatunnel.api.table.factory.Factory;
@@ -41,12 +42,20 @@ public class S3RedshiftSinkFactory implements TableSinkFactory {
     @Override
     public OptionRule optionRule() {
         return OptionRule.builder()
+                .required(S3FileBaseOptions.S3_BUCKET)
                 .required(
-                        S3FileBaseOptions.S3_BUCKET,
                         S3RedshiftSinkOptions.JDBC_URL,
+                        Conditions.notBlank(S3RedshiftSinkOptions.JDBC_URL))
+                .required(
                         S3RedshiftSinkOptions.JDBC_USER,
+                        Conditions.notBlank(S3RedshiftSinkOptions.JDBC_USER))
+                .required(
                         S3RedshiftSinkOptions.JDBC_PASSWORD,
+                        Conditions.notBlank(S3RedshiftSinkOptions.JDBC_PASSWORD))
+                .required(
                         S3RedshiftSinkOptions.EXECUTE_SQL,
+                        Conditions.notBlank(S3RedshiftSinkOptions.EXECUTE_SQL))
+                .required(
                         FileBaseSourceOptions.FILE_PATH,
                         S3FileBaseOptions.S3A_AWS_CREDENTIALS_PROVIDER_CLASS)
                 .conditional(

--- a/seatunnel-connectors-v2/connector-s3-redshift/src/test/java/org/apache/seatunnel/connectors/seatunnel/redshift/sink/S3RedshiftSinkFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-s3-redshift/src/test/java/org/apache/seatunnel/connectors/seatunnel/redshift/sink/S3RedshiftSinkFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.redshift.sink;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.file.config.FileBaseSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.file.s3.config.S3FileBaseOptions;
+import org.apache.seatunnel.connectors.seatunnel.redshift.config.S3RedshiftSinkOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class S3RedshiftSinkFactoryTest {
+
+    private final OptionRule optionRule = new S3RedshiftSinkFactory().optionRule();
+
+    @Test
+    void testValidConfiguration() {
+        Assertions.assertDoesNotThrow(() -> validate(validConfig()));
+    }
+
+    @Test
+    void testBlankRedshiftOptionsRejected() {
+        for (String key :
+                new String[] {
+                    S3RedshiftSinkOptions.JDBC_URL.key(),
+                    S3RedshiftSinkOptions.JDBC_USER.key(),
+                    S3RedshiftSinkOptions.JDBC_PASSWORD.key(),
+                    S3RedshiftSinkOptions.EXECUTE_SQL.key()
+                }) {
+            assertRejected(key, "");
+            assertRejected(key, "   \t");
+        }
+    }
+
+    private void assertRejected(String key, String value) {
+        Map<String, Object> config = validConfig();
+        config.put(key, value);
+        Assertions.assertThrows(OptionValidationException.class, () -> validate(config), key);
+    }
+
+    private void validate(Map<String, Object> config) {
+        ReadonlyConfig readonlyConfig = ReadonlyConfig.fromMap(config);
+        ConfigValidator.validateUnknownKeys(readonlyConfig, optionRule, "S3Redshift");
+        ConfigValidator.of(readonlyConfig).validate(optionRule);
+    }
+
+    private Map<String, Object> validConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(S3FileBaseOptions.S3_BUCKET.key(), "bucket");
+        config.put(S3RedshiftSinkOptions.JDBC_URL.key(), "jdbc:redshift://localhost:5439/dev");
+        config.put(S3RedshiftSinkOptions.JDBC_USER.key(), "test-user");
+        config.put(S3RedshiftSinkOptions.JDBC_PASSWORD.key(), "test-password");
+        config.put(S3RedshiftSinkOptions.EXECUTE_SQL.key(), "select 1");
+        config.put(FileBaseSourceOptions.FILE_PATH.key(), "/path");
+        config.put(S3FileBaseOptions.S3A_AWS_CREDENTIALS_PROVIDER_CLASS.key(), "test-provider");
+        return config;
+    }
+}


### PR DESCRIPTION
### Purpose of this pull request

This PR migrates declarative-eligible S3 Redshift sink configuration validation to the `OptionRule` / `Conditions` validation framework.

It is part of #11007.

### Changes

- Validate required Redshift JDBC options as non-blank:
  - `jdbc_url`
  - `jdbc_user`
  - `jdbc_password`
  - `execute_sql`
- Preserve the existing S3 credential-provider conditional requirements.
- Preserve runtime/network-dependent validation outside of the declarative option layer.
- Add focused regression tests for:
  - valid configuration
  - missing required options
  - empty required string values
  - whitespace-only required string values

### Does this PR introduce any user-facing change?

No.

Valid existing configurations are unchanged.

Invalid blank JDBC configuration values are now rejected earlier during option validation instead of reaching the runtime sink path.

### Testing

Added focused `ConfigValidator` coverage in `S3RedshiftSinkFactoryTest`.

### Related issue

#11007