### PR TITLE
[Test][Zeta] Accept either checkpoint-failure reason in trigger-dispatch-failure test

### DIFF
--- a/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointCoordinatorFailoverIT.java
+++ b/seatunnel-e2e/seatunnel-engine-e2e/connector-seatunnel-e2e-base/src/test/java/org/apache/seatunnel/engine/e2e/CheckpointCoordinatorFailoverIT.java
@@ -711,14 +711,36 @@ public class CheckpointCoordinatorFailoverIT {
      * tryTriggerPendingCheckpoint} never allocates a new id while {@code pendingCounter > 0} (line
      * ~800) -- can only happen after checkpoint id 1 has fully completed and been acknowledged.
      *
-     * <p><b>What this test proves:</b> a real checkpoint-barrier dispatch failure, on a coordinator
-     * that was previously checkpointing successfully, fails the job (terminal {@code
-     * JobStatus.FAILED}, with an error message traceable to {@code CheckpointCloseReason
-     * #CHECKPOINT_INSIDE_ERROR}) within a bounded window. <b>What it implicitly also proves:</b>
-     * the pre-fix silent-forever-{@code RUNNING} behavior from #10442 no longer occurs -- had it,
-     * the bounded {@code Awaitility} wait below for {@code JobStatus.FAILED} would time out and
-     * fail this test, since the old code left the job {@code RUNNING} with no further checkpoints
-     * and no error, forever.
+     * <p><b>Which failure path actually fires is a genuine, harmless race -- not a defect.</b>
+     * {@code CheckpointManager#sendOperationToMemberNode} (the same {@code
+     * queryTaskGroupAddress}-guarded call this class's javadoc traces above) is not only what
+     * {@code triggerCheckpoint} uses to dispatch a checkpoint's barrier; {@code notifyCompleted}
+     * (line ~466) uses the exact same call to send {@code notifyCheckpointCompleted} / {@code
+     * notifyCheckpointEnd} once a checkpoint's barrier has already been fully acknowledged, and a
+     * failure there is reported via {@code CheckpointCloseReason
+     * #CHECKPOINT_NOTIFY_COMPLETE_FAILED} instead. "Checkpoint id counter reached 2" (waited for
+     * above) only proves checkpoint 1's own {@code notifyCompleted} already succeeded -- {@code
+     * pendingCounter} is decremented (line ~1377) strictly after it returns true -- but it proves
+     * nothing about checkpoint 2's *own* lifecycle: {@code pendingCounter} is incremented (line
+     * ~1003) before checkpoint 2's barrier is even dispatched, so by the time this test's thread
+     * actually performs the removal a few Awaitility-poll-intervals later, checkpoint 2's barrier
+     * dispatch may already have completed normally and moved on to its *own* {@code
+     * notifyCompleted} call -- which then hits the very same removed entry instead. Both paths
+     * detect the identical injected fault (the missing {@code ownedSlotProfilesIMap} entry) via the
+     * identical {@code queryTaskGroupAddress} lookup and both correctly fail the job through {@code
+     * handleCoordinatorError}; only the intermediate label differs. Treating one of the two as the
+     * sole acceptable outcome makes the test flaky on nothing but scheduling timing, so it accepts
+     * either.
+     *
+     * <p><b>What this test proves:</b> a real checkpoint-barrier-or-notify-completion dispatch
+     * failure, on a coordinator that was previously checkpointing successfully, fails the job
+     * (terminal {@code JobStatus.FAILED}, with an error message traceable to either {@code
+     * CheckpointCloseReason#CHECKPOINT_INSIDE_ERROR} or {@code
+     * CheckpointCloseReason#CHECKPOINT_NOTIFY_COMPLETE_FAILED}) within a bounded window. <b>What it
+     * implicitly also proves:</b> the pre-fix silent-forever-{@code RUNNING} behavior from #10442
+     * no longer occurs -- had it, the bounded {@code Awaitility} wait below for {@code
+     * JobStatus.FAILED} would time out and fail this test, since the old code left the job {@code
+     * RUNNING} with no further checkpoints and no error, forever.
      */
     @Test
     public void testStreamJobFailsAfterCheckpointTriggerDispatchFailure() throws Exception {
@@ -823,14 +845,27 @@ public class CheckpointCoordinatorFailoverIT {
             Assertions.assertEquals(JobStatus.FAILED, jobResult.getStatus());
             Assertions.assertNotNull(
                     jobResult.getError(), "a FAILED job should carry a non-null error message");
+            // Either reason is a correct detection of the same injected fault -- see the
+            // "Which failure path actually fires is a genuine, harmless race" section of the
+            // class javadoc above for why both CheckpointManager#sendOperationToMemberNode call
+            // sites (checkpoint-trigger barrier dispatch and post-completion notify) can observe
+            // the removed ownedSlotProfilesIMap entry depending on scheduling timing.
             Assertions.assertTrue(
                     jobResult
-                            .getError()
-                            .contains(CheckpointCloseReason.CHECKPOINT_INSIDE_ERROR.message()),
+                                    .getError()
+                                    .contains(
+                                            CheckpointCloseReason.CHECKPOINT_INSIDE_ERROR.message())
+                            || jobResult
+                                    .getError()
+                                    .contains(
+                                            CheckpointCloseReason.CHECKPOINT_NOTIFY_COMPLETE_FAILED
+                                                    .message()),
                     () ->
-                            "Expected the job failure to be attributed to the checkpoint"
+                            "Expected the job failure to be attributed to either the checkpoint"
                                     + " coordinator's CHECKPOINT_INSIDE_ERROR path (see"
-                                    + " CheckpointCoordinator#handleCoordinatorError), but got: "
+                                    + " CheckpointCoordinator#handleCoordinatorError) or its"
+                                    + " CHECKPOINT_NOTIFY_COMPLETE_FAILED path (see"
+                                    + " CheckpointCoordinator#notifyCompleted), but got: "
                                     + jobResult.getError());
         } finally {
             if (engineClient != null) {


### PR DESCRIPTION
## Purpose

Fixes an intermittent CI flake in `CheckpointCoordinatorFailoverIT#testStreamJobFailsAfterCheckpointTriggerDispatchFailure` (added by #12199 for issue #10442, already merged into `dev`) which surfaces on unrelated PRs' CI, e.g.:

```
Expected the job failure to be attributed to the checkpoint coordinator's
CHECKPOINT_INSIDE_ERROR path (see CheckpointCoordinator#handleCoordinatorError),
but got: ... Checkpoint notify complete failed
```

Confirmed this is currently reproducing across many unrelated open PRs' CI runs (their diffs never touch checkpoint/engine code at all), not caused by any of those PRs.

## Root cause

The test injects a real fault by removing this job's entry from the live, shared `ownedSlotProfilesIMap`, then waits for the checkpoint id counter to reach 2 before asserting the job fails via `CheckpointCloseReason.CHECKPOINT_INSIDE_ERROR` — the error `CheckpointCoordinator#triggerCheckpoint`'s barrier-dispatch path raises through `CheckpointManager#sendOperationToMemberNode` → `JobMaster#queryTaskGroupAddress`.

However, `CheckpointCoordinator#notifyCompleted` (called once a checkpoint's barrier is already fully acknowledged, to notify subtasks the checkpoint completed) dispatches through the **exact same** `sendOperationToMemberNode`/`queryTaskGroupAddress` call, and reports a failure there via a **different** reason: `CheckpointCloseReason.CHECKPOINT_NOTIFY_COMPLETE_FAILED`.

Tracing `pendingCounter`'s increment/decrement in `CheckpointCoordinator`:
- `pendingCounter` is decremented only *after* `notifyCompleted` returns successfully (line ~1377) — so "checkpoint id counter reached 2" does correctly prove checkpoint 1's own `notifyCompleted` already succeeded.
- But `pendingCounter` is incremented (line ~1003) *before* checkpoint 2's barrier is even dispatched — so it proves nothing about checkpoint 2's own timing.

By the time the test's thread actually performs the `ownedSlotProfilesIMap` removal (a few `Awaitility` poll intervals after observing the counter reach 2), checkpoint 2's barrier dispatch may already have completed normally and moved on to its own `notifyCompleted` call — which then hits the same removed entry, producing `CHECKPOINT_NOTIFY_COMPLETE_FAILED` instead of `CHECKPOINT_INSIDE_ERROR`.

Both paths correctly detect the identical injected fault and correctly fail the job through `handleCoordinatorError`; only the `CheckpointCloseReason` label differs depending on which of the two call sites loses the race against the test's own fault-injection timing.

## Fix

Widen the test's assertion to accept **either** `CHECKPOINT_INSIDE_ERROR` or `CHECKPOINT_NOTIFY_COMPLETE_FAILED`, and document why in the class javadoc (a new "Which failure path actually fires is a genuine, harmless race" section). This does not weaken what the test actually proves: the job must still reach a terminal `FAILED` state (not the pre-#10442-fix silent-forever-`RUNNING`) within the same bounded window, regardless of which of the two equally-valid code paths caught the fault first. Test-only change; no production code touched.

## Tests

No new test added — this fixes the flakiness of an existing test without reducing its coverage. Per this repository's contribution guidance for Apache SeaTunnel, local execution was limited to `spotless:apply`/`spotless:check` (passing); this PR's own GitHub Actions CI is the verification for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
