### PR TITLE
[Feature][Connector-V2] Add Facebook Ads source connector

### DIFF
--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -159,6 +159,11 @@ email:
       - changed-files:
           - any-glob-to-any-file: seatunnel-connectors-v2/connector-email/**
           - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(email)/**'
+facebook-ads:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: seatunnel-connectors-v2/connector-facebook-ads/**
+          - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(facebook-ads)/**'
 file:
   - all:
       - changed-files:

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -61,6 +61,7 @@ connector-google-pubsub
 connector-azure-queue-storage
 connector-google-bigtable
 connector-google-ads
+connector-facebook-ads
 connector-graphql
 connector-hive
 connector-http-base

--- a/docs/en/connector-v2/source/FacebookAds.md
+++ b/docs/en/connector-v2/source/FacebookAds.md
@@ -1,0 +1,169 @@
+# FacebookAds
+
+> Facebook Ads source connector
+
+## Support Those Engines
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## Key Features
+
+- [x] [batch](../../introduction/concepts/connector-v2-features.md)
+- [ ] [stream](../../introduction/concepts/connector-v2-features.md)
+- [ ] [exactly-once](../../introduction/concepts/connector-v2-features.md)
+- [x] [column projection](../../introduction/concepts/connector-v2-features.md)
+- [ ] [parallelism](../../introduction/concepts/connector-v2-features.md)
+- [x] [support multiple table read](../../introduction/concepts/connector-v2-features.md)
+
+## Description
+
+Reads data from Facebook (Meta) ad account edges (`campaigns`, `adsets`, `ads`,
+`insights`, ...) using the Meta Marketing API (Graph API,
+`GET /{version}/act_{ad_account_id}/{edge}`). Supports single-resource and
+multi-table (`tables_configs`) batch ingestion. Results are streamed page by
+page via the `paging.cursors.after` cursor, so only one page is held in memory
+at a time.
+
+Authentication uses a long-lived access token with the `ads_read` permission,
+sent as an `Authorization: Bearer` header (never as a query parameter, so it
+cannot leak into logs).
+
+The Graph API has no field metadata service, so every output column is
+**STRING** — Facebook already returns most metrics as JSON strings, and nested
+objects/arrays are emitted as JSON text. The schema follows the `fields` list
+order, so column `i` always corresponds to selected field `i`.
+
+## Supported DataSource Info
+
+| Datasource   | Supported Versions                                          |
+|--------------|-------------------------------------------------------------|
+| Facebook Ads | Graph API v23.0 (default, configurable via `api_version`)   |
+
+## Prerequisites
+
+1. A Meta developer app with the **Marketing API** product added.
+2. An **access token** with the `ads_read` permission — e.g. a long-lived user
+   token (60 days) or a system user token (non-expiring) from Business Manager.
+3. The **ad account ID** to query (digits only, e.g. `1234567890`; a leading
+   `act_` prefix is accepted and stripped).
+
+## Source Options
+
+| Name               | Type    | Required | Default                    | Description                                                                                          |
+|--------------------|---------|----------|----------------------------|------------------------------------------------------------------------------------------------------|
+| access_token       | String  | Yes      | -                          | Meta Marketing API access token with the `ads_read` permission.                                       |
+| ad_account_id      | String  | Yes      | -                          | Ad account ID to query, digits only, e.g. `1234567890`. A leading `act_` prefix is accepted.          |
+| api_version        | String  | No       | v23.0                      | Facebook Graph API version.                                                                           |
+| resource           | String  | No*      | -                          | Ad account edge for single-table mode, e.g. `campaigns`, `adsets`, `ads`, `insights`. Requires `fields`. Exclusive with `tables_configs`. |
+| fields             | List    | No       | -                          | Ordered list of field names to select, e.g. `[id, name, status]`. The output schema follows this order. |
+| filtering          | String  | No       | -                          | JSON array passed as the Graph API `filtering` parameter, e.g. `[{"field":"effective_status","operator":"IN","value":["ACTIVE"]}]`. |
+| params             | Map     | No       | -                          | Extra query parameters appended to the request, e.g. `{date_preset = last_30d, level = campaign}` for the `insights` edge. Must not contain `fields`, `limit`, `after`, `filtering` or `access_token`. |
+| request_timeout_ms | Integer | No       | 60000                      | HTTP request timeout in milliseconds for a single call.                                               |
+| max_retries        | Integer | No       | 3                          | Maximum retries for transient HTTP failures (429/5xx/rate limits/network errors) of a single request. |
+| retry_backoff_ms   | Long    | No       | 1000                       | Base backoff in milliseconds between retries; doubled per attempt.                                    |
+| page_size          | Integer | No       | -                          | Page size for each request (the Graph API `limit` parameter). When unset the server default is used.  |
+
+\* Exactly one of `resource` or `tables_configs` must be provided.
+
+The Graph API has no `SELECT *`, so the field list is always explicit via
+`fields`. Invalid field names are rejected before any data is read, with the
+offending name in the error message. Facebook rate limits (HTTP 400/403 with
+error code 4, 17, 32 or 613, or HTTP 429) are retried with exponential backoff;
+other client errors are never retried and the API error message is surfaced
+as-is.
+
+### tables_configs entry options
+
+| Name          | Type   | Required | Description                                                                        |
+|---------------|--------|----------|------------------------------------------------------------------------------------|
+| table_path    | String | Yes      | Format: `database.resource`, e.g. `facebook_ads.campaigns`. The resource part names the edge to read. |
+| fields        | List   | Yes      | Ordered field names for this table.                                                 |
+| filtering     | String | No       | Graph API `filtering` JSON array for this table.                                    |
+| params        | Map    | No       | Extra query parameters for this table.                                              |
+| ad_account_id | String | No       | Per-table ad account ID override; falls back to the global `ad_account_id`.         |
+
+## Data Type Mapping
+
+| Facebook Ads Data Type | SeaTunnel Data Type | Notes                                                              |
+|------------------------|---------------------|--------------------------------------------------------------------|
+| Any scalar value       | STRING              | The Graph API serializes most metrics as JSON strings already.     |
+| Object / array         | STRING              | Nested objects and arrays are emitted as JSON text.                |
+
+Fields absent from a result row (the API omits empty fields entirely) are
+emitted as `null`.
+
+## Example
+
+### Single resource
+
+```hocon
+source {
+  FacebookAds {
+    access_token  = "your_access_token"
+    ad_account_id = "1234567890"
+
+    resource = "campaigns"
+    fields   = ["id", "name", "status", "objective", "created_time"]
+    filtering = "[{\"field\":\"effective_status\",\"operator\":\"IN\",\"value\":[\"ACTIVE\"]}]"
+  }
+}
+```
+
+### Insights with extra parameters
+
+```hocon
+source {
+  FacebookAds {
+    access_token  = "your_access_token"
+    ad_account_id = "1234567890"
+
+    resource = "insights"
+    fields   = ["campaign_id", "campaign_name", "impressions", "clicks", "spend"]
+    params = {
+      date_preset = "last_30d"
+      level       = "campaign"
+    }
+  }
+}
+```
+
+### Multiple tables (with per-table ad account ID)
+
+```hocon
+source {
+  FacebookAds {
+    access_token  = "your_access_token"
+    ad_account_id = "1234567890"
+
+    tables_configs = [
+      {
+        table_path = "facebook_ads.campaigns"
+        fields     = ["id", "name", "status"]
+      },
+      {
+        table_path    = "facebook_ads.insights"
+        fields        = ["campaign_id", "impressions", "spend"]
+        params        = { date_preset = "last_30d", level = "campaign" }
+        ad_account_id = "2345678901"
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Batch only; no incremental/CDC reads (use `params` with `time_range` or
+  `date_preset` for windowed extraction on the `insights` edge).
+- No parallel reading; each job reads with a single split.
+- No exactly-once semantics; re-running a job re-reads the data.
+- All columns are STRING; nested objects are emitted as JSON strings, not
+  nested rows.
+
+## Changelog
+
+### next version
+
+- Add Facebook Ads source connector with cursor pagination and multi-table support

--- a/docs/zh/connector-v2/source/FacebookAds.md
+++ b/docs/zh/connector-v2/source/FacebookAds.md
@@ -1,0 +1,162 @@
+# FacebookAds
+
+> Facebook Ads 源连接器
+
+## 支持的引擎
+
+> Spark<br/>
+> Flink<br/>
+> SeaTunnel Zeta<br/>
+
+## 主要特性
+
+- [x] [批处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [流处理](../../introduction/concepts/connector-v2-features.md)
+- [ ] [精确一次](../../introduction/concepts/connector-v2-features.md)
+- [x] [列投影](../../introduction/concepts/connector-v2-features.md)
+- [ ] [并行读取](../../introduction/concepts/connector-v2-features.md)
+- [x] [支持多表读取](../../introduction/concepts/connector-v2-features.md)
+
+## 描述
+
+通过 Meta Marketing API（Graph API，
+`GET /{version}/act_{ad_account_id}/{edge}`）读取 Facebook（Meta）广告账户
+边（edge）数据（`campaigns`、`adsets`、`ads`、`insights` 等）。支持单资源
+模式和多表（`tables_configs`）批量读取。结果通过 `paging.cursors.after`
+游标逐页流式读取，内存中同一时间只保留一页数据。
+
+认证使用具有 `ads_read` 权限的长期 access token，以
+`Authorization: Bearer` 请求头发送（不作为查询参数，避免泄漏到日志中）。
+
+Graph API 没有字段元数据服务，因此所有输出列均为 **STRING** 类型——
+Facebook 本身就以 JSON 字符串返回大多数指标，嵌套对象/数组会输出为 JSON
+文本。schema 按 `fields` 列表顺序构建，第 i 列始终对应第 i 个所选字段。
+
+## 支持的数据源信息
+
+| 数据源       | 支持版本                                        |
+|--------------|-------------------------------------------------|
+| Facebook Ads | Graph API v23.0（默认，可通过 `api_version` 配置） |
+
+## 前置条件
+
+1. 已添加 **Marketing API** 产品的 Meta 开发者应用。
+2. 具有 `ads_read` 权限的 **access token**——例如长期用户 token（60 天）
+   或 Business Manager 中的系统用户 token（不过期）。
+3. 要查询的**广告账户 ID**（纯数字，例如 `1234567890`；允许携带 `act_`
+   前缀，连接器会自动去除）。
+
+## 源选项
+
+| 名称               | 类型    | 必填 | 默认值  | 描述                                                                                       |
+|--------------------|---------|------|---------|--------------------------------------------------------------------------------------------|
+| access_token       | String  | 是   | -       | 具有 `ads_read` 权限的 Meta Marketing API access token。                                     |
+| ad_account_id      | String  | 是   | -       | 要查询的广告账户 ID，纯数字，例如 `1234567890`。允许携带 `act_` 前缀。                        |
+| api_version        | String  | 否   | v23.0   | Facebook Graph API 版本。                                                                    |
+| resource           | String  | 否*  | -       | 单表模式下的广告账户边，例如 `campaigns`、`adsets`、`ads`、`insights`。需要配合 `fields`。与 `tables_configs` 互斥。 |
+| fields             | List    | 否   | -       | 要选取的字段名有序列表，例如 `[id, name, status]`。输出 schema 按此顺序构建。                 |
+| filtering          | String  | 否   | -       | 作为 Graph API `filtering` 参数传递的 JSON 数组，例如 `[{"field":"effective_status","operator":"IN","value":["ACTIVE"]}]`。 |
+| params             | Map     | 否   | -       | 附加到请求的额外查询参数，例如 `insights` 边的 `{date_preset = last_30d, level = campaign}`。不允许包含 `fields`、`limit`、`after`、`filtering`、`access_token`。 |
+| request_timeout_ms | Integer | 否   | 60000   | 单次调用的 HTTP 请求超时（毫秒）。                                                            |
+| max_retries        | Integer | 否   | 3       | 单个请求瞬时失败（429/5xx/限流/网络错误）的最大重试次数。                                     |
+| retry_backoff_ms   | Long    | 否   | 1000    | 重试之间的基础退避时间（毫秒）；每次重试翻倍。                                                |
+| page_size          | Integer | 否   | -       | 每次请求的分页大小（Graph API `limit` 参数）。不设置时使用服务端默认值。                       |
+
+\* `resource` 和 `tables_configs` 必须且只能提供一个。
+
+Graph API 没有 `SELECT *`，字段列表必须通过 `fields` 显式给出。非法字段名
+在读取任何数据之前即被拒绝，错误信息中会指出具体字段名。Facebook 限流
+（HTTP 400/403 且错误码为 4、17、32、613，或 HTTP 429）会以指数退避重试；
+其他客户端错误不重试，并原样透出 API 错误信息。
+
+### tables_configs 条目选项
+
+| 名称          | 类型   | 必填 | 描述                                                                       |
+|---------------|--------|------|-----------------------------------------------------------------------------|
+| table_path    | String | 是   | 格式：`database.resource`，例如 `facebook_ads.campaigns`。resource 部分指定要读取的边。 |
+| fields        | List   | 是   | 该表的字段名有序列表。                                                        |
+| filtering     | String | 否   | 该表的 Graph API `filtering` JSON 数组。                                      |
+| params        | Map    | 否   | 该表的额外查询参数。                                                          |
+| ad_account_id | String | 否   | 表级广告账户 ID 覆盖；未设置时回落到全局 `ad_account_id`。                     |
+
+## 数据类型映射
+
+| Facebook Ads 数据类型 | SeaTunnel 数据类型 | 说明                                                    |
+|-----------------------|--------------------|----------------------------------------------------------|
+| 任意标量值            | STRING             | Graph API 本身就以 JSON 字符串返回大多数指标。            |
+| 对象 / 数组           | STRING             | 嵌套对象和数组输出为 JSON 文本。                          |
+
+结果行中缺失的字段（API 会完全省略空字段）输出为 `null`。
+
+## 示例
+
+### 单资源
+
+```hocon
+source {
+  FacebookAds {
+    access_token  = "your_access_token"
+    ad_account_id = "1234567890"
+
+    resource = "campaigns"
+    fields   = ["id", "name", "status", "objective", "created_time"]
+    filtering = "[{\"field\":\"effective_status\",\"operator\":\"IN\",\"value\":[\"ACTIVE\"]}]"
+  }
+}
+```
+
+### 带额外参数的 insights
+
+```hocon
+source {
+  FacebookAds {
+    access_token  = "your_access_token"
+    ad_account_id = "1234567890"
+
+    resource = "insights"
+    fields   = ["campaign_id", "campaign_name", "impressions", "clicks", "spend"]
+    params = {
+      date_preset = "last_30d"
+      level       = "campaign"
+    }
+  }
+}
+```
+
+### 多表（带表级广告账户 ID）
+
+```hocon
+source {
+  FacebookAds {
+    access_token  = "your_access_token"
+    ad_account_id = "1234567890"
+
+    tables_configs = [
+      {
+        table_path = "facebook_ads.campaigns"
+        fields     = ["id", "name", "status"]
+      },
+      {
+        table_path    = "facebook_ads.insights"
+        fields        = ["campaign_id", "impressions", "spend"]
+        params        = { date_preset = "last_30d", level = "campaign" }
+        ad_account_id = "2345678901"
+      }
+    ]
+  }
+}
+```
+
+## 限制
+
+- 仅支持批处理；无增量/CDC 读取（可在 `insights` 边上通过 `params` 的
+  `time_range` 或 `date_preset` 做窗口化抽取）。
+- 不支持并行读取；每个作业以单 split 读取。
+- 无精确一次语义；重跑作业会重新读取数据。
+- 所有列均为 STRING；嵌套对象输出为 JSON 字符串而非嵌套行。
+
+## 变更日志
+
+### next version
+
+- 新增 Facebook Ads 源连接器，支持游标分页和多表读取

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -105,6 +105,7 @@ seatunnel.sink.AzureQueueStorage = connector-azure-queue-storage
 seatunnel.source.GoogleBigtable = connector-google-bigtable
 seatunnel.sink.GoogleBigtable = connector-google-bigtable
 seatunnel.source.GoogleAds = connector-google-ads
+seatunnel.source.FacebookAds = connector-facebook-ads
 seatunnel.sink.Tablestore = connector-tablestore
 seatunnel.source.Tablestore = connector-tablestore
 seatunnel.source.Lemlist = connector-http-lemlist

--- a/seatunnel-connectors-v2/connector-facebook-ads/pom.xml
+++ b/seatunnel-connectors-v2/connector-facebook-ads/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>connector-facebook-ads</artifactId>
+    <name>SeaTunnel : Connectors V2 : Facebook Ads</name>
+
+    <properties>
+        <httpclient.version>4.5.13</httpclient.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/client/FacebookAdsClient.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/client/FacebookAdsClient.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.client;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsParameters;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorException;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@Slf4j
+public class FacebookAdsClient implements Closeable {
+
+    /**
+     * Graph API error codes that indicate rate limiting; Facebook reports them with HTTP 400/403,
+     * so the status code alone is not enough to detect a transient throttle.
+     */
+    private static final Set<Integer> RATE_LIMIT_ERROR_CODES =
+            new HashSet<>(Arrays.asList(4, 17, 32, 613));
+
+    private final FacebookAdsParameters params;
+    private final CloseableHttpClient httpClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public FacebookAdsClient(FacebookAdsParameters params) {
+        this.params = params;
+        RequestConfig requestConfig =
+                RequestConfig.custom()
+                        .setConnectTimeout(params.getRequestTimeoutMs())
+                        .setSocketTimeout(params.getRequestTimeoutMs())
+                        .build();
+        this.httpClient = HttpClients.custom().setDefaultRequestConfig(requestConfig).build();
+    }
+
+    /**
+     * Reads one ad account edge end-to-end, walking forward via the paging.cursors.after cursor.
+     * Each element of the data array is flattened to an Object[] aligned with the configured field
+     * order and pushed to rowConsumer immediately; only one page's JSON body is held in memory at a
+     * time. Every value is emitted as a string (the Graph API serializes most metrics as strings
+     * anyway); nested objects and arrays are emitted as JSON text, absent fields as null.
+     */
+    public void search(FacebookAdsTableConfig tableConfig, Consumer<Object[]> rowConsumer) {
+        String baseUrl =
+                params.getApiEndpoint()
+                        + "/"
+                        + params.getApiVersion()
+                        + "/act_"
+                        + tableConfig.getAdAccountId()
+                        + "/"
+                        + tableConfig.getResource();
+        String afterCursor = null;
+
+        do {
+            String url = buildPageUrl(baseUrl, tableConfig, afterCursor);
+            String body = executeGet(url);
+            try {
+                JsonNode json = objectMapper.readTree(body);
+                JsonNode data = json.get("data");
+                if (data != null) {
+                    for (JsonNode result : data) {
+                        Object[] row = new Object[tableConfig.getFieldNames().size()];
+                        for (int i = 0; i < tableConfig.getFieldNames().size(); i++) {
+                            JsonNode node = result.get(tableConfig.getFieldNames().get(i));
+                            row[i] =
+                                    (node == null || node.isNull())
+                                            ? null
+                                            : (node.isValueNode()
+                                                    ? node.asText()
+                                                    : node.toString());
+                        }
+                        rowConsumer.accept(row);
+                    }
+                }
+                afterCursor = nextCursor(json);
+            } catch (FacebookAdsConnectorException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new FacebookAdsConnectorException(
+                        FacebookAdsConnectorErrorCode.REQUEST_FAILED, e);
+            }
+        } while (afterCursor != null);
+    }
+
+    private String buildPageUrl(
+            String baseUrl, FacebookAdsTableConfig tableConfig, String afterCursor) {
+        try {
+            URIBuilder builder = new URIBuilder(baseUrl);
+            builder.addParameter("fields", String.join(",", tableConfig.getFieldNames()));
+            if (tableConfig.getFiltering() != null) {
+                builder.addParameter("filtering", tableConfig.getFiltering());
+            }
+            for (Map.Entry<String, String> entry : tableConfig.getParams().entrySet()) {
+                builder.addParameter(entry.getKey(), entry.getValue());
+            }
+            if (params.getPageSize() != null) {
+                builder.addParameter("limit", String.valueOf(params.getPageSize()));
+            }
+            if (afterCursor != null) {
+                builder.addParameter("after", afterCursor);
+            }
+            return builder.build().toString();
+        } catch (Exception e) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.REQUEST_FAILED, e);
+        }
+    }
+
+    /**
+     * The Graph API signals a further page by including paging.next; the after cursor is only
+     * followed when next is present, since Facebook always echoes the cursors block even on the
+     * last page.
+     */
+    private String nextCursor(JsonNode json) {
+        JsonNode paging = json.get("paging");
+        if (paging == null || paging.get("next") == null) {
+            return null;
+        }
+        JsonNode cursors = paging.get("cursors");
+        if (cursors == null || cursors.get("after") == null) {
+            return null;
+        }
+        String after = cursors.get("after").asText();
+        return after.isEmpty() ? null : after;
+    }
+
+    /**
+     * GETs a Graph API URL with the access token as a Bearer header (kept out of the URL so it
+     * cannot leak into logs). 401 fails fast as an auth error. Transient failures - HTTP 429/5xx,
+     * Facebook rate-limit error codes carried in 400/403 bodies, and IO errors - are retried up to
+     * max_retries with exponential backoff; other non-200 statuses fail fast with the API error
+     * body surfaced.
+     */
+    private String executeGet(String url) {
+        int attempt = 0;
+        while (true) {
+            try {
+                HttpGet get = new HttpGet(url);
+                get.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + params.getAccessToken());
+                try (CloseableHttpResponse response = httpClient.execute(get)) {
+                    int status = response.getStatusLine().getStatusCode();
+                    String body =
+                            EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+                    if (status == 200) {
+                        return body;
+                    }
+                    if (isRateLimited(status, body) || isTransient(status)) {
+                        if (attempt < params.getMaxRetries()) {
+                            backoff(++attempt, "HTTP " + status);
+                            continue;
+                        }
+                        throw new FacebookAdsConnectorException(
+                                FacebookAdsConnectorErrorCode.REQUEST_FAILED,
+                                "HTTP " + status + ": " + body);
+                    }
+                    if (status == 401) {
+                        throw new FacebookAdsConnectorException(
+                                FacebookAdsConnectorErrorCode.AUTH_FAILED,
+                                "HTTP " + status + ": " + body);
+                    }
+                    throw new FacebookAdsConnectorException(
+                            FacebookAdsConnectorErrorCode.REQUEST_FAILED,
+                            "HTTP " + status + ": " + body);
+                }
+            } catch (FacebookAdsConnectorException e) {
+                throw e;
+            } catch (IOException e) {
+                if (attempt < params.getMaxRetries()) {
+                    backoff(++attempt, e.getMessage());
+                    continue;
+                }
+                throw new FacebookAdsConnectorException(
+                        FacebookAdsConnectorErrorCode.REQUEST_FAILED, e);
+            }
+        }
+    }
+
+    private boolean isTransient(int status) {
+        return status == 429 || (status >= 500 && status <= 504);
+    }
+
+    private boolean isRateLimited(int status, String body) {
+        if (status != 400 && status != 403) {
+            return false;
+        }
+        try {
+            JsonNode error = objectMapper.readTree(body).get("error");
+            return error != null
+                    && error.get("code") != null
+                    && RATE_LIMIT_ERROR_CODES.contains(error.get("code").asInt());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void backoff(int attempt, String reason) {
+        long sleepMs = params.getRetryBackoffMs() * (1L << (attempt - 1));
+        log.warn(
+                "Transient Facebook Graph API failure ({}); retry {}/{} after {}ms",
+                reason,
+                attempt,
+                params.getMaxRetries(),
+                sleepMs);
+        try {
+            Thread.sleep(sleepMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.REQUEST_FAILED,
+                    "Interrupted during retry backoff");
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpClient.close();
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/config/FacebookAdsParameters.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/config/FacebookAdsParameters.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.config;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class FacebookAdsParameters implements Serializable {
+
+    private String accessToken;
+    private String adAccountId;
+    private String apiVersion;
+    private int requestTimeoutMs;
+    private int maxRetries;
+    private long retryBackoffMs;
+    private Integer pageSize;
+    private String apiEndpoint;
+
+    public void buildWithConfig(ReadonlyConfig config) {
+        this.accessToken = config.get(FacebookAdsSourceOptions.ACCESS_TOKEN);
+        this.adAccountId = config.get(FacebookAdsSourceOptions.AD_ACCOUNT_ID);
+        this.apiVersion = config.get(FacebookAdsSourceOptions.API_VERSION);
+        this.requestTimeoutMs = config.get(FacebookAdsSourceOptions.REQUEST_TIMEOUT_MS);
+        this.maxRetries = config.get(FacebookAdsSourceOptions.MAX_RETRIES);
+        this.retryBackoffMs = config.get(FacebookAdsSourceOptions.RETRY_BACKOFF_MS);
+        this.pageSize = config.getOptional(FacebookAdsSourceOptions.PAGE_SIZE).orElse(null);
+        this.apiEndpoint = config.get(FacebookAdsSourceOptions.API_ENDPOINT);
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/config/FacebookAdsSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/config/FacebookAdsSourceOptions.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.config;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.util.List;
+import java.util.Map;
+
+public class FacebookAdsSourceOptions {
+
+    public static final Option<String> ACCESS_TOKEN =
+            Options.key("access_token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Meta Marketing API access token with the ads_read permission, "
+                                    + "e.g. a long-lived user token or a system user token.");
+
+    public static final Option<String> AD_ACCOUNT_ID =
+            Options.key("ad_account_id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Facebook ad account ID to query, digits only, e.g. 1234567890. "
+                                    + "A leading act_ prefix is accepted and stripped.");
+
+    public static final Option<String> API_VERSION =
+            Options.key("api_version")
+                    .stringType()
+                    .defaultValue("v23.0")
+                    .withDescription("Facebook Graph API version, e.g. v23.0.");
+
+    public static final Option<String> RESOURCE =
+            Options.key("resource")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Ad account edge to read in single-table mode, e.g. campaigns, "
+                                    + "adsets, ads, insights. Mutually exclusive with "
+                                    + "tables_configs.");
+
+    public static final Option<List<String>> FIELDS =
+            Options.key("fields")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Ordered list of field names to select, e.g. [id, name, status]. "
+                                    + "The output schema follows this order.");
+
+    public static final Option<String> FILTERING =
+            Options.key("filtering")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "JSON array passed as the Graph API filtering parameter, e.g. "
+                                    + "[{\"field\":\"effective_status\",\"operator\":\"IN\","
+                                    + "\"value\":[\"ACTIVE\"]}].");
+
+    public static final Option<Map<String, String>> PARAMS =
+            Options.key("params")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Extra query parameters appended to the request, e.g. "
+                                    + "{date_preset = last_30d, level = campaign} for the "
+                                    + "insights edge.");
+
+    public static final Option<Integer> REQUEST_TIMEOUT_MS =
+            Options.key("request_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("HTTP request timeout in milliseconds for a single call.");
+
+    public static final Option<Integer> MAX_RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Maximum retries for transient HTTP failures (429/5xx/rate "
+                                    + "limits/network errors) of a single request.");
+
+    public static final Option<Long> RETRY_BACKOFF_MS =
+            Options.key("retry_backoff_ms")
+                    .longType()
+                    .defaultValue(1000L)
+                    .withDescription(
+                            "Base backoff in milliseconds between retries; doubled per attempt.");
+
+    public static final Option<Integer> PAGE_SIZE =
+            Options.key("page_size")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Page size for each request (the Graph API limit parameter). "
+                                    + "When unset the server default is used.");
+
+    public static final Option<String> TABLE_PATH =
+            Options.key("table_path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Table path in 'database.resource' format, e.g. "
+                                    + "facebook_ads.campaigns. Used in tables_configs entries.");
+
+    public static final Option<String> API_ENDPOINT =
+            Options.key("api_endpoint")
+                    .stringType()
+                    .defaultValue("https://graph.facebook.com")
+                    .withDescription("Facebook Graph API base endpoint. Intended for testing.");
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/config/FacebookAdsTableConfig.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/config/FacebookAdsTableConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.config;
+
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class FacebookAdsTableConfig implements Serializable {
+
+    private final String resource;
+    private final String adAccountId;
+    private final ArrayList<String> fieldNames;
+    private final String filtering;
+    private final LinkedHashMap<String, String> params;
+    private final CatalogTable catalogTable;
+
+    public FacebookAdsTableConfig(
+            String resource,
+            String adAccountId,
+            List<String> fieldNames,
+            String filtering,
+            Map<String, String> params,
+            CatalogTable catalogTable) {
+        this.resource = resource;
+        this.adAccountId = adAccountId;
+        this.fieldNames = new ArrayList<>(fieldNames);
+        this.filtering = filtering;
+        this.params = params == null ? new LinkedHashMap<>() : new LinkedHashMap<>(params);
+        this.catalogTable = catalogTable;
+    }
+
+    public String getTableId() {
+        return catalogTable.getTableId().toTablePath().toString();
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/exception/FacebookAdsConnectorErrorCode.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/exception/FacebookAdsConnectorErrorCode.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+
+public enum FacebookAdsConnectorErrorCode implements SeaTunnelErrorCode {
+    AUTH_FAILED("FACEBOOK_ADS-01", "Facebook access token was rejected by the Graph API"),
+    REQUEST_FAILED("FACEBOOK_ADS-02", "Facebook Graph API request failed"),
+    INVALID_CONFIG("FACEBOOK_ADS-03", "Invalid resource, fields or params configuration"),
+    INVALID_TABLE_PATH("FACEBOOK_ADS-04", "Invalid table_path; expected format: database.resource"),
+    DUPLICATE_RESOURCE("FACEBOOK_ADS-05", "Duplicate table found in tables_configs");
+
+    private final String code;
+    private final String description;
+
+    FacebookAdsConnectorErrorCode(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/exception/FacebookAdsConnectorException.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/exception/FacebookAdsConnectorException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception;
+
+import org.apache.seatunnel.common.exception.SeaTunnelErrorCode;
+import org.apache.seatunnel.common.exception.SeaTunnelRuntimeException;
+
+public class FacebookAdsConnectorException extends SeaTunnelRuntimeException {
+    public FacebookAdsConnectorException(
+            SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage) {
+        super(seaTunnelErrorCode, errorMessage);
+    }
+
+    public FacebookAdsConnectorException(
+            SeaTunnelErrorCode seaTunnelErrorCode, String errorMessage, Throwable cause) {
+        super(seaTunnelErrorCode, errorMessage, cause);
+    }
+
+    public FacebookAdsConnectorException(SeaTunnelErrorCode seaTunnelErrorCode, Throwable cause) {
+        super(seaTunnelErrorCode, cause);
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSource.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSource.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.source;
+
+import org.apache.seatunnel.shade.org.apache.commons.lang3.StringUtils;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.SupportColumnProjection;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.PhysicalColumn;
+import org.apache.seatunnel.api.table.catalog.TableIdentifier;
+import org.apache.seatunnel.api.table.catalog.TableSchema;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitSource;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsParameters;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsSourceOptions;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class FacebookAdsSource extends AbstractSingleSplitSource<SeaTunnelRow>
+        implements SupportColumnProjection {
+
+    private static final String PLUGIN_NAME = "FacebookAds";
+    private static final String DEFAULT_DATABASE = "facebook_ads";
+    private static final Pattern FIELD_PATTERN = Pattern.compile("^[a-z0-9_]+$");
+    private static final Pattern RESOURCE_PATTERN = Pattern.compile("^[a-z0-9_]+$");
+    private static final Pattern AD_ACCOUNT_ID_PATTERN = Pattern.compile("^[0-9]+$");
+
+    /** Query parameters the connector manages itself; user-supplied params must not clash. */
+    private static final Set<String> RESERVED_PARAMS =
+            new HashSet<>(Arrays.asList("fields", "limit", "after", "filtering", "access_token"));
+
+    private final FacebookAdsParameters params;
+    private final List<FacebookAdsTableConfig> tableConfigs;
+
+    public FacebookAdsSource(FacebookAdsParameters params, ReadonlyConfig config) {
+        this.params = params;
+        this.tableConfigs = buildTableConfigs(config);
+    }
+
+    /**
+     * Resolves resource/fields/tables_configs into one or more FacebookAdsTableConfig instances.
+     * Unlike Google Ads there is no field metadata service, so every column is STRING and the
+     * CatalogTable is built locally without any network call at createSource time.
+     */
+    private List<FacebookAdsTableConfig> buildTableConfigs(ReadonlyConfig config) {
+        if (config.getOptional(ConnectorCommonOptions.TABLE_CONFIGS).isPresent()) {
+            List<Map<String, Object>> tableConfigMaps =
+                    config.get(ConnectorCommonOptions.TABLE_CONFIGS);
+            List<FacebookAdsTableConfig> configs = new ArrayList<>();
+            for (Map<String, Object> map : tableConfigMaps) {
+                ReadonlyConfig tableConfig = ReadonlyConfig.fromMap(map);
+                FacebookAdsTableConfig built = buildOneTableConfig(tableConfig);
+                String tableId = built.getTableId();
+                boolean duplicate = configs.stream().anyMatch(c -> c.getTableId().equals(tableId));
+                if (duplicate) {
+                    throw new FacebookAdsConnectorException(
+                            FacebookAdsConnectorErrorCode.DUPLICATE_RESOURCE,
+                            "Duplicate table in tables_configs: " + tableId);
+                }
+                configs.add(built);
+            }
+            return configs;
+        } else {
+            return Collections.singletonList(
+                    buildSingleTableConfig(config, DEFAULT_DATABASE, null));
+        }
+    }
+
+    private FacebookAdsTableConfig buildOneTableConfig(ReadonlyConfig tableConfig) {
+        String tablePath =
+                tableConfig
+                        .getOptional(FacebookAdsSourceOptions.TABLE_PATH)
+                        .orElseThrow(
+                                () ->
+                                        new FacebookAdsConnectorException(
+                                                FacebookAdsConnectorErrorCode.INVALID_TABLE_PATH,
+                                                "table_path is required in tables_configs"));
+        String[] parts = tablePath.split("\\.", 2);
+        if (parts.length != 2 || StringUtils.isBlank(parts[0]) || StringUtils.isBlank(parts[1])) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.INVALID_TABLE_PATH,
+                    "table_path must be 'database.resource', got: " + tablePath);
+        }
+        return buildSingleTableConfig(tableConfig, parts[0], parts[1]);
+    }
+
+    /**
+     * Builds one table from resource + fields [+ filtering/params]. The ordered field list is the
+     * single source of truth shared by the schema, the fields query parameter, and row value
+     * extraction. expectedResource is non-null only in tables_configs mode, where the table_path
+     * names the edge and a per-entry resource option is not consulted.
+     */
+    private FacebookAdsTableConfig buildSingleTableConfig(
+            ReadonlyConfig config, String database, String expectedResource) {
+        String resource =
+                expectedResource != null
+                        ? expectedResource
+                        : config.getOptional(FacebookAdsSourceOptions.RESOURCE)
+                                .orElseThrow(
+                                        () ->
+                                                new FacebookAdsConnectorException(
+                                                        FacebookAdsConnectorErrorCode
+                                                                .INVALID_CONFIG,
+                                                        "One of resource or tables_configs is "
+                                                                + "required"));
+        if (!RESOURCE_PATTERN.matcher(resource).matches()) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                    "Invalid resource: '"
+                            + resource
+                            + "'. Expected a snake_case ad account edge like campaigns, adsets, "
+                            + "ads or insights.");
+        }
+
+        List<String> fields = config.getOptional(FacebookAdsSourceOptions.FIELDS).orElse(null);
+        if (fields == null || fields.isEmpty()) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                    "fields must be a non-empty list");
+        }
+        List<String> fieldNames = new ArrayList<>();
+        for (String field : fields) {
+            fieldNames.add(validateField(field.trim()));
+        }
+
+        Map<String, String> extraParams =
+                config.getOptional(FacebookAdsSourceOptions.PARAMS).orElse(null);
+        if (extraParams != null) {
+            for (String key : extraParams.keySet()) {
+                if (RESERVED_PARAMS.contains(key)) {
+                    throw new FacebookAdsConnectorException(
+                            FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                            "params must not contain the reserved key '"
+                                    + key
+                                    + "'; it is managed by the connector.");
+                }
+            }
+        }
+
+        String filtering = config.getOptional(FacebookAdsSourceOptions.FILTERING).orElse(null);
+        String adAccountId =
+                normalizeAdAccountId(
+                        config.getOptional(FacebookAdsSourceOptions.AD_ACCOUNT_ID)
+                                .orElse(params.getAdAccountId()));
+
+        CatalogTable catalogTable = buildCatalogTable(database, resource, fieldNames);
+        return new FacebookAdsTableConfig(
+                resource, adAccountId, fieldNames, filtering, extraParams, catalogTable);
+    }
+
+    /**
+     * The Graph API has no field metadata endpoint, so every column is STRING: Facebook already
+     * returns most metrics as JSON strings, and nested objects/arrays are emitted as JSON text.
+     */
+    private CatalogTable buildCatalogTable(
+            String database, String resource, List<String> fieldNames) {
+        TableSchema.Builder schemaBuilder = TableSchema.builder();
+        for (String fieldName : fieldNames) {
+            schemaBuilder.column(
+                    PhysicalColumn.of(
+                            fieldName, BasicType.STRING_TYPE, null, null, true, null, null));
+        }
+        return CatalogTable.of(
+                TableIdentifier.of(PLUGIN_NAME, database, resource),
+                schemaBuilder.build(),
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                "");
+    }
+
+    private String normalizeAdAccountId(String adAccountId) {
+        if (StringUtils.isBlank(adAccountId)) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG, "ad_account_id is required");
+        }
+        String normalized = adAccountId.startsWith("act_") ? adAccountId.substring(4) : adAccountId;
+        if (!AD_ACCOUNT_ID_PATTERN.matcher(normalized).matches()) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                    "Invalid ad_account_id: '"
+                            + adAccountId
+                            + "'. Expected digits, optionally prefixed with act_.");
+        }
+        return normalized;
+    }
+
+    private String validateField(String field) {
+        if (!FIELD_PATTERN.matcher(field).matches()) {
+            throw new FacebookAdsConnectorException(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                    "Invalid field name: '"
+                            + field
+                            + "'. Expected snake_case like id, name or campaign_id.");
+        }
+        return field;
+    }
+
+    List<FacebookAdsTableConfig> getTableConfigs() {
+        return tableConfigs;
+    }
+
+    @Override
+    public String getPluginName() {
+        return PLUGIN_NAME;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return tableConfigs.stream()
+                .map(FacebookAdsTableConfig::getCatalogTable)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public AbstractSingleSplitReader<SeaTunnelRow> createReader(
+            SingleSplitReaderContext readerContext) throws Exception {
+        return new FacebookAdsSourceReader(params, tableConfigs, readerContext);
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSource.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSource.java
@@ -53,8 +53,9 @@ public class FacebookAdsSource extends AbstractSingleSplitSource<SeaTunnelRow>
 
     private static final String PLUGIN_NAME = "FacebookAds";
     private static final String DEFAULT_DATABASE = "facebook_ads";
-    private static final Pattern FIELD_PATTERN = Pattern.compile("^[a-z0-9_]+$");
-    private static final Pattern RESOURCE_PATTERN = Pattern.compile("^[a-z0-9_]+$");
+    /** Shared by field and resource names: both are snake_case Graph API identifiers. */
+    private static final Pattern NAME_PATTERN = Pattern.compile("^[a-z0-9_]+$");
+
     private static final Pattern AD_ACCOUNT_ID_PATTERN = Pattern.compile("^[0-9]+$");
 
     /** Query parameters the connector manages itself; user-supplied params must not clash. */
@@ -78,6 +79,11 @@ public class FacebookAdsSource extends AbstractSingleSplitSource<SeaTunnelRow>
         if (config.getOptional(ConnectorCommonOptions.TABLE_CONFIGS).isPresent()) {
             List<Map<String, Object>> tableConfigMaps =
                     config.get(ConnectorCommonOptions.TABLE_CONFIGS);
+            if (tableConfigMaps == null || tableConfigMaps.isEmpty()) {
+                throw new FacebookAdsConnectorException(
+                        FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                        "tables_configs must contain at least one table entry");
+            }
             List<FacebookAdsTableConfig> configs = new ArrayList<>();
             for (Map<String, Object> map : tableConfigMaps) {
                 ReadonlyConfig tableConfig = ReadonlyConfig.fromMap(map);
@@ -135,7 +141,7 @@ public class FacebookAdsSource extends AbstractSingleSplitSource<SeaTunnelRow>
                                                                 .INVALID_CONFIG,
                                                         "One of resource or tables_configs is "
                                                                 + "required"));
-        if (!RESOURCE_PATTERN.matcher(resource).matches()) {
+        if (!NAME_PATTERN.matcher(resource).matches()) {
             throw new FacebookAdsConnectorException(
                     FacebookAdsConnectorErrorCode.INVALID_CONFIG,
                     "Invalid resource: '"
@@ -217,7 +223,7 @@ public class FacebookAdsSource extends AbstractSingleSplitSource<SeaTunnelRow>
     }
 
     private String validateField(String field) {
-        if (!FIELD_PATTERN.matcher(field).matches()) {
+        if (!NAME_PATTERN.matcher(field).matches()) {
             throw new FacebookAdsConnectorException(
                     FacebookAdsConnectorErrorCode.INVALID_CONFIG,
                     "Invalid field name: '"

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.source;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsParameters;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsSourceOptions;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+
+@AutoService(Factory.class)
+public class FacebookAdsSourceFactory implements TableSourceFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "FacebookAds";
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        FacebookAdsSourceOptions.ACCESS_TOKEN,
+                        FacebookAdsSourceOptions.AD_ACCOUNT_ID)
+                .exclusive(FacebookAdsSourceOptions.RESOURCE, ConnectorCommonOptions.TABLE_CONFIGS)
+                .optional(
+                        FacebookAdsSourceOptions.API_VERSION,
+                        FacebookAdsSourceOptions.FIELDS,
+                        FacebookAdsSourceOptions.FILTERING,
+                        FacebookAdsSourceOptions.PARAMS,
+                        FacebookAdsSourceOptions.REQUEST_TIMEOUT_MS,
+                        FacebookAdsSourceOptions.MAX_RETRIES,
+                        FacebookAdsSourceOptions.RETRY_BACKOFF_MS,
+                        FacebookAdsSourceOptions.PAGE_SIZE)
+                .build();
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        FacebookAdsParameters params = new FacebookAdsParameters();
+        params.buildWithConfig(context.getOptions());
+        return () ->
+                (SeaTunnelSource<T, SplitT, StateT>)
+                        new FacebookAdsSource(params, context.getOptions());
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return FacebookAdsSource.class;
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceReader.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceReader.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.source;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.client.FacebookAdsClient;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsParameters;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsTableConfig;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+public class FacebookAdsSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
+
+    private final FacebookAdsParameters params;
+    private final List<FacebookAdsTableConfig> tableConfigs;
+    private final SingleSplitReaderContext readerContext;
+    private FacebookAdsClient client;
+
+    FacebookAdsSourceReader(
+            FacebookAdsParameters params,
+            List<FacebookAdsTableConfig> tableConfigs,
+            SingleSplitReaderContext readerContext) {
+        this.params = params;
+        this.tableConfigs = tableConfigs;
+        this.readerContext = readerContext;
+    }
+
+    @Override
+    public void open() throws Exception {
+        client = new FacebookAdsClient(params);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    /**
+     * Single-pass bounded read for the assigned split. For each configured table, reads its ad
+     * account edge and forwards each Object[] downstream as a table-tagged SeaTunnelRow; rows
+     * stream through page by page without buffering the whole result set. After every table has
+     * drained, signals no-more-elements so the framework can close the split.
+     */
+    @Override
+    public void pollNext(Collector<SeaTunnelRow> output) throws Exception {
+        try {
+            for (FacebookAdsTableConfig tableConfig : tableConfigs) {
+                String tableId = tableConfig.getTableId();
+                log.info(
+                        "Reading rows from Facebook Ads resource {} for ad account {}",
+                        tableConfig.getResource(),
+                        tableConfig.getAdAccountId());
+                client.search(
+                        tableConfig,
+                        values -> {
+                            SeaTunnelRow row = new SeaTunnelRow(values);
+                            row.setTableId(tableId);
+                            output.collect(row);
+                        });
+            }
+        } finally {
+            readerContext.signalNoMoreElement();
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {}
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/FacebookAdsSourceFactoryTest.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/FacebookAdsSourceFactoryTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.source.FacebookAdsSourceFactory;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class FacebookAdsSourceFactoryTest {
+
+    private static final FacebookAdsSourceFactory FACTORY = new FacebookAdsSourceFactory();
+
+    @Test
+    void testOptionRuleIsNotNull() {
+        Assertions.assertNotNull(FACTORY.optionRule());
+    }
+
+    @Test
+    void testFactoryIdentifier() {
+        Assertions.assertEquals("FacebookAds", FACTORY.factoryIdentifier());
+    }
+
+    @Test
+    void testResourceModeValid() {
+        Map<String, Object> config = requiredConfig();
+        config.put("resource", "campaigns");
+        config.put("fields", Arrays.asList("id", "name", "status"));
+
+        Assertions.assertDoesNotThrow(
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(FACTORY.optionRule()));
+    }
+
+    @Test
+    void testResourceModeWithOptionalParamsValid() {
+        Map<String, Object> config = requiredConfig();
+        config.put("resource", "insights");
+        config.put("fields", Arrays.asList("campaign_id", "impressions", "spend"));
+        config.put(
+                "filtering",
+                "[{\"field\":\"effective_status\",\"operator\":\"IN\",\"value\":[\"ACTIVE\"]}]");
+        Map<String, String> params = new HashMap<>();
+        params.put("date_preset", "last_30d");
+        params.put("level", "campaign");
+        config.put("params", params);
+        config.put("api_version", "v23.0");
+        config.put("max_retries", 5);
+        config.put("request_timeout_ms", 30000);
+        config.put("retry_backoff_ms", 500L);
+        config.put("page_size", 100);
+
+        Assertions.assertDoesNotThrow(
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(FACTORY.optionRule()));
+    }
+
+    @Test
+    void testTablesConfigsModeValid() {
+        Map<String, Object> config = requiredConfig();
+        config.put("tables_configs", multiTableConfigs());
+
+        Assertions.assertDoesNotThrow(
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(FACTORY.optionRule()));
+    }
+
+    @Test
+    void testResourceAndTablesConfigsTogetherThrows() {
+        Map<String, Object> config = requiredConfig();
+        config.put("resource", "campaigns");
+        config.put("tables_configs", multiTableConfigs());
+
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(FACTORY.optionRule()));
+    }
+
+    @Test
+    void testNoModeSelectedThrows() {
+        Map<String, Object> config = requiredConfig();
+
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(FACTORY.optionRule()));
+    }
+
+    @Test
+    void testMissingAccessTokenThrows() {
+        assertMissingRequiredThrows("access_token");
+    }
+
+    @Test
+    void testMissingAdAccountIdThrows() {
+        assertMissingRequiredThrows("ad_account_id");
+    }
+
+    private static void assertMissingRequiredThrows(String key) {
+        Map<String, Object> config = requiredConfig();
+        config.remove(key);
+        config.put("resource", "campaigns");
+        config.put("fields", Arrays.asList("id"));
+
+        Assertions.assertThrows(
+                OptionValidationException.class,
+                () ->
+                        ConfigValidator.of(ReadonlyConfig.fromMap(config))
+                                .validate(FACTORY.optionRule()));
+    }
+
+    private static Map<String, Object> requiredConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("access_token", "test_access_token");
+        config.put("ad_account_id", "1234567890");
+        return config;
+    }
+
+    private static List<Map<String, Object>> multiTableConfigs() {
+        Map<String, Object> campaigns = new HashMap<>();
+        campaigns.put("table_path", "facebook_ads.campaigns");
+        campaigns.put("fields", Arrays.asList("id", "name"));
+
+        Map<String, Object> insights = new HashMap<>();
+        insights.put("table_path", "facebook_ads.insights");
+        insights.put("fields", Arrays.asList("campaign_id", "impressions"));
+        insights.put("ad_account_id", "2345678901");
+
+        return Arrays.asList(campaigns, insights);
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/client/FacebookAdsClientTest.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/client/FacebookAdsClientTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.client;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsParameters;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+class FacebookAdsClientTest {
+
+    private static final String AD_ACCOUNT_ID = "1234567890";
+    private static final String CAMPAIGNS_PATH = "/v23.0/act_" + AD_ACCOUNT_ID + "/campaigns";
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void searchStreamsPagesFollowingAfterCursor() throws IOException {
+        AtomicInteger hits = new AtomicInteger();
+        AtomicReference<String> secondQuery = new AtomicReference<>();
+        server.createContext(
+                CAMPAIGNS_PATH,
+                exchange -> {
+                    if (hits.incrementAndGet() == 1) {
+                        respondJson(
+                                exchange,
+                                200,
+                                "{\"data\":["
+                                        + "{\"id\":\"111\",\"name\":\"c1\","
+                                        + "\"insights\":{\"data\":[{\"spend\":\"1.5\"}]}}"
+                                        + "],\"paging\":{\"cursors\":{\"before\":\"b1\","
+                                        + "\"after\":\"cursor-2\"},"
+                                        + "\"next\":\"https://ignored/next\"}}");
+                    } else {
+                        secondQuery.set(exchange.getRequestURI().getQuery());
+                        respondJson(
+                                exchange,
+                                200,
+                                "{\"data\":[{\"id\":\"222\",\"name\":\"c2\"}],"
+                                        + "\"paging\":{\"cursors\":{\"before\":\"b2\","
+                                        + "\"after\":\"cursor-3\"}}}");
+                    }
+                });
+
+        try (FacebookAdsClient client = new FacebookAdsClient(buildParams())) {
+            List<Object[]> rows = new ArrayList<>();
+            client.search(
+                    tableConfig(Arrays.asList("id", "name", "insights", "status")), rows::add);
+
+            Assertions.assertEquals(2, rows.size());
+            Assertions.assertEquals(2, hits.get());
+            // value nodes as strings; nested object as JSON text; absent field -> null
+            Assertions.assertEquals("111", rows.get(0)[0]);
+            Assertions.assertEquals("c1", rows.get(0)[1]);
+            Assertions.assertEquals("{\"data\":[{\"spend\":\"1.5\"}]}", rows.get(0)[2]);
+            Assertions.assertNull(rows.get(0)[3]);
+            Assertions.assertEquals("222", rows.get(1)[0]);
+            // page 2 requested via the after cursor; page without next ends the read
+            Assertions.assertTrue(secondQuery.get().contains("after=cursor-2"));
+        }
+    }
+
+    @Test
+    void searchSendsBearerHeaderAndQueryParams() throws IOException {
+        AtomicReference<String> authHeader = new AtomicReference<>();
+        AtomicReference<String> query = new AtomicReference<>();
+        server.createContext(
+                CAMPAIGNS_PATH,
+                exchange -> {
+                    authHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+                    query.set(
+                            URLDecoder.decode(
+                                    exchange.getRequestURI().getRawQuery(),
+                                    StandardCharsets.UTF_8.name()));
+                    respondJson(exchange, 200, "{\"data\":[]}");
+                });
+
+        LinkedHashMap<String, String> extraParams = new LinkedHashMap<>();
+        extraParams.put("date_preset", "last_30d");
+        FacebookAdsTableConfig table =
+                new FacebookAdsTableConfig(
+                        "campaigns",
+                        AD_ACCOUNT_ID,
+                        Arrays.asList("id", "name"),
+                        "[{\"field\":\"effective_status\"}]",
+                        extraParams,
+                        null);
+
+        try (FacebookAdsClient client = new FacebookAdsClient(buildParams())) {
+            client.search(table, row -> {});
+            Assertions.assertEquals("Bearer test-token", authHeader.get());
+            Assertions.assertTrue(query.get().contains("fields=id,name"));
+            Assertions.assertTrue(
+                    query.get().contains("filtering=[{\"field\":\"effective_status\"}]"));
+            Assertions.assertTrue(query.get().contains("date_preset=last_30d"));
+            Assertions.assertTrue(query.get().contains("limit=50"));
+            Assertions.assertFalse(query.get().contains("access_token"));
+        }
+    }
+
+    @Test
+    void searchFailsFastOn401WithAuthError() throws IOException {
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext(
+                CAMPAIGNS_PATH,
+                exchange -> {
+                    hits.incrementAndGet();
+                    respondJson(
+                            exchange,
+                            401,
+                            "{\"error\":{\"message\":\"Invalid OAuth access token\","
+                                    + "\"code\":190}}");
+                });
+
+        try (FacebookAdsClient client = new FacebookAdsClient(buildParams())) {
+            FacebookAdsConnectorException ex =
+                    Assertions.assertThrows(
+                            FacebookAdsConnectorException.class,
+                            () -> client.search(tableConfig(Arrays.asList("id")), row -> {}));
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.AUTH_FAILED, ex.getSeaTunnelErrorCode());
+            Assertions.assertEquals(1, hits.get());
+        }
+    }
+
+    @Test
+    void searchRetriesTransient503UpToMaxRetries() throws IOException {
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext(
+                CAMPAIGNS_PATH,
+                exchange -> {
+                    hits.incrementAndGet();
+                    respondJson(exchange, 503, "{\"error\":\"unavailable\"}");
+                });
+
+        try (FacebookAdsClient client = new FacebookAdsClient(buildParams())) {
+            Assertions.assertThrows(
+                    FacebookAdsConnectorException.class,
+                    () -> client.search(tableConfig(Arrays.asList("id")), row -> {}));
+            // initial attempt + max_retries(2) retries
+            Assertions.assertEquals(3, hits.get());
+        }
+    }
+
+    @Test
+    void searchRetriesRateLimit400WithFacebookErrorCode() throws IOException {
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext(
+                CAMPAIGNS_PATH,
+                exchange -> {
+                    if (hits.incrementAndGet() == 1) {
+                        // code 4 = application request limit reached, carried in an HTTP 400
+                        respondJson(
+                                exchange,
+                                400,
+                                "{\"error\":{\"message\":\"Application request limit reached\","
+                                        + "\"code\":4}}");
+                    } else {
+                        respondJson(exchange, 200, "{\"data\":[{\"id\":\"1\"}]}");
+                    }
+                });
+
+        try (FacebookAdsClient client = new FacebookAdsClient(buildParams())) {
+            List<Object[]> rows = new ArrayList<>();
+            client.search(tableConfig(Arrays.asList("id")), rows::add);
+            Assertions.assertEquals(1, rows.size());
+            Assertions.assertEquals(2, hits.get());
+        }
+    }
+
+    @Test
+    void searchDoesNotRetryPlain400AndSurfacesApiError() throws IOException {
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext(
+                CAMPAIGNS_PATH,
+                exchange -> {
+                    hits.incrementAndGet();
+                    respondJson(
+                            exchange,
+                            400,
+                            "{\"error\":{\"message\":\"Unknown fields: bad_field\","
+                                    + "\"code\":100}}");
+                });
+
+        try (FacebookAdsClient client = new FacebookAdsClient(buildParams())) {
+            FacebookAdsConnectorException ex =
+                    Assertions.assertThrows(
+                            FacebookAdsConnectorException.class,
+                            () ->
+                                    client.search(
+                                            tableConfig(Arrays.asList("bad_field")), row -> {}));
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.REQUEST_FAILED, ex.getSeaTunnelErrorCode());
+            Assertions.assertEquals(1, hits.get());
+            Assertions.assertTrue(ex.getMessage().contains("Unknown fields"));
+        }
+    }
+
+    private FacebookAdsTableConfig tableConfig(List<String> fields) {
+        return new FacebookAdsTableConfig("campaigns", AD_ACCOUNT_ID, fields, null, null, null);
+    }
+
+    private static void respondJson(HttpExchange exchange, int status, String body)
+            throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(bytes);
+        }
+    }
+
+    private FacebookAdsParameters buildParams() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("access_token", "test-token");
+        map.put("ad_account_id", AD_ACCOUNT_ID);
+        map.put("api_endpoint", baseUrl);
+        map.put("max_retries", 2);
+        map.put("retry_backoff_ms", 10L);
+        map.put("page_size", 50);
+        FacebookAdsParameters params = new FacebookAdsParameters();
+        params.buildWithConfig(ReadonlyConfig.fromMap(map));
+        return params;
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceTest.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.facebook.ads.source;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+import org.apache.seatunnel.api.table.type.SqlType;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsParameters;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.config.FacebookAdsTableConfig;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorErrorCode;
+import org.apache.seatunnel.connectors.seatunnel.facebook.ads.exception.FacebookAdsConnectorException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Covers the config-resolution logic of {@link FacebookAdsSource}: mode dispatch, table_path
+ * handling, field/resource/ad_account_id validation and the all-STRING schema. No HTTP server is
+ * needed because the schema is built locally without network calls.
+ */
+class FacebookAdsSourceTest {
+
+    private static final String AD_ACCOUNT_ID = "1234567890";
+
+    @Test
+    void resourceModeBuildsStringSchemaInFieldOrder() {
+        Map<String, Object> map = baseConfig();
+        map.put("resource", "campaigns");
+        map.put("fields", Arrays.asList("id", "name", "status"));
+
+        FacebookAdsSource source = buildSource(map);
+
+        List<FacebookAdsTableConfig> configs = source.getTableConfigs();
+        Assertions.assertEquals(1, configs.size());
+        FacebookAdsTableConfig table = configs.get(0);
+        Assertions.assertEquals("campaigns", table.getResource());
+        Assertions.assertEquals(AD_ACCOUNT_ID, table.getAdAccountId());
+        Assertions.assertEquals("facebook_ads.campaigns", table.getTableId());
+        SeaTunnelRowType rowType = source.getProducedCatalogTables().get(0).getSeaTunnelRowType();
+        Assertions.assertEquals(3, rowType.getTotalFields());
+        Assertions.assertEquals("id", rowType.getFieldName(0));
+        Assertions.assertEquals("name", rowType.getFieldName(1));
+        Assertions.assertEquals("status", rowType.getFieldName(2));
+        for (int i = 0; i < rowType.getTotalFields(); i++) {
+            Assertions.assertEquals(SqlType.STRING, rowType.getFieldType(i).getSqlType());
+        }
+    }
+
+    @Test
+    void resourceModeRequiresNonEmptyFields() {
+        Map<String, Object> map = baseConfig();
+        map.put("resource", "campaigns");
+
+        FacebookAdsConnectorException ex = assertBuildFails(map);
+        Assertions.assertEquals(
+                FacebookAdsConnectorErrorCode.INVALID_CONFIG, ex.getSeaTunnelErrorCode());
+        Assertions.assertTrue(ex.getMessage().contains("fields"));
+    }
+
+    @Test
+    void missingAllModesIsRejected() {
+        FacebookAdsConnectorException ex = assertBuildFails(baseConfig());
+        Assertions.assertEquals(
+                FacebookAdsConnectorErrorCode.INVALID_CONFIG, ex.getSeaTunnelErrorCode());
+    }
+
+    @Test
+    void invalidFieldNamesAreRejectedWithOffendingName() {
+        for (String bad : Arrays.asList("Campaign.Id", "id;drop", "bad field", "id,name")) {
+            Map<String, Object> map = baseConfig();
+            map.put("resource", "campaigns");
+            map.put("fields", Arrays.asList(bad));
+
+            FacebookAdsConnectorException ex = assertBuildFails(map);
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG, ex.getSeaTunnelErrorCode());
+            Assertions.assertTrue(ex.getMessage().contains(bad), "message should name: " + bad);
+        }
+    }
+
+    @Test
+    void invalidResourceNamesAreRejected() {
+        for (String bad : Arrays.asList("Campaigns", "camp/aigns", "insights?x=1")) {
+            Map<String, Object> map = baseConfig();
+            map.put("resource", bad);
+            map.put("fields", Arrays.asList("id"));
+
+            FacebookAdsConnectorException ex = assertBuildFails(map);
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG, ex.getSeaTunnelErrorCode());
+            Assertions.assertTrue(ex.getMessage().contains(bad), "message should name: " + bad);
+        }
+    }
+
+    @Test
+    void reservedParamsAreRejected() {
+        for (String reserved :
+                Arrays.asList("fields", "limit", "after", "filtering", "access_token")) {
+            Map<String, Object> map = baseConfig();
+            map.put("resource", "campaigns");
+            map.put("fields", Arrays.asList("id"));
+            Map<String, String> params = new HashMap<>();
+            params.put(reserved, "x");
+            map.put("params", params);
+
+            FacebookAdsConnectorException ex = assertBuildFails(map);
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG, ex.getSeaTunnelErrorCode());
+            Assertions.assertTrue(
+                    ex.getMessage().contains(reserved), "message should name: " + reserved);
+        }
+    }
+
+    @Test
+    void actPrefixOnAdAccountIdIsStripped() {
+        Map<String, Object> map = baseConfig();
+        map.put("ad_account_id", "act_" + AD_ACCOUNT_ID);
+        map.put("resource", "campaigns");
+        map.put("fields", Arrays.asList("id"));
+
+        FacebookAdsTableConfig table = buildSource(map).getTableConfigs().get(0);
+        Assertions.assertEquals(AD_ACCOUNT_ID, table.getAdAccountId());
+    }
+
+    @Test
+    void invalidAdAccountIdIsRejected() {
+        for (String bad : Arrays.asList("abc", "123abc", "act_")) {
+            Map<String, Object> map = baseConfig();
+            map.put("ad_account_id", bad);
+            map.put("resource", "campaigns");
+            map.put("fields", Arrays.asList("id"));
+
+            FacebookAdsConnectorException ex = assertBuildFails(map);
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.INVALID_CONFIG,
+                    ex.getSeaTunnelErrorCode(),
+                    "ad_account_id should be rejected: " + bad);
+        }
+    }
+
+    @Test
+    void tablesConfigsBuildsMultipleTablesWithPerTableAdAccountIdFallback() {
+        Map<String, Object> entryWithOverride = new HashMap<>();
+        entryWithOverride.put("table_path", "facebook_ads.campaigns");
+        entryWithOverride.put("fields", Arrays.asList("id", "name"));
+        entryWithOverride.put("ad_account_id", "act_2222222222");
+        Map<String, Object> entryWithFallback = new HashMap<>();
+        entryWithFallback.put("table_path", "facebook_ads.insights");
+        entryWithFallback.put("fields", Arrays.asList("campaign_id", "impressions", "spend"));
+
+        Map<String, Object> map = baseConfig();
+        map.put("tables_configs", Arrays.asList(entryWithOverride, entryWithFallback));
+
+        List<FacebookAdsTableConfig> configs = buildSource(map).getTableConfigs();
+        Assertions.assertEquals(2, configs.size());
+        Assertions.assertEquals("facebook_ads.campaigns", configs.get(0).getTableId());
+        Assertions.assertEquals("2222222222", configs.get(0).getAdAccountId());
+        Assertions.assertEquals("facebook_ads.insights", configs.get(1).getTableId());
+        Assertions.assertEquals(AD_ACCOUNT_ID, configs.get(1).getAdAccountId());
+    }
+
+    @Test
+    void tablesConfigsRejectsDuplicateTablePath() {
+        Map<String, Object> entry1 = new HashMap<>();
+        entry1.put("table_path", "facebook_ads.campaigns");
+        entry1.put("fields", Arrays.asList("id"));
+        Map<String, Object> entry2 = new HashMap<>();
+        entry2.put("table_path", "facebook_ads.campaigns");
+        entry2.put("fields", Arrays.asList("name"));
+
+        Map<String, Object> map = baseConfig();
+        map.put("tables_configs", Arrays.asList(entry1, entry2));
+
+        FacebookAdsConnectorException ex = assertBuildFails(map);
+        Assertions.assertEquals(
+                FacebookAdsConnectorErrorCode.DUPLICATE_RESOURCE, ex.getSeaTunnelErrorCode());
+    }
+
+    @Test
+    void tablesConfigsRejectsMalformedTablePath() {
+        for (String badPath : Arrays.asList("campaigns", ".campaigns", "facebook_ads.")) {
+            Map<String, Object> entry = new HashMap<>();
+            entry.put("table_path", badPath);
+            entry.put("fields", Arrays.asList("id"));
+
+            Map<String, Object> map = baseConfig();
+            map.put("tables_configs", Arrays.asList(entry));
+
+            FacebookAdsConnectorException ex = assertBuildFails(map);
+            Assertions.assertEquals(
+                    FacebookAdsConnectorErrorCode.INVALID_TABLE_PATH,
+                    ex.getSeaTunnelErrorCode(),
+                    "table_path should be rejected: " + badPath);
+        }
+    }
+
+    private FacebookAdsConnectorException assertBuildFails(Map<String, Object> map) {
+        return Assertions.assertThrows(FacebookAdsConnectorException.class, () -> buildSource(map));
+    }
+
+    private FacebookAdsSource buildSource(Map<String, Object> map) {
+        ReadonlyConfig config = ReadonlyConfig.fromMap(map);
+        FacebookAdsParameters params = new FacebookAdsParameters();
+        params.buildWithConfig(config);
+        return new FacebookAdsSource(params, config);
+    }
+
+    private Map<String, Object> baseConfig() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("access_token", "test-token");
+        map.put("ad_account_id", AD_ACCOUNT_ID);
+        return map;
+    }
+}

--- a/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceTest.java
+++ b/seatunnel-connectors-v2/connector-facebook-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/facebook/ads/source/FacebookAdsSourceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -177,6 +178,17 @@ class FacebookAdsSourceTest {
         Assertions.assertEquals("2222222222", configs.get(0).getAdAccountId());
         Assertions.assertEquals("facebook_ads.insights", configs.get(1).getTableId());
         Assertions.assertEquals(AD_ACCOUNT_ID, configs.get(1).getAdAccountId());
+    }
+
+    @Test
+    void tablesConfigsRejectsEmptyList() {
+        Map<String, Object> map = baseConfig();
+        map.put("tables_configs", Collections.emptyList());
+
+        FacebookAdsConnectorException ex = assertBuildFails(map);
+        Assertions.assertEquals(
+                FacebookAdsConnectorErrorCode.INVALID_CONFIG, ex.getSeaTunnelErrorCode());
+        Assertions.assertTrue(ex.getMessage().contains("tables_configs"));
     }
 
     @Test

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -74,6 +74,7 @@
         <module>connector-google-firestore</module>
         <module>connector-google-pubsub</module>
         <module>connector-google-ads</module>
+        <module>connector-facebook-ads</module>
         <module>connector-azure-queue-storage</module>
         <module>connector-slack</module>
         <module>connector-rabbitmq</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -556,6 +556,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-facebook-ads</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-datahub</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>


### PR DESCRIPTION
### Purpose of this pull request

Add a new Connector-V2 source connector for **Facebook Ads** (Meta Marketing API), subtask of the API-source umbrella issue #10753.

The connector reads ad account edges (`campaigns`, `adsets`, `ads`, `insights`, etc.) from the Facebook Graph API as a bounded source, modeled on the Google Ads source connector (#12230):

- Cursor-based pagination following `paging.next` / `paging.cursors.after`
- Authentication via long-lived access token sent as `Authorization: Bearer` header (never in the query string)
- Rate-limit-aware retries with exponential backoff: transient HTTP errors (429/5xx) and Facebook rate-limit error codes (4, 17, 32, 613) are retried up to `max_retries`; 401 fails fast with an auth error, other 4xx fail fast surfacing the Graph API error message
- Two modes: single `resource` mode, or `tables_configs` multi-table mode with per-table `ad_account_id` override
- All columns are produced as STRING (the Graph API has no field metadata service and returns insights metrics as strings); nested objects/arrays are serialized as JSON text; the CatalogTable is built locally, so no network call happens at job compile time
- Config validation: resource/field name patterns, reserved query params, `act_` prefix normalization of ad account ids, duplicate/malformed `table_path` detection, and rejection of an empty `tables_configs` list

### Does this PR introduce _any_ user-facing change?

Yes. It adds a new source connector `FacebookAds` with its options (`access_token`, `ad_account_id`, `resource`/`tables_configs`, `fields`, `filtering`, `params`, `api_version`, `page_size`, retry options, etc.), plus new documentation:

- `docs/en/connector-v2/source/FacebookAds.md`
- `docs/zh/connector-v2/source/FacebookAds.md`

No change to any existing connector or released behavior.

### How was this patch tested?

27 unit tests added, all passing (`./mvnw -pl seatunnel-connectors-v2/connector-facebook-ads test`):

- `FacebookAdsSourceFactoryTest` (9): option rule validation — required options, `resource`/`tables_configs` exclusivity, missing-mode and missing-required rejection
- `FacebookAdsSourceTest` (12): config resolution — all-STRING schema in field order, table id generation, field/resource/ad_account_id validation, reserved param rejection, `act_` prefix stripping, multi-table build with per-table ad account fallback, duplicate and malformed `table_path` rejection, and empty `tables_configs` rejection
- `FacebookAdsClientTest` (6): HTTP behavior against an embedded `com.sun.net.httpserver.HttpServer` (no mock libraries) — cursor pagination across pages, Bearer header and query param encoding, 401 fail-fast, transient 503 retry count, rate-limit-400 (code 4) retry, plain-400 fail-fast surfacing the API error

E2E tests are not included because the Facebook Graph API requires a real ad account and access token; the HTTP contract is covered by the embedded-server client tests instead (same approach as the Google Ads connector).

### Check list

* [x] If any new Jar binary package adding in your PR, please add License Notice according
  [New License Guide](https://github.com/apache/seatunnel/blob/dev/docs/en/developer/new-license.md) — no new dependencies; reuses `httpclient`/`jackson`/`commons-lang3` already used by connector-google-ads
* [x] If necessary, please update the documentation to describe the new feature. https://github.com/apache/seatunnel/tree/dev/docs
* [x] If necessary, please update `incompatible-changes.md` to describe the incompatibility caused by this PR. — not needed, purely additive
* [x] If you are contributing the connector code, please check that the following files are updated:
  1. Update [plugin-mapping.properties](https://github.com/apache/seatunnel/blob/dev/plugin-mapping.properties) and add new connector information in it — done
  2. Update the pom file of [seatunnel-dist](https://github.com/apache/seatunnel/blob/dev/seatunnel-dist/pom.xml) — done
  3. Add ci label in [label-scope-conf](https://github.com/apache/seatunnel/blob/dev/.github/workflows/labeler/label-scope-conf.yml) — done
  4. Add e2e testcase in [seatunnel-e2e](https://github.com/apache/seatunnel/tree/dev/seatunnel-e2e/seatunnel-connector-v2-e2e/) — not added; requires a real Facebook ad account/token (see testing section)
  5. Update connector [plugin_config](https://github.com/apache/seatunnel/blob/dev/config/plugin_config) — done