### PR TITLE
[Feature][Connector-V2] Add TikTok Ads reporting source

### DIFF
--- a/.github/workflows/labeler/label-scope-conf.yml
+++ b/.github/workflows/labeler/label-scope-conf.yml
@@ -167,6 +167,11 @@ facebook-ads:
       - changed-files:
           - any-glob-to-any-file: seatunnel-connectors-v2/connector-facebook-ads/**
           - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(facebook-ads)/**'
+tiktok-ads:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file: seatunnel-connectors-v2/connector-tiktok-ads/**
+          - all-globs-to-all-files: '!seatunnel-connectors-v2/connector-!(tiktok-ads)/**'
 file:
   - all:
       - changed-files:

--- a/config/plugin_config
+++ b/config/plugin_config
@@ -62,6 +62,7 @@ connector-azure-queue-storage
 connector-google-bigtable
 connector-google-ads
 connector-facebook-ads
+connector-tiktok-ads
 connector-graphql
 connector-hive
 connector-http-base

--- a/docs/en/connectors/changelog/connector-tiktok-ads.md
+++ b/docs/en/connectors/changelog/connector-tiktok-ads.md
@@ -15,8 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Changelog
+<details><summary> Change Log </summary>
 
-## next version
+| Change | Commit | Version |
+| --- | --- | --- |
+| Add bounded BASIC AUCTION_AD synchronous reporting source with typed metrics and fail-closed pagination | | next version |
 
-- Add bounded BASIC AUCTION_AD synchronous reporting source with typed metrics and fail-closed pagination.
+</details>

--- a/docs/en/connectors/changelog/connector-tiktok-ads.md
+++ b/docs/en/connectors/changelog/connector-tiktok-ads.md
@@ -1,0 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Changelog
+
+## next version
+
+- Add bounded BASIC AUCTION_AD synchronous reporting source with typed metrics and fail-closed pagination.

--- a/docs/en/connectors/source/TikTokAds.md
+++ b/docs/en/connectors/source/TikTokAds.md
@@ -1,0 +1,157 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# TikTokAds
+
+## Description
+
+Read one advertiser's TikTok API for Business synchronous integrated report through
+`GET /open_api/v1.3/report/integrated/get/`. This source supports only `BASIC` reports,
+`AUCTION` service, `AUCTION_AD` data level and regular pagination. It does not export raw
+users/events, GMV Max reports, asynchronous reports, multiple advertisers or arbitrary filters.
+
+## Key Features
+
+- [x] Batch
+- [ ] Stream
+- [ ] Exactly-Once
+
+Use source parallelism 1. No checkpoint page-offset recovery is provided: recovery replays
+the report from page 1. The remote report is **not an immutable snapshot**. Total-count and
+repeated-dimension checks detect some pagination drift but cannot guarantee snapshot consistency
+or completeness. Metrics or rows can change between requests without those checks detecting it.
+A failed job may already have emitted records to a nontransactional sink; replay may duplicate
+or change those records. Choose downstream staging/reconciliation appropriate for reporting data.
+
+## Source Options
+
+| Name | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| token | string | yes | - | Authorized Access-Token for the advertiser, sent only as an HTTP header. Native key `token` participates in SeaTunnel log masking. |
+| advertiser_id | string | yes | - | One numeric advertiser ID, not a Business Center ID. |
+| data_level | string | yes | - | Must be `AUCTION_AD`. |
+| start_date | string | yes | - | Inclusive `yyyy-MM-dd` in the advertiser's account timezone. |
+| end_date | string | yes | - | Inclusive `yyyy-MM-dd`. At most 30 inclusive days with `stat_time_day`, 365 otherwise. |
+| dimensions | list | yes | - | Exactly `["ad_id"]` or `["ad_id", "stat_time_day"]`. |
+| metrics | list | yes | - | Nonempty unique subset of `spend`, `impressions`, `clicks`. |
+| schema | config | yes | - | Exact requested dimensions and metrics, in any output order; types below. |
+| page_size | int | no | 1000 | Requested rows per page, 1-1000. |
+| max_report_rows | int | no | 100000 | Fail above this total row count, never truncate; 1-1000000. This does not bypass TikTok's ad-ID limit. |
+| max_response_bytes | int | no | 4194304 | Response byte limit per page, 1024-16777216. |
+| request_timeout_ms | int | no | 30000 | HTTP deadline including body, 100-120000 ms. |
+| report_timeout_ms | int | no | 600000 | Report deadline, 100-3600000 ms, checked between records/requests and during retry waits. |
+| max_retries | int | no | 3 | Additional attempts per page, 0-5, only for HTTP 429, 500, 502, 503, 504. |
+| max_retry_wait_ms | int | no | 30000 | Maximum retry delay, 1000-120000 ms. Retry-After beyond this bound fails instead of retrying early. |
+| mock_url | string | no | - | Test-only HTTP origin. Requires literal `token = "mock-token"`. Never use real credentials. Not an official emulator. |
+| common-options | | no | - | Supports `parallelism = 1` and `plugin_output` / `result_table_name`. |
+
+### Schema and Report Semantics
+
+- `ad_id`: STRING. The API identifies Manual/Smart+ ads but **creatives** for Upgraded Smart+
+  Ads through this dimension. This connector does not support `ad_id_v2`.
+- `stat_time_day`: STRING. Preserve the API's `yyyy-MM-dd 00:00:00` advertiser-local day
+  label, not an invented UTC instant. Values must fall inside the requested interval.
+- `spend`: DECIMAL(p,s), precision at most 38. Currency units follow the advertiser account;
+  no cents conversion or currency conversion is performed. Values that require rounding or
+  exceed precision fail. Use a scale suitable for your report.
+- `impressions`, `clicks`: BIGINT. Invalid, fractional or overflowing count values fail.
+- Requested fields must be present as nonempty strings. Null, missing, malformed and
+  unrepresentable values fail; none is silently changed into zero. No optional output fields
+  are supplied by this first slice. Empty API results produce zero rows.
+
+The API's default `ad_status = STATUS_NOT_DELETE` filter applies: **deleted ads are excluded**.
+This is not an all-status historical export. There is no arbitrary filtering option or automatic
+ad-ID partitioning. Requests explicitly use `query_lifetime=false` and `query_mode=REGULAR`.
+Ordering is the API default, not a stable snapshot order.
+Branded Mission data requires advertiser-level reporting and is not returned through this
+connector's `ad_id` dimension.
+
+### Errors and Limits
+
+HTTP 200 with a nonzero API `code` fails without retry. Malformed envelopes, missing page
+metadata, inconsistent page/page-size/total counts, incomplete pages, repeated dimension keys,
+and changing totals fail. No retry is made for permission errors, parser errors, response
+limits or transport errors. HTTP retries use bounded exponential waits and honor valid
+Retry-After seconds or HTTP dates. Invalid Retry-After fails without echoing its value.
+
+TikTok documents `X-Tt-Ads-Throttle` as an over-limit warning. The current synchronous report
+reference describes a 20,000-ad-ID cap; older v1.3 change notes describe 10,000. This connector
+**conservatively rejects every nonempty value** of that header, including unrecognized warnings.
+It never logs the warning contents. Absence of the header does not prove complete data.
+Pagination does not bypass the synchronous endpoint's truncation. This slice cannot export an
+advertiser requiring filtered or asynchronous reporting. Synchronous API results can differ
+from Ads Manager downloads.
+
+Redirects, automatic HTTP retries, cookies and response compression are disabled. The production
+origin is fixed to `https://business-api.tiktok.com`; there is no configurable authenticated
+origin. Closing a reader aborts the current request and wakes retry waits. JVM/platform DNS
+resolution and a blocked downstream collect can outlive the configured deadlines; these are
+not hard wall-clock cancellation guarantees during those operations.
+
+## Prerequisites and Validation
+
+Obtain an authorized token with reporting access to the advertiser through TikTok API for
+Business. Provide it through a protected configuration/environment mechanism available to the
+job. Do not put the token in query parameters, schema field names, custom keys, or debug logs.
+The mock endpoint accepts only a literal nonsecret sentinel to prevent accidentally forwarding
+a real token.
+
+Local mock tests and real-engine mock jobs verify connector protocol and engine integration,
+not live advertiser permissions, production quota behavior, data freshness or completeness.
+Live advertiser validation requires separately supplied authorized access.
+
+## Example
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+source {
+  TikTokAds {
+    token = ${TIKTOK_ADS_TOKEN}
+    advertiser_id = "123456789"
+    data_level = "AUCTION_AD"
+    start_date = "2026-09-01"
+    end_date = "2026-09-02"
+    dimensions = ["ad_id", "stat_time_day"]
+    metrics = ["spend", "impressions", "clicks"]
+    schema {
+      fields {
+        ad_id = string
+        stat_time_day = string
+        spend = "decimal(38, 6)"
+        impressions = bigint
+        clicks = bigint
+      }
+    }
+  }
+}
+sink {
+  Console {}
+}
+```
+
+## References
+
+- [Synchronous report API](https://business-api.tiktok.com/portal/docs/run-a-synchronous-report/v1.3)
+- [Official SDK reporting contract](https://github.com/tiktok/tiktok-business-api-sdk/blob/main/python_sdk/docs/ReportingApi.md)
+- [Basic report dimensions](https://business-api.tiktok.com/portal/docs?id=1751443956638721)
+
+## Changelog
+
+[Connector changelog](../changelog/connector-tiktok-ads.md)

--- a/docs/en/connectors/source/TikTokAds.md
+++ b/docs/en/connectors/source/TikTokAds.md
@@ -1,3 +1,7 @@
+import ChangeLog from '../changelog/connector-tiktok-ads.md';
+
+# TikTokAds
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +18,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-# TikTokAds
 
 ## Description
 
@@ -57,7 +59,7 @@ or change those records. Choose downstream staging/reconciliation appropriate fo
 | max_retries | int | no | 3 | Additional attempts per page, 0-5, only for HTTP 429, 500, 502, 503, 504. |
 | max_retry_wait_ms | int | no | 30000 | Maximum retry delay, 1000-120000 ms. Retry-After beyond this bound fails instead of retrying early. |
 | mock_url | string | no | - | Test-only HTTP origin. Requires literal `token = "mock-token"`. Never use real credentials. Not an official emulator. |
-| common-options | | no | - | Supports `parallelism = 1` and `plugin_output` / `result_table_name`. |
+| common-options | | no | - | Supports `parallelism = 1` and `plugin_output`. |
 
 ### Schema and Report Semantics
 
@@ -154,4 +156,4 @@ sink {
 
 ## Changelog
 
-[Connector changelog](../changelog/connector-tiktok-ads.md)
+<ChangeLog />

--- a/docs/zh/connectors/changelog/connector-tiktok-ads.md
+++ b/docs/zh/connectors/changelog/connector-tiktok-ads.md
@@ -15,8 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# 变更日志
+<details><summary> Change Log </summary>
 
-## 下个版本
+| Change | Commit | Version |
+| --- | --- | --- |
+| 新增有界 BASIC AUCTION_AD 同步报表源，支持类型化指标和严格分页校验 | | next version |
 
-- 新增有界 BASIC AUCTION_AD 同步报表源，支持类型化指标和严格分页校验。
+</details>

--- a/docs/zh/connectors/changelog/connector-tiktok-ads.md
+++ b/docs/zh/connectors/changelog/connector-tiktok-ads.md
@@ -1,0 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# 变更日志
+
+## 下个版本
+
+- 新增有界 BASIC AUCTION_AD 同步报表源，支持类型化指标和严格分页校验。

--- a/docs/zh/connectors/source/TikTokAds.md
+++ b/docs/zh/connectors/source/TikTokAds.md
@@ -1,0 +1,140 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# TikTokAds
+
+## 描述
+
+通过 `GET /open_api/v1.3/report/integrated/get/` 读取单个广告主的 TikTok API for Business
+同步综合报表。仅支持 `BASIC` 报表、`AUCTION` 服务、`AUCTION_AD` 数据层级和普通分页。
+不支持原始用户或事件导出、GMV Max、异步报表、多广告主或自定义筛选。
+
+## 主要特性
+
+- [x] 批处理
+- [ ] 流处理
+- [ ] 精确一次
+
+源并行度必须为 1。恢复时从第 1 页重新读取，不恢复页偏移量。
+远端报表**不是不可变快照**。总数和重复维度检查只能检测部分分页变化，不能保证快照一致性
+或数据完整性；指标或记录可能在请求之间发生未被检测到的变化。失败前可能已有记录写入
+非事务型下游，重放可能产生重复或不同的记录。请根据业务采用暂存和对账方案。
+
+## 参数
+
+| 参数 | 类型 | 必填 | 默认值 | 说明 |
+| --- | --- | --- | --- | --- |
+| token | string | 是 | - | 具有广告主报表权限的 Access-Token，仅通过请求头发送。原生键名 token 可由 SeaTunnel 日志脱敏。 |
+| advertiser_id | string | 是 | - | 单个数字广告主 ID，不是 Business Center ID。 |
+| data_level | string | 是 | - | 必须为 AUCTION_AD。 |
+| start_date | string | 是 | - | 广告主账号时区中的 yyyy-MM-dd，包含起始日期。 |
+| end_date | string | 是 | - | 包含结束日期。包含 stat_time_day 时最多 30 个自然日，否则最多 365 日。 |
+| dimensions | list | 是 | - | 仅支持 ["ad_id"] 或 ["ad_id", "stat_time_day"]。 |
+| metrics | list | 是 | - | spend、impressions、clicks 的非空且不重复的子集。 |
+| schema | config | 是 | - | 字段必须与请求的维度和指标完全对应，输出顺序可自行指定。 |
+| page_size | int | 否 | 1000 | 每页请求行数，1-1000。 |
+| max_report_rows | int | 否 | 100000 | 总行数上限，1-1000000；超过时失败而非截断，不能绕过 API 广告 ID 上限。 |
+| max_response_bytes | int | 否 | 4194304 | 单次响应字节上限，1024-16777216。 |
+| request_timeout_ms | int | 否 | 30000 | 包含响应体读取的 HTTP 截止时间，100-120000 毫秒。 |
+| report_timeout_ms | int | 否 | 600000 | 报表截止时间，100-3600000 毫秒；在记录、请求之间和重试等待中检查。 |
+| max_retries | int | 否 | 3 | 每页额外尝试次数，0-5；仅对 HTTP 429、500、502、503、504 重试。 |
+| max_retry_wait_ms | int | 否 | 30000 | 最大重试等待，1000-120000 毫秒；Retry-After 超出时失败，不提前重试。 |
+| mock_url | string | 否 | - | 仅测试使用的 HTTP origin，要求 token 为字面值 mock-token；禁止真实令牌。不是官方模拟器。 |
+| common-options | | 否 | - | 支持 parallelism=1 和 plugin_output / result_table_name。 |
+
+### 类型和报表语义
+
+- `ad_id` 使用 STRING。对 Manual/Smart+ Ads 表示广告，对 Upgraded Smart+ Ads 表示
+  **创意**，本版本不支持 `ad_id_v2`。
+- `stat_time_day` 使用 STRING，保留 `yyyy-MM-dd 00:00:00` 的广告主本地日期标签，
+  不转换成假设的 UTC 时间戳。日期必须位于请求范围内。
+- `spend` 使用 DECIMAL(p,s)，精度不超过 38，按广告主账号货币单位表示，
+  不进行分/元换算或汇率转换。超出精度或需要舍入时失败。
+- `impressions` 和 `clicks` 使用 BIGINT，非法值、小数或溢出时失败。
+- 请求字段必须为非空字符串。缺失、null、格式错误或不可精确表示的值均失败，不补零。
+  此版本不输出可选字段，空结果输出零行。
+
+API 默认 `ad_status=STATUS_NOT_DELETE` 筛选生效，**不包括已删除广告**，不是全状态历史导出。
+不支持自定义筛选或自动按广告 ID 分区。请求显式指定 `query_lifetime=false` 和
+`query_mode=REGULAR`，采用 API 默认顺序，不保证快照顺序稳定。
+Branded Mission 数据需要广告主层级报表，本连接器的 `ad_id` 维度不返回此类数据。
+
+### 错误和限制
+
+HTTP 200 但 API code 非零时直接失败。不合法响应、缺失分页字段、页码或总数不一致、
+页面不完整、重复维度键、总数变化均失败。权限、解析、响应大小和传输错误不重试。
+HTTP 重试使用有上限的指数等待，支持 Retry-After 秒数和 HTTP 日期；非法值失败且不回显。
+
+官方当前同步报表文档描述 20,000 个广告 ID 截断上限，较早 v1.3 更新说明为 10,000。
+`X-Tt-Ads-Throttle` 用于超限警告。本连接器**保守地拒绝该响应头的任何非空值**，
+包括无法识别的警告，且不记录其内容。缺少该头不能证明数据完整，分页不能绕过截断。
+需要筛选或异步导出的广告主不属于此版本的完整导出范围。同步结果可能与 Ads Manager 下载不同。
+
+禁止自动重试、重定向、Cookie 和响应压缩。生产 origin 固定为
+`https://business-api.tiktok.com`。关闭读取器会中止请求并唤醒重试等待。
+JVM/操作系统 DNS 解析和阻塞的下游 collect 可能超过截止时间，因此在这些阶段不保证硬性取消时限。
+
+## 前提与验证
+
+需要通过 TikTok API for Business 获得具有广告主报表权限的令牌。
+通过受保护的配置或环境变量提供；不要把令牌放入查询参数、schema 字段名、自定义键或调试日志。
+mock_url 仅接受非秘密哨兵值 mock-token，防止真实令牌误传。
+
+本地模拟测试和真实引擎上的模拟作业只能验证协议处理及引擎集成，
+不能证明真实广告主权限、生产配额、数据新鲜度或完整性。真实环境验证需要另行提供授权访问。
+
+## 示例
+
+```hocon
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+source {
+  TikTokAds {
+    token = ${TIKTOK_ADS_TOKEN}
+    advertiser_id = "123456789"
+    data_level = "AUCTION_AD"
+    start_date = "2026-09-01"
+    end_date = "2026-09-02"
+    dimensions = ["ad_id", "stat_time_day"]
+    metrics = ["spend", "impressions", "clicks"]
+    schema {
+      fields {
+        ad_id = string
+        stat_time_day = string
+        spend = "decimal(38, 6)"
+        impressions = bigint
+        clicks = bigint
+      }
+    }
+  }
+}
+sink {
+  Console {}
+}
+```
+
+## 参考资料
+
+- [同步报表 API](https://business-api.tiktok.com/portal/docs/run-a-synchronous-report/v1.3)
+- [官方 SDK](https://github.com/tiktok/tiktok-business-api-sdk/blob/main/python_sdk/docs/ReportingApi.md)
+- [基本报表维度](https://business-api.tiktok.com/portal/docs?id=1751443956638721)
+
+## 变更日志
+
+[连接器变更日志](../changelog/connector-tiktok-ads.md)

--- a/docs/zh/connectors/source/TikTokAds.md
+++ b/docs/zh/connectors/source/TikTokAds.md
@@ -1,3 +1,7 @@
+import ChangeLog from '../changelog/connector-tiktok-ads.md';
+
+# TikTokAds
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +18,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-# TikTokAds
 
 ## 描述
 
@@ -54,7 +56,7 @@ limitations under the License.
 | max_retries | int | 否 | 3 | 每页额外尝试次数，0-5；仅对 HTTP 429、500、502、503、504 重试。 |
 | max_retry_wait_ms | int | 否 | 30000 | 最大重试等待，1000-120000 毫秒；Retry-After 超出时失败，不提前重试。 |
 | mock_url | string | 否 | - | 仅测试使用的 HTTP origin，要求 token 为字面值 mock-token；禁止真实令牌。不是官方模拟器。 |
-| common-options | | 否 | - | 支持 parallelism=1 和 plugin_output / result_table_name。 |
+| common-options | | 否 | - | 支持 parallelism=1 和 plugin_output。 |
 
 ### 类型和报表语义
 
@@ -137,4 +139,4 @@ sink {
 
 ## 变更日志
 
-[连接器变更日志](../changelog/connector-tiktok-ads.md)
+<ChangeLog />

--- a/plugin-mapping.properties
+++ b/plugin-mapping.properties
@@ -107,6 +107,7 @@ seatunnel.source.GoogleBigtable = connector-google-bigtable
 seatunnel.sink.GoogleBigtable = connector-google-bigtable
 seatunnel.source.GoogleAds = connector-google-ads
 seatunnel.source.FacebookAds = connector-facebook-ads
+seatunnel.source.TikTokAds = connector-tiktok-ads
 seatunnel.sink.Tablestore = connector-tablestore
 seatunnel.source.Tablestore = connector-tablestore
 seatunnel.source.Lemlist = connector-http-lemlist

--- a/seatunnel-connectors-v2/connector-tiktok-ads/pom.xml
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connectors-v2</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>connector-tiktok-ads</artifactId>
+    <name>SeaTunnel : Connectors V2 : TikTok Ads</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>seatunnel-core-starter</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.apache.http</pattern>
+                            <shadedPattern>org.apache.seatunnel.connectors.seatunnel.tiktok.ads.shaded.http</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.apache.commons.codec</pattern>
+                            <shadedPattern>org.apache.seatunnel.connectors.seatunnel.tiktok.ads.shaded.codec</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <transformers combine.children="append">
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                    </transformers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsClient.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsClient.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.common.utils.JsonUtils;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReport.failure;
+
+final class TikTokAdsClient implements Closeable {
+    private final TikTokAdsConfig config;
+    private final CloseableHttpClient client =
+            HttpClients.custom()
+                    .disableAutomaticRetries()
+                    .disableRedirectHandling()
+                    .disableCookieManagement()
+                    .disableContentCompression()
+                    .build();
+    private final ScheduledThreadPoolExecutor deadlines =
+            new ScheduledThreadPoolExecutor(
+                    1,
+                    task -> {
+                        Thread thread = new Thread(task, "tiktok-ads-request-deadline");
+                        thread.setDaemon(true);
+                        return thread;
+                    });
+    private volatile boolean closed;
+    private volatile HttpGet active;
+    private long reportDeadline;
+
+    TikTokAdsClient(TikTokAdsConfig config) {
+        this.config = config;
+        deadlines.setRemoveOnCancelPolicy(true);
+    }
+
+    void startReport() {
+        reportDeadline =
+                System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(config.getReportTimeout());
+    }
+
+    void checkActive() throws IOException {
+        if (closed || Thread.currentThread().isInterrupted()) {
+            throw failure("request cancelled");
+        }
+        if (System.nanoTime() >= reportDeadline) {
+            throw failure("report_timeout_ms exceeded");
+        }
+    }
+
+    URI requestUri(int page) throws IOException {
+        try {
+            return new URIBuilder(config.getEndpoint())
+                    .addParameter("advertiser_id", config.getAdvertiserId())
+                    .addParameter("report_type", "BASIC")
+                    .addParameter("service_type", "AUCTION")
+                    .addParameter("data_level", "AUCTION_AD")
+                    .addParameter("dimensions", JsonUtils.toJsonString(config.getDimensions()))
+                    .addParameter("metrics", JsonUtils.toJsonString(config.getMetrics()))
+                    .addParameter("start_date", config.getStartDate())
+                    .addParameter("end_date", config.getEndDate())
+                    .addParameter("query_lifetime", "false")
+                    .addParameter("query_mode", "REGULAR")
+                    .addParameter("page", Integer.toString(page))
+                    .addParameter("page_size", Integer.toString(config.getPageSize()))
+                    .build();
+        } catch (URISyntaxException e) {
+            throw failure("invalid endpoint");
+        }
+    }
+
+    Response fetch(int page) throws IOException {
+        checkActive();
+        HttpGet request = new HttpGet(requestUri(page));
+        active = request;
+        ScheduledFuture<?> abort = null;
+        try {
+            checkActive();
+            int timeout =
+                    (int)
+                            Math.max(
+                                    1,
+                                    Math.min(
+                                            config.getTimeout(),
+                                            TimeUnit.NANOSECONDS.toMillis(
+                                                    reportDeadline - System.nanoTime())));
+            request.setConfig(
+                    RequestConfig.custom()
+                            .setConnectTimeout(timeout)
+                            .setConnectionRequestTimeout(timeout)
+                            .setSocketTimeout(timeout)
+                            .build());
+            request.setHeader("Access-Token", config.getToken());
+            request.setHeader("Accept", "application/json");
+            abort = deadlines.schedule(request::abort, timeout, TimeUnit.MILLISECONDS);
+            try (CloseableHttpResponse response = client.execute(request)) {
+                // Conservative fail-closed policy: do not interpret undocumented header payloads.
+                for (Header warning : response.getHeaders("X-Tt-Ads-Throttle")) {
+                    if (!warning.getValue().trim().isEmpty()) {
+                        request.abort();
+                        throw new InvalidResponseException(
+                                "nonempty X-Tt-Ads-Throttle; report may be truncated");
+                    }
+                }
+                HttpEntity entity = response.getEntity();
+                byte[] body = new byte[0];
+                if (entity != null) {
+                    try {
+                        if (entity.getContentLength() > config.getMaxBytes()) {
+                            throw new InvalidResponseException("max_response_bytes exceeded");
+                        }
+                        body = readBounded(entity.getContent(), config.getMaxBytes());
+                    } catch (IOException e) {
+                        request.abort();
+                        throw e;
+                    }
+                }
+                checkActive();
+                if (request.isAborted()) {
+                    throw failure("request_timeout_ms exceeded");
+                }
+                return new Response(
+                        response.getStatusLine().getStatusCode(),
+                        body,
+                        response.getFirstHeader("Retry-After") == null
+                                ? null
+                                : response.getFirstHeader("Retry-After").getValue());
+            }
+        } catch (InvalidResponseException e) {
+            throw e;
+        } catch (IOException | RuntimeException e) {
+            checkActive();
+            throw failure(
+                    request.isAborted() ? "request_timeout_ms exceeded" : "HTTP transport failed");
+        } finally {
+            if (abort != null) {
+                abort.cancel(false);
+            }
+            request.abort();
+            active = null;
+        }
+    }
+
+    static byte[] readBounded(InputStream input, int limit) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(8192, limit));
+        byte[] buffer = new byte[8192];
+        int count;
+        while ((count = input.read(buffer, 0, Math.min(buffer.length, limit - output.size() + 1)))
+                != -1) {
+            if (count > limit - output.size()) {
+                throw new InvalidResponseException("max_response_bytes exceeded");
+            }
+            output.write(buffer, 0, count);
+        }
+        return output.toByteArray();
+    }
+
+    synchronized void awaitRetry(long millis) throws IOException {
+        checkActive();
+        long end = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(millis);
+        while (System.nanoTime() < end) {
+            try {
+                TimeUnit.NANOSECONDS.timedWait(
+                        this, Math.max(1, Math.min(end, reportDeadline) - System.nanoTime()));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw failure("retry interrupted");
+            }
+            checkActive();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        synchronized (this) {
+            notifyAll();
+        }
+        HttpGet request = active;
+        if (request != null) {
+            request.abort();
+        }
+        deadlines.shutdownNow();
+        client.close();
+    }
+
+    static final class Response {
+        final int status;
+        final byte[] body;
+        final String retryAfter;
+
+        Response(int status, byte[] body, String retryAfter) {
+            this.status = status;
+            this.body = body;
+            this.retryAfter = retryAfter;
+        }
+    }
+
+    private static final class InvalidResponseException extends IOException {
+        InvalidResponseException(String message) {
+            super("TikTokAds: " + message);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsConfig.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsConfig.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.configuration.util.ConfigValidator;
+import org.apache.seatunnel.api.configuration.util.OptionValidationException;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.catalog.CatalogTableUtil;
+import org.apache.seatunnel.api.table.type.BasicType;
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.SeaTunnelDataType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.ADVERTISER_ID;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.DATA_LEVEL;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.DIMENSIONS;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.END_DATE;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.MAX_BYTES;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.MAX_ROWS;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.METRICS;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.MOCK_URL;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.PAGE_SIZE;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.REPORT_TIMEOUT;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.RETRIES;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.RETRY_WAIT;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.START_DATE;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.TIMEOUT;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.TOKEN;
+
+@Getter
+final class TikTokAdsConfig implements Serializable {
+    static final String PATH = "/open_api/v1.3/report/integrated/get/";
+    private final String token;
+    private final String advertiserId;
+    private final String startDate;
+    private final String endDate;
+    private final List<String> dimensions;
+    private final List<String> metrics;
+    private final String endpoint;
+    private final int pageSize;
+    private final int maxRows;
+    private final int maxBytes;
+    private final int timeout;
+    private final int reportTimeout;
+    private final int retries;
+    private final int retryWait;
+    private final CatalogTable table;
+
+    TikTokAdsConfig(ReadonlyConfig options) {
+        // Do not retain parser causes or input values: either may contain credentials.
+        try {
+            try {
+                ConfigValidator.validateUnknownKeys(
+                        options,
+                        new TikTokAdsSourceFactory().optionRule(),
+                        TikTokAdsSource.PLUGIN_NAME);
+            } catch (OptionValidationException e) {
+                throw new ValidationException("unsupported option; see TikTokAds options");
+            }
+            Object parallelism = options.getSourceMap().get("parallelism");
+            require(
+                    parallelism == null || "1".equals(parallelism.toString()),
+                    "parallelism must be 1");
+            token = options.get(TOKEN);
+            require(
+                    token != null && token.matches("[!-~]{1,4096}"),
+                    "token must be a nonempty ASCII header value");
+            advertiserId = options.get(ADVERTISER_ID);
+            require(advertiserId.matches("[0-9]{1,30}"), "advertiser_id must be numeric");
+            require("AUCTION_AD".equals(options.get(DATA_LEVEL)), "data_level must be AUCTION_AD");
+            startDate = options.get(START_DATE);
+            endDate = options.get(END_DATE);
+            require(!date(startDate).isAfter(date(endDate)), "start_date must not exceed end_date");
+            dimensions = Collections.unmodifiableList(new ArrayList<>(options.get(DIMENSIONS)));
+            require(
+                    dimensions.equals(Collections.singletonList("ad_id"))
+                            || dimensions.equals(Arrays.asList("ad_id", "stat_time_day")),
+                    "dimensions must be [ad_id] or [ad_id, stat_time_day]");
+            long days = ChronoUnit.DAYS.between(date(startDate), date(endDate)) + 1;
+            require(
+                    days <= (dimensions.contains("stat_time_day") ? 30 : 365),
+                    "date range must be at most 30 inclusive days with stat_time_day or 365 without it");
+            metrics = Collections.unmodifiableList(new ArrayList<>(options.get(METRICS)));
+            require(
+                    !metrics.isEmpty()
+                            && new HashSet<>(metrics).size() == metrics.size()
+                            && Arrays.asList("spend", "impressions", "clicks").containsAll(metrics),
+                    "metrics must be a nonempty unique subset of spend, impressions, clicks");
+            String mock = options.getOptional(MOCK_URL).orElse(null);
+            if (mock == null) {
+                require(!"mock-token".equals(token), "mock-token requires mock_url");
+                endpoint = "https://business-api.tiktok.com" + PATH;
+            } else {
+                require("mock-token".equals(token), "mock_url requires token mock-token");
+                URI uri = URI.create(mock);
+                require(
+                        "http".equals(uri.getScheme())
+                                && uri.getHost() != null
+                                && uri.getRawUserInfo() == null
+                                && uri.getRawQuery() == null
+                                && uri.getRawFragment() == null
+                                && (uri.getPath().isEmpty() || "/".equals(uri.getPath())),
+                        "mock_url must be an HTTP origin without credentials, path, query or fragment");
+                endpoint = mock.replaceAll("/$", "") + PATH;
+            }
+            pageSize = bounded(options.get(PAGE_SIZE), 1, 1000);
+            maxRows = bounded(options.get(MAX_ROWS), 1, 1000000);
+            maxBytes = bounded(options.get(MAX_BYTES), 1024, 16777216);
+            timeout = bounded(options.get(TIMEOUT), 100, 120000);
+            reportTimeout = bounded(options.get(REPORT_TIMEOUT), 100, 3600000);
+            retries = bounded(options.get(RETRIES), 0, 5);
+            retryWait = bounded(options.get(RETRY_WAIT), 1000, 120000);
+            table = CatalogTableUtil.buildWithConfig(options);
+            validateSchema(table.getSeaTunnelRowType());
+        } catch (ValidationException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("TikTokAds: missing or invalid configuration");
+        }
+    }
+
+    private void validateSchema(SeaTunnelRowType rowType) {
+        Set<String> expected = new HashSet<>(dimensions);
+        expected.addAll(metrics);
+        require(
+                rowType.getTotalFields() == expected.size()
+                        && expected.equals(new HashSet<>(Arrays.asList(rowType.getFieldNames()))),
+                "schema must match all requested dimensions and metrics exactly");
+        for (int i = 0; i < rowType.getTotalFields(); i++) {
+            String name = rowType.getFieldName(i);
+            SeaTunnelDataType<?> type = rowType.getFieldType(i);
+            if (dimensions.contains(name)) {
+                require(BasicType.STRING_TYPE.equals(type), "dimensions require STRING");
+            } else if ("spend".equals(name)) {
+                require(type instanceof DecimalType, "spend requires DECIMAL");
+                DecimalType decimal = (DecimalType) type;
+                require(
+                        decimal.getPrecision() >= 1
+                                && decimal.getPrecision() <= 38
+                                && decimal.getScale() >= 0
+                                && decimal.getScale() <= decimal.getPrecision(),
+                        "invalid DECIMAL precision or scale");
+            } else {
+                require(BasicType.LONG_TYPE.equals(type), "impressions and clicks require BIGINT");
+            }
+        }
+    }
+
+    static LocalDate date(String value) {
+        try {
+            require(value != null && value.matches("[0-9]{4}-[0-9]{2}-[0-9]{2}"), "invalid date");
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new ValidationException("invalid calendar date");
+        }
+    }
+
+    private static int bounded(int value, int min, int max) {
+        require(value >= min && value <= max, "numeric option outside allowed bounds");
+        return value;
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) {
+            throw new ValidationException(message);
+        }
+    }
+
+    private static final class ValidationException extends IllegalArgumentException {
+        private ValidationException(String message) {
+            super("TikTokAds: " + message);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsConfig.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsConfig.java
@@ -41,21 +41,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.ADVERTISER_ID;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.DATA_LEVEL;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.DIMENSIONS;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.END_DATE;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.MAX_BYTES;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.MAX_ROWS;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.METRICS;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.MOCK_URL;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.PAGE_SIZE;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.REPORT_TIMEOUT;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.RETRIES;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.RETRY_WAIT;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.START_DATE;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.TIMEOUT;
-import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsOptions.TOKEN;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.ADVERTISER_ID;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.DATA_LEVEL;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.DIMENSIONS;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.END_DATE;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.MAX_BYTES;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.MAX_ROWS;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.METRICS;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.MOCK_URL;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.PAGE_SIZE;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.REPORT_TIMEOUT;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.RETRIES;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.RETRY_WAIT;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.START_DATE;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.TIMEOUT;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsSourceOptions.TOKEN;
 
 @Getter
 final class TikTokAdsConfig implements Serializable {

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsOptions.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsOptions.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.configuration.Option;
+import org.apache.seatunnel.api.configuration.Options;
+
+import java.util.List;
+
+public final class TikTokAdsOptions {
+    private TikTokAdsOptions() {}
+
+    public static final Option<String> TOKEN =
+            Options.key("token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Authorized TikTok Access-Token. Use mock-token only with mock_url.");
+    public static final Option<String> ADVERTISER_ID =
+            Options.key("advertiser_id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One numeric advertiser ID.");
+    public static final Option<String> DATA_LEVEL =
+            Options.key("data_level")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Only AUCTION_AD is supported; report_type is always BASIC.");
+    public static final Option<String> START_DATE =
+            Options.key("start_date")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Inclusive yyyy-MM-dd date in the advertiser timezone.");
+    public static final Option<String> END_DATE =
+            Options.key("end_date")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Inclusive yyyy-MM-dd date in the advertiser timezone.");
+    public static final Option<List<String>> DIMENSIONS =
+            Options.key("dimensions")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("ad_id, optionally followed by stat_time_day.");
+    public static final Option<List<String>> METRICS =
+            Options.key("metrics")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Explicit nonempty subset of spend, impressions, clicks.");
+    public static final Option<String> MOCK_URL =
+            Options.key("mock_url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Test-only HTTP origin, requires literal token mock-token; never use real credentials.");
+    public static final Option<Integer> PAGE_SIZE =
+            Options.key("page_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Requested rows per page, 1 to 1000.");
+    public static final Option<Integer> MAX_ROWS =
+            Options.key("max_report_rows")
+                    .intType()
+                    .defaultValue(100000)
+                    .withDescription(
+                            "Fail rather than truncate above this total row bound, 1 to 1000000.");
+    public static final Option<Integer> MAX_BYTES =
+            Options.key("max_response_bytes")
+                    .intType()
+                    .defaultValue(4194304)
+                    .withDescription("Response byte limit per request, 1024 to 16777216.");
+    public static final Option<Integer> TIMEOUT =
+            Options.key("request_timeout_ms")
+                    .intType()
+                    .defaultValue(30000)
+                    .withDescription(
+                            "HTTP deadline including body, 100 to 120000 ms; DNS resolution is platform controlled.");
+    public static final Option<Integer> REPORT_TIMEOUT =
+            Options.key("report_timeout_ms")
+                    .intType()
+                    .defaultValue(600000)
+                    .withDescription(
+                            "Report deadline checked between records and requests, 100 to 3600000 ms.");
+    public static final Option<Integer> RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Additional attempts for HTTP 429/500/502/503/504 only, 0 to 5.");
+    public static final Option<Integer> RETRY_WAIT =
+            Options.key("max_retry_wait_ms")
+                    .intType()
+                    .defaultValue(30000)
+                    .withDescription(
+                            "Maximum retry wait, 1000 to 120000 ms; longer Retry-After fails.");
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsReport.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsReport.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonFactory;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.core.JsonParser;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.core.StreamReadConstraints;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.DeserializationFeature;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.seatunnel.shade.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.seatunnel.api.table.type.DecimalType;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.api.table.type.SeaTunnelRowType;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+final class TikTokAdsReport {
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper(
+                            JsonFactory.builder()
+                                    .streamReadConstraints(
+                                            StreamReadConstraints.builder()
+                                                    .maxNestingDepth(16)
+                                                    .maxStringLength(4096)
+                                                    .maxNumberLength(128)
+                                                    .build())
+                                    .build())
+                    .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
+                    .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                    .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+
+    private TikTokAdsReport() {}
+
+    static Page parse(
+            byte[] body, int requestedPage, TikTokAdsConfig config, Set<List<String>> seen)
+            throws IOException {
+        JsonNode root;
+        try {
+            root = MAPPER.readTree(body);
+        } catch (IOException | RuntimeException e) {
+            // Parser diagnostics can embed the entire response, including an echoed Access-Token.
+            throw failure("invalid JSON response");
+        }
+        int code = integer(root, "code");
+        if (code != 0) {
+            throw failure(
+                    "API returned nonzero code "
+                            + code
+                            + "; check authorization, request compatibility and quota");
+        }
+        JsonNode data = object(root, "data");
+        JsonNode info = object(data, "page_info");
+        int page = integer(info, "page");
+        int pageSize = integer(info, "page_size");
+        int totalPages = integer(info, "total_page");
+        int total = integer(info, "total_number");
+        JsonNode records = data.get("list");
+        if (records == null
+                || !records.isArray()
+                || page != requestedPage
+                || pageSize != config.getPageSize()
+                || total > config.getMaxRows()) {
+            throw failure("invalid page metadata or max_report_rows exceeded");
+        }
+        // Empty reports can advertise zero pages or the requested first page.
+        int expectedPages = (int) ((total + (long) pageSize - 1) / pageSize);
+        if (total == 0) {
+            if (page != 1 || !records.isEmpty() || (totalPages != 0 && totalPages != 1)) {
+                throw failure("inconsistent empty report metadata");
+            }
+        } else if (totalPages != expectedPages
+                || page > totalPages
+                || records.size() != Math.min(pageSize, total - (long) (page - 1) * pageSize)) {
+            throw failure("inconsistent pagination counts");
+        }
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        SeaTunnelRowType type = config.getTable().getSeaTunnelRowType();
+        for (JsonNode record : records) {
+            JsonNode dimensions = object(record, "dimensions");
+            JsonNode metrics = object(record, "metrics");
+            List<String> key = new ArrayList<>();
+            for (String name : config.getDimensions()) {
+                String value = string(dimensions, name);
+                if ("ad_id".equals(name) && !value.matches("[0-9]{1,30}")) {
+                    throw failure("invalid ad_id dimension");
+                }
+                if ("stat_time_day".equals(name)) {
+                    validateDay(value, config);
+                }
+                key.add(value);
+            }
+            if (!seen.add(key)) {
+                throw failure("repeated dimension key; report pagination is not stable");
+            }
+            Object[] fields = new Object[type.getTotalFields()];
+            for (int i = 0; i < fields.length; i++) {
+                String name = type.getFieldName(i);
+                if (config.getDimensions().contains(name)) {
+                    fields[i] = string(dimensions, name);
+                } else {
+                    String value = string(metrics, name);
+                    try {
+                        if ("spend".equals(name)) {
+                            DecimalType decimalType = (DecimalType) type.getFieldType(i);
+                            if (!value.matches("[0-9]{1,38}(\\.[0-9]{1,38})?")) {
+                                throw failure("invalid spend decimal");
+                            }
+                            BigDecimal decimal =
+                                    new BigDecimal(value)
+                                            .setScale(
+                                                    decimalType.getScale(),
+                                                    RoundingMode.UNNECESSARY);
+                            if (decimal.precision() > decimalType.getPrecision()) {
+                                throw failure("spend exceeds schema precision");
+                            }
+                            fields[i] = decimal;
+                        } else {
+                            if (!value.matches("[0-9]{1,19}")) {
+                                throw failure("invalid count metric");
+                            }
+                            fields[i] = Long.parseLong(value);
+                        }
+                    } catch (ArithmeticException | NumberFormatException e) {
+                        throw failure("metric cannot be represented exactly by schema");
+                    }
+                }
+            }
+            rows.add(new SeaTunnelRow(fields));
+        }
+        return new Page(total, totalPages, rows);
+    }
+
+    private static void validateDay(String value, TikTokAdsConfig config) throws IOException {
+        // TikTok returns a report-local midnight label, not a UTC timestamp.
+        if (!value.matches("[0-9]{4}-[0-9]{2}-[0-9]{2} 00:00:00")) {
+            throw failure("invalid stat_time_day label");
+        }
+        try {
+            LocalDate day = TikTokAdsConfig.date(value.substring(0, 10));
+            if (day.isBefore(TikTokAdsConfig.date(config.getStartDate()))
+                    || day.isAfter(TikTokAdsConfig.date(config.getEndDate()))) {
+                throw failure("stat_time_day outside requested dates");
+            }
+        } catch (IllegalArgumentException e) {
+            throw failure("invalid stat_time_day calendar date");
+        }
+    }
+
+    private static JsonNode object(JsonNode parent, String field) throws IOException {
+        JsonNode node = parent == null ? null : parent.get(field);
+        if (node == null || !node.isObject()) {
+            throw failure("missing or invalid " + field + " object");
+        }
+        return node;
+    }
+
+    private static int integer(JsonNode parent, String field) throws IOException {
+        JsonNode node = parent == null ? null : parent.get(field);
+        if (node == null
+                || !node.isIntegralNumber()
+                || !node.canConvertToInt()
+                || node.intValue() < 0) {
+            throw failure("missing or invalid " + field + " integer");
+        }
+        return node.intValue();
+    }
+
+    private static String string(JsonNode parent, String field) throws IOException {
+        JsonNode node = parent.get(field);
+        if (node == null || !node.isTextual() || node.textValue().isEmpty()) {
+            throw failure("missing or invalid requested field " + field);
+        }
+        return node.textValue();
+    }
+
+    static IOException failure(String message) {
+        return new IOException("TikTokAds: " + message);
+    }
+
+    static final class Page {
+        final int total;
+        final int totalPages;
+        final List<SeaTunnelRow> rows;
+
+        Page(int total, int totalPages, List<SeaTunnelRow> rows) {
+            this.total = total;
+            this.totalPages = totalPages;
+            this.rows = rows;
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSource.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSource.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.table.catalog.CatalogTable;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitSource;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TikTokAdsSource extends AbstractSingleSplitSource<SeaTunnelRow> {
+    public static final String PLUGIN_NAME = "TikTokAds";
+    private final TikTokAdsConfig config;
+
+    public TikTokAdsSource(ReadonlyConfig options) {
+        config = new TikTokAdsConfig(options);
+    }
+
+    @Override
+    public void setJobContext(JobContext context) {
+        if (context.getJobMode() != JobMode.BATCH) {
+            throw new IllegalArgumentException("TikTokAds supports batch jobs only");
+        }
+    }
+
+    @Override
+    public String getPluginName() {
+        return PLUGIN_NAME;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public List<CatalogTable> getProducedCatalogTables() {
+        return Collections.singletonList(config.getTable());
+    }
+
+    @Override
+    public AbstractSingleSplitReader<SeaTunnelRow> createReader(SingleSplitReaderContext context) {
+        return new TikTokAdsSourceReader(config, context);
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.configuration.util.OptionRule;
+import org.apache.seatunnel.api.options.ConnectorCommonOptions;
+import org.apache.seatunnel.api.options.MultiTableCommonOptions;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceSplit;
+import org.apache.seatunnel.api.table.connector.TableSource;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactory;
+import org.apache.seatunnel.api.table.factory.TableSourceFactoryContext;
+
+import com.google.auto.service.AutoService;
+
+import java.io.Serializable;
+
+@AutoService(Factory.class)
+public class TikTokAdsSourceFactory implements TableSourceFactory {
+    @Override
+    public String factoryIdentifier() {
+        return TikTokAdsSource.PLUGIN_NAME;
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        TikTokAdsOptions.TOKEN,
+                        TikTokAdsOptions.ADVERTISER_ID,
+                        TikTokAdsOptions.DATA_LEVEL,
+                        TikTokAdsOptions.START_DATE,
+                        TikTokAdsOptions.END_DATE,
+                        TikTokAdsOptions.DIMENSIONS,
+                        TikTokAdsOptions.METRICS,
+                        ConnectorCommonOptions.SCHEMA)
+                .optional(
+                        MultiTableCommonOptions.MULTI_TABLE_FAILURE_POLICY,
+                        TikTokAdsOptions.MOCK_URL,
+                        TikTokAdsOptions.PAGE_SIZE,
+                        TikTokAdsOptions.MAX_ROWS,
+                        TikTokAdsOptions.MAX_BYTES,
+                        TikTokAdsOptions.TIMEOUT,
+                        TikTokAdsOptions.REPORT_TIMEOUT,
+                        TikTokAdsOptions.RETRIES,
+                        TikTokAdsOptions.RETRY_WAIT)
+                .build();
+    }
+
+    @Override
+    public <T, SplitT extends SourceSplit, StateT extends Serializable>
+            TableSource<T, SplitT, StateT> createSource(TableSourceFactoryContext context) {
+        return () -> (SeaTunnelSource<T, SplitT, StateT>) new TikTokAdsSource(context.getOptions());
+    }
+
+    @Override
+    public Class<? extends SeaTunnelSource> getSourceClass() {
+        return TikTokAdsSource.class;
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceFactory.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceFactory.java
@@ -42,24 +42,24 @@ public class TikTokAdsSourceFactory implements TableSourceFactory {
     public OptionRule optionRule() {
         return OptionRule.builder()
                 .required(
-                        TikTokAdsOptions.TOKEN,
-                        TikTokAdsOptions.ADVERTISER_ID,
-                        TikTokAdsOptions.DATA_LEVEL,
-                        TikTokAdsOptions.START_DATE,
-                        TikTokAdsOptions.END_DATE,
-                        TikTokAdsOptions.DIMENSIONS,
-                        TikTokAdsOptions.METRICS,
+                        TikTokAdsSourceOptions.TOKEN,
+                        TikTokAdsSourceOptions.ADVERTISER_ID,
+                        TikTokAdsSourceOptions.DATA_LEVEL,
+                        TikTokAdsSourceOptions.START_DATE,
+                        TikTokAdsSourceOptions.END_DATE,
+                        TikTokAdsSourceOptions.DIMENSIONS,
+                        TikTokAdsSourceOptions.METRICS,
                         ConnectorCommonOptions.SCHEMA)
                 .optional(
                         MultiTableCommonOptions.MULTI_TABLE_FAILURE_POLICY,
-                        TikTokAdsOptions.MOCK_URL,
-                        TikTokAdsOptions.PAGE_SIZE,
-                        TikTokAdsOptions.MAX_ROWS,
-                        TikTokAdsOptions.MAX_BYTES,
-                        TikTokAdsOptions.TIMEOUT,
-                        TikTokAdsOptions.REPORT_TIMEOUT,
-                        TikTokAdsOptions.RETRIES,
-                        TikTokAdsOptions.RETRY_WAIT)
+                        TikTokAdsSourceOptions.MOCK_URL,
+                        TikTokAdsSourceOptions.PAGE_SIZE,
+                        TikTokAdsSourceOptions.MAX_ROWS,
+                        TikTokAdsSourceOptions.MAX_BYTES,
+                        TikTokAdsSourceOptions.TIMEOUT,
+                        TikTokAdsSourceOptions.REPORT_TIMEOUT,
+                        TikTokAdsSourceOptions.RETRIES,
+                        TikTokAdsSourceOptions.RETRY_WAIT)
                 .build();
     }
 

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceOptions.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceOptions.java
@@ -22,8 +22,8 @@ import org.apache.seatunnel.api.configuration.Options;
 
 import java.util.List;
 
-public final class TikTokAdsOptions {
-    private TikTokAdsOptions() {}
+public final class TikTokAdsSourceOptions {
+    private TikTokAdsSourceOptions() {}
 
     public static final Option<String> TOKEN =
             Options.key("token")

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceReader.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/main/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceReader.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.AbstractSingleSplitReader;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReport.failure;
+
+final class TikTokAdsSourceReader extends AbstractSingleSplitReader<SeaTunnelRow> {
+    private final TikTokAdsConfig config;
+    private final SingleSplitReaderContext context;
+    private volatile TikTokAdsClient client;
+    private boolean closed;
+
+    TikTokAdsSourceReader(TikTokAdsConfig config, SingleSplitReaderContext context) {
+        this.config = config;
+        this.context = context;
+    }
+
+    /** Create worker-local resources only; the source remains serializable. */
+    @Override
+    public synchronized void open() throws IOException {
+        if (closed) {
+            throw failure("reader closed");
+        }
+        if (client == null) {
+            client = new TikTokAdsClient(config);
+        }
+    }
+
+    /**
+     * Read one bounded report. Restore intentionally replays page one, not a mutable page offset.
+     */
+    @Override
+    public void internalPollNext(Collector<SeaTunnelRow> output) throws Exception {
+        TikTokAdsClient current = client;
+        if (current == null) {
+            throw failure("reader is not open");
+        }
+        current.startReport();
+        Set<List<String>> seen = new HashSet<>();
+        int total = -1;
+        int pages = -1;
+        int emitted = 0;
+        for (int number = 1; ; number++) {
+            TikTokAdsClient.Response response = fetchWithRetry(current, number);
+            TikTokAdsReport.Page page = TikTokAdsReport.parse(response.body, number, config, seen);
+            if (total != -1 && (total != page.total || pages != page.totalPages)) {
+                throw failure("report totals changed during pagination");
+            }
+            total = page.total;
+            pages = page.totalPages;
+            for (SeaTunnelRow row : page.rows) {
+                current.checkActive();
+                output.collect(row);
+                emitted++;
+            }
+            if (number >= pages) {
+                if (emitted != total) {
+                    throw failure("incomplete report");
+                }
+                current.checkActive();
+                context.signalNoMoreElement();
+                return;
+            }
+        }
+    }
+
+    private TikTokAdsClient.Response fetchWithRetry(TikTokAdsClient current, int page)
+            throws IOException {
+        for (int attempt = 0; ; attempt++) {
+            TikTokAdsClient.Response response = current.fetch(page);
+            if (response.status == 200) {
+                return response;
+            }
+            boolean transientStatus =
+                    response.status == 429
+                            || response.status == 500
+                            || response.status == 502
+                            || response.status == 503
+                            || response.status == 504;
+            if (!transientStatus || attempt >= config.getRetries()) {
+                throw failure("HTTP " + response.status + "; request failed");
+            }
+            current.awaitRetry(retryDelay(response.retryAfter, attempt, config.getRetryWait()));
+        }
+    }
+
+    static long retryDelay(String retryAfter, int attempt, int maxWait) throws IOException {
+        long delay = Math.min(maxWait, 1000L << attempt);
+        if (retryAfter != null) {
+            try {
+                long requested =
+                        retryAfter.matches("[0-9]{1,9}")
+                                ? Math.multiplyExact(Long.parseLong(retryAfter), 1000L)
+                                : Math.max(
+                                        0,
+                                        ZonedDateTime.parse(
+                                                                retryAfter,
+                                                                DateTimeFormatter
+                                                                        .RFC_1123_DATE_TIME)
+                                                        .toInstant()
+                                                        .toEpochMilli()
+                                                - System.currentTimeMillis());
+                if (requested > maxWait) {
+                    throw failure("Retry-After exceeds max_retry_wait_ms");
+                }
+                delay = Math.max(delay, requested);
+            } catch (DateTimeParseException | ArithmeticException e) {
+                throw failure("invalid Retry-After header");
+            }
+        }
+        return delay;
+    }
+
+    /** Abort active IO and wake retry waits even when pollNext holds the checkpoint lock. */
+    @Override
+    public synchronized void close() throws IOException {
+        closed = true;
+        if (client != null) {
+            client.close();
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TestTikTokAdsPackagingIT.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TestTikTokAdsPackagingIT.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class TikTokAdsPackagingIT {
+class TestTikTokAdsPackagingIT {
     @Test
     void packagedFactoryAndRelocatedHttpExecuteRealLocalRequest() throws Exception {
         Path artifact;

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsPackagingIT.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsPackagingIT.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SeaTunnelSource;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.bytes;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.options;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.page;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.row;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TikTokAdsPackagingIT {
+    @Test
+    void packagedFactoryAndRelocatedHttpExecuteRealLocalRequest() throws Exception {
+        Path artifact;
+        try (Stream<Path> files = Files.list(Paths.get("target"))) {
+            artifact =
+                    files.filter(
+                                    path ->
+                                            path.getFileName()
+                                                    .toString()
+                                                    .matches("connector-tiktok-ads-.*[.]jar"))
+                            .filter(path -> !path.getFileName().toString().contains("sources"))
+                            .filter(path -> !path.getFileName().toString().contains("javadoc"))
+                            .findFirst()
+                            .orElseThrow(() -> new IOException("packaged artifact missing"));
+        }
+        try (JarFile jar = new JarFile(artifact.toFile())) {
+            assertNotNull(
+                    jar.getEntry(
+                            "META-INF/services/org.apache.seatunnel.api.table.factory.Factory"));
+            assertNotNull(jar.getEntry("META-INF/NOTICE"));
+        }
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        AtomicInteger requests = new AtomicInteger();
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    assertEquals(
+                            "mock-token", exchange.getRequestHeaders().getFirst("Access-Token"));
+                    requests.incrementAndGet();
+                    byte[] body = bytes(page(1, 1, row("100")));
+                    exchange.sendResponseHeaders(200, body.length);
+                    exchange.getResponseBody().write(body);
+                    exchange.close();
+                });
+        server.start();
+        String prefix = "org.apache.seatunnel.connectors.seatunnel.tiktok.ads.";
+        try (URLClassLoader loader =
+                new URLClassLoader(
+                        new URL[] {artifact.toUri().toURL()}, getClass().getClassLoader()) {
+                    @Override
+                    protected Class<?> loadClass(String name, boolean resolve)
+                            throws ClassNotFoundException {
+                        synchronized (getClassLoadingLock(name)) {
+                            if (!name.startsWith(prefix)) {
+                                return super.loadClass(name, resolve);
+                            }
+                            Class<?> type = findLoadedClass(name);
+                            if (type == null) {
+                                type = findClass(name);
+                            }
+                            if (resolve) {
+                                resolveClass(type);
+                            }
+                            return type;
+                        }
+                    }
+                }) {
+            assertSame(
+                    loader,
+                    loader.loadClass(prefix + "shaded.http.impl.client.HttpClients")
+                            .getClassLoader());
+            Object factory =
+                    loader.loadClass(prefix + "TikTokAdsSourceFactory")
+                            .getConstructor()
+                            .newInstance();
+            assertEquals(
+                    "TikTokAds", factory.getClass().getMethod("factoryIdentifier").invoke(factory));
+            Map<String, Object> config = options();
+            config.put("token", "mock-token");
+            config.put("mock_url", "http://127.0.0.1:" + server.getAddress().getPort());
+            SeaTunnelSource source =
+                    (SeaTunnelSource)
+                            loader.loadClass(prefix + "TikTokAdsSource")
+                                    .getConstructor(ReadonlyConfig.class)
+                                    .newInstance(ReadonlyConfig.fromMap(config));
+            SourceReader.Context context = mock(SourceReader.Context.class);
+            SourceReader reader = source.createReader(context);
+            Collector<SeaTunnelRow> output = mock(Collector.class);
+            when(output.getCheckpointLock()).thenReturn(new Object());
+            List<SeaTunnelRow> rows = new ArrayList<>();
+            doAnswer(
+                            call -> {
+                                rows.add(call.getArgument(0));
+                                return null;
+                            })
+                    .when(output)
+                    .collect(any(SeaTunnelRow.class));
+            try {
+                reader.open();
+                reader.pollNext(output);
+                assertEquals(1, rows.size());
+                assertEquals("100", rows.get(0).getField(2));
+                assertTrue(rows.get(0).getField(1) instanceof java.math.BigDecimal);
+                verify(context).signalNoMoreElement();
+            } finally {
+                reader.close();
+            }
+            assertEquals(1, requests.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsReportTest.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsReportTest.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.shade.com.typesafe.config.ConfigFactory;
+
+import org.apache.seatunnel.api.common.JobContext;
+import org.apache.seatunnel.api.common.multitable.MultiTableFailureHelper;
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.options.MultiTableCommonOptions;
+import org.apache.seatunnel.api.options.MultiTableFailurePolicy;
+import org.apache.seatunnel.api.source.Boundedness;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.factory.Factory;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.common.constants.JobMode;
+import org.apache.seatunnel.core.starter.utils.ConfigBuilder;
+import org.apache.seatunnel.core.starter.utils.ConfigShadeUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TikTokAdsReportTest {
+    static final String SECRET = "sensitive-test-token-never-output";
+
+    static Map<String, Object> options() {
+        Map<String, Object> options = new LinkedHashMap<>();
+        options.put("token", SECRET);
+        options.put("advertiser_id", "123456789");
+        options.put("data_level", "AUCTION_AD");
+        options.put("start_date", "2026-09-01");
+        options.put("end_date", "2026-09-02");
+        options.put("dimensions", Arrays.asList("ad_id", "stat_time_day"));
+        options.put("metrics", Arrays.asList("spend", "impressions", "clicks"));
+        options.put("page_size", 2);
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put("clicks", "bigint");
+        fields.put("spend", "decimal(38, 6)");
+        fields.put("ad_id", "string");
+        fields.put("stat_time_day", "string");
+        fields.put("impressions", "bigint");
+        options.put("schema", Collections.singletonMap("fields", fields));
+        return options;
+    }
+
+    static String row(String id) {
+        return "{\"dimensions\":{\"ad_id\":\""
+                + id
+                + "\",\"stat_time_day\":\"2026-09-01 00:00:00\"},\"metrics\":{"
+                + "\"spend\":\"123456789012345678901234567890.123456\","
+                + "\"impressions\":\"9223372036854775807\",\"clicks\":\"2\"}}";
+    }
+
+    static String page(int page, int total, String... rows) {
+        return "{\"code\":0,\"data\":{\"page_info\":{\"page\":"
+                + page
+                + ",\"page_size\":2,\"total_number\":"
+                + total
+                + ",\"total_page\":"
+                + ((total + 1) / 2)
+                + "},\"list\":["
+                + String.join(",", rows)
+                + "]}}";
+    }
+
+    static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    static TikTokAdsReport.Page parse(String value) throws IOException {
+        return TikTokAdsReport.parse(
+                bytes(value),
+                1,
+                new TikTokAdsConfig(ReadonlyConfig.fromMap(options())),
+                new HashSet<>());
+    }
+
+    @Test
+    void preservesSchemaOrderDecimalPrecisionAndAdvertiserDayLabel() throws Exception {
+        SeaTunnelRow result = parse(page(1, 1, row("100"))).rows.get(0);
+        assertEquals(2L, result.getField(0));
+        assertEquals(new BigDecimal("123456789012345678901234567890.123456"), result.getField(1));
+        assertEquals("100", result.getField(2));
+        assertEquals("2026-09-01 00:00:00", result.getField(3));
+        assertEquals(Long.MAX_VALUE, result.getField(4));
+    }
+
+    @Test
+    void acceptsEmptyReportWithoutInventingARow() throws Exception {
+        assertTrue(parse(page(1, 0)).rows.isEmpty());
+        assertTrue(
+                parse(page(1, 0).replace("\"total_page\":0", "\"total_page\":1")).rows.isEmpty());
+    }
+
+    @Test
+    void boundsJsonNestingWithoutExposingParserCause() {
+        String nested =
+                String.join("", Collections.nCopies(30, "["))
+                        + "\"TOKEN\""
+                        + String.join("", Collections.nCopies(30, "]"));
+        IOException error = assertThrows(IOException.class, () -> parse(nested));
+        assertNull(error.getCause());
+        assertFalse(error.getMessage().contains("TOKEN"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "{}",
+                "null",
+                "[]",
+                "{\"code\":40100,\"message\":\"TOKEN\"}",
+                "{\"code\":0,\"code\":0}",
+                "{\"code\":\"0\"}",
+                "{\"code\":0,\"data\":null}",
+                "{broken TOKEN",
+                "{\"code\":0} {}"
+            })
+    void rejectsInvalidEnvelopesWithoutLeakingResponse(String invalid) {
+        IOException error =
+                assertThrows(IOException.class, () -> parse(invalid.replace("TOKEN", SECRET)));
+        assertFalse(error.toString().contains(SECRET));
+        assertNull(error.getCause());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"page", "page_size", "total_number", "total_page"})
+    void rejectsMissingPaginationFields(String key) {
+        String valid = page(1, 1, row("100"));
+        assertThrows(
+                IOException.class, () -> parse(valid.replace("\"" + key + "\":", "\"missing\":")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "\"page\":0",
+                "\"page\":2",
+                "\"page\":1.0",
+                "\"page_size\":0",
+                "\"page_size\":3",
+                "\"total_number\":3",
+                "\"total_number\":-1",
+                "\"total_page\":2",
+                "\"total_number\":2147483648"
+            })
+    void rejectsInconsistentCounts(String replacement) {
+        String key = replacement.substring(0, replacement.indexOf(':') + 1);
+        String valid = page(1, 1, row("100"));
+        String changed =
+                valid.replaceAll(
+                        java.util.regex.Pattern.quote(key) + "[0-9]+",
+                        java.util.regex.Matcher.quoteReplacement(replacement));
+        assertThrows(IOException.class, () -> parse(changed));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ad_id", "stat_time_day", "spend", "impressions", "clicks"})
+    void rejectsMissingAndNullRequestedFields(String field) {
+        String valid = page(1, 1, row("100"));
+        assertThrows(
+                IOException.class,
+                () -> parse(valid.replace("\"" + field + "\":", "\"missing\":")));
+        String changed = valid.replaceAll("\"" + field + "\":\"[^\"]*\"", "\"" + field + "\":null");
+        assertThrows(IOException.class, () -> parse(changed));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "NaN",
+                "1e1000000",
+                "1.0000001",
+                "10000000000000000000000000000000000",
+                "-Infinity"
+            })
+    void rejectsUnrepresentableSpend(String amount) {
+        assertThrows(
+                IOException.class,
+                () ->
+                        parse(
+                                page(
+                                        1,
+                                        1,
+                                        row("100")
+                                                .replace(
+                                                        "123456789012345678901234567890.123456",
+                                                        amount))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"9223372036854775808", "-1", "1.0", "NaN", ""})
+    void rejectsInvalidCounts(String count) {
+        assertThrows(
+                IOException.class,
+                () -> parse(page(1, 1, row("100").replace("9223372036854775807", count))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "2026-08-31 00:00:00",
+                "2026-09-31 00:00:00",
+                "2026-09-01T00:00:00Z",
+                "2026-09-01 01:00:00"
+            })
+    void rejectsInvalidReportDay(String day) {
+        assertThrows(
+                IOException.class,
+                () -> parse(page(1, 1, row("100").replace("2026-09-01 00:00:00", day))));
+    }
+
+    @Test
+    void rejectsRepeatedDimensionKeysAcrossPages() throws Exception {
+        HashSet<List<String>> seen = new HashSet<>();
+        TikTokAdsConfig config = new TikTokAdsConfig(ReadonlyConfig.fromMap(options()));
+        TikTokAdsReport.parse(bytes(page(1, 3, row("100"), row("101"))), 1, config, seen);
+        assertThrows(
+                IOException.class,
+                () -> TikTokAdsReport.parse(bytes(page(2, 3, row("100"))), 2, config, seen));
+    }
+
+    @Test
+    void acceptsAdOnlyReportAndExplicitMetricSubset() {
+        Map<String, Object> config = options();
+        config.put("dimensions", Collections.singletonList("ad_id"));
+        config.put("metrics", Collections.singletonList("clicks"));
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("ad_id", "string");
+        fields.put("clicks", "bigint");
+        config.put("schema", Collections.singletonMap("fields", fields));
+        assertNotNull(new TikTokAdsSource(ReadonlyConfig.fromMap(config)));
+    }
+
+    @Test
+    void validatesInclusiveDateRangeLimits() {
+        Map<String, Object> config = options();
+        config.put("start_date", "2026-01-01");
+        config.put("end_date", "2026-01-30");
+        assertNotNull(new TikTokAdsSource(ReadonlyConfig.fromMap(config)));
+        config.put("end_date", "2026-01-31");
+        assertTrue(
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)))
+                        .getMessage()
+                        .contains("30 inclusive"));
+        config.put("dimensions", Collections.singletonList("ad_id"));
+        config.put("metrics", Collections.singletonList("clicks"));
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("ad_id", "string");
+        fields.put("clicks", "bigint");
+        config.put("schema", Collections.singletonMap("fields", fields));
+        config.put("end_date", "2026-12-31");
+        assertNotNull(new TikTokAdsSource(ReadonlyConfig.fromMap(config)));
+        config.put("end_date", "2027-01-01");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"data_level", "dimensions", "metrics", "start_date", "token", "schema"})
+    void rejectsMissingRequiredOptions(String key) {
+        Map<String, Object> config = options();
+        config.remove(key);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)));
+    }
+
+    @Test
+    void rejectsUnsupportedOptionsAndPreservesSafeDiagnostics() {
+        Map<String, Object> config = options();
+        config.put("data_level", "AUCTION_CAMPAIGN");
+        assertTrue(
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)))
+                        .getMessage()
+                        .contains("data_level"));
+        config.put("data_level", "AUCTION_AD");
+        config.put("query_mode", "CHUNK");
+        assertTrue(
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)))
+                        .getMessage()
+                        .contains("unsupported"));
+    }
+
+    @Test
+    void rejectsSchemaMismatchAndDecimalRounding() {
+        Map<String, Object> config = options();
+        config.put(
+                "schema",
+                Collections.singletonMap("fields", Collections.singletonMap("raw", "string")));
+        assertTrue(
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)))
+                        .getMessage()
+                        .contains("schema"));
+    }
+
+    @Test
+    void configMaskingUsesParsedNativeTokenKey() {
+        Map<String, Object> parsed =
+                ConfigFactory.parseString("source {TikTokAds {token = \"" + SECRET + "\"}}")
+                        .root()
+                        .unwrapped();
+        Map<String, Object> masked =
+                ConfigBuilder.configDesensitization(
+                        parsed, ConfigShadeUtils.getLogDesensitizationOptions(null));
+        assertFalse(masked.toString().contains(SECRET));
+        assertTrue(masked.toString().contains("******"));
+        Map<String, Object> invalid = options();
+        invalid.put("page_size", SECRET);
+        Throwable error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new TikTokAdsSource(ReadonlyConfig.fromMap(invalid)));
+        assertFalse(error.toString().contains(SECRET));
+        assertNull(error.getCause());
+    }
+
+    @Test
+    void preventsRealTokenOnMockEndpointAndHeaderInjection() {
+        Map<String, Object> config = options();
+        config.put("mock_url", "http://127.0.0.1:1080");
+        assertTrue(
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)))
+                        .getMessage()
+                        .contains("mock-token"));
+        config.put("token", SECRET + "\r\nInjected: header");
+        assertFalse(
+                assertThrows(
+                                IllegalArgumentException.class,
+                                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(config)))
+                        .toString()
+                        .contains(SECRET));
+    }
+
+    @Test
+    void discoversFactoryAndSerializesSourceWithoutClient() throws Exception {
+        List<Factory> factories = new ArrayList<>();
+        ServiceLoader.load(Factory.class).forEach(factories::add);
+        assertTrue(factories.stream().anyMatch(f -> f instanceof TikTokAdsSourceFactory));
+        TikTokAdsSource source = new TikTokAdsSource(ReadonlyConfig.fromMap(options()));
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(source);
+        }
+        try (ObjectInputStream in =
+                new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            TikTokAdsSource restored = (TikTokAdsSource) in.readObject();
+            assertEquals(Boundedness.BOUNDED, restored.getBoundedness());
+            assertEquals(
+                    source.getProducedCatalogTables().get(0).getSeaTunnelRowType(),
+                    restored.getProducedCatalogTables().get(0).getSeaTunnelRowType());
+        }
+        JobContext job = new JobContext();
+        job.setJobMode(JobMode.STREAMING);
+        assertThrows(IllegalArgumentException.class, () -> source.setJobContext(job));
+        SourceReader.Context context = mock(SourceReader.Context.class);
+        when(context.getIndexOfSubtask()).thenReturn(1);
+        assertThrows(IllegalArgumentException.class, () -> source.createReader(context));
+    }
+
+    @Test
+    void acceptsEngineInjectedFailurePolicyAndStillRejectsUnknownOptions() {
+        ReadonlyConfig parsed = ReadonlyConfig.fromConfig(ConfigFactory.parseMap(options()));
+        ReadonlyConfig injected =
+                MultiTableFailureHelper.withMultiTableFailurePolicy(
+                        parsed, ReadonlyConfig.fromConfig(ConfigFactory.empty()));
+        assertEquals(
+                MultiTableFailurePolicy.FAIL_FAST,
+                injected.get(MultiTableCommonOptions.MULTI_TABLE_FAILURE_POLICY));
+        assertNotNull(new TikTokAdsSource(injected));
+        Map<String, Object> invalid = new LinkedHashMap<>(injected.getSourceMap());
+        invalid.put("unsupported_option", "value");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new TikTokAdsSource(ReadonlyConfig.fromMap(invalid)));
+    }
+
+    @Test
+    void acceptsNativeCommonOptionsAndNestedDagParsingMode() {
+        Map<String, Object> config = options();
+        config.put("metadata_datasource_id", "metadata-source");
+        config.put("dag-parsing", Collections.singletonMap("mode", "STATIC"));
+        config.put("plugin_output", "report");
+        assertNotNull(new TikTokAdsSource(ReadonlyConfig.fromMap(config)));
+    }
+}

