### PR TITLE
[Fix][CI] Remove invalid Build ruleset source pin

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -86,7 +86,6 @@ github:
             strict_required_status_checks_policy: false
             required_status_checks:
               - context: Build
-                integration_id: 15368
         - type: merge_queue
           parameters:
             # Allow enough time for runner scheduling before the 30-minute job starts.


### PR DESCRIPTION
## Summary
- Remove the optional GitHub Actions integration ID from the `Build` raw ruleset check.
- Keep `Build` required and retain all bypass actors and merge-gate rules.
- Address ASF GitHub-feature validation failure at `rules[3]`.

## Validation
- YAML ruleset payload assertion
- `git diff --check`
- Independent Maintainer Review: PASS
- Local Maven validation unavailable in the configuration-only sparse worktree; GitHub CI pending.