--- a/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceReaderTest.java
+++ b/seatunnel-connectors-v2/connector-tiktok-ads/src/test/java/org/apache/seatunnel/connectors/seatunnel/tiktok/ads/TikTokAdsSourceReaderTest.java
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.connectors.seatunnel.tiktok.ads;
+
+import org.apache.seatunnel.api.configuration.ReadonlyConfig;
+import org.apache.seatunnel.api.source.Collector;
+import org.apache.seatunnel.api.source.SourceReader;
+import org.apache.seatunnel.api.table.type.SeaTunnelRow;
+import org.apache.seatunnel.connectors.seatunnel.common.source.SingleSplitReaderContext;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.bytes;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.options;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.page;
+import static org.apache.seatunnel.connectors.seatunnel.tiktok.ads.TikTokAdsReportTest.row;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TikTokAdsSourceReaderTest {
+    private HttpServer server;
+    private ExecutorService executor;
+    private TikTokAdsSourceReader reader;
+    private Map<String, Object> settings;
+    private AtomicInteger requests;
+    private final List<Map<String, String>> queries = new ArrayList<>();
+    private SourceReader.Context context;
+    private final CountDownLatch release = new CountDownLatch(1);
+
+    @BeforeEach
+    void start() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        executor = Executors.newCachedThreadPool();
+        server.setExecutor(executor);
+        server.start();
+        settings = options();
+        settings.put("token", "mock-token");
+        settings.put("mock_url", "http://127.0.0.1:" + server.getAddress().getPort());
+        requests = new AtomicInteger();
+        context = mock(SourceReader.Context.class);
+    }
+
+    @AfterEach
+    void close() throws Exception {
+        release.countDown();
+        if (reader != null) {
+            reader.close();
+        }
+        server.stop(0);
+        executor.shutdownNow();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    private void respond(HttpExchange exchange, int status, String body) throws IOException {
+        requests.incrementAndGet();
+        assertEquals("GET", exchange.getRequestMethod());
+        assertEquals("mock-token", exchange.getRequestHeaders().getFirst("Access-Token"));
+        assertEquals(TikTokAdsConfig.PATH, exchange.getRequestURI().getPath());
+        synchronized (queries) {
+            queries.add(
+                    URLEncodedUtils.parse(exchange.getRequestURI(), StandardCharsets.UTF_8).stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            NameValuePair::getName, NameValuePair::getValue)));
+        }
+        byte[] bytes = bytes(body);
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+    private List<SeaTunnelRow> run() throws Exception {
+        reader =
+                new TikTokAdsSourceReader(
+                        new TikTokAdsConfig(ReadonlyConfig.fromMap(settings)),
+                        new SingleSplitReaderContext(context));
+        reader.open();
+        Collector<SeaTunnelRow> output = mock(Collector.class);
+        when(output.getCheckpointLock()).thenReturn(new Object());
+        List<SeaTunnelRow> rows = new ArrayList<>();
+        doAnswer(
+                        call -> {
+                            rows.add(call.getArgument(0));
+                            return null;
+                        })
+                .when(output)
+                .collect(any(SeaTunnelRow.class));
+        reader.pollNext(output);
+        reader.pollNext(output);
+        return rows;
+    }
+
+    @Test
+    void readsPagesUsingExactApiQueryAndSignalsCompletionOnce() throws Exception {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange ->
+                        respond(
+                                exchange,
+                                200,
+                                exchange.getRequestURI().getQuery().contains("page=1&")
+                                        ? page(1, 3, row("100"), row("101"))
+                                        : page(2, 3, row("102"))));
+        assertEquals(3, run().size());
+        assertEquals(2, requests.get());
+        assertEquals("[\"ad_id\",\"stat_time_day\"]", queries.get(0).get("dimensions"));
+        assertEquals("[\"spend\",\"impressions\",\"clicks\"]", queries.get(0).get("metrics"));
+        assertEquals("AUCTION_AD", queries.get(0).get("data_level"));
+        assertEquals("BASIC", queries.get(0).get("report_type"));
+        assertEquals("REGULAR", queries.get(0).get("query_mode"));
+        assertEquals("false", queries.get(0).get("query_lifetime"));
+        assertEquals("123456789", queries.get(0).get("advertiser_id"));
+        assertEquals("2026-09-01", queries.get(0).get("start_date"));
+        assertEquals("2026-09-02", queries.get(0).get("end_date"));
+        assertEquals("2", queries.get(1).get("page"));
+        assertFalse(queries.toString().contains("mock-token"));
+        verify(context).signalNoMoreElement();
+    }
+
+    @Test
+    void emptyReportCompletesWithoutRows() throws Exception {
+        server.createContext(TikTokAdsConfig.PATH, exchange -> respond(exchange, 200, page(1, 0)));
+        assertTrue(run().isEmpty());
+        verify(context).signalNoMoreElement();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {429, 500, 502, 503, 504})
+    void retriesOnlyDocumentedTransientHttpStatusAndDoesNotRepeatRows(int status) throws Exception {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    if (requests.get() == 0) {
+                        exchange.getResponseHeaders().set("Retry-After", "0");
+                        respond(exchange, status, "{\"message\":\"mock-token\"}");
+                    } else {
+                        respond(exchange, 200, page(1, 1, row("100")));
+                    }
+                });
+        assertEquals(1, run().size());
+        assertEquals(2, requests.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {301, 302, 400, 401, 403, 404})
+    void failsWithoutFollowingRedirectOrRetryingPermanentErrors(int status) {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.getResponseHeaders()
+                            .set("Location", settings.get("mock_url") + "/leak");
+                    respond(exchange, status, "mock-token");
+                });
+        AtomicInteger redirected = new AtomicInteger();
+        server.createContext(
+                "/leak",
+                exchange -> {
+                    redirected.incrementAndGet();
+                    exchange.close();
+                });
+        IOException error = assertThrows(IOException.class, this::run);
+        assertFalse(error.toString().contains("mock-token"));
+        assertNull(error.getCause());
+        assertEquals(1, requests.get());
+        assertEquals(0, redirected.get());
+    }
+
+    @Test
+    void failsNonzeroApiCodeWithoutRetryEvenOnHttp200() {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> respond(exchange, 200, "{\"code\":40100,\"message\":\"mock-token\"}"));
+        IOException error = assertThrows(IOException.class, this::run);
+        assertTrue(error.getMessage().contains("40100"));
+        assertFalse(error.toString().contains("mock-token"));
+        assertEquals(1, requests.get());
+        verify(context, never()).signalNoMoreElement();
+    }
+
+    @Test
+    void rejectsThrottleWarningBeforeEmittingRows() {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.getResponseHeaders().set("X-Tt-Ads-Throttle", "over 20k mock-token");
+                    respond(exchange, 200, page(1, 1, row("100")));
+                });
+        IOException error = assertThrows(IOException.class, this::run);
+        assertTrue(error.getMessage().contains("X-Tt-Ads-Throttle"));
+        assertFalse(error.toString().contains("mock-token"));
+        assertEquals(1, requests.get());
+    }
+
+    @Test
+    void rejectsWarningEvenAfterAnEmptyThrottleHeader() {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.getResponseHeaders().add("X-Tt-Ads-Throttle", "");
+                    exchange.getResponseHeaders().add("X-Tt-Ads-Throttle", "truncated");
+                    respond(exchange, 200, page(1, 1, row("100")));
+                });
+        assertTrue(
+                assertThrows(IOException.class, this::run)
+                        .getMessage()
+                        .contains("X-Tt-Ads-Throttle"));
+    }
+
+    @Test
+    void boundsChunkedBodyWithoutContentLength() {
+        settings.put("max_response_bytes", 1024);
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    requests.incrementAndGet();
+                    exchange.sendResponseHeaders(200, 0);
+                    try {
+                        exchange.getResponseBody().write(new byte[2048]);
+                    } finally {
+                        exchange.close();
+                    }
+                });
+        assertTrue(
+                assertThrows(IOException.class, this::run)
+                        .getMessage()
+                        .contains("max_response_bytes"));
+        assertEquals(1, requests.get());
+    }
+
+    @Test
+    void rejectsOversizedBodyWithoutRetry() {
+        settings.put("max_response_bytes", 1024);
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange ->
+                        respond(
+                                exchange,
+                                200,
+                                String.join("", java.util.Collections.nCopies(300, "mock-token"))));
+        assertTrue(
+                assertThrows(IOException.class, this::run)
+                        .getMessage()
+                        .contains("max_response_bytes"));
+        assertEquals(1, requests.get());
+    }
+
+    @Test
+    void rejectsChangedTotalsAndRepeatedPagesWithoutSuccessSignal() {
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange ->
+                        respond(
+                                exchange,
+                                200,
+                                requests.get() == 0
+                                        ? page(1, 3, row("100"), row("101"))
+                                        : page(2, 4, row("102"), row("103"))));
+        assertTrue(
+                assertThrows(IOException.class, this::run).getMessage().contains("totals changed"));
+        verify(context, never()).signalNoMoreElement();
+    }
+
+    @Test
+    void stopsAfterConfiguredRetryCount() {
+        settings.put("max_retries", 1);
+        server.createContext(
+                TikTokAdsConfig.PATH, exchange -> respond(exchange, 503, "mock-token"));
+        assertThrows(IOException.class, this::run);
+        assertEquals(2, requests.get());
+    }
+
+    @Test
+    void boundsRetryAfterWithoutLeakingHeader() {
+        assertTrue(
+                assertThrows(
+                                IOException.class,
+                                () -> TikTokAdsSourceReader.retryDelay("999", 0, 1000))
+                        .getMessage()
+                        .contains("max_retry_wait_ms"));
+        IOException error =
+                assertThrows(
+                        IOException.class,
+                        () -> TikTokAdsSourceReader.retryDelay("mock-token", 0, 1000));
+        assertFalse(error.toString().contains("mock-token"));
+        assertNull(error.getCause());
+    }
+
+    @Test
+    void requestDeadlineIncludesResponseBody() throws Exception {
+        settings.put("request_timeout_ms", 200);
+        CountDownLatch started = new CountDownLatch(1);
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.sendResponseHeaders(200, 0);
+                    exchange.getResponseBody().write('{');
+                    exchange.getResponseBody().flush();
+                    started.countDown();
+                    try {
+                        release.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    exchange.close();
+                });
+        Future<Throwable> pending =
+                executor.submit(
+                        () -> {
+                            try {
+                                run();
+                                return null;
+                            } catch (Throwable e) {
+                                return e;
+                            }
+                        });
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+        assertTrue(pending.get(3, TimeUnit.SECONDS) instanceof IOException);
+    }
+
+    @Test
+    void closeAbortsInflightBodyRead() throws Exception {
+        settings.put("request_timeout_ms", 30000);
+        CountDownLatch started = new CountDownLatch(1);
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.sendResponseHeaders(200, 0);
+                    exchange.getResponseBody().write('{');
+                    exchange.getResponseBody().flush();
+                    started.countDown();
+                    try {
+                        release.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    exchange.close();
+                });
+        Future<Throwable> pending =
+                executor.submit(
+                        () -> {
+                            try {
+                                run();
+                                return null;
+                            } catch (Throwable e) {
+                                return e;
+                            }
+                        });
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+        reader.close();
+        assertTrue(pending.get(3, TimeUnit.SECONDS) instanceof IOException);
+        verify(context, never()).signalNoMoreElement();
+    }
+
+    @Test
+    void closeWakesActualRetryWait() throws Exception {
+        settings.put("max_retry_wait_ms", 30000);
+        CountDownLatch responseSent = new CountDownLatch(1);
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.getResponseHeaders().set("Retry-After", "30");
+                    respond(exchange, 429, "{}");
+                    responseSent.countDown();
+                });
+        java.util.concurrent.atomic.AtomicReference<Thread> worker =
+                new java.util.concurrent.atomic.AtomicReference<>();
+        Future<Throwable> pending =
+                executor.submit(
+                        () -> {
+                            worker.set(Thread.currentThread());
+                            try {
+                                run();
+                                return null;
+                            } catch (Throwable e) {
+                                return e;
+                            }
+                        });
+        assertTrue(responseSent.await(5, TimeUnit.SECONDS));
+        org.awaitility.Awaitility.await()
+                .atMost(3, TimeUnit.SECONDS)
+                .until(
+                        () ->
+                                Arrays.stream(worker.get().getStackTrace())
+                                        .anyMatch(
+                                                frame ->
+                                                        frame.getMethodName()
+                                                                .equals("awaitRetry")));
+        reader.close();
+        assertTrue(pending.get(3, TimeUnit.SECONDS) instanceof IOException);
+        assertEquals(1, requests.get());
+    }
+
+    @Test
+    void reportDeadlineBoundsRetryWait() {
+        settings.put("report_timeout_ms", 200);
+        server.createContext(
+                TikTokAdsConfig.PATH,
+                exchange -> {
+                    exchange.getResponseHeaders().set("Retry-After", "30");
+                    respond(exchange, 429, "{}");
+                });
+        assertTrue(
+                assertThrows(IOException.class, this::run)
+                        .getMessage()
+                        .contains("report_timeout_ms"));
+    }
+}

--- a/seatunnel-connectors-v2/pom.xml
+++ b/seatunnel-connectors-v2/pom.xml
@@ -75,6 +75,7 @@
         <module>connector-google-pubsub</module>
         <module>connector-google-ads</module>
         <module>connector-facebook-ads</module>
+        <module>connector-tiktok-ads</module>
         <module>connector-azure-queue-storage</module>
         <module>connector-slack</module>
         <module>connector-rabbitmq</module>

--- a/seatunnel-dist/pom.xml
+++ b/seatunnel-dist/pom.xml
@@ -568,6 +568,12 @@
                 </dependency>
                 <dependency>
                     <groupId>org.apache.seatunnel</groupId>
+                    <artifactId>connector-tiktok-ads</artifactId>
+                    <version>${project.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.seatunnel</groupId>
                     <artifactId>connector-datahub</artifactId>
                     <version>${project.version}</version>
                     <scope>provided</scope>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tiktok-ads-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tiktok-ads-e2e/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.seatunnel</groupId>
+        <artifactId>seatunnel-connector-v2-e2e</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>connector-tiktok-ads-e2e</artifactId>
+    <name>SeaTunnel : E2E : Connector V2 : TikTok Ads</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-tiktok-ads</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.seatunnel</groupId>
+            <artifactId>connector-assert</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
+            <version>5.14.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tiktok-ads-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tiktok/ads/TikTokAdsIT.java
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tiktok-ads-e2e/src/test/java/org/apache/seatunnel/e2e/connector/tiktok/ads/TikTokAdsIT.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.seatunnel.e2e.connector.tiktok.ads;
+
+import org.apache.seatunnel.e2e.common.TestResource;
+import org.apache.seatunnel.e2e.common.TestSuiteBase;
+import org.apache.seatunnel.e2e.common.container.TestContainer;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.verify.VerificationTimes;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+public class TikTokAdsIT extends TestSuiteBase implements TestResource {
+    private GenericContainer<?> fixture;
+    private MockServerClient client;
+
+    @BeforeAll
+    @Override
+    public void startUp() {
+        fixture =
+                new GenericContainer<>(DockerImageName.parse("mockserver/mockserver:5.14.0"))
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases("tiktok-fixture")
+                        .withExposedPorts(1080)
+                        .withEnv("MOCKSERVER_LOG_LEVEL", "WARN")
+                        .waitingFor(Wait.forHttp("/").forStatusCode(404));
+        fixture.start();
+        client = new MockServerClient(fixture.getHost(), fixture.getMappedPort(1080));
+    }
+
+    @AfterAll
+    @Override
+    public void tearDown() {
+        try {
+            if (client != null) {
+                client.close();
+            }
+        } finally {
+            try {
+                if (fixture != null) {
+                    fixture.stop();
+                }
+            } finally {
+                // Engine callbacks finish before this single-class module's teardown.
+                NETWORK.close();
+            }
+        }
+    }
+
+    @TestTemplate
+    protected void readsTypedPaginatedReport(TestContainer container) throws Exception {
+        client.reset();
+        HttpRequest first = request("1");
+        HttpRequest last = request("2");
+        client.when(first)
+                .respond(
+                        HttpResponse.response()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(report(1, row("100") + "," + row("101"))));
+        client.when(last)
+                .respond(
+                        HttpResponse.response()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(report(2, row("102"))));
+        Container.ExecResult result = container.executeJob("/tiktok_ads_to_assert.conf");
+        Assertions.assertEquals(0, result.getExitCode(), result.getStderr());
+        client.verify(first, VerificationTimes.exactly(1));
+        client.verify(last, VerificationTimes.exactly(1));
+        client.verify(
+                HttpRequest.request().withPath("/open_api/v1.3/report/integrated/get/"),
+                VerificationTimes.exactly(2));
+    }
+
+    private HttpRequest request(String page) {
+        return HttpRequest.request()
+                .withMethod("GET")
+                .withPath("/open_api/v1.3/report/integrated/get/")
+                .withHeader("Access-Token", "mock-token")
+                .withQueryStringParameter("advertiser_id", "123456789")
+                .withQueryStringParameter("report_type", "BASIC")
+                .withQueryStringParameter("service_type", "AUCTION")
+                .withQueryStringParameter("data_level", "AUCTION_AD")
+                .withQueryStringParameter("dimensions", "[\"ad_id\",\"stat_time_day\"]")
+                .withQueryStringParameter("metrics", "[\"spend\",\"impressions\",\"clicks\"]")
+                .withQueryStringParameter("start_date", "2026-09-01")
+                .withQueryStringParameter("end_date", "2026-09-02")
+                .withQueryStringParameter("query_lifetime", "false")
+                .withQueryStringParameter("query_mode", "REGULAR")
+                .withQueryStringParameter("page", page)
+                .withQueryStringParameter("page_size", "2");
+    }
+
+    private String report(int page, String rows) {
+        return "{\"code\":0,\"message\":\"OK\",\"data\":{\"page_info\":{\"page\":"
+                + page
+                + ",\"page_size\":2,\"total_number\":3,\"total_page\":2},\"list\":["
+                + rows
+                + "]}}";
+    }
+
+    private String row(String id) {
+        return "{\"dimensions\":{\"ad_id\":\""
+                + id
+                + "\",\"stat_time_day\":\"2026-09-01 00:00:00\"},"
+                + "\"metrics\":{\"spend\":\"1.234567\",\"impressions\":\"100\",\"clicks\":\"2\"}}";
+    }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tiktok-ads-e2e/src/test/resources/tiktok_ads_to_assert.conf
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/connector-tiktok-ads-e2e/src/test/resources/tiktok_ads_to_assert.conf
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+source {
+  TikTokAds {
+    token = "mock-token"
+    mock_url = "http://tiktok-fixture:1080"
+    page_size = 2
+    advertiser_id = "123456789"
+    data_level = "AUCTION_AD"
+    start_date = "2026-09-01"
+    end_date = "2026-09-02"
+    dimensions = ["ad_id", "stat_time_day"]
+    metrics = ["spend", "impressions", "clicks"]
+    schema {
+      fields {
+        ad_id = string
+        stat_time_day = string
+        spend = "decimal(38, 6)"
+        impressions = bigint
+        clicks = bigint
+      }
+    }
+  }
+}
+sink {
+  Assert {
+    rules {
+      row_rules = [
+        { rule_type = MIN_ROW, rule_value = 3 },
+        { rule_type = MAX_ROW, rule_value = 3 }
+      ]
+      field_rules = [
+        { field_name = ad_id, field_type = string, field_value = [{ rule_type = NOT_NULL }] },
+        { field_name = stat_time_day, field_type = string, field_value = [{ equals_to = "2026-09-01 00:00:00" }] },
+        { field_name = spend, field_type = "decimal(38, 6)", field_value = [{ rule_type = NOT_NULL }] },
+        { field_name = impressions, field_type = bigint, field_value = [{ rule_type = MIN, rule_value = 100 }, { rule_type = MAX, rule_value = 100 }] },
+        { field_name = clicks, field_type = bigint, field_value = [{ rule_type = MIN, rule_value = 2 }, { rule_type = MAX, rule_value = 2 }] }
+      ]
+    }
+  }
+}

--- a/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
+++ b/seatunnel-e2e/seatunnel-connector-v2-e2e/pom.xml
@@ -51,6 +51,7 @@
         <module>connector-cassandra-e2e</module>
         <module>connector-neo4j-e2e</module>
         <module>connector-http-e2e</module>
+        <module>connector-tiktok-ads-e2e</module>
         <module>connector-rabbitmq-e2e</module>
         <module>connector-kafka-e2e</module>
         <module>connector-doris-e2e</module>

--- a/seatunnel-examples/seatunnel-engine-examples/src/main/resources/examples/tiktok_ads_to_console.conf
+++ b/seatunnel-examples/seatunnel-engine-examples/src/main/resources/examples/tiktok_ads_to_console.conf
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+env {
+  parallelism = 1
+  job.mode = "BATCH"
+}
+source {
+  TikTokAds {
+    token = ${TIKTOK_ADS_TOKEN}
+    advertiser_id = "123456789"
+    data_level = "AUCTION_AD"
+    start_date = "2026-09-01"
+    end_date = "2026-09-02"
+    dimensions = ["ad_id", "stat_time_day"]
+    metrics = ["spend", "impressions", "clicks"]
+    schema {
+      fields {
+        ad_id = string
+        stat_time_day = string
+        spend = "decimal(38, 6)"
+        impressions = bigint
+        clicks = bigint
+      }
+    }
+  }
+}
+sink {
+  Console {}
+}


### PR DESCRIPTION
### Purpose of this pull request
Related to #10753.
- Adds a bounded synchronous reporting source for one advertiser.
- Reads ad-level spend, impressions and clicks with optional daily breakdown and exact numeric mapping.
- Checks pagination and truncation warnings, with bounded responses, deadlines, retries and cancellation.

### Does this PR introduce _any_ user-facing change?
Yes. Adds `TikTokAds` as a single-reader BATCH source supporting BASIC/AUCTION_AD reports. Asynchronous reports and arbitrary filters are outside this slice; the API's default deleted-ad exclusion applies. Recovery replays the report without exactly-once or snapshot guarantees. Existing connectors are unchanged.

### How was this patch tested?
- Java 8 and 11: 85 unit tests plus one packaged SPI/HTTP integration test per JDK.
- Coverage includes queries, pagination, exact values, native options, masking, retries, cancellation and malformed responses.
- Mock-backed E2E passed on Zeta, Flink 1.18 and Spark 3.3.
- Spotless and whitespace checks passed.
- Live advertiser validation and the full repository matrix were not run.

### Check list
* [x] License/NOTICE reviewed; existing HTTP libraries reused with connector-local relocation.
* [x] English and Chinese documentation and changelogs added.
* [ ] `incompatible-changes.md`: not applicable; additive connector.
* [x] Connector integration updated: `plugin-mapping.properties`, `seatunnel-dist/pom.xml`, CI label configuration, E2E tests and `config/plugin_config`.